### PR TITLE
Improve table features in the HTML Editor

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -610,8 +610,6 @@ export class HtmlEditor {
 
     private removeUnwantedMenuItems() {
         this.editor.on('instanceReady', () => {
-            this.editor.removeMenuItem('table');
-            this.editor.removeMenuItem('tablecell_properties');
             this.editor.removeMenuItem('paste');
         });
     }
@@ -836,7 +834,7 @@ class HtmlEditorConfigBuilder {
             ],
             removePlugins: this.getPluginsToRemove(),
             removeButtons: this.toolsToExlcude,
-            extraPlugins: 'macro,image2',
+            extraPlugins: 'macro,image2,tableresize',
             extraAllowedContent: 'iframe code address dl dt dd blockquote script;img[data-src]',
             format_tags: 'p;h1;h2;h3;h4;h5;h6;pre;div',
             image2_disableResizer: true,

--- a/src/main/resources/assets/lib/ckeditor/plugins/table/dialogs/table.js
+++ b/src/main/resources/assets/lib/ckeditor/plugins/table/dialogs/table.js
@@ -1,0 +1,557 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+(function () {
+    var defaultToPixel = CKEDITOR.tools.cssLength;
+
+    var commitValue = function (data) {
+        var id = this.id;
+        if (!data.info) {
+            data.info = {};
+        }
+        data.info[id] = this.getValue();
+    };
+
+    function tableColumns(table) {
+        var cols = 0,
+            maxCols = 0;
+        for (var i = 0, row, rows = table.$.rows.length; i < rows; i++) {
+            row = table.$.rows[i], cols = 0;
+            for (var j = 0, cell, cells = row.cells.length; j < cells; j++) {
+                cell = row.cells[j];
+                cols += cell.colSpan;
+            }
+
+            cols > maxCols && (maxCols = cols);
+        }
+
+        return maxCols;
+    }
+
+
+    // Whole-positive-integer validator.
+    function validatorNum(msg) {
+        return function () {
+            var value = this.getValue(),
+                pass = !!(CKEDITOR.dialog.validate.integer().call(this, value) && value > 0);
+
+            if (!pass) {
+                alert(msg); // jshint ignore:line
+                this.select();
+            }
+
+            return pass;
+        };
+    }
+
+    function tableDialog(editor, command) {
+        var makeElement = function (name) {
+            return new CKEDITOR.dom.element(name, editor.document);
+        };
+
+        var editable = editor.editable();
+
+        var dialogadvtab = editor.plugins.dialogadvtab;
+
+        return {
+            title: editor.lang.table.title,
+            minWidth: 310,
+            minHeight: CKEDITOR.env.ie ? 310 : 280,
+
+            onLoad: function () {
+                var dialog = this;
+
+                var styles = dialog.getContentElement('advanced', 'advStyles');
+
+                if (styles) {
+                    styles.on('change', function () {
+                        // Synchronize width value.
+                        var width = this.getStyle('width', ''),
+                            txtWidth = dialog.getContentElement('info', 'txtWidth');
+
+                        txtWidth && txtWidth.setValue(width, true);
+
+                        // Synchronize height value.
+                        var height = this.getStyle('height', ''),
+                            txtHeight = dialog.getContentElement('info', 'txtHeight');
+
+                        txtHeight && txtHeight.setValue(height, true);
+                    });
+                }
+            },
+
+            onShow: function () {
+                // Detect if there's a selected table.
+                var selection = editor.getSelection(),
+                    ranges = selection.getRanges(),
+                    table;
+
+                var rowsInput = this.getContentElement('info', 'txtRows'),
+                    colsInput = this.getContentElement('info', 'txtCols'),
+                    widthInput = this.getContentElement('info', 'txtWidth'),
+                    heightInput = this.getContentElement('info', 'txtHeight');
+
+                if (command == 'tableProperties') {
+                    var selected = selection.getSelectedElement();
+                    if (selected && selected.is('table')) {
+                        table = selected;
+                    } else if (ranges.length > 0) {
+                        // Webkit could report the following range on cell selection (https://dev.ckeditor.com/ticket/4948):
+                        // <table><tr><td>[&nbsp;</td></tr></table>]
+                        if (CKEDITOR.env.webkit) {
+                            ranges[0].shrink(CKEDITOR.NODE_ELEMENT);
+                        }
+
+                        table = editor.elementPath(ranges[0].getCommonAncestor(true)).contains('table', 1);
+                    }
+
+                    // Save a reference to the selected table, and push a new set of default values.
+                    this._.selectedElement = table;
+                }
+
+                // Enable or disable the row, cols, width fields.
+                if (table) {
+                    this.setupContent(table);
+                    rowsInput && rowsInput.disable();
+                    colsInput && colsInput.disable();
+                } else {
+                    rowsInput && rowsInput.enable();
+                    colsInput && colsInput.enable();
+                }
+
+                // Call the onChange method for the widht and height fields so
+                // they get reflected into the Advanced tab.
+                widthInput && widthInput.onChange();
+                heightInput && heightInput.onChange();
+            },
+            onOk: function () {
+                var selection = editor.getSelection(),
+                    bms = this._.selectedElement && selection.createBookmarks();
+
+                var table = this._.selectedElement || makeElement('table'),
+                    data = {};
+
+                this.commitContent(data, table);
+
+                if (data.info) {
+                    var info = data.info;
+
+                    // Generate the rows and cols.
+                    if (!this._.selectedElement) {
+                        var tbody = table.append(makeElement('tbody')),
+                            rows = parseInt(info.txtRows, 10) || 0,
+                            cols = parseInt(info.txtCols, 10) || 0;
+
+                        for (var i = 0; i < rows; i++) {
+                            var row = tbody.append(makeElement('tr'));
+                            for (var j = 0; j < cols; j++) {
+                                var cell = row.append(makeElement('td'));
+                                cell.appendBogus();
+                            }
+                        }
+                    }
+
+                    // Modify the table headers. Depends on having rows and cols generated
+                    // correctly so it can't be done in commit functions.
+
+                    // Should we make a <thead>?
+                    var headers = info.selHeaders;
+                    if (!table.$.tHead && (headers == 'row' || headers == 'both')) {
+                        var thead = table.getElementsByTag('thead').getItem(0);
+                        tbody = table.getElementsByTag('tbody').getItem(0);
+                        var theRow = tbody.getElementsByTag('tr').getItem(0);
+
+                        if (!thead) {
+                            thead = new CKEDITOR.dom.element('thead');
+                            thead.insertBefore(tbody);
+                        }
+
+                        // Change TD to TH:
+                        for (i = 0; i < theRow.getChildCount(); i++) {
+                            var th = theRow.getChild(i);
+                            // Skip bookmark nodes. (https://dev.ckeditor.com/ticket/6155)
+                            if (th.type == CKEDITOR.NODE_ELEMENT && !th.data('cke-bookmark')) {
+                                th.renameNode('th');
+                                th.setAttribute('scope', 'col');
+                            }
+                        }
+                        thead.append(theRow.remove());
+                    }
+
+                    if (table.$.tHead !== null && !(headers == 'row' || headers == 'both')) {
+                        // Move the row out of the THead and put it in the TBody:
+                        thead = new CKEDITOR.dom.element(table.$.tHead);
+                        tbody = table.getElementsByTag('tbody').getItem(0);
+
+                        var previousFirstRow = tbody.getFirst();
+                        while (thead.getChildCount() > 0) {
+                            theRow = thead.getFirst();
+                            for (i = 0; i < theRow.getChildCount(); i++) {
+                                var newCell = theRow.getChild(i);
+                                if (newCell.type == CKEDITOR.NODE_ELEMENT) {
+                                    newCell.renameNode('td');
+                                    newCell.removeAttribute('scope');
+                                }
+                            }
+                            theRow.insertBefore(previousFirstRow);
+                        }
+                        thead.remove();
+                    }
+
+                    // Should we make all first cells in a row TH?
+                    if (!this.hasColumnHeaders && (headers == 'col' || headers == 'both')) {
+                        for (row = 0; row < table.$.rows.length; row++) {
+                            newCell = new CKEDITOR.dom.element(table.$.rows[row].cells[0]);
+                            newCell.renameNode('th');
+                            newCell.setAttribute('scope', 'row');
+                        }
+                    }
+
+                    // Should we make all first TH-cells in a row make TD? If 'yes' we do it the other way round :-)
+                    if ((this.hasColumnHeaders) && !(headers == 'col' || headers == 'both')) {
+                        for (i = 0; i < table.$.rows.length; i++) {
+                            row = new CKEDITOR.dom.element(table.$.rows[i]);
+                            if (row.getParent().getName() == 'tbody') {
+                                newCell = new CKEDITOR.dom.element(row.$.cells[0]);
+                                newCell.renameNode('td');
+                                newCell.removeAttribute('scope');
+                            }
+                        }
+                    }
+
+                    // Set the width and height.
+                    info.txtHeight ? table.setStyle('height', info.txtHeight) : table.removeStyle('height');
+                    info.txtWidth ? table.setStyle('width', info.txtWidth) : table.removeStyle('width');
+
+                    if (!table.getAttribute('style')) {
+                        table.removeAttribute('style');
+                    }
+                }
+
+                // Insert the table element if we're creating one.
+                if (!this._.selectedElement) {
+                    editor.insertElement(table);
+                    // Override the default cursor position after insertElement to place
+                    // cursor inside the first cell (https://dev.ckeditor.com/ticket/7959), IE needs a while.
+                    setTimeout(function () {
+                        var firstCell = new CKEDITOR.dom.element(table.$.rows[0].cells[0]);
+                        var range = editor.createRange();
+                        range.moveToPosition(firstCell, CKEDITOR.POSITION_AFTER_START);
+                        range.select();
+                    }, 0);
+                }
+                // Properly restore the selection, (https://dev.ckeditor.com/ticket/4822) but don't break
+                // because of this, e.g. updated table caption.
+                else {
+                    try {
+                        selection.selectBookmarks(bms);
+                    } catch (er) {
+                    }
+                }
+            },
+            contents: [{
+                id: 'info',
+                label: editor.lang.table.title,
+                elements: [{
+                    type: 'hbox',
+                    widths: [null, null],
+                    styles: ['vertical-align:top'],
+                    children: [{
+                        type: 'vbox',
+                        padding: 0,
+                        children: [{
+                            type: 'text',
+                            id: 'txtRows',
+                            'default': 3,
+                            label: editor.lang.table.rows,
+                            required: true,
+                            controlStyle: 'width:5em',
+                            validate: validatorNum(editor.lang.table.invalidRows),
+                            setup: function (selectedElement) {
+                                this.setValue(selectedElement.$.rows.length);
+                            },
+                            commit: commitValue
+                        },
+                            {
+                                type: 'text',
+                                id: 'txtCols',
+                                'default': 2,
+                                label: editor.lang.table.columns,
+                                required: true,
+                                controlStyle: 'width:5em',
+                                validate: validatorNum(editor.lang.table.invalidCols),
+                                setup: function (selectedTable) {
+                                    this.setValue(tableColumns(selectedTable));
+                                },
+                                commit: commitValue
+                            },
+                            {
+                                type: 'html',
+                                html: '&nbsp;'
+                            },
+                            {
+                                type: 'select',
+                                id: 'selHeaders',
+                                requiredContent: 'th',
+                                'default': '',
+                                label: editor.lang.table.headers,
+                                items: [
+                                    [editor.lang.table.headersNone, ''],
+                                    [editor.lang.table.headersRow, 'row'],
+                                    [editor.lang.table.headersColumn, 'col'],
+                                    [editor.lang.table.headersBoth, 'both']
+                                ],
+                                setup: function (selectedTable) {
+                                    // Fill in the headers field.
+                                    var dialog = this.getDialog();
+                                    dialog.hasColumnHeaders = true;
+
+                                    // Check if all the first cells in every row are TH
+                                    for (var row = 0; row < selectedTable.$.rows.length; row++) {
+                                        // If just one cell isn't a TH then it isn't a header column
+                                        var headCell = selectedTable.$.rows[row].cells[0];
+                                        if (headCell && headCell.nodeName.toLowerCase() != 'th') {
+                                            dialog.hasColumnHeaders = false;
+                                            break;
+                                        }
+                                    }
+
+                                    // Check if the table contains <thead>.
+                                    if ((selectedTable.$.tHead !== null)) {
+                                        this.setValue(dialog.hasColumnHeaders ? 'both' : 'row');
+                                    } else {
+                                        this.setValue(dialog.hasColumnHeaders ? 'col' : '');
+                                    }
+                                },
+                                commit: commitValue
+                            },
+                            {
+                                type: 'text',
+                                id: 'txtBorder',
+                                requiredContent: 'table[border]',
+                                // Avoid setting border which will then disappear.
+                                'default': editor.filter.check('table[border]') ? 1 : 0,
+                                label: editor.lang.table.border,
+                                controlStyle: 'width:3em',
+                                validate: CKEDITOR.dialog.validate.number(editor.lang.table.invalidBorder),
+                                setup: function (selectedTable) {
+                                    this.setValue(selectedTable.getAttribute('border') || '');
+                                },
+                                commit: function (data, selectedTable) {
+                                    if (this.getValue()) {
+                                        selectedTable.setAttribute('border', this.getValue());
+                                    } else {
+                                        selectedTable.removeAttribute('border');
+                                    }
+                                }
+                            },
+                            {
+                                id: 'cmbAlign',
+                                type: 'select',
+                                requiredContent: 'table[align]',
+                                'default': '',
+                                label: editor.lang.common.align,
+                                items: [
+                                    [editor.lang.common.notSet, ''],
+                                    [editor.lang.common.left, 'left'],
+                                    [editor.lang.common.center, 'center'],
+                                    [editor.lang.common.right, 'right']
+                                ],
+                                setup: function (selectedTable) {
+                                    this.setValue(selectedTable.getAttribute('align') || '');
+                                },
+                                commit: function (data, selectedTable) {
+                                    if (this.getValue()) {
+                                        selectedTable.setAttribute('align', this.getValue());
+                                    } else {
+                                        selectedTable.removeAttribute('align');
+                                    }
+                                }
+                            }]
+                    },
+                        {
+                            type: 'vbox',
+                            padding: 0,
+                            children: [{
+                                type: 'hbox',
+                                widths: ['5em'],
+                                children: [{
+                                    type: 'text',
+                                    id: 'txtWidth',
+                                    requiredContent: 'table{width}',
+                                    controlStyle: 'width:5em',
+                                    label: editor.lang.common.width,
+                                    title: editor.lang.common.cssLengthTooltip,
+                                    // Smarter default table width. (https://dev.ckeditor.com/ticket/9600)
+                                    'default': editor.filter.check('table{width}') ? (editable.getSize('width') < 500 ? '100%' : 500) : 0,
+                                    getValue: defaultToPixel,
+                                    validate: CKEDITOR.dialog.validate.cssLength(
+                                        editor.lang.common.invalidCssLength.replace('%1', editor.lang.common.width)),
+                                    onChange: function () {
+                                        var styles = this.getDialog().getContentElement('advanced', 'advStyles');
+                                        styles && styles.updateStyle('width', this.getValue());
+                                    },
+                                    setup: function (selectedTable) {
+                                        var val = selectedTable.getStyle('width');
+                                        this.setValue(val);
+                                    },
+                                    commit: commitValue
+                                }]
+                            },
+                                {
+                                    type: 'hbox',
+                                    widths: ['5em'],
+                                    children: [{
+                                        type: 'text',
+                                        id: 'txtHeight',
+                                        requiredContent: 'table{height}',
+                                        controlStyle: 'width:5em',
+                                        label: editor.lang.common.height,
+                                        title: editor.lang.common.cssLengthTooltip,
+                                        'default': '',
+                                        getValue: defaultToPixel,
+                                        validate: CKEDITOR.dialog.validate.cssLength(
+                                            editor.lang.common.invalidCssLength.replace('%1', editor.lang.common.height)),
+                                        onChange: function () {
+                                            var styles = this.getDialog().getContentElement('advanced', 'advStyles');
+                                            styles && styles.updateStyle('height', this.getValue());
+                                        },
+
+                                        setup: function (selectedTable) {
+                                            var val = selectedTable.getStyle('height');
+                                            val && this.setValue(val);
+                                        },
+                                        commit: commitValue
+                                    }]
+                                },
+                                {
+                                    type: 'html',
+                                    html: '&nbsp;'
+                                },
+                                {
+                                    type: 'text',
+                                    id: 'txtCellSpace',
+                                    requiredContent: 'table[cellspacing]',
+                                    controlStyle: 'width:3em',
+                                    label: editor.lang.table.cellSpace,
+                                    'default': editor.filter.check('table[cellspacing]') ? 1 : 0,
+                                    validate: CKEDITOR.dialog.validate.number(editor.lang.table.invalidCellSpacing),
+                                    setup: function (selectedTable) {
+                                        this.setValue(selectedTable.getAttribute('cellSpacing') || '');
+                                    },
+                                    commit: function (data, selectedTable) {
+                                        if (this.getValue()) {
+                                            selectedTable.setAttribute('cellSpacing', this.getValue());
+                                        } else {
+                                            selectedTable.removeAttribute('cellSpacing');
+                                        }
+                                    }
+                                },
+                                {
+                                    type: 'text',
+                                    id: 'txtCellPad',
+                                    requiredContent: 'table[cellpadding]',
+                                    controlStyle: 'width:3em',
+                                    label: editor.lang.table.cellPad,
+                                    'default': editor.filter.check('table[cellpadding]') ? 1 : 0,
+                                    validate: CKEDITOR.dialog.validate.number(editor.lang.table.invalidCellPadding),
+                                    setup: function (selectedTable) {
+                                        this.setValue(selectedTable.getAttribute('cellPadding') || '');
+                                    },
+                                    commit: function (data, selectedTable) {
+                                        if (this.getValue()) {
+                                            selectedTable.setAttribute('cellPadding', this.getValue());
+                                        } else {
+                                            selectedTable.removeAttribute('cellPadding');
+                                        }
+                                    }
+                                }]
+                        }]
+                },
+                    {
+                        type: 'html',
+                        align: 'right',
+                        html: ''
+                    },
+                    {
+                        type: 'vbox',
+                        padding: 0,
+                        children: [{
+                            type: 'text',
+                            id: 'txtCaption',
+                            requiredContent: 'caption',
+                            label: editor.lang.table.caption,
+                            setup: function (selectedTable) {
+                                this.enable();
+
+                                var nodeList = selectedTable.getElementsByTag('caption');
+                                if (nodeList.count() > 0) {
+                                    var caption = nodeList.getItem(0);
+                                    var firstElementChild = caption.getFirst(CKEDITOR.dom.walker.nodeType(CKEDITOR.NODE_ELEMENT));
+
+                                    if (firstElementChild && !firstElementChild.equals(caption.getBogus())) {
+                                        this.disable();
+                                        this.setValue(caption.getText());
+                                        return;
+                                    }
+
+                                    caption = CKEDITOR.tools.trim(caption.getText());
+                                    this.setValue(caption);
+                                }
+                            },
+                            commit: function (data, table) {
+                                if (!this.isEnabled()) {
+                                    return;
+                                }
+
+                                var caption = this.getValue(),
+                                    captionElement = table.getElementsByTag('caption');
+                                if (caption) {
+                                    if (captionElement.count() > 0) {
+                                        captionElement = captionElement.getItem(0);
+                                        captionElement.setHtml('');
+                                    } else {
+                                        captionElement = new CKEDITOR.dom.element('caption', editor.document);
+                                        table.append(captionElement, true);
+                                    }
+                                    captionElement.append(new CKEDITOR.dom.text(caption, editor.document));
+                                } else if (captionElement.count() > 0) {
+                                    for (var i = captionElement.count() - 1; i >= 0; i--) {
+                                        captionElement.getItem(i).remove();
+                                    }
+                                }
+                            }
+                        },
+                            {
+                                type: 'text',
+                                id: 'txtSummary',
+                                bidi: true,
+                                requiredContent: 'table[summary]',
+                                label: editor.lang.table.summary,
+                                setup: function (selectedTable) {
+                                    this.setValue(selectedTable.getAttribute('summary') || '');
+                                },
+                                commit: function (data, selectedTable) {
+                                    if (this.getValue()) {
+                                        selectedTable.setAttribute('summary', this.getValue());
+                                    } else {
+                                        selectedTable.removeAttribute('summary');
+                                    }
+                                }
+                            }]
+                    }]
+            },
+                dialogadvtab && dialogadvtab.createAdvancedTab(editor, null, 'table')
+            ]
+        };
+    }
+
+    CKEDITOR.dialog.add('table', function (editor) {
+        return tableDialog(editor, 'table');
+    });
+    CKEDITOR.dialog.add('tableProperties', function (editor) {
+        return tableDialog(editor, 'tableProperties');
+    });
+})();

--- a/src/main/resources/assets/lib/ckeditor/plugins/tableresize/plugin.js
+++ b/src/main/resources/assets/lib/ckeditor/plugins/tableresize/plugin.js
@@ -1,0 +1,453 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+(function () {
+    var pxUnit = CKEDITOR.tools.cssLength,
+        needsIEHacks = CKEDITOR.env.ie && (CKEDITOR.env.ie7Compat || CKEDITOR.env.quirks);
+
+    function getWidth(el) {
+        return CKEDITOR.env.ie ? el.$.clientWidth : parseInt(el.getComputedStyle('width'), 10);
+    }
+
+    function getBorderWidth(element, side) {
+        var computed = element.getComputedStyle('border-' + side + '-width'),
+            borderMap = {
+                thin: '0px',
+                medium: '1px',
+                thick: '2px'
+            };
+
+        if (computed.indexOf('px') < 0) {
+            // look up keywords
+            if (computed in borderMap && element.getComputedStyle('border-style') != 'none') {
+                computed = borderMap[computed];
+            } else {
+                computed = 0;
+            }
+        }
+
+        return parseInt(computed, 10);
+    }
+
+    // Sets pillar height and position based on given table element (head, body, footer).
+    function setPillarDimensions(nativeTableElement) {
+        if (nativeTableElement) {
+            var tableElement = new CKEDITOR.dom.element(nativeTableElement);
+            return {height: tableElement.$.offsetHeight, position: tableElement.getDocumentPosition()};
+        }
+    }
+
+    function buildTableColumnPillars(table) {
+        var pillars = [],
+            pillarIndexMap = {},
+            rtl = (table.getComputedStyle('direction') == 'rtl');
+
+        var rows = table.$.rows;
+
+        CKEDITOR.tools.array.forEach(rows, function (item, index) {
+            var $tr = item,
+                pillarIndex = -1,
+                pillarRow,
+                pillarHeight = 0,
+                pillarPosition = null,
+                pillarDimensions = setPillarDimensions($tr);
+
+            pillarHeight = pillarDimensions.height;
+            pillarPosition = pillarDimensions.position;
+
+            // Loop thorugh all cells, building pillars after each one of them.
+            for (var i = 0, len = $tr.cells.length; i < len; i++) {
+                // Both the current cell and the successive one will be used in the
+                // pillar size calculation.
+                var td = new CKEDITOR.dom.element($tr.cells[i]),
+                    nextTd = $tr.cells[i + 1] && new CKEDITOR.dom.element($tr.cells[i + 1]),
+                    pillar;
+
+                pillarIndex += td.$.colSpan || 1;
+                pillarRow = index;
+
+                // Calculate the pillar boundary positions.
+                var pillarLeft, pillarRight, pillarWidth;
+
+                var x = td.getDocumentPosition().x;
+
+                // Calculate positions based on the current cell.
+                rtl ? pillarRight = x + getBorderWidth(td, 'left') : pillarLeft = x + td.$.offsetWidth - getBorderWidth(td, 'right');
+
+                // Calculate positions based on the next cell, if available.
+                if (nextTd) {
+                    x = nextTd.getDocumentPosition().x;
+
+                    rtl ? pillarLeft = x + nextTd.$.offsetWidth - getBorderWidth(nextTd, 'right') : pillarRight =
+                        x + getBorderWidth(nextTd, 'left');
+                }
+                // Otherwise calculate positions based on the table (for last cell).
+                else {
+                    x = table.getDocumentPosition().x;
+
+                    rtl ? pillarLeft = x : pillarRight = x + table.$.offsetWidth;
+                }
+
+                pillarWidth = Math.max(pillarRight - pillarLeft, 3);
+
+                // The pillar should reflects exactly the shape of the hovered
+                // column border line.
+                pillar = {
+                    table: table,
+                    index: pillarIndex,
+                    x: pillarLeft,
+                    y: pillarPosition.y,
+                    width: pillarWidth,
+                    height: pillarHeight,
+                    rtl: rtl
+                };
+                pillarIndexMap[pillarIndex] = pillarIndexMap[pillarIndex] || [];
+                pillarIndexMap[pillarIndex].push(pillar);
+                pillar.alignedPillars = pillarIndexMap[pillarIndex];
+
+                pillars.push(pillar);
+            }
+
+        });
+
+        return pillars;
+    }
+
+    function checkWithinDimensions(posX, posY, element) {
+        return posX >= element.x && posX <= (element.x + element.width) &&
+               posY >= element.y && posY <= (element.y + element.height);
+    }
+
+    function getPillarAtPosition(pillars, position) {
+        for (var i = 0, len = pillars.length; i < len; i++) {
+            var pillar = pillars[i];
+
+            if (checkWithinDimensions(position.x, position.y, pillar)) {
+                return pillar;
+            }
+        }
+        return null;
+    }
+
+    function cancel(evt) {
+        (evt.data || evt).preventDefault();
+    }
+
+    function columnResizer(editor) {
+        var pillar, document, resizer, isResizing, startOffset, currentShift, move;
+
+        var leftSideCells, rightSideCells, leftShiftBoundary, rightShiftBoundary;
+
+        function detach() {
+            pillar = null;
+            currentShift = 0;
+            isResizing = 0;
+
+            document.removeListener('mouseup', onMouseUp);
+            resizer.removeListener('mousedown', onMouseDown);
+            resizer.removeListener('mousemove', onMouseMove);
+
+            document.getBody().setStyle('cursor', 'auto');
+
+            // Hide the resizer (remove it on IE7 - https://dev.ckeditor.com/ticket/5890).
+            needsIEHacks ? resizer.remove() : resizer.hide();
+        }
+
+        function resizeStart() {
+            // Before starting to resize, figure out which cells to change
+            // and the boundaries of this resizing shift.
+
+            var columnIndex = pillar.index,
+                map = CKEDITOR.tools.buildTableMap(pillar.table),
+                leftColumnCells = [],
+                rightColumnCells = [],
+                leftMinSize = Number.MAX_VALUE,
+                rightMinSize = leftMinSize,
+                rtl = pillar.rtl;
+
+            for (var i = 0, len = map.length; i < len; i++) {
+                var row = map[i],
+                    leftCell = row[columnIndex + (rtl ? 1 : 0)],
+                    rightCell = row[columnIndex + (rtl ? 0 : 1)];
+
+                leftCell = leftCell && new CKEDITOR.dom.element(leftCell);
+                rightCell = rightCell && new CKEDITOR.dom.element(rightCell);
+
+                if (!leftCell || !rightCell || !leftCell.equals(rightCell)) {
+                    leftCell && (leftMinSize = Math.min(leftMinSize, getWidth(leftCell)));
+                    rightCell && (rightMinSize = Math.min(rightMinSize, getWidth(rightCell)));
+
+                    leftColumnCells.push(leftCell);
+                    rightColumnCells.push(rightCell);
+                }
+            }
+
+            // Cache the list of cells to be resized.
+            leftSideCells = leftColumnCells;
+            rightSideCells = rightColumnCells;
+
+            // Cache the resize limit boundaries.
+            leftShiftBoundary = pillar.x - leftMinSize;
+            rightShiftBoundary = pillar.x + rightMinSize;
+
+            resizer.setOpacity(0.5);
+            startOffset = parseInt(resizer.getStyle('left'), 10);
+            currentShift = 0;
+            isResizing = 1;
+
+            resizer.on('mousemove', onMouseMove);
+
+            // Prevent the native drag behavior otherwise 'mousemove' won't fire.
+            document.on('dragstart', cancel);
+        }
+
+        function resizeEnd() {
+            isResizing = 0;
+
+            resizer.setOpacity(0);
+
+            currentShift && resizeColumn();
+
+            var table = pillar.table;
+            setTimeout(function () {
+                table.removeCustomData('_cke_table_pillars');
+            }, 0);
+
+            document.removeListener('dragstart', cancel);
+        }
+
+        function resizeColumn() {
+            var rtl = pillar.rtl,
+                cellsCount = rtl ? rightSideCells.length : leftSideCells.length,
+                cellsSaved = 0;
+
+            // Perform the actual resize to table cells, only for those by side of the pillar.
+            for (var i = 0; i < cellsCount; i++) {
+                var leftCell = leftSideCells[i],
+                    rightCell = rightSideCells[i],
+                    table = pillar.table;
+
+                // Defer the resizing to avoid any interference among cells.
+                CKEDITOR.tools.setTimeout(function (leftCell, leftOldWidth, rightCell, rightOldWidth, tableWidth, sizeShift) {
+                    // 1px is the minimum valid width (https://dev.ckeditor.com/ticket/11626).
+                    leftCell && leftCell.setStyle('width', pxUnit(Math.max(leftOldWidth + sizeShift, 1)));
+                    rightCell && rightCell.setStyle('width', pxUnit(Math.max(rightOldWidth - sizeShift, 1)));
+
+                    // If we're in the last cell, we need to resize the table as well
+                    if (tableWidth) {
+                        table.setStyle('width', pxUnit(tableWidth + sizeShift * (rtl ? -1 : 1)));
+                    }
+
+                    // Cells resizing is asynchronous-y, so we have to use syncing
+                    // to save snapshot only after all cells are resized. (https://dev.ckeditor.com/ticket/13388)
+                    if (++cellsSaved == cellsCount) {
+                        editor.fire('saveSnapshot');
+                    }
+                }, 0, this, [
+                    leftCell, leftCell && getWidth(leftCell),
+                    rightCell, rightCell && getWidth(rightCell),
+                    (!leftCell || !rightCell) && (getWidth(table) + getBorderWidth(table, 'left') + getBorderWidth(table, 'right')),
+                    currentShift
+                ]);
+            }
+        }
+
+        function onMouseDown(evt) {
+            cancel(evt);
+
+            // Save editor's state before we do any magic with cells. (https://dev.ckeditor.com/ticket/13388)
+            editor.fire('saveSnapshot');
+            resizeStart();
+
+            document.on('mouseup', onMouseUp, this);
+        }
+
+        function onMouseUp(evt) {
+            evt.removeListener();
+
+            resizeEnd();
+        }
+
+        function onMouseMove(evt) {
+            move(evt.data.getPageOffset().x);
+        }
+
+        document = editor.document;
+
+        resizer = CKEDITOR.dom.element.createFromHtml('<div data-cke-temp=1 contenteditable=false unselectable=on ' +
+                                                      'style="position:absolute;cursor:col-resize;filter:alpha(opacity=0);opacity:0;' +
+                                                      'padding:0;background-color:#004;background-image:none;border:0px none;z-index:10"></div>',
+            document);
+
+        // Clean DOM when editor is destroyed.
+        editor.on('destroy', function () {
+            resizer.remove();
+        });
+
+        // Except on IE6/7 (https://dev.ckeditor.com/ticket/5890), place the resizer after body to prevent it
+        // from being editable.
+        if (!needsIEHacks) {
+            document.getDocumentElement().append(resizer);
+        }
+
+        this.attachTo = function (targetPillar) {
+            var firstAligned,
+                lastAligned,
+                resizerHeight,
+                resizerY;
+            // Accept only one pillar at a time.
+            if (isResizing) {
+                return;
+            }
+
+            // On IE6/7, we append the resizer everytime we need it. (https://dev.ckeditor.com/ticket/5890)
+            if (needsIEHacks) {
+                document.getBody().append(resizer);
+                currentShift = 0;
+            }
+
+            pillar = targetPillar;
+            firstAligned = pillar.alignedPillars[0];
+            lastAligned = pillar.alignedPillars[pillar.alignedPillars.length - 1];
+            resizerY = firstAligned.y;
+            resizerHeight = lastAligned.height + lastAligned.y - firstAligned.y;
+
+            resizer.setStyles({
+                width: pxUnit(targetPillar.width),
+                height: pxUnit(resizerHeight),
+                left: pxUnit(targetPillar.x),
+                top: pxUnit(resizerY)
+            });
+
+            // In IE6/7, it's not possible to have custom cursors for floating
+            // elements in an editable document. Show the resizer in that case,
+            // to give the user a visual clue.
+            needsIEHacks && resizer.setOpacity(0.25);
+
+            resizer.on('mousedown', onMouseDown, this);
+
+            document.getBody().setStyle('cursor', 'col-resize');
+
+            // Display the resizer to receive events but don't show it,
+            // only change the cursor to resizable shape.
+            resizer.show();
+        };
+
+        move = this.move = function (posX, posY) {
+            if (!pillar) {
+                return 0;
+            }
+
+            if (!isResizing && !checkWithinDimensions(posX, posY, pillar)) {
+                detach();
+                return 0;
+            }
+            var resizerNewPosition = posX - Math.round(resizer.$.offsetWidth / 2);
+
+            if (isResizing) {
+                if (resizerNewPosition == leftShiftBoundary || resizerNewPosition == rightShiftBoundary) {
+                    return 1;
+                }
+
+                resizerNewPosition = Math.max(resizerNewPosition, leftShiftBoundary);
+                resizerNewPosition = Math.min(resizerNewPosition, rightShiftBoundary);
+
+                currentShift = resizerNewPosition - startOffset;
+            }
+
+            resizer.setStyle('left', pxUnit(resizerNewPosition));
+
+            return 1;
+        };
+    }
+
+    function clearPillarsCache(evt) {
+        var target = evt.data.getTarget();
+
+        if (evt.name == 'mouseout') {
+            // Bypass interal mouse move.
+            if (!target.is('table')) {
+                return;
+            }
+
+            var dest = new CKEDITOR.dom.element(evt.data.$.relatedTarget || evt.data.$.toElement);
+            while (dest && dest.$ && !dest.equals(target) && !dest.is('body')) {
+                dest = dest.getParent();
+            }
+            if (!dest || dest.equals(target)) {
+                return;
+            }
+        }
+
+        target.getAscendant('table', 1).removeCustomData('_cke_table_pillars');
+        evt.removeListener();
+    }
+
+    CKEDITOR.plugins.add('tableresize', {
+        requires: 'tabletools',
+
+        init: function (editor) {
+            editor.on('contentDom', function () {
+                var resizer,
+                    editable = editor.editable();
+
+                // In Classic editor it is better to use document
+                // instead of editable so event will work below body.
+                editable.attachListener(editable.isInline() ? editable : editor.document, 'mousemove', function (evt) {
+                    evt = evt.data;
+
+                    var target = evt.getTarget();
+
+                    // FF may return document and IE8 some UFO (object with no nodeType property...)
+                    // instead of an element (https://dev.ckeditor.com/ticket/11823).
+                    if (target.type != CKEDITOR.NODE_ELEMENT) {
+                        return;
+                    }
+
+                    var page = {
+                        x: evt.getPageOffset().x,
+                        y: evt.getPageOffset().y
+                    };
+
+                    // If we're already attached to a pillar, simply move the
+                    // resizer.
+                    if (resizer && resizer.move(page.x, page.y)) {
+                        cancel(evt);
+                        return;
+                    }
+
+                    // Considering table, tr, td, tbody, thead, tfoot but nothing else.
+                    var table, pillars;
+
+                    if (!target.is('table') && !target.getAscendant({thead: 1, tbody: 1, tfoot: 1}, 1)) {
+                        return;
+                    }
+
+                    table = target.getAscendant('table', 1);
+
+                    // Make sure the table we found is inside the container
+                    // (eg. we should not use tables the editor is embedded within)
+                    if (!editor.editable().contains(table)) {
+                        return;
+                    }
+
+                    if (!(pillars = table.getCustomData('_cke_table_pillars'))) {
+                        // Cache table pillars calculation result.
+                        table.setCustomData('_cke_table_pillars', (pillars = buildTableColumnPillars(table)));
+                        table.on('mouseout', clearPillarsCache);
+                        table.on('mousedown', clearPillarsCache);
+                    }
+
+                    var pillar = getPillarAtPosition(pillars, page);
+                    if (pillar) {
+                        !resizer && (resizer = new columnResizer(editor));
+                        resizer.attachTo(pillar);
+                    }
+                });
+            });
+        }
+    });
+
+})();

--- a/src/main/resources/assets/lib/ckeditor/plugins/tabletools/dialogs/tableCell.js
+++ b/src/main/resources/assets/lib/ckeditor/plugins/tabletools/dialogs/tableCell.js
@@ -1,0 +1,511 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+CKEDITOR.dialog.add('cellProperties', function (editor) {
+    var langTable = editor.lang.table,
+        langCell = langTable.cell,
+        langCommon = editor.lang.common,
+        validate = CKEDITOR.dialog.validate,
+        widthPattern = /^(\d+(?:\.\d+)?)(px|%)$/,
+        spacer = {type: 'html', html: '&nbsp;'},
+        hiddenSpacer,
+        rtl = editor.lang.dir == 'rtl',
+        colorDialog = editor.plugins.colordialog;
+
+    // Returns a function, which runs regular "setup" for all selected cells to find out
+    // whether the initial value of the field would be the same for all cells. If so,
+    // the value is displayed just as if a regular "setup" was executed. Otherwise,
+    // i.e. when there are several cells of different value of the property, a field
+    // gets empty value.
+    //
+    // * @param {Function} setup Setup function which returns a value instead of setting it.
+    // * @returns {Function} A function to be used in dialog definition.
+    function setupCells(setup) {
+        return function (cells) {
+            var fieldValue = setup(cells[0]);
+
+            // If one of the cells would have a different value of the
+            // property, set the empty value for a field.
+            for (var i = 1; i < cells.length; i++) {
+                if (setup(cells[i]) !== fieldValue) {
+                    fieldValue = null;
+                    break;
+                }
+            }
+
+            // Setting meaningful or empty value only makes sense
+            // when setup returns some value. Otherwise, a *default* value
+            // is used for that field.
+            if (typeof fieldValue != 'undefined') {
+                this.setValue(fieldValue);
+
+                // The only way to have an empty select value in Firefox is
+                // to set a negative selectedIndex.
+                if (CKEDITOR.env.gecko && this.type == 'select' && !fieldValue) {
+                    this.getInputElement().$.selectedIndex = -1;
+                }
+            }
+        };
+    }
+
+    // Reads the unit of width property of the table cell.
+    //
+    // * @param {CKEDITOR.dom.element} cell An element representing table cell.
+    // * @returns {String} A unit of width: 'px', '%' or undefined if none.
+    function getCellWidthType(cell) {
+        var match = widthPattern.exec(
+            cell.getStyle('width') || cell.getAttribute('width'));
+
+        if (match) {
+            return match[2];
+        }
+    }
+
+    return {
+        title: langCell.title,
+        minWidth: CKEDITOR.env.ie && CKEDITOR.env.quirks ? 450 : 410,
+        minHeight: CKEDITOR.env.ie && (CKEDITOR.env.ie7Compat || CKEDITOR.env.quirks) ? 230 : 220,
+        contents: [{
+            id: 'info',
+            label: langCell.title,
+            accessKey: 'I',
+            elements: [{
+                type: 'hbox',
+                widths: ['40%', '5%', '40%'],
+                children: [{
+                    type: 'vbox',
+                    padding: 0,
+                    children: [{
+                        type: 'hbox',
+                        widths: ['70%', '30%'],
+                        children: [{
+                            type: 'text',
+                            id: 'width',
+                            width: '100px',
+                            requiredContent: 'td{width,height}',
+                            label: langCommon.width,
+                            validate: validate.number(langCell.invalidWidth),
+
+                            // Extra labelling of width unit type.
+                            onLoad: function () {
+                                var widthType = this.getDialog().getContentElement('info', 'widthType'),
+                                    labelElement = widthType.getElement(),
+                                    inputElement = this.getInputElement(),
+                                    ariaLabelledByAttr = inputElement.getAttribute('aria-labelledby');
+
+                                inputElement.setAttribute('aria-labelledby', [ariaLabelledByAttr, labelElement.$.id].join(' '));
+                            },
+
+                            setup: setupCells(function (element) {
+                                var widthAttr = parseInt(element.getAttribute('width'), 10),
+                                    widthStyle = parseInt(element.getStyle('width'), 10);
+
+                                return !isNaN(widthStyle) ? widthStyle :
+                                       !isNaN(widthAttr) ? widthAttr : '';
+                            }),
+                            commit: function (element) {
+                                var value = parseInt(this.getValue(), 10),
+
+                                    // There might be no widthType value, i.e. when multiple cells are
+                                    // selected but some of them have width expressed in pixels and some
+                                    // of them in percent. Try to re-read the unit from the cell in such
+                                    // case (https://dev.ckeditor.com/ticket/11439).
+                                    unit = this.getDialog().getValueOf('info', 'widthType') || getCellWidthType(element);
+
+                                if (!isNaN(value)) {
+                                    element.setStyle('width', value + unit);
+                                } else {
+                                    element.removeStyle('width');
+                                }
+
+                                element.removeAttribute('width');
+                            },
+                            'default': ''
+                        },
+                            {
+                                type: 'select',
+                                id: 'widthType',
+                                requiredContent: 'td{width,height}',
+                                label: editor.lang.table.widthUnit,
+                                labelStyle: 'visibility:hidden',
+                                'default': 'px',
+                                items: [
+                                    [langTable.widthPx, 'px'],
+                                    [langTable.widthPc, '%']
+                                ],
+                                setup: setupCells(getCellWidthType)
+                            }]
+                    },
+                        {
+                            type: 'hbox',
+                            widths: ['70%', '30%'],
+                            children: [{
+                                type: 'text',
+                                id: 'height',
+                                requiredContent: 'td{width,height}',
+                                label: langCommon.height,
+                                width: '100px',
+                                'default': '',
+                                validate: validate.number(langCell.invalidHeight),
+
+                                // Extra labelling of height unit type.
+                                onLoad: function () {
+                                    var heightType = this.getDialog().getContentElement('info', 'htmlHeightType'),
+                                        labelElement = heightType.getElement(),
+                                        inputElement = this.getInputElement(),
+                                        ariaLabelledByAttr = inputElement.getAttribute('aria-labelledby');
+
+                                    if (this.getDialog().getContentElement('info', 'height').isVisible()) {
+                                        labelElement.setHtml('<br />' + langTable.widthPx);
+                                        labelElement.setStyle('display', 'block');
+
+                                        this.getDialog().getContentElement('info', 'hiddenSpacer').getElement().setStyle('display',
+                                            'block');
+                                    }
+
+                                    inputElement.setAttribute('aria-labelledby', [ariaLabelledByAttr, labelElement.$.id].join(' '));
+                                },
+
+                                setup: setupCells(function (element) {
+                                    var heightAttr = parseInt(element.getAttribute('height'), 10),
+                                        heightStyle = parseInt(element.getStyle('height'), 10);
+
+                                    return !isNaN(heightStyle) ? heightStyle :
+                                           !isNaN(heightAttr) ? heightAttr : '';
+                                }),
+                                commit: function (element) {
+                                    var value = parseInt(this.getValue(), 10);
+
+                                    if (!isNaN(value)) {
+                                        element.setStyle('height', CKEDITOR.tools.cssLength(value));
+                                    } else {
+                                        element.removeStyle('height');
+                                    }
+
+                                    element.removeAttribute('height');
+                                }
+                            },
+                                {
+                                    id: 'htmlHeightType',
+                                    type: 'html',
+                                    html: '',
+                                    style: 'display: none'
+                                }]
+                        },
+                        hiddenSpacer = {
+                            type: 'html',
+                            id: 'hiddenSpacer',
+                            html: '&nbsp;',
+                            style: 'display: none'
+                        },
+                        {
+                            type: 'select',
+                            id: 'wordWrap',
+                            label: langCell.wordWrap,
+                            'default': 'yes',
+                            items: [
+                                [langCell.yes, 'yes'],
+                                [langCell.no, 'no']
+                            ],
+                            setup: setupCells(function (element) {
+                                var wordWrapAttr = element.getAttribute('noWrap'),
+                                    wordWrapStyle = element.getStyle('white-space');
+
+                                if (wordWrapStyle == 'nowrap' || wordWrapAttr) {
+                                    return 'no';
+                                }
+                            }),
+                            commit: function (element) {
+                                if (this.getValue() == 'no') {
+                                    element.setStyle('white-space', 'nowrap');
+                                } else {
+                                    element.removeStyle('white-space');
+                                }
+
+                                element.removeAttribute('noWrap');
+                            }
+                        },
+                        spacer,
+                        {
+                            type: 'select',
+                            id: 'hAlign',
+                            label: langCell.hAlign,
+                            'default': '',
+                            items: [
+                                [langCommon.notSet, ''],
+                                [langCommon.left, 'left'],
+                                [langCommon.center, 'center'],
+                                [langCommon.right, 'right'],
+                                [langCommon.justify, 'justify']
+                            ],
+                            setup: setupCells(function (element) {
+                                var alignAttr = element.getAttribute('align'),
+                                    textAlignStyle = element.getStyle('text-align');
+
+                                return textAlignStyle || alignAttr || '';
+                            }),
+                            commit: function (selectedCell) {
+                                var value = this.getValue();
+
+                                if (value) {
+                                    selectedCell.setStyle('text-align', value);
+                                } else {
+                                    selectedCell.removeStyle('text-align');
+                                }
+
+                                selectedCell.removeAttribute('align');
+                            }
+                        },
+                        {
+                            type: 'select',
+                            id: 'vAlign',
+                            label: langCell.vAlign,
+                            'default': '',
+                            items: [
+                                [langCommon.notSet, ''],
+                                [langCommon.alignTop, 'top'],
+                                [langCommon.alignMiddle, 'middle'],
+                                [langCommon.alignBottom, 'bottom'],
+                                [langCell.alignBaseline, 'baseline']
+                            ],
+                            setup: setupCells(function (element) {
+                                var vAlignAttr = element.getAttribute('vAlign'),
+                                    vAlignStyle = element.getStyle('vertical-align');
+
+                                switch (vAlignStyle) {
+                                    // Ignore all other unrelated style values..
+                                case 'top':
+                                case 'middle':
+                                case 'bottom':
+                                case 'baseline':
+                                    break;
+                                default:
+                                    vAlignStyle = '';
+                                }
+
+                                return vAlignStyle || vAlignAttr || '';
+                            }),
+                            commit: function (element) {
+                                var value = this.getValue();
+
+                                if (value) {
+                                    element.setStyle('vertical-align', value);
+                                } else {
+                                    element.removeStyle('vertical-align');
+                                }
+
+                                element.removeAttribute('vAlign');
+                            }
+                        }]
+                },
+                    spacer,
+                    {
+                        type: 'vbox',
+                        padding: 0,
+                        children: [{
+                            type: 'select',
+                            id: 'cellType',
+                            label: langCell.cellType,
+                            'default': 'td',
+                            items: [
+                                [langCell.data, 'td'],
+                                [langCell.header, 'th']
+                            ],
+                            setup: setupCells(function (selectedCell) {
+                                return selectedCell.getName();
+                            }),
+                            commit: function (selectedCell) {
+                                selectedCell.renameNode(this.getValue());
+                            }
+                        },
+                            spacer,
+                            {
+                                type: 'text',
+                                id: 'rowSpan',
+                                label: langCell.rowSpan,
+                                'default': '',
+                                validate: validate.integer(langCell.invalidRowSpan),
+                                setup: setupCells(function (selectedCell) {
+                                    var attrVal = parseInt(selectedCell.getAttribute('rowSpan'), 10);
+                                    if (attrVal && attrVal != 1) {
+                                        return attrVal;
+                                    }
+                                }),
+                                commit: function (selectedCell) {
+                                    var value = parseInt(this.getValue(), 10);
+                                    if (value && value != 1) {
+                                        selectedCell.setAttribute('rowSpan', this.getValue());
+                                    } else {
+                                        selectedCell.removeAttribute('rowSpan');
+                                    }
+                                }
+                            },
+                            {
+                                type: 'text',
+                                id: 'colSpan',
+                                label: langCell.colSpan,
+                                'default': '',
+                                validate: validate.integer(langCell.invalidColSpan),
+                                setup: setupCells(function (element) {
+                                    var attrVal = parseInt(element.getAttribute('colSpan'), 10);
+                                    if (attrVal && attrVal != 1) {
+                                        return attrVal;
+                                    }
+                                }),
+                                commit: function (selectedCell) {
+                                    var value = parseInt(this.getValue(), 10);
+                                    if (value && value != 1) {
+                                        selectedCell.setAttribute('colSpan', this.getValue());
+                                    } else {
+                                        selectedCell.removeAttribute('colSpan');
+                                    }
+                                }
+                            },
+                            spacer,
+                            {
+                                type: 'hbox',
+                                padding: 0,
+                                widths: ['60%', '40%'],
+                                children: [{
+                                    type: 'text',
+                                    id: 'bgColor',
+                                    label: langCell.bgColor,
+                                    'default': '',
+                                    setup: setupCells(function (element) {
+                                        var bgColorAttr = element.getAttribute('bgColor'),
+                                            bgColorStyle = element.getStyle('background-color');
+
+                                        return bgColorStyle || bgColorAttr;
+                                    }),
+                                    commit: function (selectedCell) {
+                                        var value = this.getValue();
+
+                                        if (value) {
+                                            selectedCell.setStyle('background-color', this.getValue());
+                                        } else {
+                                            selectedCell.removeStyle('background-color');
+                                        }
+
+                                        selectedCell.removeAttribute('bgColor');
+                                    }
+                                },
+                                    colorDialog ? {
+                                        type: 'button',
+                                        id: 'bgColorChoose',
+                                        'class': 'colorChooser', // jshint ignore:line
+                                        label: langCell.chooseColor,
+                                        onLoad: function () {
+                                            // Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
+                                            this.getElement().getParent().setStyle('vertical-align', 'bottom');
+                                        },
+                                        onClick: function () {
+                                            editor.getColorFromDialog(function (color) {
+                                                if (color) {
+                                                    this.getDialog().getContentElement('info', 'bgColor').setValue(color);
+                                                }
+                                                this.focus();
+                                            }, this);
+                                        }
+                                    } : spacer]
+                            },
+                            spacer,
+                            {
+                                type: 'hbox',
+                                padding: 0,
+                                widths: ['60%', '40%'],
+                                children: [{
+                                    type: 'text',
+                                    id: 'borderColor',
+                                    label: langCell.borderColor,
+                                    'default': '',
+                                    setup: setupCells(function (element) {
+                                        var borderColorAttr = element.getAttribute('borderColor'),
+                                            borderColorStyle = element.getStyle('border-color');
+
+                                        return borderColorStyle || borderColorAttr;
+                                    }),
+                                    commit: function (selectedCell) {
+                                        var value = this.getValue();
+                                        if (value) {
+                                            selectedCell.setStyle('border-color', this.getValue());
+                                        } else {
+                                            selectedCell.removeStyle('border-color');
+                                        }
+
+                                        selectedCell.removeAttribute('borderColor');
+                                    }
+                                },
+
+                                    colorDialog ? {
+                                        type: 'button',
+                                        id: 'borderColorChoose',
+                                        'class': 'colorChooser', // jshint ignore:line
+                                        label: langCell.chooseColor,
+                                        style: (rtl ? 'margin-right' : 'margin-left') + ': 10px',
+                                        onLoad: function () {
+                                            // Stick the element to the bottom (https://dev.ckeditor.com/ticket/5587)
+                                            this.getElement().getParent().setStyle('vertical-align', 'bottom');
+                                        },
+                                        onClick: function () {
+                                            editor.getColorFromDialog(function (color) {
+                                                if (color) {
+                                                    this.getDialog().getContentElement('info', 'borderColor').setValue(color);
+                                                }
+                                                this.focus();
+                                            }, this);
+                                        }
+                                    } : spacer]
+                            }]
+                    }]
+            }]
+        }],
+        onShow: function () {
+            this.cells = CKEDITOR.plugins.tabletools.getSelectedCells(this._.editor.getSelection());
+            this.setupContent(this.cells);
+        },
+        onOk: function () {
+            var selection = this._.editor.getSelection(),
+                bookmarks = selection.createBookmarks();
+
+            var cells = this.cells;
+            for (var i = 0; i < cells.length; i++) {
+                this.commitContent(cells[i]);
+            }
+
+            this._.editor.forceNextSelectionCheck();
+            selection.selectBookmarks(bookmarks);
+            this._.editor.selectionChange();
+        },
+        onLoad: function () {
+            var saved = {};
+
+            // Prevent from changing cell properties when the field's value
+            // remains unaltered, i.e. when selected multiple cells and dialog loaded
+            // only the properties of the first cell (https://dev.ckeditor.com/ticket/11439).
+            this.foreach(function (field) {
+                if (!field.setup || !field.commit) {
+                    return;
+                }
+
+                // Save field's value every time after "setup" is called.
+                field.setup = CKEDITOR.tools.override(field.setup, function (orgSetup) {
+                    return function () {
+                        orgSetup.apply(this, arguments);
+                        saved[field.id] = field.getValue();
+                    };
+                });
+
+                // Compare saved value with actual value. Update cell only if value has changed.
+                field.commit = CKEDITOR.tools.override(field.commit, function (orgCommit) {
+                    return function () {
+                        if (saved[field.id] !== field.getValue()) {
+                            orgCommit.apply(this, arguments);
+                        }
+                    };
+                });
+            });
+        }
+    };
+});


### PR DESCRIPTION
-added missing dialogs for table and tabletools plugins
-added tableresize plugin
-brought back table context menu items: cell properties and table properties
NB: cell properties and table properties dialogs are native cke's dialogs, will need to add our versions of these modal dialogs