### PR TITLE
CKEditor: Newly opened Link dialog shows old values #44

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
+++ b/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
@@ -210,10 +210,6 @@ export class HtmlArea
                 if (api.BrowserHelper.isIE()) {
                     this.setupStickyEditorToolbarForInputOccurence(textAreaWrapper, id);
                 }
-
-                this.onRemoved(() => {
-                    this.destroyEditor(id);
-                });
             }
 
             this.moveButtonToBottomBar(textAreaWrapper, '.cke_button__fullscreen');

--- a/src/main/resources/assets/js/app/inputtype/ui/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/siteconfigurator/SiteConfiguratorDialog.ts
@@ -19,11 +19,13 @@ export class SiteConfiguratorDialog
         const dialogElement: HTMLElement = this.getHTMLElement();
 
         for (let i in ckeInstances) {
-            const ckeInstance: CKEDITOR.editor = CKEDITOR.instances[i];
+            if (CKEDITOR.instances[i]) {
+                const ckeInstance: CKEDITOR.editor = CKEDITOR.instances[i];
 
-            if (dialogElement.contains(ckeInstance.container.$)) {
-                ckeInstance.focusManager.blur(true);
-                ckeInstance.destroy();
+                if (dialogElement.contains(ckeInstance.container.$)) {
+                    ckeInstance.focusManager.blur(true);
+                    ckeInstance.destroy();
+                }
             }
         }
     }

--- a/src/main/resources/assets/js/app/inputtype/ui/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/siteconfigurator/SiteConfiguratorDialog.ts
@@ -16,11 +16,12 @@ export class SiteConfiguratorDialog
 
     private destroyCkeInstancesInDialog() {
         const ckeInstances: { [id: string]: CKEDITOR.editor } = CKEDITOR.instances;
+        const dialogElement: HTMLElement = this.getHTMLElement();
 
         for (let i in ckeInstances) {
             const ckeInstance: CKEDITOR.editor = CKEDITOR.instances[i];
 
-            if (this.getHTMLElement().contains(ckeInstance.container.$)) {
+            if (dialogElement.contains(ckeInstance.container.$)) {
                 ckeInstance.focusManager.blur(true);
                 ckeInstance.destroy();
             }

--- a/src/main/resources/assets/js/app/inputtype/ui/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/siteconfigurator/SiteConfiguratorDialog.ts
@@ -7,4 +7,23 @@ export class SiteConfiguratorDialog
     protected hasSubDialog(): boolean {
         return super.hasSubDialog() || !!HTMLAreaDialogHandler.getOpenDialog();
     }
+
+    close() {
+        this.destroyCkeInstancesInDialog();
+        super.close();
+        this.remove();
+    }
+
+    private destroyCkeInstancesInDialog() {
+        const ckeInstances: { [id: string]: CKEDITOR.editor } = CKEDITOR.instances;
+
+        for (let i in ckeInstances) {
+            const ckeInstance: CKEDITOR.editor = CKEDITOR.instances[i];
+
+            if (this.getHTMLElement().contains(ckeInstance.container.$)) {
+                ckeInstance.focusManager.blur(true);
+                ckeInstance.destroy();
+            }
+        }
+    }
 }

--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -26,8 +26,6 @@ export class HtmlEditor {
 
     private editor: CKEDITOR.editor;
 
-    private hasActiveDialog: boolean = false;
-
     private static readonly imgInlineStyle: string = 'max-height:100%; max-width:100%; width:100%';
 
     private constructor(config: CKEDITOR.config, htmlEditorParams: HtmlEditorParams) {
@@ -84,6 +82,10 @@ export class HtmlEditor {
             this.editor.on('instanceReady', this.editorParams.getEditorReadyHandler().bind(this));
         }
 
+        if (this.editorParams.hasBlurHandler()) {
+            this.editor.on('blur', this.editorParams.getBlurHandler().bind(this));
+        }
+
         this.editor.on('dataReady', (e: eventInfo) => {
             const rootElement: CKEDITOR.dom.element = this.editorParams.isInline() ? e.editor.container : e.editor.document.getBody();
 
@@ -99,7 +101,6 @@ export class HtmlEditor {
 
         this.handleFullScreenModeToggled();
         this.handleMouseEvents();
-        this.handleEditorBlurEvent();
         this.handleElementSelection();
         this.handleImageAlignButtonPressed();
     }
@@ -243,20 +244,6 @@ export class HtmlEditor {
         api.dom.Body.get().onMouseUp(() => {
             if (mousePressed) {
                 mousePressed = false;
-            }
-        });
-    }
-
-    private handleEditorBlurEvent() {
-        this.editor.on('blur', (e: eventInfo) => {
-
-            if (this.hasActiveDialog) {
-                e.stop();
-                this.hasActiveDialog = false;
-            }
-
-            if (this.editorParams.hasBlurHandler()) {
-                this.editorParams.getBlurHandler()(<any>e);
             }
         });
     }
@@ -676,8 +663,6 @@ export class HtmlEditor {
     }
 
     private publishCreateDialogEvent(event: CreateHtmlAreaDialogEvent) {
-        this.hasActiveDialog = true;
-
         if (this.editorParams.hasCreateDialogListener()) {
             this.editorParams.getCreateDialogListener()(event);
         }


### PR DESCRIPTION
-we used to stop cke native blur event, that seems to prevent cke's handlers to finalize it's routine; now not stopping blur event
-destroying cke instance after element is already removed has no sense because destroy supposed to be invoked before element removed from dom; also that seems to bring errors in siteconfigurator dialog