### PR TITLE
HTML Editor: Fix shortcut for heading and tab cycle

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -535,7 +535,6 @@ export class HtmlEditor {
 
         const commandDef: CKEDITOR.commandDefinition = {
             exec: function () {
-                console.log(this.name);
                 editor.applyStyle(new CKEDITOR.style({element: this.name}, null)); // name is command name
                 return true;
             }
@@ -552,10 +551,6 @@ export class HtmlEditor {
         this.editor.addCommand('address', commandDef);
 
         this.editor.on('instanceReady', () => {
-            // indent/outdent on tab/shift+tab removed to make native focus/blur element work;
-            // indent/outdent are available as buttons in toolbar
-            // this.editor.setKeystroke(9, 'indent'); // Indent on TAB ;
-            // this.editor.setKeystroke(CKEDITOR.SHIFT + 9, 'outdent'); // Outdent on SHIFT + TAB
             this.editor.setKeystroke(CKEDITOR.CTRL + 70, 'find'); // open find dialog on CTRL + F
             this.editor.setKeystroke(CKEDITOR.CTRL + 75, 'link'); // open link dialog on CTRL + K
             this.editor.setKeystroke(CKEDITOR.CTRL + 76, 'image'); // open link dialog on CTRL + L

--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -531,9 +531,12 @@ export class HtmlEditor {
     }
 
     private setupKeyboardShortcuts() {
+        const editor: CKEDITOR.editor = this.editor;
+
         const commandDef: CKEDITOR.commandDefinition = {
-            exec: function (/* editor: HTMLAreaEditor */) {
-                // editor.applyStyle(new CKEDITOR.style(<any>{ element: this.name })); // name is command name
+            exec: function () {
+                console.log(this.name);
+                editor.applyStyle(new CKEDITOR.style({element: this.name}, null)); // name is command name
                 return true;
             }
         };
@@ -549,8 +552,10 @@ export class HtmlEditor {
         this.editor.addCommand('address', commandDef);
 
         this.editor.on('instanceReady', () => {
-            this.editor.setKeystroke(9, 'indent'); // Indent on TAB
-            this.editor.setKeystroke(CKEDITOR.SHIFT + 9, 'outdent'); // Outdent on SHIFT + TAB
+            // indent/outdent on tab/shift+tab removed to make native focus/blur element work;
+            // indent/outdent are available as buttons in toolbar
+            // this.editor.setKeystroke(9, 'indent'); // Indent on TAB ;
+            // this.editor.setKeystroke(CKEDITOR.SHIFT + 9, 'outdent'); // Outdent on SHIFT + TAB
             this.editor.setKeystroke(CKEDITOR.CTRL + 70, 'find'); // open find dialog on CTRL + F
             this.editor.setKeystroke(CKEDITOR.CTRL + 75, 'link'); // open link dialog on CTRL + K
             this.editor.setKeystroke(CKEDITOR.CTRL + 76, 'image'); // open link dialog on CTRL + L


### PR DESCRIPTION
-Made formatting shortcuts work
-disabled indent/outdent shortcut to make TAB key focus on next element on windows;
now indent/outdent commands executed only via buttons on toolbar