### PR TITLE
Sort content dialog reopens if it's closed before all of the items ar…

### DIFF
--- a/src/main/resources/assets/js/app/browse/SortContentTreeGrid.ts
+++ b/src/main/resources/assets/js/app/browse/SortContentTreeGrid.ts
@@ -34,6 +34,7 @@ export class SortContentTreeGrid extends TreeGrid<ContentSummaryAndCompareStatus
                 behavior: 'selectAndMove'
             }])
             .setPartialLoadEnabled(true)
+            .setAutoLoad(false)
             .setCheckableRows(false)
             .setShowToolbar(false)
             .setDragAndDrop(true)


### PR DESCRIPTION
…e loaded #148

-Made SortContentTreeGrid not trigger load when added to dom (it was triggering load when opening browse panel )
-Fixed loading mask to be shown when sort dialog is opened and grid is loading
-Adding/removing grid loaded listener on dialog open/close (that was issue origin, loaded handler was opening dialog even after dialog is closed)