### PR TITLE
An image added via DnD won't get saved in a new HTML Area content #186

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -147,6 +147,8 @@ export class HtmlEditor {
                                  `<img src="${upload.url}" data-src="${dataSrc}">` +
                                  '<figcaption> </figcaption>' +
                                  '</figure>');
+
+                editor.fire('change');
             };
         });
     }


### PR DESCRIPTION
-Editor's change event (after uploading image) might be fired before uploaded handler, so change handler doesn't see uploaded image yet.
Solved by triggering change event ourselves after image upload.