### PR TITLE
Incorrect number of widgets in the context panel #198

### DIFF
--- a/src/main/resources/assets/js/app/view/context/ContextSplitPanel.ts
+++ b/src/main/resources/assets/js/app/view/context/ContextSplitPanel.ts
@@ -36,8 +36,8 @@ export class ContextSplitPanel
     private leftPanel: api.ui.panel.Panel;
     private mobileContextPanel: MobileContextPanel;
 
-    constructor(leftPanel: api.ui.panel.Panel, actions: api.ui.Action[], data?: PageEditorData) {
-        const contextView = new ContextView(data);
+    constructor(leftPanel: api.ui.panel.Panel, actions: api.ui.Action[], insideWizard: boolean = false, data?: PageEditorData) {
+        const contextView = new ContextView(insideWizard, data);
         const dockedContextPanel = new DockedContextPanel(contextView);
 
         const builder = new SplitPanelBuilder(leftPanel, dockedContextPanel)

--- a/src/main/resources/assets/js/app/view/context/ContextSplitPanel.ts
+++ b/src/main/resources/assets/js/app/view/context/ContextSplitPanel.ts
@@ -36,8 +36,8 @@ export class ContextSplitPanel
     private leftPanel: api.ui.panel.Panel;
     private mobileContextPanel: MobileContextPanel;
 
-    constructor(leftPanel: api.ui.panel.Panel, actions: api.ui.Action[], insideWizard: boolean = false, data?: PageEditorData) {
-        const contextView = new ContextView(insideWizard, data);
+    constructor(leftPanel: api.ui.panel.Panel, actions: api.ui.Action[], data?: PageEditorData) {
+        const contextView = new ContextView(data);
         const dockedContextPanel = new DockedContextPanel(contextView);
 
         const builder = new SplitPanelBuilder(leftPanel, dockedContextPanel)
@@ -66,9 +66,13 @@ export class ContextSplitPanel
         return this.data != null;
     }
 
+    private isPageEditorPresent(): boolean {
+        return this.isInsideWizard() && this.data.liveFormPanel != null;
+    }
+
     private renderAfterDockedPanelReady() {
         const nonMobileContextPanelsManagerBuilder = NonMobileContextPanelsManager.create();
-        if (this.isInsideWizard()) {
+        if (this.isPageEditorPresent()) {
             nonMobileContextPanelsManagerBuilder.setPageEditor(this.data.liveFormPanel);
             nonMobileContextPanelsManagerBuilder.setWizardPanel(<Panel>(<SplitPanel>this.leftPanel).getFirstChild());
             nonMobileContextPanelsManagerBuilder.setIsMobileMode(() => {

--- a/src/main/resources/assets/js/app/view/context/ContextView.ts
+++ b/src/main/resources/assets/js/app/view/context/ContextView.ts
@@ -47,6 +47,8 @@ export class ContextView
 
     private data: PageEditorData;
 
+    private insideWizard: boolean;
+
     private alreadyFetchedCustomWidgets: boolean;
 
     private sizeChangedListeners: {(): void}[] = [];
@@ -55,9 +57,10 @@ export class ContextView
 
     public static debug: boolean = false;
 
-    constructor(data?: PageEditorData) {
+    constructor(insideWizard: boolean, data?: PageEditorData) {
         super('context-panel-view');
 
+        this.insideWizard = insideWizard;
         this.data = data;
 
         this.contextContainer = new DivEl('context-container');
@@ -285,7 +288,7 @@ export class ContextView
 
     private initCommonWidgetViews() {
 
-        if (this.isInsideWizard()) {
+        if (this.isPageEditorPresent()) {
             this.pageEditorWidgetView = WidgetView.create()
                 .setName(i18n('field.contextPanel.pageEditor'))
                 .setDescription(i18n('field.contextPanel.pageEditor.description'))
@@ -357,7 +360,11 @@ export class ContextView
     }
 
     private isInsideWizard(): boolean {
-        return this.data != null;
+        return this.insideWizard;
+    }
+
+    private isPageEditorPresent(): boolean {
+        return this.insideWizard && this.data != null;
     }
 
     private fetchCustomWidgetViews(): wemQ.Promise<Widget[]> {
@@ -493,7 +500,7 @@ export class ContextView
             }
         }
 
-        if (this.isInsideWizard()) {
+        if (this.isPageEditorPresent()) {
             const emulatorWidgetPresent = checkWidgetPresent(this.emulatorWidgetView);
             const emulatorWidgetActive = checkWidgetActive(this.emulatorWidgetView);
 

--- a/src/main/resources/assets/js/app/view/context/ContextView.ts
+++ b/src/main/resources/assets/js/app/view/context/ContextView.ts
@@ -50,8 +50,6 @@ export class ContextView
 
     private data: PageEditorData;
 
-    private insideWizard: boolean;
-
     private alreadyFetchedCustomWidgets: boolean;
 
     private contentRenderable: boolean;
@@ -64,10 +62,9 @@ export class ContextView
 
     public static debug: boolean = false;
 
-    constructor(insideWizard: boolean, data?: PageEditorData) {
+    constructor(data?: PageEditorData) {
         super('context-panel-view');
 
-        this.insideWizard = insideWizard;
         this.data = data;
 
         this.contentRenderable = false;
@@ -379,11 +376,11 @@ export class ContextView
     }
 
     private isInsideWizard(): boolean {
-        return this.insideWizard;
+        return this.data != null;
     }
 
     private isPageEditorPresent(): boolean {
-        return this.insideWizard && this.data != null;
+        return this.isInsideWizard() && this.data.liveFormPanel != null;
     }
 
     private fetchCustomWidgetViews(): wemQ.Promise<Widget[]> {

--- a/src/main/resources/assets/js/app/view/context/ContextView.ts
+++ b/src/main/resources/assets/js/app/view/context/ContextView.ts
@@ -18,6 +18,9 @@ import {ContentWidgetItemView} from './widget/details/ContentWidgetItemView';
 import {InspectEvent} from '../../event/InspectEvent';
 import {EmulatedEvent} from '../../event/EmulatedEvent';
 import {EmulatorDevice} from './widget/emulator/EmulatorDevice';
+import {ShowLiveEditEvent} from '../../wizard/ShowLiveEditEvent';
+import {ShowSplitEditEvent} from '../../wizard/ShowSplitEditEvent';
+import {ShowContentFormEvent} from '../../wizard/ShowContentFormEvent';
 import Widget = api.content.Widget;
 import ApplicationEvent = api.application.ApplicationEvent;
 import ApplicationEventType = api.application.ApplicationEventType;
@@ -51,6 +54,10 @@ export class ContextView
 
     private alreadyFetchedCustomWidgets: boolean;
 
+    private contentRenderable: boolean;
+
+    private pageEditorVisible: boolean;
+
     private sizeChangedListeners: {(): void}[] = [];
 
     private widgetsUpdateList: {[key: string]: (key: string, type: ApplicationEventType) => void } = {};
@@ -62,6 +69,9 @@ export class ContextView
 
         this.insideWizard = insideWizard;
         this.data = data;
+
+        this.contentRenderable = false;
+        this.pageEditorVisible = false;
 
         this.contextContainer = new DivEl('context-container');
 
@@ -81,7 +91,9 @@ export class ContextView
         this.layout();
 
         this.getCustomWidgetViewsAndUpdateDropdown();
+    }
 
+    private subscribeOnEvents() {
         this.onRendered(() => {
             // Remove `.no-selection` css class, making context-container visible, to calculate the offset right
             this.layout(false);
@@ -92,15 +104,22 @@ export class ContextView
         const handleWidgetsUpdate = (e) => this.handleWidgetsUpdate(e);
         ApplicationEvent.on(handleWidgetsUpdate);
         this.onRemoved(() => ApplicationEvent.un(handleWidgetsUpdate));
-    }
 
-    private subscribeOnEvents() {
-        ActiveContentVersionSetEvent.on((event: ActiveContentVersionSetEvent) => {
+        ActiveContentVersionSetEvent.on(() => {
             if (ActiveContextPanelManager.getActiveContextPanel().isVisibleOrAboutToBeVisible() && !!this.activeWidget &&
                 this.activeWidget.getWidgetName() === i18n('field.widget.versionHistory')) {
                 this.updateActiveWidget();
             }
         });
+
+        const createPageEditorVisibilityChangedHandler = (visible: boolean) => () => {
+            this.pageEditorVisible = visible;
+            this.updateWidgetsVisibility();
+        };
+
+        ShowLiveEditEvent.on(createPageEditorVisibilityChangedHandler(true));
+        ShowSplitEditEvent.on(createPageEditorVisibilityChangedHandler(true));
+        ShowContentFormEvent.on(createPageEditorVisibilityChangedHandler(false));
     }
 
     private initDivForNoSelection() {
@@ -474,23 +493,32 @@ export class ContextView
     }
 
     updateRenderableStatus(renderable: boolean) {
+        this.contentRenderable = renderable;
+        this.updateWidgetsVisibility();
+    }
+
+    updateWidgetsVisibility() {
         const checkWidgetPresent = (widget: WidgetView) => this.widgetViews.some(w => widget.compareByType(w));
         const checkWidgetActive = (widget: WidgetView) => widget.compareByType(this.activeWidget);
 
         let widgetsUpdated = false;
 
-        if (this.pageEditorWidgetView) {
+        const canAddPageEditorWidget = this.isPageEditorPresent() && this.pageEditorWidgetView != null;
+        const canAddEmulatorWidget = this.isPageEditorPresent();
+
+        if (canAddPageEditorWidget) {
             const pageEditorWidgetPresent = checkWidgetPresent(this.pageEditorWidgetView);
             const pageEditorWidgetActive = checkWidgetActive(this.pageEditorWidgetView);
+            const shouldPageEditorWidgetBePresent = this.contentRenderable && this.pageEditorVisible;
 
-            if (renderable && !pageEditorWidgetPresent) {
+            if (shouldPageEditorWidgetBePresent && !pageEditorWidgetPresent) {
                 this.insertWidget(this.pageEditorWidgetView, 0);
                 if (!pageEditorWidgetActive) {
                     this.defaultWidgetView = this.pageEditorWidgetView;
                     this.activateDefaultWidget();
                 }
                 widgetsUpdated = true;
-            } else if (!renderable && pageEditorWidgetPresent) {
+            } else if (pageEditorWidgetPresent) {
                 this.defaultWidgetView = this.propertiesWidgetView;
                 if (pageEditorWidgetActive) {
                     this.activateDefaultWidget();
@@ -500,15 +528,16 @@ export class ContextView
             }
         }
 
-        if (this.isPageEditorPresent()) {
+        if (canAddEmulatorWidget) {
             const emulatorWidgetPresent = checkWidgetPresent(this.emulatorWidgetView);
             const emulatorWidgetActive = checkWidgetActive(this.emulatorWidgetView);
+            const shouldEmulatorWidgetBePresent = this.contentRenderable && this.pageEditorVisible;
 
-            if (renderable && !emulatorWidgetPresent) {
+            if (shouldEmulatorWidgetBePresent && !emulatorWidgetPresent) {
                 const index = this.getIndexOfLastInternalWidget() + 1;
                 this.insertWidget(this.emulatorWidgetView, index);
                 widgetsUpdated = true;
-            } else if (!renderable && emulatorWidgetPresent) {
+            } else if (emulatorWidgetPresent) {
                 if (emulatorWidgetActive) {
                     this.activateDefaultWidget();
                 }

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -803,6 +803,7 @@ export class ContentWizardPanel
 
         InspectEvent.on((event: InspectEvent) => {
             const minimizeWizard = event.isShowPanel() &&
+                                   !this.isMinimized() &&
                                    !this.contextSplitPanel.isMobileMode() &&
                                    ResponsiveRanges._1380_1620.isFitOrSmaller(this.getEl().getWidthWithBorder());
             if (minimizeWizard) {

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -337,7 +337,7 @@ export class ContentWizardPanel
         ];
 
         const data = this.getLivePanel() ? this.getLivePanel().getPageEditorData() : null;
-        this.contextSplitPanel = new ContextSplitPanel(leftPanel, contextActions, data);
+        this.contextSplitPanel = new ContextSplitPanel(leftPanel, contextActions, true, data);
 
         this.onRendered(() => {
             const mainToolbar = this.getMainToolbar();

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -805,6 +805,7 @@ export class ContentWizardPanel
             const minimizeWizard = event.isShowPanel() &&
                                    !this.isMinimized() &&
                                    this.renderable &&
+                                   this.getLivePanel().isShown() &&
                                    !this.contextSplitPanel.isMobileMode() &&
                                    ResponsiveRanges._1380_1620.isFitOrSmaller(this.getEl().getWidthWithBorder());
             if (minimizeWizard) {

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -804,6 +804,7 @@ export class ContentWizardPanel
         InspectEvent.on((event: InspectEvent) => {
             const minimizeWizard = event.isShowPanel() &&
                                    !this.isMinimized() &&
+                                   this.renderable &&
                                    !this.contextSplitPanel.isMobileMode() &&
                                    ResponsiveRanges._1380_1620.isFitOrSmaller(this.getEl().getWidthWithBorder());
             if (minimizeWizard) {

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -336,8 +336,8 @@ export class ContentWizardPanel
             wizardActions.getDuplicateAction()
         ];
 
-        const data = this.getLivePanel() ? this.getLivePanel().getPageEditorData() : null;
-        this.contextSplitPanel = new ContextSplitPanel(leftPanel, contextActions, true, data);
+        const data = this.getLivePanel() ? this.getLivePanel().getPageEditorData() : LiveFormPanel.createEmptyPageEditorData();
+        this.contextSplitPanel = new ContextSplitPanel(leftPanel, contextActions, data);
 
         this.onRendered(() => {
             const mainToolbar = this.getMainToolbar();

--- a/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -84,8 +84,8 @@ export interface LiveFormPanelConfig {
 }
 
 export interface PageEditorData {
-    contextWindow: ContextWindow;
-    liveFormPanel: LiveFormPanel;
+    contextWindow?: ContextWindow;
+    liveFormPanel?: LiveFormPanel;
 }
 
 export class LiveFormPanel
@@ -363,6 +363,10 @@ export class LiveFormPanel
             contextWindow: this.contextWindow,
             liveFormPanel: this
         };
+    }
+
+    static createEmptyPageEditorData(): PageEditorData {
+        return {};
     }
 
     doRender(): Q.Promise<boolean> {

--- a/src/main/resources/assets/page-editor/styles/partials/page-view.less
+++ b/src/main/resources/assets/page-editor/styles/partials/page-view.less
@@ -19,6 +19,7 @@
       }
 
       .page-placeholder-info {
+        position: relative;
 
         &:not(.empty) {
           .icon-page-template;
@@ -31,10 +32,6 @@
             margin-left: -50px;
             margin-top: 65px;
           }
-        }
-
-        &.empty {
-          margin-left: 45px;
         }
 
         .page-placeholder-info-line1 {

--- a/src/main/resources/assets/styles/view/context/context-panel.less
+++ b/src/main/resources/assets/styles/view/context/context-panel.less
@@ -10,7 +10,7 @@
   width: 280px;
   top: 0;
   right: -280px;
-  box-shadow: 0 2px 20px -8px @admin-black, 0 0 0 0 rgba(0, 0, 0, 0.3);
+  box-shadow: 0 12px 20px -8px @admin-black, 0 8px 12px -4px rgba(0, 0, 0, 0.1);
   background-color: @admin-white;
   transition: all 0.5s ease-in-out;
 

--- a/src/main/resources/assets/styles/view/context/context-panel.less
+++ b/src/main/resources/assets/styles/view/context/context-panel.less
@@ -10,9 +10,13 @@
   width: 280px;
   top: 0;
   right: -280px;
-  box-shadow: 0 2px 20px -8px #000000, 0 0 0 0 rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 20px -8px @admin-black, 0 0 0 0 rgba(0, 0, 0, 0.3);
   background-color: @admin-white;
   transition: all 0.5s ease-in-out;
+
+  &.mobile {
+    background-color: rgba(255, 255, 255, 0.95);
+  }
 
   @media screen and (max-width: 540px) {
     display: none;
@@ -219,6 +223,6 @@
     position: fixed;
     top: @app-header-height + @toolbar-with-border-height;
     outline: 1px solid @admin-bg-light-gray;
-    background-color: rgba(255, 255, 255, 0.9);
+    background-color: rgba(255, 255, 255, 0.95);
   }
 }

--- a/src/main/resources/assets/styles/view/mobile-content-item-statistics-panel.less
+++ b/src/main/resources/assets/styles/view/mobile-content-item-statistics-panel.less
@@ -178,11 +178,10 @@
 
   .context-panel {
 
-    background-color: @admin-bg-almost-white;
+    background-color: rgba(255, 255, 255, 0.95);
     display: inherit;
     width: 100%;
     right: 0;
-    opacity: 0.95;
 
     > .context-container {
       left: 0;

--- a/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -239,7 +239,7 @@
     overflow: visible;
     &.floating-context-panel {
       top: @toolbar-with-border-height;
-      z-index: 2000;
+      z-index: @z-index-tab-menu - 1;
     }
 
     .non-mobile-details-panel-toggle-button {

--- a/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -286,7 +286,7 @@
       }
     }
 
-    .@{_COMMON_PREFIX}button.cycle-button:not(.form) {
+    .@{_COMMON_PREFIX}button.cycle-button {
       margin-left: auto;
     }
 


### PR DESCRIPTION
* Fixed the presence of the Emulator in the wizard, when content is not renderable.
* Fixed the `z-index` of the context panel, making it render behind the toolbar.
* Updated context panel, disabling components and emulator in the wizard when page editor is not visible.

**Depends on PR #196.**