### PR TITLE
Part/layout configs: values in inspection panel are not set after pag…

### DIFF
--- a/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -806,10 +806,10 @@ export class LiveFormPanel
             this.imageInspectionPanel.setImageComponent(<ImageComponentView>componentView);
             this.contextWindow.showInspectionPanel(this.imageInspectionPanel);
         } else if (api.ObjectHelper.iFrameSafeInstanceOf(componentView, PartComponentView)) {
-            this.partInspectionPanel.setPartComponent(<PartComponentView>componentView);
+            this.partInspectionPanel.setDescriptorBasedComponent(<PartComponent>componentView.getComponent());
             this.contextWindow.showInspectionPanel(this.partInspectionPanel);
         } else if (api.ObjectHelper.iFrameSafeInstanceOf(componentView, LayoutComponentView)) {
-            this.layoutInspectionPanel.setLayoutComponent(<LayoutComponentView>componentView);
+            this.layoutInspectionPanel.setDescriptorBasedComponent(<LayoutComponent>componentView.getComponent());
             this.contextWindow.showInspectionPanel(this.layoutInspectionPanel);
         } else if (api.ObjectHelper.iFrameSafeInstanceOf(componentView, TextComponentView)) {
             this.textInspectionPanel.setTextComponent(<TextComponentView>componentView);

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/ComponentDescriptorDropdown.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/ComponentDescriptorDropdown.ts
@@ -1,0 +1,16 @@
+import {DescriptorBasedDropdown} from '../DescriptorBasedDropdown';
+import {ComponentDescriptorLoader} from './ComponentDescriptorLoader';
+import Descriptor = api.content.page.Descriptor;
+import ApplicationKey = api.application.ApplicationKey;
+
+export abstract class ComponentDescriptorDropdown<DESCRIPTOR extends Descriptor>
+    extends DescriptorBasedDropdown<DESCRIPTOR> {
+
+    protected loader: ComponentDescriptorLoader<any, DESCRIPTOR>;
+
+    loadDescriptors(applicationKeys: ApplicationKey[]) {
+        this.loader.setApplicationKeys(applicationKeys);
+
+        super.load();
+    }
+}

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/ComponentDescriptorLoader.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/ComponentDescriptorLoader.ts
@@ -1,0 +1,26 @@
+import ApplicationKey = api.application.ApplicationKey;
+import Descriptor = api.content.page.Descriptor;
+import {DescriptorByDisplayNameComparator} from '../DescriptorByDisplayNameComparator';
+import {GetComponentDescriptorsByApplicationsRequest} from './GetComponentDescriptorsByApplicationsRequest';
+
+
+export abstract class ComponentDescriptorLoader<JSON, DESCRIPTOR extends Descriptor>
+    extends api.util.loader.BaseLoader<JSON, DESCRIPTOR> {
+
+    protected request: GetComponentDescriptorsByApplicationsRequest<JSON, DESCRIPTOR>;
+
+    constructor() {
+        super();
+
+        this.setComparator(new DescriptorByDisplayNameComparator());
+    }
+
+    filterFn(descriptor: Descriptor) {
+        return descriptor.getDisplayName().toString().toLowerCase().indexOf(this.getSearchString().toLowerCase()) !== -1;
+    }
+
+    setApplicationKeys(applicationKeys: ApplicationKey[]) {
+        this.request.setApplicationKeys(applicationKeys);
+    }
+
+}

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/ComponentInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/ComponentInspectionPanel.ts
@@ -16,7 +16,7 @@ export abstract class ComponentInspectionPanel<COMPONENT extends Component>
 
     formContext: ContentFormContext;
 
-    private component: COMPONENT;
+    protected component: COMPONENT;
 
     constructor(config: ComponentInspectionPanelConfig) {
         super();

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/DescriptorBasedComponentInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/DescriptorBasedComponentInspectionPanel.ts
@@ -2,10 +2,16 @@ import {ComponentInspectionPanel, ComponentInspectionPanelConfig} from './Compon
 import {LiveEditModel} from '../../../../../../page-editor/LiveEditModel';
 import {ApplicationAddedEvent} from '../../../../../site/ApplicationAddedEvent';
 import {ApplicationRemovedEvent} from '../../../../../site/ApplicationRemovedEvent';
-import {DescriptorBasedDropdown} from '../DescriptorBasedDropdown';
 import {DescriptorBasedComponent} from '../../../../../page/region/DescriptorBasedComponent';
+import {ComponentPropertyChangedEvent} from '../../../../../page/region/ComponentPropertyChangedEvent';
+import {DescriptorBasedDropdownForm} from './DescriptorBasedDropdownForm';
+import {ComponentDescriptorDropdown} from './ComponentDescriptorDropdown';
 import FormView = api.form.FormView;
 import Descriptor = api.content.page.Descriptor;
+import DescriptorKey = api.content.page.DescriptorKey;
+import Option = api.ui.selector.Option;
+import OptionSelectedEvent = api.ui.selector.OptionSelectedEvent;
+import ResourceRequest = api.rest.ResourceRequest;
 
 export interface DescriptorBasedComponentInspectionPanelConfig
     extends ComponentInspectionPanelConfig {
@@ -17,7 +23,11 @@ export abstract class DescriptorBasedComponentInspectionPanel<COMPONENT extends 
 
     private formView: FormView;
 
-    protected selector: DescriptorBasedDropdown<DESCRIPTOR>;
+    private selector: ComponentDescriptorDropdown<DESCRIPTOR>;
+
+    private handleSelectorEvents: boolean = true;
+
+    private componentPropertyChangedEventHandler: (event: ComponentPropertyChangedEvent) => void;
 
     private applicationUnavailableListener: (applicationEvent: api.application.ApplicationEvent) => void;
 
@@ -35,6 +45,29 @@ export abstract class DescriptorBasedComponentInspectionPanel<COMPONENT extends 
         this.applicationAddedListener = this.reloadDescriptorsOnApplicationChange.bind(this);
 
         this.applicationRemovedListener = this.reloadDescriptorsOnApplicationChange.bind(this);
+    }
+
+    private layout() {
+
+        this.removeChildren();
+
+        this.selector = this.createSelector();
+        const form = new DescriptorBasedDropdownForm(this.selector, this.getFormName());
+
+        this.selector.loadDescriptors(this.liveEditModel.getSiteModel().getApplicationKeys());
+
+        this.componentPropertyChangedEventHandler = (event: ComponentPropertyChangedEvent) => {
+
+            // Ensure displayed config form and selector option are removed when descriptor is removed
+            if (event.getPropertyName() === DescriptorBasedComponent.PROPERTY_DESCRIPTOR) {
+                if (!this.component.hasDescriptor()) {
+                    this.setSelectorValue(null, false);
+                }
+            }
+        };
+
+        this.initSelectorListeners();
+        this.appendChild(form);
     }
 
     setModel(liveEditModel: LiveEditModel) {
@@ -57,16 +90,86 @@ export abstract class DescriptorBasedComponentInspectionPanel<COMPONENT extends 
         }
     }
 
-    protected layout() {
-        throw new Error('Must be implemented in inheritors');
-    }
-
-    protected applicationUnavailableHandler() {
+    private applicationUnavailableHandler() {
         this.selector.hideDropdown();
     }
 
-    protected reloadDescriptorsOnApplicationChange() {
-        this.selector.load();
+    private reloadDescriptorsOnApplicationChange() {
+        if (this.selector) {
+            this.selector.loadDescriptors(this.liveEditModel.getSiteModel().getApplicationKeys());
+        }
+    }
+
+    private registerComponentListeners(component: COMPONENT) {
+        component.onPropertyChanged(this.componentPropertyChangedEventHandler);
+    }
+
+    private unregisterComponentListeners(component: COMPONENT) {
+        component.unPropertyChanged(this.componentPropertyChangedEventHandler);
+    }
+
+    setComponent(component: COMPONENT, descriptor?: Descriptor) {
+
+        super.setComponent(component);
+        this.selector.setDescriptor(descriptor);
+    }
+
+    protected abstract createGetDescriptorRequest(key: DescriptorKey): ResourceRequest<any, DESCRIPTOR>;
+
+    protected abstract createSelector(): ComponentDescriptorDropdown<DESCRIPTOR>;
+
+    protected abstract getFormName(): string;
+
+    private setSelectorValue(descriptor: Descriptor, silent: boolean = true) {
+        if (silent) {
+            this.handleSelectorEvents = false;
+        }
+
+        this.selector.setDescriptor(descriptor);
+        this.setupComponentForm(this.component, descriptor);
+
+        this.handleSelectorEvents = true;
+    }
+
+    setDescriptorBasedComponent(component: COMPONENT) {
+
+        if (this.component) {
+            this.unregisterComponentListeners(this.component);
+        }
+
+        this.setComponent(component);
+
+        const key: DescriptorKey = this.component.getDescriptor();
+        if (key) {
+            const descriptor: Descriptor = this.selector.getDescriptor(key);
+            if (descriptor) {
+                this.setSelectorValue(descriptor);
+            } else {
+                this.createGetDescriptorRequest(key).sendAndParse().then((receivedDescriptor: Descriptor) => {
+                    this.setSelectorValue(receivedDescriptor);
+                }).catch((reason: any) => {
+                    if (this.isNotFoundError(reason)) {
+                        this.setSelectorValue(null);
+                    } else {
+                        api.DefaultErrorHandler.handle(reason);
+                    }
+                }).done();
+            }
+        } else {
+            this.setSelectorValue(null);
+        }
+
+        this.registerComponentListeners(this.component);
+    }
+
+    private initSelectorListeners() {
+        this.selector.onOptionSelected((event: OptionSelectedEvent<Descriptor>) => {
+            if (this.handleSelectorEvents) {
+                let option: Option<Descriptor> = event.getOption();
+                let selectedDescriptorKey: DescriptorKey = option.displayValue.getKey();
+                this.component.setDescriptor(selectedDescriptorKey, option.displayValue);
+            }
+        });
     }
 
     setupComponentForm(component: DescriptorBasedComponent, descriptor: Descriptor) {
@@ -83,6 +186,7 @@ export abstract class DescriptorBasedComponentInspectionPanel<COMPONENT extends 
         let form = descriptor.getConfig();
         let config = component.getConfig();
         this.formView = new FormView(this.formContext, form, config.getRoot());
+        this.formView.setLazyRender(false);
         this.appendChild(this.formView);
         component.setDisableEventForwarding(true);
         this.formView.layout().catch((reason: any) => {

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetComponentDescriptorsByApplicationsRequest.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetComponentDescriptorsByApplicationsRequest.ts
@@ -1,0 +1,31 @@
+import Descriptor = api.content.page.Descriptor;
+import ApplicationKey = api.application.ApplicationKey;
+import ResourceRequest = api.rest.ResourceRequest;
+
+export abstract class GetComponentDescriptorsByApplicationsRequest<JSON, DESCRIPTOR extends Descriptor>
+    extends api.rest.ResourceRequest<JSON, DESCRIPTOR[]> {
+
+    private applicationKeys: ApplicationKey[];
+
+    setApplicationKeys(applicationKeys: ApplicationKey[]) {
+        this.applicationKeys = applicationKeys;
+    }
+
+    sendAndParse(): wemQ.Promise<DESCRIPTOR[]> {
+
+        if (this.applicationKeys.length > 0) {
+
+            const request = (appKey: ApplicationKey) => this.createGetDescriptorsByApplicationRequest(appKey).sendAndParse();
+
+            const promises = this.applicationKeys.map(request);
+
+            return wemQ.all(promises).then((results: DESCRIPTOR[][]) => {
+                return results.reduce((prev: DESCRIPTOR[], curr: DESCRIPTOR[]) => prev.concat(curr), []);
+            });
+        }
+
+        return wemQ.resolve([]);
+    }
+
+    protected abstract createGetDescriptorsByApplicationRequest(applicationKey: ApplicationKey): ResourceRequest<JSON, DESCRIPTOR[]>;
+}

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetLayoutDescriptorsByApplicationsRequest.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetLayoutDescriptorsByApplicationsRequest.ts
@@ -2,38 +2,12 @@ import ApplicationKey = api.application.ApplicationKey;
 import LayoutDescriptor = api.content.page.region.LayoutDescriptor;
 import LayoutDescriptorsJson = api.content.page.region.LayoutDescriptorsJson;
 import {GetLayoutDescriptorsByApplicationRequest} from '../../../../../resource/GetLayoutDescriptorsByApplicationRequest';
-import {LayoutDescriptorResourceRequest} from '../../../../../resource/LayoutDescriptorResourceRequest';
+import {GetComponentDescriptorsByApplicationsRequest} from './GetComponentDescriptorsByApplicationsRequest';
 
 export class GetLayoutDescriptorsByApplicationsRequest
-    extends LayoutDescriptorResourceRequest<LayoutDescriptorsJson, LayoutDescriptor[]> {
+    extends GetComponentDescriptorsByApplicationsRequest<LayoutDescriptorsJson, LayoutDescriptor> {
 
-    private applicationKeys: api.application.ApplicationKey[];
-
-    setApplicationKeys(applicationKeys: api.application.ApplicationKey[]) {
-        this.applicationKeys = applicationKeys;
-    }
-
-    getParams(): Object {
-        throw new Error('Unexpected call');
-    }
-
-    getRequestPath(): api.rest.Path {
-        throw new Error('Unexpected call');
-    }
-
-    sendAndParse(): wemQ.Promise<LayoutDescriptor[]> {
-
-        const req = (applicationKey: ApplicationKey) => new GetLayoutDescriptorsByApplicationRequest(applicationKey).sendAndParse();
-
-        let promises = this.applicationKeys.map(req);
-
-        return wemQ.all(promises).
-        then((results: LayoutDescriptor[][]) => {
-            let all: LayoutDescriptor[] = [];
-            results.forEach((result: LayoutDescriptor[]) => {
-                Array.prototype.push.apply(all, result);
-            });
-            return all;
-        });
+    protected createGetDescriptorsByApplicationRequest(applicationKey: ApplicationKey): GetLayoutDescriptorsByApplicationRequest {
+        return new GetLayoutDescriptorsByApplicationRequest(applicationKey);
     }
 }

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetPartDescriptorsByApplicationsRequest.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetPartDescriptorsByApplicationsRequest.ts
@@ -2,29 +2,12 @@ import ApplicationKey = api.application.ApplicationKey;
 import PartDescriptor = api.content.page.region.PartDescriptor;
 import PartDescriptorsJson = api.content.page.region.PartDescriptorsJson;
 import {GetPartDescriptorsByApplicationRequest} from '../../../../../resource/GetPartDescriptorsByApplicationRequest';
+import {GetComponentDescriptorsByApplicationsRequest} from './GetComponentDescriptorsByApplicationsRequest';
 
 export class GetPartDescriptorsByApplicationsRequest
-    extends api.rest.ResourceRequest<PartDescriptorsJson, PartDescriptor[]> {
+    extends GetComponentDescriptorsByApplicationsRequest<PartDescriptorsJson, PartDescriptor> {
 
-    private applicationKeys: ApplicationKey[];
-
-    setApplicationKeys(applicationKeys: ApplicationKey[]) {
-        this.applicationKeys = applicationKeys;
-    }
-
-    sendAndParse(): wemQ.Promise<PartDescriptor[]> {
-
-        if (this.applicationKeys.length > 0) {
-
-            const request = (applicationKey: ApplicationKey) => new GetPartDescriptorsByApplicationRequest(applicationKey).sendAndParse();
-
-            const promises = this.applicationKeys.map(request);
-
-            return wemQ.all(promises).then((results: PartDescriptor[][]) => {
-                return results.reduce((prev: PartDescriptor[], curr: PartDescriptor[]) => prev.concat(curr), []);
-            });
-        }
-
-        return wemQ.resolve([]);
+    protected createGetDescriptorsByApplicationRequest(applicationKey: ApplicationKey): GetPartDescriptorsByApplicationRequest {
+        return new GetPartDescriptorsByApplicationRequest(applicationKey);
     }
 }

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/ImageInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/ImageInspectionPanel.ts
@@ -127,6 +127,7 @@ export class ImageInspectionPanel
         let configData = imageComponent.getConfig();
         let configForm = imageComponent.getForm();
         this.formView = new api.form.FormView(this.formContext, configForm, configData.getRoot());
+        this.formView.setLazyRender(false);
         this.appendChild(this.formView);
         this.formView.setVisible(this.imageComponent.hasImage());
         imageComponent.setDisableEventForwarding(true);

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/LayoutDescriptorDropdown.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/LayoutDescriptorDropdown.ts
@@ -1,13 +1,10 @@
 import LayoutDescriptor = api.content.page.region.LayoutDescriptor;
-import ApplicationKey = api.application.ApplicationKey;
-import {DescriptorBasedDropdown} from '../DescriptorBasedDropdown';
 import {LayoutDescriptorLoader} from './LayoutDescriptorLoader';
 import {DescriptorViewer} from '../DescriptorViewer';
+import {ComponentDescriptorDropdown} from './ComponentDescriptorDropdown';
 
 export class LayoutDescriptorDropdown
-    extends DescriptorBasedDropdown<LayoutDescriptor> {
-
-    protected loader: LayoutDescriptorLoader;
+    extends ComponentDescriptorDropdown<LayoutDescriptor> {
 
     constructor() {
 
@@ -16,12 +13,6 @@ export class LayoutDescriptorDropdown
             dataIdProperty: 'value',
             noOptionsText: 'No layouts available'
         });
-    }
-
-    loadDescriptors(applicationKeys: ApplicationKey[]) {
-        this.loader.setApplicationKeys(applicationKeys);
-
-        super.load();
     }
 
     protected createLoader(): LayoutDescriptorLoader {

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/LayoutDescriptorLoader.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/LayoutDescriptorLoader.ts
@@ -1,29 +1,12 @@
-import ApplicationKey = api.application.ApplicationKey;
 import LayoutDescriptorsJson = api.content.page.region.LayoutDescriptorsJson;
 import LayoutDescriptor = api.content.page.region.LayoutDescriptor;
-import {DescriptorByDisplayNameComparator} from '../DescriptorByDisplayNameComparator';
 import {GetLayoutDescriptorsByApplicationsRequest} from './GetLayoutDescriptorsByApplicationsRequest';
+import {ComponentDescriptorLoader} from './ComponentDescriptorLoader';
 
 export class LayoutDescriptorLoader
-    extends api.util.loader.BaseLoader<LayoutDescriptorsJson, LayoutDescriptor> {
-
-    protected request: GetLayoutDescriptorsByApplicationsRequest;
-
-    constructor() {
-        super();
-
-        this.setComparator(new DescriptorByDisplayNameComparator());
-    }
-
-    filterFn(descriptor: LayoutDescriptor) {
-        return descriptor.getDisplayName().toString().toLowerCase().indexOf(this.getSearchString().toLowerCase()) !== -1;
-    }
+    extends ComponentDescriptorLoader<LayoutDescriptorsJson, LayoutDescriptor> {
 
     protected createRequest(): GetLayoutDescriptorsByApplicationsRequest {
         return new GetLayoutDescriptorsByApplicationsRequest();
-    }
-
-    setApplicationKeys(applicationKeys: ApplicationKey[]) {
-        this.request.setApplicationKeys(applicationKeys);
     }
 }

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/LayoutInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/LayoutInspectionPanel.ts
@@ -2,34 +2,16 @@ import {
     DescriptorBasedComponentInspectionPanel,
     DescriptorBasedComponentInspectionPanelConfig
 } from './DescriptorBasedComponentInspectionPanel';
-import {DescriptorBasedDropdownForm} from './DescriptorBasedDropdownForm';
-import {LayoutComponentView} from '../../../../../../page-editor/layout/LayoutComponentView';
 import {ItemViewIconClassResolver} from '../../../../../../page-editor/ItemViewIconClassResolver';
 import {GetLayoutDescriptorByKeyRequest} from './GetLayoutDescriptorByKeyRequest';
 import {LayoutDescriptorDropdown} from './LayoutDescriptorDropdown';
 import {LayoutComponent} from '../../../../../page/region/LayoutComponent';
-import {ComponentPropertyChangedEvent} from '../../../../../page/region/ComponentPropertyChangedEvent';
-import {DescriptorBasedComponent} from '../../../../../page/region/DescriptorBasedComponent';
 import LayoutDescriptor = api.content.page.region.LayoutDescriptor;
 import DescriptorKey = api.content.page.DescriptorKey;
-import Option = api.ui.selector.Option;
-import OptionSelectedEvent = api.ui.selector.OptionSelectedEvent;
 import i18n = api.util.i18n;
 
 export class LayoutInspectionPanel
     extends DescriptorBasedComponentInspectionPanel<LayoutComponent, LayoutDescriptor> {
-
-    private layoutView: LayoutComponentView;
-
-    private layoutComponent: LayoutComponent;
-
-    private layoutForm: DescriptorBasedDropdownForm;
-
-    private handleSelectorEvents: boolean = true;
-
-    private componentPropertyChangedEventHandler: (event: ComponentPropertyChangedEvent) => void;
-
-    protected selector: LayoutDescriptorDropdown;
 
     constructor() {
         super(<DescriptorBasedComponentInspectionPanelConfig>{
@@ -37,108 +19,16 @@ export class LayoutInspectionPanel
         });
     }
 
-    protected layout() {
-
-        this.removeChildren();
-
-        this.selector = new LayoutDescriptorDropdown();
-        this.layoutForm = new DescriptorBasedDropdownForm(this.selector, i18n('field.layout'));
-
-        this.selector.loadDescriptors(this.liveEditModel.getSiteModel().getApplicationKeys());
-
-        this.componentPropertyChangedEventHandler = (event: ComponentPropertyChangedEvent) => {
-
-            // Ensure displayed config form and selector option are removed when descriptor is removed
-            if (event.getPropertyName() === DescriptorBasedComponent.PROPERTY_DESCRIPTOR) {
-                if (!this.layoutComponent.hasDescriptor()) {
-                    this.setSelectorValue(null, false);
-                }
-            }
-        };
-
-        this.initSelectorListeners();
-        this.appendChild(this.layoutForm);
-
+    protected createSelector(): LayoutDescriptorDropdown {
+        return new LayoutDescriptorDropdown();
     }
 
-    protected reloadDescriptorsOnApplicationChange() {
-        if (this.selector) {
-            this.selector.loadDescriptors(this.liveEditModel.getSiteModel().getApplicationKeys());
-        }
+    protected getFormName(): string {
+        return i18n('field.layout');
     }
 
-    protected applicationUnavailableHandler() {
-        this.selector.hideDropdown();
-    }
-
-    private registerComponentListeners(component: LayoutComponent) {
-        component.onPropertyChanged(this.componentPropertyChangedEventHandler);
-    }
-
-    private unregisterComponentListeners(component: LayoutComponent) {
-        component.unPropertyChanged(this.componentPropertyChangedEventHandler);
-    }
-
-    setComponent(component: LayoutComponent, descriptor?: LayoutDescriptor) {
-
-        super.setComponent(component);
-        this.selector.setDescriptor(descriptor);
-    }
-
-    setLayoutComponent(layoutView: LayoutComponentView) {
-
-        if (this.layoutComponent) {
-            this.unregisterComponentListeners(this.layoutComponent);
-        }
-
-        this.layoutView = layoutView;
-        this.layoutComponent = <LayoutComponent> layoutView.getComponent();
-
-        this.setComponent(this.layoutComponent);
-        const key: DescriptorKey = this.layoutComponent.getDescriptor();
-        if (key) {
-            const descriptor: LayoutDescriptor = this.selector.getDescriptor(key);
-            if (descriptor) {
-                this.setSelectorValue(descriptor);
-            } else {
-                new GetLayoutDescriptorByKeyRequest(key).sendAndParse().then((receivedDescriptor: LayoutDescriptor) => {
-                    this.setSelectorValue(receivedDescriptor);
-                }).catch((reason: any) => {
-                    if (this.isNotFoundError(reason)) {
-                        this.setSelectorValue(null);
-                    } else {
-                        api.DefaultErrorHandler.handle(reason);
-                    }
-                }).done();
-            }
-        } else {
-            this.setSelectorValue(null);
-        }
-
-        this.registerComponentListeners(this.layoutComponent);
-    }
-
-    private setSelectorValue(descriptor: LayoutDescriptor, silent: boolean = true) {
-        if (silent) {
-            this.handleSelectorEvents = false;
-        }
-
-        this.selector.setDescriptor(descriptor);
-        this.setupComponentForm(this.layoutComponent, descriptor);
-
-        this.handleSelectorEvents = true;
-    }
-
-    private initSelectorListeners() {
-        this.selector.onOptionSelected((event: OptionSelectedEvent<LayoutDescriptor>) => {
-            if (this.handleSelectorEvents) {
-
-                let option: Option<LayoutDescriptor> = event.getOption();
-
-                let selectedDescriptorKey: DescriptorKey = option.displayValue.getKey();
-                this.layoutComponent.setDescriptor(selectedDescriptorKey, option.displayValue);
-            }
-        });
+    protected createGetDescriptorRequest(key: DescriptorKey): GetLayoutDescriptorByKeyRequest {
+        return new GetLayoutDescriptorByKeyRequest(key);
     }
 
     getName(): string {

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/PartDescriptorDropdown.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/PartDescriptorDropdown.ts
@@ -1,13 +1,10 @@
-import ApplicationKey = api.application.ApplicationKey;
 import PartDescriptor = api.content.page.region.PartDescriptor;
-import {DescriptorBasedDropdown} from '../DescriptorBasedDropdown';
 import {PartDescriptorLoader} from './PartDescriptorLoader';
 import {DescriptorViewer} from '../DescriptorViewer';
+import {ComponentDescriptorDropdown} from './ComponentDescriptorDropdown';
 
 export class PartDescriptorDropdown
-    extends DescriptorBasedDropdown<PartDescriptor> {
-
-    protected loader: PartDescriptorLoader;
+    extends ComponentDescriptorDropdown<PartDescriptor> {
 
     constructor() {
 
@@ -16,12 +13,6 @@ export class PartDescriptorDropdown
             dataIdProperty: 'value',
             noOptionsText: 'No parts available'
         });
-    }
-
-    loadDescriptors(applicationKeys: ApplicationKey[]) {
-        this.loader.setApplicationKeys(applicationKeys);
-
-        super.load();
     }
 
     protected createLoader(): PartDescriptorLoader {

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/PartDescriptorLoader.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/PartDescriptorLoader.ts
@@ -1,30 +1,13 @@
-import ApplicationKey = api.application.ApplicationKey;
 import PartDescriptorsJson = api.content.page.region.PartDescriptorsJson;
 import PartDescriptor = api.content.page.region.PartDescriptor;
-import {DescriptorByDisplayNameComparator} from '../DescriptorByDisplayNameComparator';
 import {GetPartDescriptorsByApplicationsRequest} from './GetPartDescriptorsByApplicationsRequest';
+import {ComponentDescriptorLoader} from './ComponentDescriptorLoader';
 
 export class PartDescriptorLoader
-    extends api.util.loader.BaseLoader<PartDescriptorsJson, PartDescriptor> {
-
-    protected request: GetPartDescriptorsByApplicationsRequest;
-
-    constructor() {
-        super();
-
-        this.setComparator(new DescriptorByDisplayNameComparator());
-    }
-
-    filterFn(descriptor: PartDescriptor) {
-        return descriptor.getDisplayName().toString().toLowerCase().indexOf(this.getSearchString().toLowerCase()) !== -1;
-    }
+    extends ComponentDescriptorLoader<PartDescriptorsJson, PartDescriptor> {
 
     protected createRequest(): GetPartDescriptorsByApplicationsRequest {
         return new GetPartDescriptorsByApplicationsRequest();
-    }
-
-    setApplicationKeys(applicationKeys: ApplicationKey[]) {
-        this.request.setApplicationKeys(applicationKeys);
     }
 
 }

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/PartInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/PartInspectionPanel.ts
@@ -2,34 +2,16 @@ import {
     DescriptorBasedComponentInspectionPanel,
     DescriptorBasedComponentInspectionPanelConfig
 } from './DescriptorBasedComponentInspectionPanel';
-import {DescriptorBasedDropdownForm} from './DescriptorBasedDropdownForm';
-import {PartComponentView} from '../../../../../../page-editor/part/PartComponentView';
 import {ItemViewIconClassResolver} from '../../../../../../page-editor/ItemViewIconClassResolver';
 import {GetPartDescriptorByKeyRequest} from './GetPartDescriptorByKeyRequest';
 import {PartDescriptorDropdown} from './PartDescriptorDropdown';
 import {PartComponent} from '../../../../../page/region/PartComponent';
-import {ComponentPropertyChangedEvent} from '../../../../../page/region/ComponentPropertyChangedEvent';
-import {DescriptorBasedComponent} from '../../../../../page/region/DescriptorBasedComponent';
 import PartDescriptor = api.content.page.region.PartDescriptor;
 import DescriptorKey = api.content.page.DescriptorKey;
-import Option = api.ui.selector.Option;
-import OptionSelectedEvent = api.ui.selector.OptionSelectedEvent;
 import i18n = api.util.i18n;
 
 export class PartInspectionPanel
     extends DescriptorBasedComponentInspectionPanel<PartComponent, PartDescriptor> {
-
-    private partView: PartComponentView;
-
-    private partComponent: PartComponent;
-
-    private partForm: DescriptorBasedDropdownForm;
-
-    private handleSelectorEvents: boolean = true;
-
-    private componentPropertyChangedEventHandler: (event: ComponentPropertyChangedEvent) => void;
-
-    protected selector: PartDescriptorDropdown;
 
     constructor() {
         super(<DescriptorBasedComponentInspectionPanelConfig>{
@@ -37,102 +19,16 @@ export class PartInspectionPanel
         });
     }
 
-    protected layout() {
-
-        this.removeChildren();
-
-        this.selector = new PartDescriptorDropdown();
-        this.partForm = new DescriptorBasedDropdownForm(this.selector, i18n('field.part'));
-
-        this.selector.loadDescriptors(this.liveEditModel.getSiteModel().getApplicationKeys());
-
-        this.componentPropertyChangedEventHandler = (event: ComponentPropertyChangedEvent) => {
-
-            // Ensure displayed config form and selector option are removed when descriptor is removed
-            if (event.getPropertyName() === DescriptorBasedComponent.PROPERTY_DESCRIPTOR) {
-                if (!this.partComponent.hasDescriptor()) {
-                    this.setSelectorValue(null, false);
-                }
-            }
-        };
-
-        this.initSelectorListeners();
-        this.appendChild(this.partForm);
+    protected createSelector(): PartDescriptorDropdown {
+        return new PartDescriptorDropdown();
     }
 
-    protected reloadDescriptorsOnApplicationChange() {
-        if (this.selector) {
-            this.selector.loadDescriptors(this.liveEditModel.getSiteModel().getApplicationKeys());
-        }
+    protected getFormName(): string {
+        return i18n('field.part');
     }
 
-    setComponent(component: PartComponent, descriptor?: PartDescriptor) {
-
-        super.setComponent(component);
-        this.selector.setDescriptor(descriptor);
-    }
-
-    private setSelectorValue(descriptor: PartDescriptor, silent: boolean = true) {
-        if (silent) {
-            this.handleSelectorEvents = false;
-        }
-
-        this.selector.setDescriptor(descriptor);
-        this.setupComponentForm(this.partComponent, descriptor);
-
-        this.handleSelectorEvents = true;
-    }
-
-    private registerComponentListeners(component: PartComponent) {
-        component.onPropertyChanged(this.componentPropertyChangedEventHandler);
-    }
-
-    private unregisterComponentListeners(component: PartComponent) {
-        component.unPropertyChanged(this.componentPropertyChangedEventHandler);
-    }
-
-    setPartComponent(partView: PartComponentView) {
-
-        if (this.partComponent) {
-            this.unregisterComponentListeners(this.partComponent);
-        }
-
-        this.partView = partView;
-        this.partComponent = <PartComponent>partView.getComponent();
-
-        this.setComponent(this.partComponent);
-        const key: DescriptorKey = this.partComponent.getDescriptor();
-        if (key) {
-            const descriptor: PartDescriptor = this.selector.getDescriptor(key);
-            if (descriptor) {
-                this.setSelectorValue(descriptor);
-            } else {
-                new GetPartDescriptorByKeyRequest(key).sendAndParse().then((receivedDescriptor: PartDescriptor) => {
-                    this.setSelectorValue(receivedDescriptor);
-                }).catch((reason: any) => {
-                    if (this.isNotFoundError(reason)) {
-                        this.setSelectorValue(null);
-                    } else {
-                        api.DefaultErrorHandler.handle(reason);
-                    }
-                }).done();
-            }
-        } else {
-            this.setSelectorValue(null);
-        }
-
-        this.registerComponentListeners(this.partComponent);
-    }
-
-    private initSelectorListeners() {
-
-        this.selector.onOptionSelected((event: OptionSelectedEvent<PartDescriptor>) => {
-            if (this.handleSelectorEvents) {
-                let option: Option<PartDescriptor> = event.getOption();
-                let selectedDescriptorKey: DescriptorKey = option.displayValue.getKey();
-                this.partComponent.setDescriptor(selectedDescriptorKey, option.displayValue);
-            }
-        });
+    protected createGetDescriptorRequest(key: DescriptorKey): GetPartDescriptorByKeyRequest {
+        return new GetPartDescriptorByKeyRequest(key);
     }
 
     getName(): string {


### PR DESCRIPTION
…e reload #209

-Refactored Part and Layout inspection panels to remove duplicated code
-Making config's form view to be rendered for inspection panels immediately via formView.setLazyRender(false), otherwise form view not rendered when inspection panel is hidden (panel is sliding with animation and lazy rendering thinks that panel is not in viewport yet)