### PR TITLE
Live edit: values in inspection panel config form disappear after Pag…

### DIFF
--- a/src/main/resources/assets/js/app/page/region/DescriptorBasedComponent.ts
+++ b/src/main/resources/assets/js/app/page/region/DescriptorBasedComponent.ts
@@ -18,7 +18,7 @@ export class DescriptorBasedComponent
 
     private disableEventForwarding: boolean;
 
-    private descriptor: DescriptorKey;
+    private descriptorKey: DescriptorKey;
 
     private description: string;
 
@@ -30,7 +30,7 @@ export class DescriptorBasedComponent
 
         super(builder);
 
-        this.descriptor = builder.descriptor;
+        this.descriptorKey = builder.descriptor;
         this.config = builder.config;
 
         this.configChangedHandler = (event: PropertyEvent) => {
@@ -50,22 +50,21 @@ export class DescriptorBasedComponent
     }
 
     hasDescriptor(): boolean {
-        return !!this.descriptor;
+        return !!this.descriptorKey;
     }
 
-    getDescriptor(): DescriptorKey {
-        return this.descriptor;
+    getDescriptorKey(): DescriptorKey {
+        return this.descriptorKey;
     }
 
-    setDescriptor(descriptorKey: DescriptorKey, descriptor: Descriptor) {
-
-        let oldValue = this.descriptor;
-        this.descriptor = descriptorKey;
+    setDescriptor(descriptor: Descriptor) {
+        const oldDescriptorKeyValue = this.descriptorKey;
+        this.descriptorKey = descriptor ? descriptor.getKey() : null;
 
         this.setName(descriptor ? new ComponentName(descriptor.getDisplayName()) : this.getType().getDefaultName());
         this.description = descriptor ? descriptor.getDescription() : null;
 
-        if (!api.ObjectHelper.equals(oldValue, descriptorKey)) {
+        if (!api.ObjectHelper.equals(oldDescriptorKeyValue, this.descriptorKey)) {
             this.notifyPropertyChanged(DescriptorBasedComponent.PROPERTY_DESCRIPTOR);
         }
 
@@ -93,15 +92,19 @@ export class DescriptorBasedComponent
         return this.description;
     }
 
+    setDescription(value: string) {
+        this.description = value;
+    }
+
     doReset() {
-        this.setDescriptor(null, null);
+        this.setDescriptor(null);
     }
 
     toComponentJson(): DescriptorBasedComponentJson {
 
         return <DescriptorBasedComponentJson>{
             name: this.getName() ? this.getName().toString() : null,
-            descriptor: this.descriptor != null ? this.descriptor.toString() : null,
+            descriptor: this.descriptorKey != null ? this.descriptorKey.toString() : null,
             config: this.config != null ? this.config.toJson() : null
         };
     }
@@ -117,7 +120,7 @@ export class DescriptorBasedComponent
         }
         let other = <DescriptorBasedComponent>o;
 
-        if (!api.ObjectHelper.equals(this.descriptor, other.descriptor)) {
+        if (!api.ObjectHelper.equals(this.descriptorKey, other.descriptorKey)) {
             return false;
         }
 
@@ -143,7 +146,7 @@ export class DescriptorBasedComponentBuilder<DESCRIPTOR_BASED_COMPONENT extends 
     constructor(source?: DescriptorBasedComponent) {
         super(source);
         if (source) {
-            this.descriptor = source.getDescriptor();
+            this.descriptor = source.getDescriptorKey();
             this.config = source.getConfig() ? source.getConfig().copy() : null;
         } else {
             this.config = new PropertyTree();

--- a/src/main/resources/assets/js/app/page/region/LayoutComponent.ts
+++ b/src/main/resources/assets/js/app/page/region/LayoutComponent.ts
@@ -1,5 +1,4 @@
 import PropertyTree = api.data.PropertyTree;
-import DescriptorKey = api.content.page.DescriptorKey;
 import LayoutDescriptor = api.content.page.region.LayoutDescriptor;
 import {Regions} from './Regions';
 import {ComponentPropertyChangedEvent} from './ComponentPropertyChangedEvent';
@@ -94,9 +93,9 @@ export class LayoutComponent
         }
     }
 
-    setDescriptor(descriptorKey: DescriptorKey, descriptor?: LayoutDescriptor) {
+    setDescriptor(descriptor: LayoutDescriptor) {
+        super.setDescriptor(descriptor);
 
-        super.setDescriptor(descriptorKey, descriptor);
         if (descriptor) {
             this.addRegions(descriptor);
         }

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/DescriptorBasedComponentInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/DescriptorBasedComponentInspectionPanel.ts
@@ -9,7 +9,6 @@ import {ComponentDescriptorDropdown} from './ComponentDescriptorDropdown';
 import FormView = api.form.FormView;
 import Descriptor = api.content.page.Descriptor;
 import DescriptorKey = api.content.page.DescriptorKey;
-import Option = api.ui.selector.Option;
 import OptionSelectedEvent = api.ui.selector.OptionSelectedEvent;
 import ResourceRequest = api.rest.ResourceRequest;
 
@@ -139,7 +138,7 @@ export abstract class DescriptorBasedComponentInspectionPanel<COMPONENT extends 
 
         this.setComponent(component);
 
-        const key: DescriptorKey = this.component.getDescriptor();
+        const key: DescriptorKey = this.component.getDescriptorKey();
         if (key) {
             const descriptor: Descriptor = this.selector.getDescriptor(key);
             if (descriptor) {
@@ -165,9 +164,8 @@ export abstract class DescriptorBasedComponentInspectionPanel<COMPONENT extends 
     private initSelectorListeners() {
         this.selector.onOptionSelected((event: OptionSelectedEvent<Descriptor>) => {
             if (this.handleSelectorEvents) {
-                let option: Option<Descriptor> = event.getOption();
-                let selectedDescriptorKey: DescriptorKey = option.displayValue.getKey();
-                this.component.setDescriptor(selectedDescriptorKey, option.displayValue);
+                const descriptor: Descriptor = event.getOption().displayValue;
+                this.component.setDescriptor(descriptor);
             }
         });
     }

--- a/src/main/resources/assets/js/page-editor/layout/LayoutPlaceholder.ts
+++ b/src/main/resources/assets/js/page-editor/layout/LayoutPlaceholder.ts
@@ -25,10 +25,10 @@ export class LayoutPlaceholder
 
         this.comboBox.onOptionSelected((event: SelectedOptionEvent<LayoutDescriptor>) => {
             this.layoutComponentView.showLoadingSpinner();
-            let descriptor = event.getSelectedOption().getOption().displayValue;
+            const descriptor = event.getSelectedOption().getOption().displayValue;
 
-            let layoutComponent: LayoutComponent = this.layoutComponentView.getComponent();
-            layoutComponent.setDescriptor(descriptor.getKey(), descriptor);
+            const layoutComponent: LayoutComponent = this.layoutComponentView.getComponent();
+            layoutComponent.setDescriptor(descriptor);
         });
 
         let siteModel = layoutView.getLiveEditModel().getSiteModel();

--- a/src/main/resources/assets/js/page-editor/part/PartPlaceholder.ts
+++ b/src/main/resources/assets/js/page-editor/part/PartPlaceholder.ts
@@ -31,8 +31,8 @@ export class PartPlaceholder
 
         this.comboBox.onOptionSelected((event: SelectedOptionEvent<PartDescriptor>) => {
             this.partComponentView.showLoadingSpinner();
-            let descriptor: Descriptor = event.getSelectedOption().getOption().displayValue;
-            partComponent.setDescriptor(descriptor.getKey(), descriptor);
+            const descriptor: Descriptor = event.getSelectedOption().getOption().displayValue;
+            partComponent.setDescriptor(descriptor);
         });
 
         let siteModel = partView.getLiveEditModel().getSiteModel();


### PR DESCRIPTION
…eComponentsView is open #222

-When PCV is open it fetches component descriptors to set descriptions for them in it's tree grid, but currently when setting descriptor to a component it will reset component's config. Fixed by setting only descriptions to components after descriptors fetched
-Refactored setComponent() method in DescriptorBasedComponent since having 2 args is redundant