### PR TITLE
Incorrect events/feedback in the Publish dialog during long publish o…

### DIFF
--- a/src/main/resources/assets/js/app/publish/ContentPublishDialog.ts
+++ b/src/main/resources/assets/js/app/publish/ContentPublishDialog.ts
@@ -173,6 +173,7 @@ export class ContentPublishDialog
 
     open() {
         this.publishProcessor.resetExcludedIds();
+        this.publishProcessor.setIgnoreDependantItemsChanged(false);
 
         CreateIssueDialog.get().reset();
 
@@ -280,6 +281,7 @@ export class ContentPublishDialog
     private doPublish(scheduled: boolean = false) {
 
         this.lockControls();
+        this.publishProcessor.setIgnoreDependantItemsChanged(true);
 
         this.setSubTitle(i18n('dialog.publish.publishing', this.countTotal()));
 

--- a/src/main/resources/assets/js/app/publish/PublishProcessor.ts
+++ b/src/main/resources/assets/js/app/publish/PublishProcessor.ts
@@ -25,6 +25,8 @@ export class PublishProcessor {
 
     private ignoreItemsChanged: boolean;
 
+    private ignoreDependantItemsChanged: boolean;
+
     private loadingStartedListeners: { (): void }[] = [];
 
     private loadingFinishedListeners: { (): void }[] = [];
@@ -73,7 +75,9 @@ export class PublishProcessor {
         });
 
         this.dependantList.onListChanged(() => {
-            this.reloadDependenciesDebounced(true);
+            if (!this.ignoreDependantItemsChanged) {
+                this.reloadDependenciesDebounced(true);
+            }
         });
     }
 
@@ -197,6 +201,10 @@ export class PublishProcessor {
 
     public setIgnoreItemsChanged(value: boolean) {
         this.ignoreItemsChanged = value;
+    }
+
+    public setIgnoreDependantItemsChanged(value: boolean) {
+        this.ignoreDependantItemsChanged = value;
     }
 
     private countToPublish(summaries: ContentSummaryAndCompareStatus[]): number {


### PR DESCRIPTION
…peration #232

-After dependant items published we receive update event from websocket that is processed by publish processor and triggers dependant items reload that causes titles to change etc. Added possibility to disable dependant list change event handler