### PR TITLE
The Context panel auto-expands in the Wizard #242

### DIFF
--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -2146,7 +2146,8 @@ export class ContentWizardPanel
         }
 
         this.getSplitPanel().showSecondPanel();
-        livePanel.clearPageViewSelectionAndOpenInspectPage(false);
+        const showInspectionPanel = ResponsiveRanges._1920_UP.isFitOrBigger(this.getEl().getWidthWithBorder());
+        livePanel.clearPageViewSelectionAndOpenInspectPage(showInspectionPanel);
         this.showMinimizeEditButton();
     }
 

--- a/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -24,8 +24,6 @@ import {LiveEditPageViewReadyEvent} from '../../../page-editor/LiveEditPageViewR
 import {LiveEditPageInitializationErrorEvent} from '../../../page-editor/LiveEditPageInitializationErrorEvent';
 import {PartComponentView} from '../../../page-editor/part/PartComponentView';
 import {LayoutComponentView} from '../../../page-editor/layout/LayoutComponentView';
-import {PageLockedEvent} from '../../../page-editor/PageLockedEvent';
-import {PageUnlockedEvent} from '../../../page-editor/PageUnlockedEvent';
 import {RegionView} from '../../../page-editor/RegionView';
 import {PageSelectedEvent} from '../../../page-editor/PageSelectedEvent';
 import {RegionSelectedEvent} from '../../../page-editor/RegionSelectedEvent';
@@ -563,11 +561,11 @@ export class LiveFormPanel
     }
 
     private liveEditListen() {
-        this.liveEditPageProxy.onPageLocked((event: PageLockedEvent) => {
-            this.inspectPage();
+        this.liveEditPageProxy.onPageLocked(() => {
+            this.inspectPage(false);
         });
 
-        this.liveEditPageProxy.onPageUnlocked((event: PageUnlockedEvent) => {
+        this.liveEditPageProxy.onPageUnlocked(() => {
             //this.contextWindow.clearSelection();
             this.minimizeContentFormPanelIfNeeded();
         });


### PR DESCRIPTION
Disabled context panel auto-expand on startup from small screens (smaller than 1920).