### PR TITLE
Page Components View - context menu is cut off after expanding sub-menu #254

### DIFF
--- a/src/main/resources/assets/js/page-editor/ItemViewContextMenu.ts
+++ b/src/main/resources/assets/js/page-editor/ItemViewContextMenu.ts
@@ -99,9 +99,12 @@ export class ItemViewContextMenu
         this.menu.onItemExpanded((heightChange: number) => {
             const isDown = this.orientation === ItemViewContextMenuOrientation.DOWN;
             const el = this.getEl();
+            const arrowHeight = this.arrow ? this.arrow.getHeight() : 0;
 
             // Cursor is positioned 1px above/below the menu
-            const y = isDown ? (el.getTopPx() - 1) : (el.getTopPx() + el.getHeightWithBorder() - heightChange + 1);
+            const y = isDown ?
+                      (el.getTopPx() - arrowHeight - 1) :
+                      (el.getTopPx() + el.getHeightWithBorder() - heightChange + arrowHeight + 1);
             const x = el.getLeftPx() + el.getWidth() / 2;
 
             this.showAt(x, y);

--- a/src/main/resources/assets/js/page-editor/ItemViewContextMenu.ts
+++ b/src/main/resources/assets/js/page-editor/ItemViewContextMenu.ts
@@ -1,4 +1,3 @@
-import './../api.ts';
 import {ItemViewContextMenuTitle} from './ItemViewContextMenuTitle';
 import MinimizeWizardPanelEvent = api.app.wizard.MinimizeWizardPanelEvent;
 import Action = api.ui.Action;
@@ -8,12 +7,20 @@ export enum ItemViewContextMenuOrientation {
     DOWN
 }
 
+interface Coordinates {
+    x: number;
+    y: number;
+}
+
 export class ItemViewContextMenu
     extends api.dom.DivEl {
 
     private title: ItemViewContextMenuTitle;
+
     private menu: api.ui.menu.TreeContextMenu;
+
     private arrow: ItemViewContextMenuArrow;
+
     private orientation: ItemViewContextMenuOrientation = ItemViewContextMenuOrientation.DOWN;
 
     private orientationListeners: { (orientation: ItemViewContextMenuOrientation): void }[] = [];
@@ -31,7 +38,7 @@ export class ItemViewContextMenu
 
         this.title = menuTitle;
         if (this.title) {
-            let lastPosition: { x: number, y: number };
+            let lastPosition: Coordinates;
 
             dragListener = (e: MouseEvent) => {
                 e.preventDefault();
@@ -66,6 +73,16 @@ export class ItemViewContextMenu
         this.menu = new api.ui.menu.TreeContextMenu(actions, false);
         this.menu.onItemClicked(() => {
             this.hide();
+        });
+        this.menu.onItemExpanded((heightChange: number) => {
+            const isDown = this.orientation === ItemViewContextMenuOrientation.DOWN;
+            const el = this.getEl();
+
+            // Cursor is positioned 1px above/below the menu
+            const y = isDown ? (el.getTopPx() - 1) : (el.getTopPx() + el.getHeightWithBorder() - heightChange + 1);
+            const x = el.getLeftPx() + el.getWidth() / 2;
+
+            this.showAt(x, y);
         });
         this.appendChild(this.menu);
 

--- a/src/main/resources/assets/js/page-editor/ItemViewContextMenu.ts
+++ b/src/main/resources/assets/js/page-editor/ItemViewContextMenu.ts
@@ -107,7 +107,7 @@ export class ItemViewContextMenu
                       (el.getTopPx() + el.getHeightWithBorder() - heightChange + arrowHeight + 1);
             const x = el.getLeftPx() + el.getWidth() / 2;
 
-            this.showAt(x, y);
+            this.showAt(x, y, false, true);
         });
 
         this.appendChild(this.menu);
@@ -131,8 +131,8 @@ export class ItemViewContextMenu
         this.onRemoved(() => MinimizeWizardPanelEvent.un(minimizeHandler));
     }
 
-    showAt(x: number, y: number, notClicked: boolean = false) {
-        this.menu.showAt.call(this, this.restrainX(x), this.restrainY(y, notClicked));
+    showAt(x: number, y: number, notClicked: boolean = false, keepOrientation: boolean = false) {
+        this.menu.showAt.call(this, this.restrainX(x), this.restrainY(y, notClicked, keepOrientation));
     }
 
     moveBy(dx: number, dy: number) {
@@ -212,8 +212,8 @@ export class ItemViewContextMenu
         return resultX;
     }
 
-    private restrainY(y: number, notClicked?: boolean): number {
-        let orientation = ItemViewContextMenuOrientation.DOWN;
+    private restrainY(y: number, notClicked?: boolean, keepOrientation?: boolean): number {
+        let orientation = keepOrientation ? this.orientation : ItemViewContextMenuOrientation.DOWN;
         let arrowHeight = this.arrow ? this.arrow.getHeight() : 0;
         let height = this.getEl().getHeight();
         let minY = 0;


### PR DESCRIPTION
* Updated context menu to reposition, when it's expanded or collapsed.
* Refactored constructor.