### PR TITLE
Floating context panel is shifted down whenever modal dialog opens #290

### DIFF
--- a/src/main/resources/assets/styles/view/context/context-panel.less
+++ b/src/main/resources/assets/styles/view/context/context-panel.less
@@ -12,7 +12,7 @@
   right: -280px;
   box-shadow: 0 12px 20px -8px @admin-black, 0 8px 12px -4px rgba(0, 0, 0, 0.1);
   background-color: @admin-white;
-  transition: all 0.5s ease-in-out;
+  transition: right 0.5s ease-in-out;
 
   &.mobile {
     background-color: rgba(255, 255, 255, 0.95);
@@ -230,5 +230,14 @@
     top: @app-header-height + @toolbar-with-border-height;
     outline: 1px solid @admin-bg-light-gray;
     background-color: rgba(255, 255, 255, 0.95);
+  }
+}
+
+.blurred .context-panel {
+  &.floating-context-panel {
+    top: @toolbar-with-border-height;
+  }
+  .non-mobile-details-panel-toggle-button {
+    top: 0;
   }
 }


### PR DESCRIPTION
* Updated transition to be applied to the sliding (`right`) only.
* Updated position of the floating panel, when the upper container is blurred, since 
  > ... value other than none for the filter property results in the creation of a containing block for absolute and fixed positioned descendants.

  Thus, the position of the floating panel must be adjusted.