### PR TITLE
Context panel - Page tab should remain active after changing page template #296

### DIFF
--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/ContextWindow.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/ContextWindow.ts
@@ -103,7 +103,11 @@ export class ContextWindow extends api.ui.panel.DockedPanel {
         if (this.inspectTab) {
             this.inspectTab.setLabel(this.getShownPanelName());
         }
-        this.selectPanel(this.insertablesPanel);
+
+        const selectDefault = !isPageInspectionPanelSelectable && this.inspectTab.isActive();
+        if (selectDefault) {
+            this.selectPanel(this.insertablesPanel);
+        }
     }
 
     private getShownPanelName(): string {


### PR DESCRIPTION
* Updated change of the selection in the `ContextWindow` to not to change the selection if the inspections panel accessible.