### PR TITLE
Avoid blinking in the Inspect panel when switching between page compo…

### DIFF
--- a/src/main/resources/assets/js/page-editor/ItemView.ts
+++ b/src/main/resources/assets/js/page-editor/ItemView.ts
@@ -756,7 +756,7 @@ export class ItemView
             return;
         } else if (selectedView) {
             // deselect selected item view if any
-            selectedView.deselect();
+            selectedView.deselect(true);
         }
 
         // selecting anything should exit the text edit mode


### PR DESCRIPTION
…nents #326

Updated item view selection, making deselection of the previously selected item silent, to prevent switch to the default page inspection panel.