### PR TITLE
Page Editor - An extra click is required to unlock the page

### DIFF
--- a/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
+++ b/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
@@ -706,7 +706,7 @@ export class PageComponentsView
         }
 
         if (!this.contextMenu) {
-            this.contextMenu = new ItemViewContextMenu(null, contextMenuActions, false, false);
+            this.contextMenu = new ItemViewContextMenu(null, contextMenuActions, false);
             this.contextMenu.onHidden(this.removeMenuOpenStyleFromMenuIcon.bind(this));
         } else {
             this.contextMenu.setActions(contextMenuActions);

--- a/src/main/resources/assets/js/page-editor/ItemViewContextMenu.ts
+++ b/src/main/resources/assets/js/page-editor/ItemViewContextMenu.ts
@@ -1,5 +1,4 @@
 import {ItemViewContextMenuTitle} from './ItemViewContextMenuTitle';
-import MinimizeWizardPanelEvent = api.app.wizard.MinimizeWizardPanelEvent;
 import Action = api.ui.Action;
 
 export enum ItemViewContextMenuOrientation {
@@ -25,7 +24,7 @@ export class ItemViewContextMenu
 
     private orientationListeners: { (orientation: ItemViewContextMenuOrientation): void }[] = [];
 
-    constructor(title: ItemViewContextMenuTitle, actions: Action[], showArrow: boolean = true, listenToWizard: boolean = true) {
+    constructor(title: ItemViewContextMenuTitle, actions: Action[], showArrow: boolean = true) {
         super('menu item-view-context-menu');
 
         if (showArrow) {
@@ -36,7 +35,7 @@ export class ItemViewContextMenu
 
         this.createMenu(actions);
 
-        this.initListeners(listenToWizard);
+        this.initListeners();
 
         api.dom.Body.get().appendChild(this);
     }
@@ -113,22 +112,12 @@ export class ItemViewContextMenu
         this.appendChild(this.menu);
     }
 
-    initListeners(listenToWizard: boolean) {
+    initListeners() {
         this.onClicked((e: MouseEvent) => {
             // menu itself was clicked so do nothing
             e.preventDefault();
             e.stopPropagation();
         });
-
-        let minimizeHandler = () => {
-            this.hide();
-        };
-
-        if (listenToWizard) {
-            MinimizeWizardPanelEvent.on(minimizeHandler);
-        }
-
-        this.onRemoved(() => MinimizeWizardPanelEvent.un(minimizeHandler));
     }
 
     showAt(x: number, y: number, notClicked: boolean = false, keepOrientation: boolean = false) {

--- a/src/main/resources/assets/js/page-editor/PageView.ts
+++ b/src/main/resources/assets/js/page-editor/PageView.ts
@@ -583,6 +583,10 @@ export class PageView
         return this;
     }
 
+    getCurrentContextMenu(): ItemViewContextMenu {
+        return this.lockedContextMenu || super.getCurrentContextMenu();
+    }
+
     private updateVerticalSpaceForEditorToolbar() {
         const result = this.getEditorToolbarWidth();
 


### PR DESCRIPTION
Updated check for the `ItemView.handleClick` event, to prevent hiding of the context menu due to invalid event calls order.
Refactored event bindings, making it easier to debug.