### PR TITLE
Page Editor - selection of a component descriptor causes reload of the entire page #367

### DIFF
--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -1211,7 +1211,10 @@ export class ContentWizardPanel
                             content.dataEquals(current.getContentData(), true) &&
                             content.getPermissions().equals(current.getPermissions());
         } else {
-            isEqualToForm = content.equals(current, true);
+            // Use `content` as `this` value in the `equals` call:
+            // `current` is instance of `Content`, while content may be the instance of `Site`.
+            // Another order may result in returning `false`.
+            isEqualToForm = current.equals(content, true);
         }
 
         if (!isEqualToForm) {


### PR DESCRIPTION
Updated `ContentWizardPanel.updatePersistedItemIfNeeded()` check for regular content, by changing the `this` value for the `equals()` call, since the `content` may be of type `Site`, while the `current` is always `Content`. Calling the `Site.equals(Content)` will always return `false`, which will cause the update of the wizard.