### PR TITLE
[MS Edge] Controller Selector is not displayed in the site wizard aft…

### DIFF
--- a/src/main/resources/assets/js/app/application/ApplicationBasedCache.ts
+++ b/src/main/resources/assets/js/app/application/ApplicationBasedCache.ts
@@ -19,7 +19,7 @@ export class ApplicationBasedCache<T extends Descriptor> {
 
         const cacheName = `${api.ClassHelper.getFunctionName(descriptor)}Cache`;
 
-        if (!topWindow[cacheName]) {
+        if (!topWindow[cacheName] || api.BrowserHelper.isIE()) { // IE: Cache fails to work after frame reload (issue with freed script)
             const loadByApplication = (key: ApplicationKey) => new Request(key).sendAndParse().catch(api.DefaultErrorHandler.handle);
             topWindow[cacheName] = new ApplicationBasedCache<T>(loadByApplication);
         }

--- a/src/main/resources/assets/js/app/resource/GetPageDescriptorsByApplicationRequest.ts
+++ b/src/main/resources/assets/js/app/resource/GetPageDescriptorsByApplicationRequest.ts
@@ -29,13 +29,9 @@ export class GetPageDescriptorsByApplicationRequest
     }
 
     sendAndParse(): wemQ.Promise<PageDescriptor[]> {
-        // In case frame was reloaded in IE it can't use objects from cache
-        // as they are from old unreachable for IE frame
-        if (!api.BrowserHelper.isIE()) {
-            const cached = this.cache.getByApplication(this.applicationKey);
-            if (cached) {
-                return wemQ(cached);
-            }
+        const cached = this.cache.getByApplication(this.applicationKey);
+        if (cached) {
+            return wemQ(cached);
         }
 
         return this.send().then((response: api.rest.JsonResponse<PageDescriptorsJson>) => {


### PR DESCRIPTION
…er selecting an application #396 

-Same problem with IE as always - attempt to use code from old frame after frame reload leads to errors, now in ApplicationBasedCache. Fixed by not saving cache object in Window parent for IE