### PR TITLE
Switch to Insert tab after unselecting a component in the Page Editor…

### DIFF
--- a/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -475,7 +475,7 @@ export class LiveFormPanel
         this.pageModel.unComponentPropertyChangedEvent(this.componentPropertyChangedHandler);
         this.pageModel.onComponentPropertyChangedEvent(this.componentPropertyChangedHandler);
 
-        this.clearSelection(showPanel);
+        this.clearSelectionAndInspect(showPanel);
 
         this.handleContentUpdatedEvent();
     }
@@ -511,7 +511,7 @@ export class LiveFormPanel
         if (this.pageSkipReload === false && !this.pageLoading) {
 
             if (clearInspection) {
-                this.clearSelection(false);
+                this.clearSelectionAndInspect(false);
             }
 
             this.pageLoading = true;
@@ -642,7 +642,7 @@ export class LiveFormPanel
         });
 
         this.liveEditPageProxy.onItemViewDeselected((event: ItemViewDeselectedEvent) => {
-            this.clearSelection(false, false);
+            this.clearSelection();
         });
 
         this.liveEditPageProxy.onComponentRemoved((event: ComponentRemovedEvent) => {
@@ -651,7 +651,7 @@ export class LiveFormPanel
                 this.pageModel.initializePageFromDefault(this);
             }
 
-            this.clearSelection(true);
+            this.clearSelection();
         });
 
         this.liveEditPageProxy.onComponentViewDragDropped((event: ComponentViewDragDroppedEvent) => {
@@ -744,13 +744,22 @@ export class LiveFormPanel
         this.contextWindow.showInspectionPanel(this.pageInspectionPanel, unlocked && showWidget, unlocked && showPanel);
     }
 
-    private clearSelection(showPanel: boolean, showWidget: boolean = true): void {
-        let pageModel = this.liveEditModel.getPageModel();
-        let customizedWithController = pageModel.isCustomized() && pageModel.hasController();
-        let isFragmentContent = pageModel.getMode() === PageMode.FRAGMENT;
+    private clearSelection(showInsertables: boolean = true): boolean {
+        const pageModel = this.liveEditModel.getPageModel();
+        const customizedWithController = pageModel.isCustomized() && pageModel.hasController();
+        const isFragmentContent = pageModel.getMode() === PageMode.FRAGMENT;
         if (pageModel.hasDefaultPageTemplate() || customizedWithController || isFragmentContent) {
-            this.contextWindow.clearSelection();
-            this.inspectPage(showPanel, showWidget);
+            this.contextWindow.clearSelection(showInsertables);
+            return true;
+        }
+
+        return false;
+    }
+
+    private clearSelectionAndInspect(showPanel: boolean) {
+        const cleared = this.clearSelection(false);
+        if (cleared) {
+            this.inspectPage(showPanel, true);
         } else {
             this.inspectPage(false);
         }

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/ContextWindow.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/ContextWindow.ts
@@ -94,7 +94,7 @@ export class ContextWindow extends api.ui.panel.DockedPanel {
         }
     }
 
-    public clearSelection() {
+    public clearSelection(showInsertables?: boolean) {
         this.inspectionsPanel.clearInspection();
 
         const isPageInspectionPanelSelectable = this.isPanelSelectable(this.inspectionsPanel.getPanelShown());
@@ -104,7 +104,7 @@ export class ContextWindow extends api.ui.panel.DockedPanel {
             this.inspectTab.setLabel(this.getShownPanelName());
 
             const selectDefault = !isPageInspectionPanelSelectable && this.inspectTab.isActive();
-            if (selectDefault) {
+            if (showInsertables || selectDefault) {
                 this.selectPanel(this.insertablesPanel);
             }
         }


### PR DESCRIPTION
… #381

Moved inspection events from the `clearSelection` to the separate function.
Updated `ContextWindow.clearSelection()` method to be able to choose, if the switch to the Insertables panel needed or not.