### PR TITLE
Don't open closed Context panel after save #384

### DIFF
--- a/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -633,11 +633,11 @@ export class LiveFormPanel
 
         this.liveEditPageProxy.onItemViewSelected((event: ItemViewSelectedEvent) => {
             const itemView = event.getItemView();
-            const rightClicked = event.isRightClicked();
-            const restoredSelection = event.isRestoredSelection();
+            const defaultClicked = !event.isRightClicked();
+            const newSelection = !event.isRestoredSelection();
 
             if (api.ObjectHelper.iFrameSafeInstanceOf(itemView, ComponentView)) {
-                this.inspectComponent(<ComponentView<Component>>itemView, !restoredSelection, !rightClicked);
+                this.inspectComponent(<ComponentView<Component>>itemView, newSelection, newSelection && defaultClicked);
             }
         });
 


### PR DESCRIPTION
Fixed inspection event options, fired after the selection is restored.