### PR TITLE
Browser spellchecker disabled for html-area #391

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -820,7 +820,8 @@ class HtmlEditorConfigBuilder {
                 StyleHelper.STYLE.ALIGNMENT.JUSTIFY.CLASS],
             disallowedContent: 'img[width,height]',
             uploadUrl: api.util.UriHelper.getRestUri('content/createMedia'),
-            sharedSpaces: this.editorParams.isInline() ? {top: this.editorParams.getFixedToolbarContainer()} : null
+            sharedSpaces: this.editorParams.isInline() ? {top: this.editorParams.getFixedToolbarContainer()} : null,
+            disableNativeSpellChecker: false
         };
 
         if (!this.isToolExcluded('Code')) {


### PR DESCRIPTION
-By default, browser native spell check functionality is disabled in the editor. Enabled it