### PR TITLE
Image Editor - tooltip remains on the page after rotating of flipping…

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageEditor.ts
@@ -868,6 +868,13 @@ export class ImageEditor
         this.mirrorButton.setEnabled(value);
         this.editCropButton.setEnabled(value);
         this.editFocusButton.setEnabled(value);
+        if (!value) {
+            this.disableButtonsTooltip();
+        }
+    }
+
+    private disableButtonsTooltip() {
+        wemjq('.button-rotate, .button-mirror').mouseleave();
     }
 
     private rotate90() {


### PR DESCRIPTION
… the image #529

-Disabling buttons suppresses mouseleave events that supposed to remove tooltip