### PR TITLE
'Publish...' should be the default action for content in Deleted stat…

### DIFF
--- a/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -594,11 +594,20 @@ export class ContentBrowsePanel
             showCreateIssueButtonByDefault: true
         });
 
-        this.treeGrid.onSelectionChanged(
-            (currentSel: TreeNode<ContentSummaryAndCompareStatus>[], fullSel: TreeNode<ContentSummaryAndCompareStatus>[],
-             highlighted: boolean) => {
-                return contentPublishMenuButton.setItem(fullSel.length === 1 ? fullSel[0].getData() : null);
-            });
+        let previousSelectionSize = this.treeGrid.getRoot().getFullSelection().length;
+        this.treeGrid.onSelectionChanged((
+            currentSelection: TreeNode<ContentSummaryAndCompareStatus>[],
+            fullSelection: TreeNode<ContentSummaryAndCompareStatus>[]
+        ) => {
+            const isSingleSelected = fullSelection.length === 1;
+            const hadMultipleSelection = previousSelectionSize > 1;
+
+            previousSelectionSize = fullSelection.length;
+            contentPublishMenuButton.setItem(isSingleSelected ? fullSelection[0].getData() : null);
+            if (hadMultipleSelection && isSingleSelected) {
+                contentPublishMenuButton.updateActiveClass();
+            }
+        });
 
         this.treeGrid.onHighlightingChanged(
             (item: TreeNode<ContentSummaryAndCompareStatus>) => contentPublishMenuButton.setItem(item ? item.getData() : null));

--- a/src/main/resources/assets/js/app/browse/ContentBrowsePublishMenuButton.ts
+++ b/src/main/resources/assets/js/app/browse/ContentBrowsePublishMenuButton.ts
@@ -58,7 +58,7 @@ export class ContentBrowsePublishMenuButton
         });
     }
 
-    protected updateActiveClass() {
+    updateActiveClass() {
         if (!this.item) {
             if (this.markAsReadyAction.isEnabled()) {
                 this.setActiveClass(this.markAsReadyAction.getActionClass());
@@ -67,6 +67,8 @@ export class ContentBrowsePublishMenuButton
             } else {
                 this.setActiveClass('no-item');
             }
+        } else if (this.publishAction.isEnabled() && this.isItemPendingDelete()) {
+            this.setActiveClass(this.publishAction.getActionClass());
         } else if (this.markAsReadyAction.isEnabled()) {
             this.setActiveClass(this.markAsReadyAction.getActionClass());
         } else if (this.publishAction.isEnabled()) {

--- a/src/main/resources/assets/js/app/browse/ContentPublishMenuButton.ts
+++ b/src/main/resources/assets/js/app/browse/ContentPublishMenuButton.ts
@@ -3,7 +3,6 @@ import {IssueStatus} from '../issue/IssueStatus';
 import {IssueDialogsManager} from '../issue/IssueDialogsManager';
 import {Issue} from '../issue/Issue';
 import {ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
-import {IssueType} from '../issue/IssueType';
 import MenuButton = api.ui.button.MenuButton;
 import Action = api.ui.Action;
 import MenuButtonProgressBarManager = api.ui.button.MenuButtonProgressBarManager;
@@ -167,7 +166,7 @@ export class ContentPublishMenuButton
     }
 
     private handleActionsUpdated() {
-        const actionUpdatedHandler: () => void = api.util.AppHelper.debounce(() => {
+        const actionUpdatedHandler = api.util.AppHelper.debounce(() => {
             this.updateActiveClass();
         }, 50);
 
@@ -178,7 +177,11 @@ export class ContentPublishMenuButton
         }));
     }
 
-    protected updateActiveClass() {
+    protected isItemPendingDelete(): boolean {
+        return this.item != null && this.item.isPendingDelete();
+    }
+
+    updateActiveClass() {
         if (this.markAsReadyAction.isEnabled()) {
             this.setActiveClass(this.markAsReadyAction.getActionClass());
         } else if (this.publishAction.isEnabled()) {

--- a/src/main/resources/assets/js/app/browse/ContentWizardPublishMenuButton.ts
+++ b/src/main/resources/assets/js/app/browse/ContentWizardPublishMenuButton.ts
@@ -1,10 +1,10 @@
 import {Issue} from '../issue/Issue';
 import {IssueType} from '../issue/IssueType';
 import {ContentPublishMenuAction, ContentPublishMenuButton, ContentPublishMenuButtonConfig} from './ContentPublishMenuButton';
+import {IssueDialogsManager} from '../issue/IssueDialogsManager';
 import Action = api.ui.Action;
 import ActionButton = api.ui.button.ActionButton;
 import ContentId = api.content.ContentId;
-import {IssueDialogsManager} from '../issue/IssueDialogsManager';
 
 export interface ContentWizardPublishMenuButtonConfig extends ContentPublishMenuButtonConfig {
     openRequestAction: Action;
@@ -69,8 +69,10 @@ export class ContentWizardPublishMenuButton
         });
     }
 
-    protected updateActiveClass() {
-        if (this.openRequestAction.isEnabled()) {
+    updateActiveClass() {
+        if (this.isItemPendingDelete() && this.publishAction.isEnabled()) {
+            this.setActiveClass(this.publishAction.getActionClass());
+        } else if (this.openRequestAction.isEnabled()) {
             this.setActiveClass(this.openRequestAction.getActionClass());
         } else {
             super.updateActiveClass();

--- a/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatus.ts
+++ b/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatus.ts
@@ -2,6 +2,7 @@ import UploadItem = api.ui.uploader.UploadItem;
 import ContentSummary = api.content.ContentSummary;
 import ContentPath = api.content.ContentPath;
 import ContentId = api.content.ContentId;
+import ContentSummaryBuilder = api.content.ContentSummaryBuilder;
 import {CompareStatus, CompareStatusChecker, CompareStatusFormatter} from './CompareStatus';
 import {PublishStatus, PublishStatusFormatter} from '../publish/PublishStatus';
 
@@ -187,5 +188,16 @@ export class ContentSummaryAndCompareStatus
 
     isNew(): boolean {
         return CompareStatusChecker.isNew(this.getCompareStatus());
+    }
+
+    clone(): ContentSummaryAndCompareStatus {
+        const contentSummary = new ContentSummaryBuilder(this.getContentSummary()).build();
+        const clone = ContentSummaryAndCompareStatus.fromContentAndCompareAndPublishStatus(
+            contentSummary,
+            this.compareStatus,
+            this.publishStatus
+        );
+        clone.setReadOnly(this.readOnly);
+        return clone;
     }
 }

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -886,8 +886,12 @@ export class ContentWizardPanel
     }
 
     private updateContent(compareStatus: CompareStatus) {
-        this.persistedContent = this.currentContent.setCompareStatus(compareStatus);
-        this.getMainToolbar().setItem(this.currentContent);
+        const newContent = this.currentContent.clone();
+        newContent.setCompareStatus(compareStatus);
+
+        this.currentContent = newContent;
+        this.persistedContent = newContent;
+        this.getMainToolbar().setItem(newContent);
         this.updateWorkflowStateIcons();
 
         this.wizardActions.refreshPendingDeleteDecorations();
@@ -1003,7 +1007,8 @@ export class ContentWizardPanel
         const publishOrUnpublishHandler = (contents: ContentSummaryAndCompareStatus[]) => {
             contents.forEach(content => {
                 if (this.isCurrentContentId(content.getContentId())) {
-                    this.persistedContent = this.currentContent = content;
+                    this.currentContent = content;
+                    this.persistedContent = content;
                     this.getMainToolbar().setItem(content);
                     this.updateWorkflowStateIcons();
                     this.refreshScheduleWizardStep();
@@ -1150,7 +1155,8 @@ export class ContentWizardPanel
     }
 
     private setUpdatedContent(updatedContent: ContentSummaryAndCompareStatus) {
-        this.persistedContent = this.currentContent = updatedContent;
+        this.currentContent = updatedContent;
+        this.persistedContent = updatedContent;
         this.getMainToolbar().setItem(updatedContent);
         this.updateWorkflowStateIcons();
         this.contextSplitPanel.setContent(updatedContent);
@@ -1371,10 +1377,10 @@ export class ContentWizardPanel
 
     private updatePersistedContent(persistedContent: Content) {
         return ContentSummaryAndCompareStatusFetcher.fetchByContent(persistedContent).then((summaryAndStatus) => {
-            this.persistedContent = this.currentContent = summaryAndStatus;
-
+            this.currentContent = summaryAndStatus;
+            this.persistedContent = summaryAndStatus;
+            this.getMainToolbar().setItem(summaryAndStatus);
             this.getWizardHeader().toggleNameGeneration(this.currentContent.getCompareStatus() === CompareStatus.NEW);
-            this.getMainToolbar().setItem(this.currentContent);
             this.updateWorkflowStateIcons();
             new IsAuthenticatedRequest().sendAndParse().then((loginResult: LoginResult) => {
                 const userCanPublish: boolean = this.isContentPublishableByUser(loginResult);
@@ -2342,9 +2348,7 @@ export class ContentWizardPanel
 
             } else {
                 if (this.currentContent === this.persistedContent) {
-                    this.currentContent =
-                        ContentSummaryAndCompareStatus.fromContentAndCompareAndPublishStatus(this.persistedContent.getContentSummary(),
-                            this.persistedContent.getCompareStatus(), this.persistedContent.getPublishStatus());
+                    this.currentContent = this.persistedContent.clone();
                 }
                 if (publishControls.isOnline()) {
                     this.currentContent.setCompareStatus(CompareStatus.NEWER);


### PR DESCRIPTION
…e #692

* Updated action button switch in the ContentPublishMenuButton, making 'Publish' the default action, when content is in status 'pending delete'.
* Added update of the menu button, when items in the grid were deselected.
* Removed side effects from the ContentWizardPanel, when updating content in the toolbar.