### PR TITLE
Don't show confirmation when marking a single item is ready #711

### DIFF
--- a/src/main/resources/assets/js/app/wizard/action/MarkAsReadyAction.ts
+++ b/src/main/resources/assets/js/app/wizard/action/MarkAsReadyAction.ts
@@ -12,7 +12,7 @@ export class MarkAsReadyAction
 
         this.wizard = wizard;
 
-        this.onExecuted(this.handleExecuted.bind(this));
+        this.onExecuted(() => this.handleExecuted());
     }
 
     private handleExecuted() {

--- a/src/main/resources/i18n/phrases.properties
+++ b/src/main/resources/i18n/phrases.properties
@@ -83,6 +83,7 @@ notify.item.duplicated=Item "{0}" is duplicated.
 notify.item.saved=Item "{0}" is saved.
 notify.item.savedUnnamed=Item is saved.
 notify.item.isMarkedAsReady=Item {0} is marked as ready
+notify.item.isMarkedAsReady.multiple={0} items are marked as ready
 notify.issue.status=The issue is {0}.
 notify.issue.closed=Issue "{0}" is closed.
 notify.issue.closeError=Failed to close issue "{0}".
@@ -307,7 +308,7 @@ dialog.newIssue=New Issue
 dialog.image.style.apply=Apply style
 dialog.template.change=Switching to a page template will discard all of the custom changes made to the page. Are you sure?
 dialog.controller.change=Changing a page controller will result in losing changes made to the page. Are you sure?
-dialog.markAsReady.question=Are you sure you want to mark the item(s) as ready?
+dialog.markAsReady.question=Are you sure you want to mark the items as ready?
 
 #
 #    HTML Area Dialogs

--- a/src/main/resources/i18n/phrases_ru.properties
+++ b/src/main/resources/i18n/phrases_ru.properties
@@ -83,6 +83,7 @@ notify.item.duplicated=Элемент "{0}" скопирован.
 notify.item.saved=Элемент "{0}" сохранен.
 notify.item.savedUnnamed=Элемент сохранен.
 notify.item.isMarkedAsReady=Контент {0} помечен как готовый к публикации
+notify.item.isMarkedAsReady.multiple={0} элементов помечено готовыми к публикации
 notify.issue.status=Задание {0}.
 notify.issue.closed=Задание "{0}" закрыто.
 notify.issue.closeError=Не удалось закрыть задание "{0}".


### PR DESCRIPTION
Updated browse panel MarkAsReady action, removing confirmation, when single item is selected.