### PR TITLE
"In progress" icon blinks when saving a new content #732

### DIFF
--- a/src/main/resources/assets/js/app/ContentStatusToolbar.ts
+++ b/src/main/resources/assets/js/app/ContentStatusToolbar.ts
@@ -19,7 +19,7 @@ export class ContentStatusToolbar
         statusWrapper.appendChildren(this.status, this.author);
     }
 
-    setItem(item: ContentSummaryAndCompareStatus, silent?: boolean) {
+    setItem(item: ContentSummaryAndCompareStatus) {
         if (item && !item.equals(this.getItem())) {
             const content = ContentSummaryAndCompareStatus
                 .fromContentAndCompareStatus(item.getContentSummary(), item.getCompareStatus())

--- a/src/main/resources/assets/js/app/ContentStatusToolbar.ts
+++ b/src/main/resources/assets/js/app/ContentStatusToolbar.ts
@@ -19,13 +19,14 @@ export class ContentStatusToolbar
         statusWrapper.appendChildren(this.status, this.author);
     }
 
-    setItem(item: ContentSummaryAndCompareStatus) {
+    setItem(item: ContentSummaryAndCompareStatus, silent?: boolean) {
         if (item && !item.equals(this.getItem())) {
             const content = ContentSummaryAndCompareStatus
                 .fromContentAndCompareStatus(item.getContentSummary(), item.getCompareStatus())
                 .setPublishStatus(item.getPublishStatus());
+            const isValid = content.getContentSummary() && content.getContentSummary().isValid();
             super.setItem(content);
-            this.toggleValid(content.getContentSummary() && content.getContentSummary().isValid());
+            this.toggleValid(isValid);
             this.updateStatus(content);
             this.updateAuthor(content);
         }

--- a/src/main/resources/assets/js/app/wizard/ContentWizardToolbar.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardToolbar.ts
@@ -20,6 +20,7 @@ export class ContentWizardToolbar
     private stateElement: api.dom.Element;
     private hasUnsavedChanges: boolean;
     private isValid: boolean;
+    private skipNextIconStateUpdate: boolean;
 
     constructor(application: Application, actions: ContentWizardActions, item?: ContentSummaryAndCompareStatus) {
         super('content-wizard-toolbar');
@@ -45,6 +46,10 @@ export class ContentWizardToolbar
     setHasUnsavedChanges(value: boolean) {
         this.hasUnsavedChanges = value;
         this.updateStateIconElement();
+    }
+
+    setSkipNextIconStateUpdate(skipIconStateUpdate: boolean) {
+        this.skipNextIconStateUpdate = skipIconStateUpdate;
     }
 
     private addHomeButton(application: Application) {
@@ -120,6 +125,11 @@ export class ContentWizardToolbar
     }
 
     private updateStateIconElement() {
+        if (this.skipNextIconStateUpdate) {
+            this.skipNextIconStateUpdate = false;
+            return;
+        }
+
         const isReady: boolean = this.isValid && !this.hasUnsavedChanges && this.isContentReady();
         const isInProgress: boolean = this.isValid && (this.hasUnsavedChanges || this.isContentInProgress());
         this.stateElement.getEl().removeAttribute('title');


### PR DESCRIPTION
Added ignore of the status icon update in case, when content was unnamed, but later was saved with a new name and displayName (server generates two sequential node update events).