### PR TITLE
Dropdown of the Publish button is not closed after action is selected…

### DIFF
--- a/src/main/resources/assets/js/app/browse/ContentWizardPublishMenuButton.ts
+++ b/src/main/resources/assets/js/app/browse/ContentWizardPublishMenuButton.ts
@@ -2,6 +2,7 @@ import {Issue} from '../issue/Issue';
 import {IssueType} from '../issue/IssueType';
 import {ContentPublishMenuAction, ContentPublishMenuButton, ContentPublishMenuButtonConfig} from './ContentPublishMenuButton';
 import {IssueDialogsManager} from '../issue/IssueDialogsManager';
+import {BasePublishAction} from '../wizard/action/BasePublishAction';
 import Action = api.ui.Action;
 import ActionButton = api.ui.button.ActionButton;
 import ContentId = api.content.ContentId;
@@ -23,6 +24,7 @@ export class ContentWizardPublishMenuButton
 
     constructor(config: ContentWizardPublishMenuButtonConfig) {
         super(config);
+        this.initMenuActionsListeners();
     }
 
     protected initMenuActions(config: ContentWizardPublishMenuButtonConfig) {
@@ -35,6 +37,32 @@ export class ContentWizardPublishMenuButton
         });
     }
 
+    protected initButtons() {
+        super.initButtons();
+        this.openRequestButton = new ActionButton(this.openRequestAction.getAction());
+    }
+
+    protected initMenuActionsListeners() {
+        const actionsWithSaveBeforeExecution: BasePublishAction[] = [
+            <BasePublishAction>this.publishAction.getAction(),
+            <BasePublishAction>this.requestPublishAction.getAction()
+        ];
+        actionsWithSaveBeforeExecution.forEach(action => {
+            action.onBeforeExecute(() => {
+                if (action.mustSaveBeforeExecution()) {
+                    this.hideDropdown();
+                }
+            });
+        });
+    }
+
+    doRender(): Q.Promise<boolean> {
+        return super.doRender().then((rendered: boolean) => {
+            this.openRequestButton.addClass('open-request-action-button');
+            return rendered;
+        });
+    }
+
     protected getActions(): Action[] {
         return [
             this.markAsReadyAction.getAction(),
@@ -44,18 +72,6 @@ export class ContentWizardPublishMenuButton
             this.openRequestAction.getAction(),
             this.createIssueAction.getAction()
         ];
-    }
-
-    protected initButtons() {
-        super.initButtons();
-        this.openRequestButton = new ActionButton(this.openRequestAction.getAction());
-    }
-
-    doRender(): Q.Promise<boolean> {
-        return super.doRender().then((rendered: boolean) => {
-            this.openRequestButton.addClass('open-request-action-button');
-            return rendered;
-        });
     }
 
     protected getButtons(): ActionButton[] {

--- a/src/main/resources/assets/js/app/wizard/action/BasePublishAction.ts
+++ b/src/main/resources/assets/js/app/wizard/action/BasePublishAction.ts
@@ -21,10 +21,10 @@ export abstract class BasePublishAction extends api.ui.Action {
         this.setEnabled(false);
 
         const callback = () => {
-            if (config.wizard.hasUnsavedChanges() || this.isSaveRequired()) {
+            if (this.mustSaveBeforeExecution()) {
 
                 this.setEnabled(false);
-                config.wizard.saveChanges().then((content) => {
+                this.config.wizard.saveChanges().then((content) => {
                     if (content) {
                         this.firePromptEvent();
                     }
@@ -59,5 +59,9 @@ export abstract class BasePublishAction extends api.ui.Action {
 
     protected isSaveRequired(): boolean {
         return false;
+    }
+
+    mustSaveBeforeExecution(): boolean {
+        return this.config.wizard.hasUnsavedChanges() || this.isSaveRequired();
     }
 }


### PR DESCRIPTION
… #750

Added manual dropdown hide for all BasePublishAction if the save is required since the action will be disabled during the save, which is preventing menu hiding from default handlers.