### PR TITLE
Display layer icon/item details for local items in the Layers widget #772

### DIFF
--- a/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatusViewer.ts
+++ b/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatusViewer.ts
@@ -14,7 +14,7 @@ export class ContentSummaryAndCompareStatusViewer
 
         if (contentSummary) {
             const language = contentSummary.getLanguage();
-            const languageStr = language ? `<el>(${language})</el>` : '';
+            const languageStr = language ? `<span>(${language})</span>` : '';
             return contentSummary.getDisplayName() + languageStr;
         }
 

--- a/src/main/resources/assets/js/app/layer/ContentOfLayerViewer.ts
+++ b/src/main/resources/assets/js/app/layer/ContentOfLayerViewer.ts
@@ -1,37 +1,26 @@
 import {ContentLayer} from '../content/ContentLayer';
-import {LayerViewer} from './LayerViewer';
 import {ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
-import ContentPath = api.content.ContentPath;
+import {ContentSummaryAndCompareStatusViewer} from '../content/ContentSummaryAndCompareStatusViewer';
+import {LayerIcon} from './LayerIcon';
 
 
 export class ContentOfLayerViewer
-    extends LayerViewer {
+    extends ContentSummaryAndCompareStatusViewer {
 
-    protected content: ContentSummaryAndCompareStatus;
+    protected layer: ContentLayer;
 
     constructor() {
-        super('content-of-layer-viewer');
+        super();
+        this.addClass('content-of-layer-viewer');
     }
 
-    setObjects(object: ContentLayer, content: ContentSummaryAndCompareStatus) {
-        this.content = content;
+    setObjects(object: ContentSummaryAndCompareStatus, layer: ContentLayer) {
+        this.layer = layer;
         return this.setObject(object);
     }
 
-    resolveDisplayName(object: ContentLayer): string {
-        return `${object.getDisplayName()} (${object.getName()})`;
-    }
-
-    resolveSubName(): string {
-        if (this.content && this.content.getContentSummary()) {
-            const contentSummary = this.content.getContentSummary();
-            const contentName = contentSummary.getName();
-            return !contentName.isUnnamed() ? contentSummary.getPath().toString() :
-                   ContentPath.fromParent(contentSummary.getPath().getParentPath(),
-                       api.content.ContentUnnamed.prettifyUnnamed()).toString();
-        }
-
-        return '';
+    resolveIconEl(object: ContentSummaryAndCompareStatus): api.dom.Element {
+        return this.layer ? new LayerIcon(this.layer.getLanguage()) : null;
     }
 
 }

--- a/src/main/resources/assets/js/app/layer/ContentOfLayerViewer.ts
+++ b/src/main/resources/assets/js/app/layer/ContentOfLayerViewer.ts
@@ -1,0 +1,37 @@
+import {ContentLayer} from '../content/ContentLayer';
+import {LayerViewer} from './LayerViewer';
+import {ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
+import ContentPath = api.content.ContentPath;
+
+
+export class ContentOfLayerViewer
+    extends LayerViewer {
+
+    protected content: ContentSummaryAndCompareStatus;
+
+    constructor() {
+        super('content-of-layer-viewer');
+    }
+
+    setObjects(object: ContentLayer, content: ContentSummaryAndCompareStatus) {
+        this.content = content;
+        return this.setObject(object);
+    }
+
+    resolveDisplayName(object: ContentLayer): string {
+        return `${object.getDisplayName()} (${object.getName()})`;
+    }
+
+    resolveSubName(): string {
+        if (this.content && this.content.getContentSummary()) {
+            const contentSummary = this.content.getContentSummary();
+            const contentName = contentSummary.getName();
+            return !contentName.isUnnamed() ? contentSummary.getPath().toString() :
+                   ContentPath.fromParent(contentSummary.getPath().getParentPath(),
+                       api.content.ContentUnnamed.prettifyUnnamed()).toString();
+        }
+
+        return '';
+    }
+
+}

--- a/src/main/resources/assets/js/app/view/context/widget/layers/LayersWidgetStateView.ts
+++ b/src/main/resources/assets/js/app/view/context/widget/layers/LayersWidgetStateView.ts
@@ -1,11 +1,16 @@
+import H6El = api.dom.H6El;
+import SpanEl = api.dom.SpanEl;
+import ActionButton = api.ui.button.ActionButton;
+import DivEl = api.dom.DivEl;
+
 export abstract class LayersWidgetStateView
-    extends api.dom.DivEl {
+    extends DivEl {
 
-    protected header: api.dom.Element;
+    protected header: H6El;
 
-    protected subHeader: api.dom.Element;
+    protected subHeader: SpanEl;
 
-    protected button: api.ui.button.ActionButton;
+    protected button: ActionButton;
 
     protected constructor(className: string) {
         super(className);
@@ -14,14 +19,14 @@ export abstract class LayersWidgetStateView
     }
 
     protected initElements() {
-        this.header = new api.dom.H6El('header');
+        this.header = new H6El('header');
         this.header.setHtml(this.getHeaderText());
-        this.subHeader = new api.dom.SpanEl('sub-header');
+        this.subHeader = new SpanEl('sub-header');
         this.subHeader.setHtml(this.getSubHeaderText());
-        this.button = new api.ui.button.ActionButton(this.getAction());
+        this.button = new ActionButton(this.getAction());
     }
 
-    doRender(): Q.Promise<boolean> {
+    doRender(): wemQ.Promise<boolean> {
         return super.doRender().then((rendered: boolean) => {
             this.doAppendChildren();
 

--- a/src/main/resources/assets/js/app/view/context/widget/layers/LayersWidgetStateViewLocal.ts
+++ b/src/main/resources/assets/js/app/view/context/widget/layers/LayersWidgetStateViewLocal.ts
@@ -16,7 +16,7 @@ export class LayersWidgetStateViewLocal
         super('local');
 
         this.item = item;
-        this.viewer.setObjects(LayerContext.get().getCurrentLayer(), this.item);
+        this.viewer.setObjects(this.item, LayerContext.get().getCurrentLayer());
     }
 
     protected initElements() {

--- a/src/main/resources/assets/js/app/view/context/widget/layers/LayersWidgetStateViewLocal.ts
+++ b/src/main/resources/assets/js/app/view/context/widget/layers/LayersWidgetStateViewLocal.ts
@@ -1,10 +1,14 @@
 import {LayersWidgetStateView} from './LayersWidgetStateView';
 import {ContentSummaryAndCompareStatus} from '../../../../content/ContentSummaryAndCompareStatus';
 import {ContentDeletePromptEvent} from '../../../../browse/ContentDeletePromptEvent';
+import {LayerContext} from '../../../../layer/LayerContext';
+import {ContentOfLayerViewer} from '../../../../layer/ContentOfLayerViewer';
 import i18n = api.util.i18n;
 
 export class LayersWidgetStateViewLocal
     extends LayersWidgetStateView {
+
+    private viewer: ContentOfLayerViewer;
 
     private item: ContentSummaryAndCompareStatus;
 
@@ -12,10 +16,18 @@ export class LayersWidgetStateViewLocal
         super('local');
 
         this.item = item;
+        this.viewer.setObjects(LayerContext.get().getCurrentLayer(), this.item);
     }
 
-    protected getHeaderText(): string {
-        return i18n('widget.layers.header.local');
+    protected initElements() {
+        super.initElements();
+        this.viewer = new ContentOfLayerViewer();
+    }
+
+    protected doAppendChildren() {
+        this.appendChild(this.viewer);
+        this.appendChild(this.subHeader);
+        this.appendChild(this.button);
     }
 
     protected getSubHeaderText(): string {

--- a/src/main/resources/assets/styles/browse/content-tree-grid.less
+++ b/src/main/resources/assets/styles/browse/content-tree-grid.less
@@ -19,8 +19,7 @@
       opacity: 0.5;
     }
 
-    .@{_COMMON_PREFIX}main-name el {
-      margin-left: 5px;
+    .@{_COMMON_PREFIX}main-name span {
       color: @admin-font-gray2;
     }
 
@@ -34,7 +33,7 @@
             color: @admin-white;
           }
 
-          .@{_COMMON_PREFIX}main-name el {
+          .@{_COMMON_PREFIX}main-name span {
             color: @admin-font-gray;
           }
         }

--- a/src/main/resources/assets/styles/content/content-summary-and-compare-status-viewer.less
+++ b/src/main/resources/assets/styles/content/content-summary-and-compare-status-viewer.less
@@ -1,0 +1,5 @@
+.content-summary-and-compare-status-viewer {
+  .@{_COMMON_PREFIX}main-name > span::before {
+    content: ' ';
+  }
+}

--- a/src/main/resources/assets/styles/main.less
+++ b/src/main/resources/assets/styles/main.less
@@ -21,6 +21,7 @@
 @import "view/context/context-split-panel";
 @import "view/context/widget-view";
 @import "view/context/widget-version";
+@import "view/context/widget-layers";
 @import "view/context/widget-dependency";
 @import "view/context/widget-details";
 @import "view/context/widget-emulator";

--- a/src/main/resources/assets/styles/main.less
+++ b/src/main/resources/assets/styles/main.less
@@ -29,6 +29,7 @@
 @import "browse/content-tree-grid";
 @import "browse/content-tree-grid-toolbar";
 @import "browse/sort-content-dialog";
+@import "content/content-summary-and-compare-status-viewer";
 @import "new/new-content-dialog";
 @import "wizard/compare-content-grid";
 @import "wizard/content-wizard-toolbar";

--- a/src/main/resources/assets/styles/view/context/widget-layers.less
+++ b/src/main/resources/assets/styles/view/context/widget-layers.less
@@ -1,0 +1,44 @@
+.widget-view.layers-widget {
+  .layers-widget-item-view {
+
+    .header {
+      margin-bottom: 10px;
+      padding: 5px;
+      text-align: center;
+      font-size: 16px;
+    }
+
+    .sub-header {
+      display: inline-block;
+    }
+
+    .local {
+      button {
+        .button(@form-button-font, @input-red-text);
+      }
+    }
+
+    .inherited {
+      button {
+        .button(@form-button-font, @admin-button-blue2);
+      }
+    }
+
+    .local,
+    .inherited,
+    .multi-layers {
+      button {
+        display: block;
+        width: 100%;
+        height: 28px;
+        margin: 15px auto 0;
+        text-align: center;
+      }
+    }
+
+    .local .content-of-layer-viewer,
+    .multi-layers .layer-viewer {
+      margin-bottom: 15px;
+    }
+  }
+}

--- a/src/main/resources/assets/styles/view/context/widget-view.less
+++ b/src/main/resources/assets/styles/view/context/widget-view.less
@@ -51,49 +51,5 @@
       position: relative;
     }
 
-    .layers-widget-item-view {
-      text-align: center;
-
-      .header {
-        font-size: 16px;
-        padding: 5px;
-        margin: 5px auto 10px auto;
-        width: 80%;
-      }
-
-      .sub-header {
-        padding: 5px;
-        display: inline-block;
-      }
-
-      button {
-        display: block !important;
-        margin: 15px auto 10px auto !important;
-        width: 80%;
-        height: 28px;
-      }
-
-      .local {
-        button {
-          .button(@form-button-font, @input-red-text);
-        }
-      }
-
-      .inherited {
-        button {
-          .button(@form-button-font, @admin-button-blue2);
-        }
-      }
-
-      .multi-layers {
-        .layer-viewer {
-          padding: 5px;
-          width: 80%;
-          margin: auto;
-          text-align: left;
-        }
-      }
-    }
-
   }
 }

--- a/src/main/resources/i18n/phrases.properties
+++ b/src/main/resources/i18n/phrases.properties
@@ -434,7 +434,6 @@ widget.layers.button.create=Create Layer
 widget.layers.button.settings=Layer settings
 widget.layers.header.inherited=Inherited item
 widget.layers.subheader.inherited=The item is inherited from parent layer. Click edit to create a local copy
-widget.layers.header.local=Local copy
 widget.layers.subheader.local=The item overwrites the parent layer item. Click delete to restore the parent version
 
 #


### PR DESCRIPTION
* Updated layers widget view styling.
* Added content and layer viewer to the head of the local item.
* Replaced `<el>` with `<span>` and `margin` with whitespace in the `::before` to match the current font size and width.