### PR TITLE
Content should remain in state "Ready" after page component(s) were s…

### DIFF
--- a/src/main/resources/assets/js/app/page/Page.ts
+++ b/src/main/resources/assets/js/app/page/Page.ts
@@ -16,6 +16,8 @@ import {LayoutComponentType} from './region/LayoutComponentType';
 import {ComponentTypeWrapperJson} from './region/ComponentTypeWrapperJson';
 import {ComponentFactory} from './region/ComponentFactory';
 import {PageJson} from './PageJson';
+import {ComponentPath} from './region/ComponentPath';
+import {ComponentType} from './region/ComponentType';
 
 export class Page
     implements api.Equitable, api.Cloneable {
@@ -162,6 +164,60 @@ export class Page
                 return false;
             });
         });
+    }
+
+    findComponentById(id: ContentId, regions?: Region[]): Component {
+        const regionsList = regions != null ? regions : this.getRegions().getRegions();
+        for (let i = 0; i < regionsList.length; i++) {
+            const components = regionsList[i].getComponents();
+            for (let j = 0; j < components.length; j++) {
+                const component = components[j];
+                if (ObjectHelper.iFrameSafeInstanceOf(component.getType(), FragmentComponentType)) {
+                    if ((<FragmentComponent>component).getFragment().equals(id)) {
+                        return component;
+                    }
+                } else if (ObjectHelper.iFrameSafeInstanceOf(component.getType(), ImageComponentType)) {
+                    if ((<ImageComponent>component).getImage().equals(id)) {
+                        return component;
+                    }
+                } else if (ObjectHelper.iFrameSafeInstanceOf(component.getType(), LayoutComponentType)) {
+                    const layout = <LayoutComponent>component;
+                    return this.findComponentById(id, layout.getRegions().getRegions());
+                }
+            }
+        }
+
+        return null;
+    }
+
+    findComponentByPath(componentPath: ComponentPath, regions?: Region[]): Component {
+        if (componentPath == null) {
+            return null;
+        }
+
+        const regionsList = regions != null ? regions : this.getRegions().getRegions();
+
+        for (let i = 0; i < regionsList.length; i++) {
+            const regionPath = `${regionsList[i].getPath().toString()}/`;
+            if (componentPath.toString().indexOf(regionPath) !== 0) {
+                continue;
+            }
+
+            const components = regionsList[i].getComponents();
+            for (let j = 0; j < components.length; j++) {
+                const component = components[j];
+                if (ObjectHelper.iFrameSafeInstanceOf(component.getType(), ComponentType)) {
+                    if ((<Component>component).getPath().equals(componentPath)) {
+                        return component;
+                    }
+                } else if (ObjectHelper.iFrameSafeInstanceOf(component.getType(), LayoutComponentType)) {
+                    const layout = <LayoutComponent>component;
+                    return this.findComponentByPath(componentPath, layout.getRegions().getRegions());
+                }
+            }
+        }
+
+        return null;
     }
 }
 

--- a/src/main/resources/assets/js/app/page/Page.ts
+++ b/src/main/resources/assets/js/app/page/Page.ts
@@ -166,30 +166,6 @@ export class Page
         });
     }
 
-    findComponentById(id: ContentId, regions?: Region[]): Component {
-        const regionsList = regions != null ? regions : this.getRegions().getRegions();
-        for (let i = 0; i < regionsList.length; i++) {
-            const components = regionsList[i].getComponents();
-            for (let j = 0; j < components.length; j++) {
-                const component = components[j];
-                if (ObjectHelper.iFrameSafeInstanceOf(component.getType(), FragmentComponentType)) {
-                    if ((<FragmentComponent>component).getFragment().equals(id)) {
-                        return component;
-                    }
-                } else if (ObjectHelper.iFrameSafeInstanceOf(component.getType(), ImageComponentType)) {
-                    if ((<ImageComponent>component).getImage().equals(id)) {
-                        return component;
-                    }
-                } else if (ObjectHelper.iFrameSafeInstanceOf(component.getType(), LayoutComponentType)) {
-                    const layout = <LayoutComponent>component;
-                    return this.findComponentById(id, layout.getRegions().getRegions());
-                }
-            }
-        }
-
-        return null;
-    }
-
     findComponentByPath(componentPath: ComponentPath, regions?: Region[]): Component {
         if (componentPath == null) {
             return null;
@@ -210,7 +186,8 @@ export class Page
                     if ((<Component>component).getPath().equals(componentPath)) {
                         return component;
                     }
-                } else if (ObjectHelper.iFrameSafeInstanceOf(component.getType(), LayoutComponentType)) {
+                }
+                if (ObjectHelper.iFrameSafeInstanceOf(component.getType(), LayoutComponentType)) {
                     const layout = <LayoutComponent>component;
                     return this.findComponentByPath(componentPath, layout.getRegions().getRegions());
                 }

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -2120,7 +2120,7 @@ export class ContentWizardPanel
         return this.getSplitPanel() && this.getSplitPanel().hasClass('toggle-live');
     }
 
-    private assembleViewedContent(viewedContentBuilder: ContentBuilder, cleanFormRedundantData: boolean = false): ContentBuilder {
+    assembleViewedContent(viewedContentBuilder: ContentBuilder, cleanFormRedundantData: boolean = false): ContentBuilder {
 
         viewedContentBuilder.setName(this.resolveContentNameForUpdateRequest());
         viewedContentBuilder.setDisplayName(this.getWizardHeader().getDisplayName());

--- a/src/main/resources/assets/js/app/wizard/action/UnpublishAction.ts
+++ b/src/main/resources/assets/js/app/wizard/action/UnpublishAction.ts
@@ -6,7 +6,7 @@ import i18n = api.util.i18n;
 
 export class UnpublishAction extends BasePublishAction {
     constructor(wizard: ContentWizardPanel) {
-        super({wizard, label: i18n('action.unpublish'), omitCanPublishCheck: true});
+        super({wizard, label: i18n('action.unpublishMore'), omitCanPublishCheck: true});
     }
 
     protected createPromptEvent(summary: ContentSummaryAndCompareStatus[]): void {


### PR DESCRIPTION
…aved as fragment #787

Updated checks for the changes in the content, preventing setting the status to Ready if something, except fragment, is updated.
Updated unpublish action title in the wizard.