### PR TITLE
Modifying published content does not change default action to "Mark a…

### DIFF
--- a/src/main/resources/assets/js/app/wizard/ContentWizardToolbar.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardToolbar.ts
@@ -14,17 +14,28 @@ export class ContentWizardToolbar
     extends ContentStatusToolbar {
 
     private componentsViewToggler: TogglerButton;
+
     private cycleViewModeButton: CycleButton;
+
     private contentWizardToolbarPublishControls: ContentWizardToolbarPublishControls;
+
     private mobileItemStatisticsButton: TogglerButton;
+
     private stateElement: api.dom.Element;
+
     private hasUnsavedChanges: boolean;
+
     private isValid: boolean;
+
     private skipNextIconStateUpdate: boolean;
 
     constructor(application: Application, actions: ContentWizardActions, item?: ContentSummaryAndCompareStatus) {
         super('content-wizard-toolbar');
 
+        this.initElements(application, actions, item);
+    }
+
+    protected initElements(application: Application, actions: ContentWizardActions, item?: ContentSummaryAndCompareStatus) {
         this.addHomeButton(application);
         this.addActionButtons(actions);
         this.addPublishMenuButton(actions);
@@ -33,6 +44,7 @@ export class ContentWizardToolbar
         this.addStateIcon();
 
         if (item) {
+            this.updateCanBeMarkedAsReadyControl(true);
             this.setItem(item);
         }
     }
@@ -46,6 +58,7 @@ export class ContentWizardToolbar
     setHasUnsavedChanges(value: boolean) {
         this.hasUnsavedChanges = value;
         this.updateStateIconElement();
+        this.updateCanBeMarkedAsReadyControl();
     }
 
     setSkipNextIconStateUpdate(skipIconStateUpdate: boolean) {
@@ -122,6 +135,12 @@ export class ContentWizardToolbar
         }
 
         this.updateStateIconElement();
+        this.updateCanBeMarkedAsReadyControl();
+    }
+
+    private updateCanBeMarkedAsReadyControl(silent?: boolean) {
+        const isInProgress: boolean = this.isValid && (this.hasUnsavedChanges || this.isContentInProgress());
+        this.contentWizardToolbarPublishControls.setContentCanBeMarkedAsReady(isInProgress, !silent);
     }
 
     private updateStateIconElement() {

--- a/src/main/resources/assets/js/app/wizard/ContentWizardToolbarPublishControls.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardToolbarPublishControls.ts
@@ -21,6 +21,7 @@ export class ContentWizardToolbarPublishControls
     private userCanPublish: boolean = true;
     private isContentValid: boolean = false;
     private hasPublishRequest: boolean = false;
+    private contentCanBeMarkedAsReady: boolean = false;
     private content: ContentSummaryAndCompareStatus;
     private publishButtonForMobile: ActionButton;
 
@@ -101,6 +102,14 @@ export class ContentWizardToolbarPublishControls
         return this;
     }
 
+    setContentCanBeMarkedAsReady(value: boolean, refresh: boolean = true): ContentWizardToolbarPublishControls {
+        this.contentCanBeMarkedAsReady = value;
+        if (refresh) {
+            this.refreshState();
+        }
+        return this;
+    }
+
     refreshState() {
 
         if (!this.content) {
@@ -113,7 +122,7 @@ export class ContentWizardToolbarPublishControls
     private doRefreshState() {
         const canBePublished: boolean = !this.isOnline() && this.contentCanBePublished && this.userCanPublish;
         const canBeUnpublished: boolean = this.content.isPublished() && this.userCanPublish;
-        const canBeMarkedAsReady: boolean = this.isContentValid && !this.content.isOnline() && !this.content.getContentSummary().isReady();
+        const canBeMarkedAsReady: boolean = this.contentCanBeMarkedAsReady;
         const canBeRequestedPublish: boolean = this.isContentValid && !this.content.isOnline() && !this.content.isPendingDelete();
 
         this.publishAction.setEnabled(canBePublished);


### PR DESCRIPTION
…s Ready" #847

Updated logic to enable "Mark as ready" button, making it enabled, when content can be saved.