### PR TITLE
Ask for confirmation about creating a local copy in the Content Grid …

### DIFF
--- a/src/main/resources/assets/js/app/ContentAppBarTabId.ts
+++ b/src/main/resources/assets/js/app/ContentAppBarTabId.ts
@@ -4,20 +4,106 @@ import {LayerContext} from './layer/LayerContext';
 export class ContentAppBarTabId
     extends AppBarTabId {
 
-    static forEdit(id: string): ContentAppBarTabId {
-        return new ContentAppBarTabId('edit', id);
-    }
+    private tabMode: ContentAppBarTabMode;
 
     static forNew(id: string): ContentAppBarTabId {
-        return new ContentAppBarTabId('new', id);
+        return new ContentAppBarTabId(ContentAppBarTabMode.NEW, id);
+    }
+
+    static forBrowse(id: string): ContentAppBarTabId {
+        return new ContentAppBarTabId(ContentAppBarTabMode.BROWSE, id);
+    }
+
+    static forEdit(id: string): ContentAppBarTabId {
+        return new ContentAppBarTabId(ContentAppBarTabMode.EDIT, id);
+    }
+
+    static forView(id: string): ContentAppBarTabId {
+        return new ContentAppBarTabId(ContentAppBarTabMode.VIEW, id);
+    }
+
+    static forLocalize(id: string): ContentAppBarTabId {
+        return new ContentAppBarTabId(ContentAppBarTabMode.LOCALIZE, id);
+    }
+
+    static forIssue(id: string): ContentAppBarTabId {
+        return new ContentAppBarTabId(ContentAppBarTabMode.ISSUE, id);
+    }
+
+    static forInbound(id: string): ContentAppBarTabId {
+        return new ContentAppBarTabId(ContentAppBarTabMode.INBOUND, id);
+    }
+
+    static forOutbound(id: string): ContentAppBarTabId {
+        return new ContentAppBarTabId(ContentAppBarTabMode.OUTBOUND, id);
+    }
+
+    static forCustom(mode: string, id: string): ContentAppBarTabId {
+        return new ContentAppBarTabId(ContentAppBarTabMode.CUSTOM, id);
+    }
+
+    static fromString(mode: string, id: string): ContentAppBarTabId {
+        const modeStringUpperCase: string = mode.toLowerCase();
+
+        if (modeStringUpperCase === ContentAppBarTabMode.NEW) {
+            return this.forNew(id);
+        }
+
+        if (modeStringUpperCase === ContentAppBarTabMode.BROWSE) {
+            return this.forBrowse(id);
+        }
+
+        if (modeStringUpperCase === ContentAppBarTabMode.EDIT) {
+            return this.forEdit(id);
+        }
+
+        if (modeStringUpperCase === ContentAppBarTabMode.VIEW) {
+            return this.forView(id);
+        }
+
+        if (modeStringUpperCase === ContentAppBarTabMode.LOCALIZE) {
+            return this.forLocalize(id);
+        }
+
+        if (modeStringUpperCase === ContentAppBarTabMode.ISSUE) {
+            return this.forIssue(id);
+        }
+
+        if (modeStringUpperCase === ContentAppBarTabMode.INBOUND) {
+            return this.forInbound(id);
+        }
+
+        if (modeStringUpperCase === ContentAppBarTabMode.OUTBOUND) {
+            return this.forOutbound(id);
+        }
+
+        return this.forCustom(mode, id);
+    }
+
+    static fromMode(mode: ContentAppBarTabMode, id: string): ContentAppBarTabId {
+        return new ContentAppBarTabId(mode, id);
+    }
+
+    private constructor(tabMode: ContentAppBarTabMode, id: string, modeString?: string) {
+        if (tabMode === ContentAppBarTabMode.CUSTOM) {
+            super(modeString, id);
+        } else {
+            super(tabMode, id);
+        }
+
+        this.tabMode = tabMode;
     }
 
     isViewMode(): boolean {
-        return this.getMode() === 'view';
+        return this.tabMode === ContentAppBarTabMode.VIEW;
     }
 
     isLocalizeMode(): boolean {
-        return this.getMode() === 'localize';
+        return this.tabMode === ContentAppBarTabMode.LOCALIZE;
+    }
+
+    isBrowseMode(): boolean {
+        return this.tabMode === ContentAppBarTabMode.BROWSE;
     }
 
     toString(): string {
@@ -25,4 +111,9 @@ export class ContentAppBarTabId
 
         return `${this.getMode()}:${layer}/${this.getId()}`;
     }
+}
+
+export enum ContentAppBarTabMode {
+    NEW = 'new', BROWSE = 'browse', EDIT = 'edit', VIEW = 'view', LOCALIZE = 'localize', ISSUE = 'issue',
+    INBOUND = 'inbound', OUTBOUND = 'outbound', CUSTOM = 'custom'
 }

--- a/src/main/resources/assets/js/app/ContentAppBarTabId.ts
+++ b/src/main/resources/assets/js/app/ContentAppBarTabId.ts
@@ -8,6 +8,18 @@ export class ContentAppBarTabId
         return new ContentAppBarTabId('edit', id);
     }
 
+    static forNew(id: string): ContentAppBarTabId {
+        return new ContentAppBarTabId('new', id);
+    }
+
+    isViewMode(): boolean {
+        return this.getMode() === 'view';
+    }
+
+    isLocalizeMode(): boolean {
+        return this.getMode() === 'localize';
+    }
+
     toString(): string {
         const layer: string = LayerContext.get().getCurrentLayer().getName();
 

--- a/src/main/resources/assets/js/app/ContentAppPanel.ts
+++ b/src/main/resources/assets/js/app/ContentAppPanel.ts
@@ -14,6 +14,7 @@ import {ContentSummaryAndCompareStatus} from './content/ContentSummaryAndCompare
 import {ResolveDependenciesRequest} from './resource/ResolveDependenciesRequest';
 import {ResolveDependenciesResult} from './resource/ResolveDependenciesResult';
 import {ResolveDependencyResult} from './resource/ResolveDependencyResult';
+import {ContentAppBarTabMode} from './ContentAppBarTabId';
 import ContentId = api.content.ContentId;
 import ShowBrowsePanelEvent = api.app.ShowBrowsePanelEvent;
 import AppPanel = api.app.AppPanel;
@@ -38,11 +39,12 @@ export class ContentAppPanel
 
     private route(path?: api.rest.Path) {
         const action = path ? path.getElement(1) : null;
+        const actionAsTabMode: ContentAppBarTabMode = !!action ? ContentAppBarTabMode[action.toUpperCase()] : null;
         const id = path ? path.getElement(2) : null;
         const type = path ? path.getElement(3) : null;
 
-        switch (action) {
-        case 'edit':
+        switch (actionAsTabMode) {
+        case ContentAppBarTabMode.EDIT:
             if (id) {
                 ContentSummaryAndCompareStatusFetcher.fetch(new ContentId(id)).done(
                     (content: ContentSummaryAndCompareStatus) => {
@@ -50,7 +52,7 @@ export class ContentAppPanel
                     });
             }
             break;
-        case 'view' :
+        case ContentAppBarTabMode.VIEW :
             if (id) {
                 ContentSummaryAndCompareStatusFetcher.fetch(new ContentId(id)).done(
                     (content: ContentSummaryAndCompareStatus) => {
@@ -58,7 +60,7 @@ export class ContentAppPanel
                     });
             }
             break;
-        case 'issue' :
+        case ContentAppBarTabMode.ISSUE :
             new ShowBrowsePanelEvent().fire();
             if (id) {
                 new GetIssueRequest(id).sendAndParse().then(
@@ -67,10 +69,10 @@ export class ContentAppPanel
                     });
             }
             break;
-        case 'inbound' :
+        case ContentAppBarTabMode.INBOUND :
             this.handleDependencies(id, true, type);
             break;
-        case 'outbound' :
+        case ContentAppBarTabMode.OUTBOUND :
             this.handleDependencies(id, false, type);
             break;
         default:
@@ -144,7 +146,7 @@ export class ContentAppPanel
             (content: ContentSummaryAndCompareStatus) => {
                 new ToggleSearchPanelWithDependenciesEvent(content.getContentSummary(), inbound, type).fire();
 
-                const mode: string = inbound ? 'inbound' : 'outbound';
+                const mode: string = inbound ? ContentAppBarTabMode.INBOUND : ContentAppBarTabMode.OUTBOUND;
                 const hash: string = !!type ? `${mode}/${id}/${type}` : `${mode}/${id}`;
 
                 Router.get().setHash(hash);

--- a/src/main/resources/assets/js/app/ContentEventsProcessor.ts
+++ b/src/main/resources/assets/js/app/ContentEventsProcessor.ts
@@ -10,8 +10,11 @@ import {EditContentEvent} from './event/EditContentEvent';
 import {ContentSummaryAndCompareStatus} from './content/ContentSummaryAndCompareStatus';
 import {LayerContext} from './layer/LayerContext';
 import {ContentAppBarTabId} from './ContentAppBarTabId';
+import {ConfirmLocalContentCreateDialog} from './layer/ConfirmLocalContentCreateDialog';
 import AppBarTabId = api.app.bar.AppBarTabId;
 import i18n = api.util.i18n;
+import ContentSummary = api.content.ContentSummary;
+import ContentTypeName = api.schema.content.ContentTypeName;
 
 export class ContentEventsProcessor {
 
@@ -41,7 +44,7 @@ export class ContentEventsProcessor {
     static handleNew(newContentEvent: NewContentEvent) {
 
         let contentTypeSummary = newContentEvent.getContentType();
-        let tabId = AppBarTabId.forNew(contentTypeSummary.getName());
+        let tabId = ContentAppBarTabId.forNew(contentTypeSummary.getName());
 
         let wizardParams = new ContentWizardPanelParams()
             .setTabId(tabId)
@@ -53,24 +56,56 @@ export class ContentEventsProcessor {
     }
 
     static handleEdit(event: EditContentEvent) {
+        const inheritedContents: ContentSummaryAndCompareStatus[] = ContentEventsProcessor.getInheritedContents(event.getModels());
+        const localContents: ContentSummaryAndCompareStatus[] = ContentEventsProcessor.getLocalContents(event.getModels());
+        const hasInherited: boolean = inheritedContents.length > 0;
 
-        event.getModels().every((content: ContentSummaryAndCompareStatus) => {
+        if (hasInherited) {
+            const confirmDialog: ConfirmLocalContentCreateDialog = new ConfirmLocalContentCreateDialog();
+            confirmDialog.setYesCallback(() => {
+                this.handleEditContents(localContents, 'edit');
+                this.handleEditContents(inheritedContents, 'localize');
+            });
+            confirmDialog.setNoCallback(() => {
+                this.handleEditContents(localContents, 'edit');
+                this.handleEditContents(inheritedContents, 'view');
+            });
+            confirmDialog.open();
+        } else {
+            this.handleEditContents(event.getModels(), 'edit');
+        }
+    }
+
+    private static getInheritedContents(contents: ContentSummaryAndCompareStatus[]): ContentSummaryAndCompareStatus[] {
+        return contents.filter((content: ContentSummaryAndCompareStatus) => {
+            return content.getContentSummary().isInherited();
+        });
+    }
+
+    private static getLocalContents(contents: ContentSummaryAndCompareStatus[]): ContentSummaryAndCompareStatus[] {
+        return contents.filter((content: ContentSummaryAndCompareStatus) => {
+            return !content.getContentSummary().isInherited();
+        });
+    }
+
+    private static handleEditContents(contents: ContentSummaryAndCompareStatus[], mode: string) {
+        contents.every((content: ContentSummaryAndCompareStatus) => {
 
             if (!content || !content.getContentSummary()) {
                 return true;
             }
 
-            let contentSummary = content.getContentSummary();
-            let contentTypeName = contentSummary.getType();
+            const contentSummary: ContentSummary = content.getContentSummary();
+            const contentTypeName: ContentTypeName = contentSummary.getType();
 
-            let tabId: ContentAppBarTabId = ContentAppBarTabId.forEdit(contentSummary.getId());
+            const tabId: ContentAppBarTabId = new ContentAppBarTabId(mode, contentSummary.getId());
 
-            let wizardParams = new ContentWizardPanelParams()
+            const wizardParams: ContentWizardPanelParams = new ContentWizardPanelParams()
                 .setTabId(tabId)
                 .setContentTypeName(contentTypeName)
                 .setContentId(contentSummary.getContentId());
 
-            let win = ContentEventsProcessor.openWizardTab(wizardParams, tabId);
+            const win: Window = ContentEventsProcessor.openWizardTab(wizardParams, tabId);
 
             if (ContentEventsProcessor.popupBlocked(win)) {
                 api.notify.showWarning(i18n('notify.popupBlocker.admin'), false);

--- a/src/main/resources/assets/js/app/ContentEventsProcessor.ts
+++ b/src/main/resources/assets/js/app/ContentEventsProcessor.ts
@@ -9,7 +9,7 @@ import {ContentUpdatedEvent} from './event/ContentUpdatedEvent';
 import {EditContentEvent} from './event/EditContentEvent';
 import {ContentSummaryAndCompareStatus} from './content/ContentSummaryAndCompareStatus';
 import {LayerContext} from './layer/LayerContext';
-import {ContentAppBarTabId} from './ContentAppBarTabId';
+import {ContentAppBarTabId, ContentAppBarTabMode} from './ContentAppBarTabId';
 import {ConfirmLocalContentCreateDialog} from './layer/ConfirmLocalContentCreateDialog';
 import AppBarTabId = api.app.bar.AppBarTabId;
 import i18n = api.util.i18n;
@@ -63,16 +63,16 @@ export class ContentEventsProcessor {
         if (hasInherited) {
             const confirmDialog: ConfirmLocalContentCreateDialog = new ConfirmLocalContentCreateDialog();
             confirmDialog.setYesCallback(() => {
-                this.handleEditContents(localContents, 'edit');
-                this.handleEditContents(inheritedContents, 'localize');
+                this.handleEditContents(localContents, ContentAppBarTabMode.EDIT);
+                this.handleEditContents(inheritedContents, ContentAppBarTabMode.LOCALIZE);
             });
             confirmDialog.setNoCallback(() => {
-                this.handleEditContents(localContents, 'edit');
-                this.handleEditContents(inheritedContents, 'view');
+                this.handleEditContents(localContents, ContentAppBarTabMode.EDIT);
+                this.handleEditContents(inheritedContents, ContentAppBarTabMode.VIEW);
             });
             confirmDialog.open();
         } else {
-            this.handleEditContents(event.getModels(), 'edit');
+            this.handleEditContents(event.getModels(), ContentAppBarTabMode.EDIT);
         }
     }
 
@@ -88,7 +88,7 @@ export class ContentEventsProcessor {
         });
     }
 
-    private static handleEditContents(contents: ContentSummaryAndCompareStatus[], mode: string) {
+    private static handleEditContents(contents: ContentSummaryAndCompareStatus[], mode: ContentAppBarTabMode) {
         contents.every((content: ContentSummaryAndCompareStatus) => {
 
             if (!content || !content.getContentSummary()) {
@@ -98,7 +98,7 @@ export class ContentEventsProcessor {
             const contentSummary: ContentSummary = content.getContentSummary();
             const contentTypeName: ContentTypeName = contentSummary.getType();
 
-            const tabId: ContentAppBarTabId = new ContentAppBarTabId(mode, contentSummary.getId());
+            const tabId: ContentAppBarTabId = ContentAppBarTabId.fromMode(mode, contentSummary.getId());
 
             const wizardParams: ContentWizardPanelParams = new ContentWizardPanelParams()
                 .setTabId(tabId)
@@ -132,7 +132,7 @@ export class ContentEventsProcessor {
     }
 
     static handleShowDependencies(event: ShowDependenciesEvent) {
-        const mode: string = event.isInbound() ? 'inbound' : 'outbound';
+        const mode: string = event.isInbound() ? ContentAppBarTabMode.INBOUND : ContentAppBarTabMode.OUTBOUND;
         const id: string = event.getId().toString();
         const type: string = event.getContentType() ? event.getContentType().toString() : null;
         const layer: string = LayerContext.get().getCurrentLayer().getName();

--- a/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -27,6 +27,7 @@ import {ContentBrowsePublishMenuButton} from './ContentBrowsePublishMenuButton';
 import {ContextPanel} from '../view/context/ContextPanel';
 import {PreviewContentHandler} from './action/handler/PreviewContentHandler';
 import {LayerChangedEvent} from '../layer/LayerChangedEvent';
+import {ContentAppBarTabMode} from '../ContentAppBarTabId';
 import TreeNode = api.ui.treegrid.TreeNode;
 import BrowseItem = api.app.browse.BrowseItem;
 import UploadItem = api.ui.uploader.UploadItem;
@@ -60,7 +61,7 @@ export class ContentBrowsePanel
         super();
 
         this.onShown(() => {
-            Router.get().setHash('browse');
+            Router.get().setHash(ContentAppBarTabMode.BROWSE);
         });
 
         ResponsiveManager.onAvailableSizeChanged(this, (item: ResponsiveItem) => {

--- a/src/main/resources/assets/js/app/duplicate/ContentDuplicateDialog.ts
+++ b/src/main/resources/assets/js/app/duplicate/ContentDuplicateDialog.ts
@@ -7,11 +7,11 @@ import {ContentWizardPanelParams} from '../wizard/ContentWizardPanelParams';
 import {ContentEventsProcessor} from '../ContentEventsProcessor';
 import {ContentServerEventsHandler} from '../event/ContentServerEventsHandler';
 import {ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
+import {ContentAppBarTabId} from '../ContentAppBarTabId';
 import ManagedActionExecutor = api.managedaction.ManagedActionExecutor;
 import ListBox = api.ui.selector.list.ListBox;
 import i18n = api.util.i18n;
 import TaskState = api.task.TaskState;
-import AppBarTabId = api.app.bar.AppBarTabId;
 import ContentSummary = api.content.ContentSummary;
 
 export class ContentDuplicateDialog
@@ -228,7 +228,7 @@ export class ContentDuplicateDialog
     }
 
     private openTab(content: ContentSummary) {
-        const tabId = AppBarTabId.forEdit(content.getContentId().toString());
+        const tabId = ContentAppBarTabId.forEdit(content.getContentId().toString());
 
         const wizardParams = new ContentWizardPanelParams()
             .setTabId(tabId)

--- a/src/main/resources/assets/js/app/layer/ConfirmLocalContentCreateDialog.ts
+++ b/src/main/resources/assets/js/app/layer/ConfirmLocalContentCreateDialog.ts
@@ -1,21 +1,14 @@
-import ModalDialog = api.ui.dialog.ModalDialog;
 import i18n = api.util.i18n;
 import ModalDialogConfig = api.ui.dialog.ModalDialogConfig;
-import Action = api.ui.Action;
 import Element = api.dom.Element;
 import LocaleViewer = api.ui.locale.LocaleViewer;
 import Locale = api.locale.Locale;
 import GetLocalesRequest = api.locale.GetLocalesRequest;
+import ConfirmationDialog = api.ui.dialog.ConfirmationDialog;
 import {LayerContext} from './LayerContext';
 
 export class ConfirmLocalContentCreateDialog
-    extends ModalDialog {
-
-    private createLocalCopyAction: Action;
-
-    private localCopyCreateHandler: Function;
-
-    private cancelHandler: Function;
+    extends ConfirmationDialog {
 
     constructor() {
         super(<ModalDialogConfig>{
@@ -27,47 +20,22 @@ export class ConfirmLocalContentCreateDialog
     initElements() {
         super.initElements();
 
-        this.createLocalCopyAction =
-            new Action(i18n('dialog.layers.confirm.local.create.button', LayerContext.get().getCurrentLayer().getDisplayName()));
+        this.yesAction.setLabel(i18n('dialog.layers.confirm.local.create.button', LayerContext.get().getCurrentLayer().getDisplayName()));
     }
 
     protected initListeners() {
         super.initListeners();
-
-        this.createLocalCopyAction.onExecuted(() => {
-            this.close(false);
-
-            if (this.localCopyCreateHandler) {
-                this.localCopyCreateHandler();
-            }
-        });
     }
 
     doRender(): Q.Promise<boolean> {
         return super.doRender().then((rendered: boolean) => {
+            this.addClass('layer-dialog layer-confirm-local-content-create-dialog');
             this.appendChildToHeader(this.createSubHeader());
             this.appendChildToContentPanel(this.createBodyText());
             this.appendChildToContentPanel(this.createLocaleViewer());
-            this.addCancelButtonToBottom();
-            this.addAction(this.createLocalCopyAction, true);
 
             return rendered;
         });
-    }
-
-    close(invokeCancelHandler: boolean = true) {
-        super.close();
-        if (invokeCancelHandler) {
-            this.cancelHandler();
-        }
-    }
-
-    setLocalCopyCreateHandler(handler: Function) {
-        this.localCopyCreateHandler = handler;
-    }
-
-    setCancelHandler(handler: Function) {
-        this.cancelHandler = handler;
     }
 
     private createSubHeader(): Element {

--- a/src/main/resources/assets/js/app/layer/event/LayerServerEventsHandler.ts
+++ b/src/main/resources/assets/js/app/layer/event/LayerServerEventsHandler.ts
@@ -64,7 +64,7 @@ export class LayerServerEventsHandler {
     private handleLayersUpdated() {
         new ListContentLayerRequest().sendAndParse().then((layers: ContentLayer[]) => {
             this.updateCurrentLayer(layers);
-            this.notifyIssueUpdated(layers);
+            this.notifyLayerUpdated(layers);
         }).catch(api.DefaultErrorHandler.handle);
     }
 
@@ -125,7 +125,7 @@ export class LayerServerEventsHandler {
             });
     }
 
-    private notifyIssueUpdated(layers: ContentLayer[]) {
+    private notifyLayerUpdated(layers: ContentLayer[]) {
         this.layerUpdatedListeners.forEach((listener: (layers: ContentLayer[]) => void) => {
             listener(layers);
         });

--- a/src/main/resources/assets/js/app/remove/DeleteItemViewer.ts
+++ b/src/main/resources/assets/js/app/remove/DeleteItemViewer.ts
@@ -27,7 +27,7 @@ export class DeleteItemViewer
 
             const contentSummary = this.getObject().getContentSummary();
 
-            let tabId = new ContentAppBarTabId('browse', contentSummary.getId());
+            let tabId = ContentAppBarTabId.forBrowse(contentSummary.getId());
 
             let wizardParams = new ContentWizardPanelParams()
                 .setTabId(tabId)

--- a/src/main/resources/assets/js/app/remove/DeleteItemViewer.ts
+++ b/src/main/resources/assets/js/app/remove/DeleteItemViewer.ts
@@ -2,8 +2,8 @@ import {ContentWizardPanelParams} from '../wizard/ContentWizardPanelParams';
 import {ContentEventsProcessor} from '../ContentEventsProcessor';
 import {ToggleSearchPanelWithDependenciesGlobalEvent} from '../browse/ToggleSearchPanelWithDependenciesGlobalEvent';
 import {ContentSummaryAndCompareStatusViewer} from '../content/ContentSummaryAndCompareStatusViewer';
+import {ContentAppBarTabId} from '../ContentAppBarTabId';
 import AEl = api.dom.AEl;
-import AppBarTabId = api.app.bar.AppBarTabId;
 import i18n = api.util.i18n;
 
 export class DeleteItemViewer
@@ -27,7 +27,7 @@ export class DeleteItemViewer
 
             const contentSummary = this.getObject().getContentSummary();
 
-            let tabId = new AppBarTabId('browse', contentSummary.getId());
+            let tabId = new ContentAppBarTabId('browse', contentSummary.getId());
 
             let wizardParams = new ContentWizardPanelParams()
                 .setTabId(tabId)

--- a/src/main/resources/assets/js/app/wizard/ContentAppHelper.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentAppHelper.ts
@@ -14,15 +14,15 @@ export class ContentAppHelper {
             return true;
         }
 
-        if (action === ContentAppBarTabMode.EDIT.toLowerCase()) {
+        if (action === ContentAppBarTabMode.EDIT) {
             return true;
         }
 
-        if (action === ContentAppBarTabMode.VIEW.toLowerCase()) {
+        if (action === ContentAppBarTabMode.VIEW) {
             return true;
         }
 
-        if (action === ContentAppBarTabMode.LOCALIZE.toLowerCase()) {
+        if (action === ContentAppBarTabMode.LOCALIZE) {
             return true;
         }
 

--- a/src/main/resources/assets/js/app/wizard/ContentAppHelper.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentAppHelper.ts
@@ -1,5 +1,5 @@
 import {ContentWizardPanelParams} from './ContentWizardPanelParams';
-import {ContentAppBarTabId} from '../ContentAppBarTabId';
+import {ContentAppBarTabId, ContentAppBarTabMode} from '../ContentAppBarTabId';
 import Path = api.rest.Path;
 import ContentTypeName = api.schema.content.ContentTypeName;
 import ContentId = api.content.ContentId;
@@ -10,14 +10,30 @@ export class ContentAppHelper {
         const path: Path = app.getPath();
         const action: string = path.getElement(1);
 
-        return action === 'new' || action === 'edit' || action === 'view' || action === 'localize';
+        if (action === ContentAppBarTabMode.NEW) {
+            return true;
+        }
+
+        if (action === ContentAppBarTabMode.EDIT.toLowerCase()) {
+            return true;
+        }
+
+        if (action === ContentAppBarTabMode.VIEW.toLowerCase()) {
+            return true;
+        }
+
+        if (action === ContentAppBarTabMode.LOCALIZE.toLowerCase()) {
+            return true;
+        }
+
+        return false;
     }
 
     static createWizardParamsFromApp(app: api.app.Application): ContentWizardPanelParams {
         const path: Path = app.getPath();
         const action: string = path.getElement(1);
 
-        if (action === 'new') {
+        if (action === ContentAppBarTabMode.NEW) {
             return ContentAppHelper.createWizardParamsForNew(app);
         }
 
@@ -44,7 +60,7 @@ export class ContentAppHelper {
     private static createWizardParamsForEdit(app: api.app.Application, action: string): ContentWizardPanelParams {
         const path: Path = app.getPath();
         const contentId = new ContentId(!!path.getElement(2) ? path.getElement(2) : path.getElement(1));
-        const tabId: ContentAppBarTabId = new ContentAppBarTabId(action, contentId.toString());
+        const tabId: ContentAppBarTabId = ContentAppBarTabId.fromString(action, contentId.toString());
 
         return new ContentWizardPanelParams()
             .setApplication(app)

--- a/src/main/resources/assets/js/app/wizard/ContentAppHelper.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentAppHelper.ts
@@ -1,7 +1,7 @@
 import {ContentWizardPanelParams} from './ContentWizardPanelParams';
+import {ContentAppBarTabId} from '../ContentAppBarTabId';
 import Path = api.rest.Path;
 import ContentTypeName = api.schema.content.ContentTypeName;
-import AppBarTabId = api.app.bar.AppBarTabId;
 import ContentId = api.content.ContentId;
 
 export class ContentAppHelper {
@@ -10,7 +10,7 @@ export class ContentAppHelper {
         const path: Path = app.getPath();
         const action: string = path.getElement(1);
 
-        return action === 'new' || action === 'edit';
+        return action === 'new' || action === 'edit' || action === 'view' || action === 'localize';
     }
 
     static createWizardParamsFromApp(app: api.app.Application): ContentWizardPanelParams {
@@ -21,13 +21,13 @@ export class ContentAppHelper {
             return ContentAppHelper.createWizardParamsForNew(app);
         }
 
-        return ContentAppHelper.createWizardParamsForEdit(app);
+        return ContentAppHelper.createWizardParamsForEdit(app, action);
     }
 
     private static createWizardParamsForNew(app: api.app.Application): ContentWizardPanelParams {
         const path: Path = app.getPath();
         const contentTypeName: ContentTypeName = new ContentTypeName(path.getElement(2));
-        const tabId: AppBarTabId = AppBarTabId.forNew(contentTypeName.getApplicationKey().getName());
+        const tabId: ContentAppBarTabId = ContentAppBarTabId.forNew(contentTypeName.getApplicationKey().getName());
         let parentContentId;
         if (path.getElement(3)) {
             parentContentId = new ContentId(path.getElement(3));
@@ -41,10 +41,10 @@ export class ContentAppHelper {
             .setTabId(tabId);
     }
 
-    private static createWizardParamsForEdit(app: api.app.Application): ContentWizardPanelParams {
+    private static createWizardParamsForEdit(app: api.app.Application, action: string): ContentWizardPanelParams {
         const path: Path = app.getPath();
         const contentId = new ContentId(!!path.getElement(2) ? path.getElement(2) : path.getElement(1));
-        const tabId: AppBarTabId = AppBarTabId.forEdit(contentId.toString());
+        const tabId: ContentAppBarTabId = new ContentAppBarTabId(action, contentId.toString());
 
         return new ContentWizardPanelParams()
             .setApplication(app)

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanelParams.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanelParams.ts
@@ -1,6 +1,6 @@
 import '../../api.ts';
 import {LayerContext} from '../layer/LayerContext';
-import {ContentAppBarTabId} from '../ContentAppBarTabId';
+import {ContentAppBarTabId, ContentAppBarTabMode} from '../ContentAppBarTabId';
 import Application = api.app.Application;
 
 export class ContentWizardPanelParams {
@@ -50,11 +50,11 @@ export class ContentWizardPanelParams {
     toString(): string {
         const layer: string = LayerContext.get().getCurrentLayer().getName();
 
-        return this.tabId && this.tabId.getMode() === 'browse'
+        return this.tabId && this.tabId.isBrowseMode()
             ? this.tabId.getMode() + '/' + this.tabId.getId()
             : this.contentId
               ? `${layer}/${this.tabId.getMode()}/${this.contentId.toString()}`
-              : `${layer}/new/${this.contentTypeName.toString()}` +
-                     (this.parentContentId ? '/' + this.parentContentId.toString() : '');
+              : `${layer}/${ContentAppBarTabMode.NEW}/${this.contentTypeName.toString()}` +
+                (this.parentContentId ? '/' + this.parentContentId.toString() : '');
     }
 }

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanelParams.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanelParams.ts
@@ -1,5 +1,6 @@
 import '../../api.ts';
 import {LayerContext} from '../layer/LayerContext';
+import {ContentAppBarTabId} from '../ContentAppBarTabId';
 import Application = api.app.Application;
 
 export class ContentWizardPanelParams {
@@ -8,7 +9,7 @@ export class ContentWizardPanelParams {
 
     createSite: boolean = false;
 
-    tabId: api.app.bar.AppBarTabId;
+    tabId: ContentAppBarTabId;
 
     contentTypeName: api.schema.content.ContentTypeName;
 
@@ -21,7 +22,7 @@ export class ContentWizardPanelParams {
         return this;
     }
 
-    setTabId(value: api.app.bar.AppBarTabId): ContentWizardPanelParams {
+    setTabId(value: ContentAppBarTabId): ContentWizardPanelParams {
         this.tabId = value;
         return this;
     }
@@ -52,7 +53,7 @@ export class ContentWizardPanelParams {
         return this.tabId && this.tabId.getMode() === 'browse'
             ? this.tabId.getMode() + '/' + this.tabId.getId()
             : this.contentId
-              ? `${layer}/edit/${this.contentId.toString()}`
+              ? `${layer}/${this.tabId.getMode()}/${this.contentId.toString()}`
               : `${layer}/new/${this.contentTypeName.toString()}` +
                      (this.parentContentId ? '/' + this.parentContentId.toString() : '');
     }

--- a/src/main/resources/assets/js/main.ts
+++ b/src/main/resources/assets/js/main.ts
@@ -258,21 +258,25 @@ function preLoadApplication() {
 
         if (!body.isRendered() && !body.isRendering()) {
             dataPreloaded = true;
-            // body is not rendered if the tab is in background
-            if (wizardParams.contentId) {
-                new GetContentByIdRequest(wizardParams.contentId).sendAndParse().then((content: Content) => {
-                    refreshTab(content);
+            new ListContentLayerRequest().sendAndParse().then((layers: ContentLayer[]) => {
+                initCurrentContentLayer(application, layers);
 
-                    if (shouldUpdateFavicon(content.getType())) {
-                        refreshTabOnContentUpdate(content);
-                    }
+                // body is not rendered if the tab is in background
+                if (wizardParams.contentId) {
+                    new GetContentByIdRequest(wizardParams.contentId).sendAndParse().then((content: Content) => {
+                        refreshTab(content);
 
-                });
-            } else {
-                new GetContentTypeByNameRequest(wizardParams.contentTypeName).sendAndParse().then((contentType) => {
-                    updateTabTitle(api.content.ContentUnnamed.prettifyUnnamed(contentType.getDisplayName()));
-                });
-            }
+                        if (shouldUpdateFavicon(content.getType())) {
+                            refreshTabOnContentUpdate(content);
+                        }
+
+                    });
+                } else {
+                    new GetContentTypeByNameRequest(wizardParams.contentTypeName).sendAndParse().then((contentType) => {
+                        updateTabTitle(api.content.ContentUnnamed.prettifyUnnamed(contentType.getDisplayName()));
+                    });
+                }
+            }).catch(api.DefaultErrorHandler.handle);
         }
     }
 }

--- a/src/main/resources/assets/styles/layer/layer-dialog.less
+++ b/src/main/resources/assets/styles/layer/layer-dialog.less
@@ -225,5 +225,13 @@
         margin-top: 10px;
       }
     }
+
+    .modal-dialog-footer {
+      .dialog-buttons {
+        .cancel {
+          background-color: @form-button-bg;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
…#856

-Using 'view' in url path instead of 'edit' when opening content in readonly mode (/norsk/view/bd25e18b-c23...)
-Using 'localize' in url path to let wizard know that save is required on open; setting url back to 'edit' after successful save (/norsk/localize/bd25e18b-c23...) -> (/norsk/edit/bd25e18b-c23...)