### PR TITLE
ui-tests issue#891

### DIFF
--- a/testing/page_objects/browsepanel/content.browse.panel.js
+++ b/testing/page_objects/browsepanel/content.browse.panel.js
@@ -196,6 +196,16 @@ class ContentBrowsePanel extends Page {
         })
     }
 
+    async waitForStateIconNotDisplayed(displayName) {
+        try {
+            let xpath = XPATH.contentSummaryByDisplayName(displayName);
+            return await this.waitForElementDisplayed(xpath, appConst.TIMEOUT_2);
+        } catch (err) {
+            this.saveScreenshot("err_browse_panel_workflow_state_should_be_hidden");
+            throw new Error("Workflow state should not be visible! " + err);
+        }
+    }
+
     //Wait for `Publish Menu` Button gets 'Mark as ready'
     waitForMarkAsReadyButtonVisible() {
         return this.waitForElementDisplayed(this.markAsReadyButton, appConst.TIMEOUT_3).catch(err => {

--- a/testing/page_objects/components/loader.combobox.js
+++ b/testing/page_objects/components/loader.combobox.js
@@ -24,6 +24,8 @@ class LoaderComboBox extends Page {
             return this.clickOnElement(optionSelector).catch(err => {
                 this.saveScreenshot('err_select_option');
                 throw new Error('Error when clicking on the option!' + optionDisplayName + " " + err);
+            }).then(() => {
+                return this.pause(300);
             })
         })
     }

--- a/testing/page_objects/wizardpanel/content.wizard.panel.js
+++ b/testing/page_objects/wizardpanel/content.wizard.panel.js
@@ -14,6 +14,7 @@ const ContentPublishDialog = require("../../page_objects/content.publish.dialog"
 const VersionsWidget = require('../../page_objects/wizardpanel/details/wizard.versions.widget');
 const RequestPublishDialog = require('../../page_objects/issue/request.content.publish.dialog');
 const BrowsePanel = require('../../page_objects/browsepanel/content.browse.panel');
+const ContentDeleteDialog = require('../../page_objects/delete.content.dialog');
 
 const XPATH = {
     container: `//div[contains(@id,'ContentWizardPanel')]`,
@@ -164,7 +165,7 @@ class ContentWizardPanel extends Page {
         let versionPanel = new VersionsWidget();
         await this.openDetailsPanel();
         await detailsPanel.openVersionHistory();
-        return versionPanel.waitForVersionsLoaded();
+        return await versionPanel.waitForVersionsLoaded();
     }
 
     waitForXdataTogglerVisible() {
@@ -229,7 +230,7 @@ class ContentWizardPanel extends Page {
             await this.pause(1000);
             return await this.getBrowser().keys(['Alt', 'w']);
         } catch (err) {
-            return this.doSwitchToContentBrowsePanel();
+            return await this.doSwitchToContentBrowsePanel();
         }
     }
 
@@ -362,6 +363,14 @@ class ContentWizardPanel extends Page {
             this.saveScreenshot('err_delete_wizard');
             throw new Error('Error when Delete button has been clicked ' + err);
         });
+    }
+
+    async clickOnDeleteAndConfirm() {
+        let contentDeleteDialog = new ContentDeleteDialog();
+        await this.clickOnDelete(this.deleteButton);
+        await contentDeleteDialog.waitForDialogOpened();
+        await contentDeleteDialog.clickOnDeleteButton();
+        return contentDeleteDialog.waitForDialogClosed();
     }
 
     //clicks on 'Publish...' button
@@ -704,6 +713,16 @@ class ContentWizardPanel extends Page {
 
         } else {
             throw new Error("Error when getting content's state, class is:" + result);
+        }
+    }
+
+    async waitForStateIconNotDisplayed() {
+        try {
+            let selector = XPATH.toolbar + XPATH.toolbarStateIcon;
+            return await this.waitForElementNotDisplayed(selector, appConst.TIMEOUT_4);
+        } catch (err) {
+            this.saveScreenshot("err_workflow_state_should_not_be_visible");
+            throw new Error("Workflow state should be not visible!" + err);
         }
     }
 

--- a/testing/specs/publish/wizard.publish.menu.workflow.spec.js
+++ b/testing/specs/publish/wizard.publish.menu.workflow.spec.js
@@ -14,7 +14,7 @@ const ScheduleForm = require('../../page_objects/wizardpanel/schedule.wizard.ste
 const ContentUnpublishDialog = require('../../page_objects/content.unpublish.dialog');
 const DeleteContentDialog = require('../../page_objects/delete.content.dialog');
 
-describe('wizard.publish.menu.spec - publishes and unpublishes single folder in wizard`', function () {
+describe('wizard.publish.menu.workflow.spec - publishes and unpublishes single folder in wizard`', function () {
     this.timeout(appConst.SUITE_TIMEOUT);
     webDriverHelper.setupBrowser();
     let TEST_FOLDER;
@@ -91,9 +91,7 @@ describe('wizard.publish.menu.spec - publishes and unpublishes single folder in 
             //GIVEN: folder is published
             await contentWizard.openPublishMenuAndPublish();
             //WHEN: the folder has been deleted:
-            await contentWizard.clickOnDelete();
-            await deleteContentDialog.waitForDialogOpened();
-            await deleteContentDialog.clickOnDeleteButton();
+            await contentWizard.clickOnDeleteAndConfirm();
             //THEN: Schedule form should be visible:
             await scheduleForm.waitForDisplayed();
 


### PR DESCRIPTION
verifies - https://github.com/enonic/app-contentstudio/issues/891 Work In Progress state should not be displayed for Deleted content
    verifies https://github.com/enonic/app-contentstudio/issues/692   'Publish...' should be the default action for content in Deleted state