### PR TITLE
Issue Details Dialog - increase top padding in the footer #871

### DIFF
--- a/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
+++ b/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
@@ -171,16 +171,17 @@
       display: none;
 
       .dependants-header:not(:empty) {
-        margin: 10px 0 10px;
+        margin-top: 10px;
         cursor: pointer;
         color: @admin-blue;
       }
 
       .dependants-body {
         display: none;
+        margin-top: 10px;
 
         .dependants-desc {
-          margin: 0 0 10px;
+          margin-bottom: 10px;
           font-weight: bold;
         }
 

--- a/src/main/resources/assets/styles/publish/issue-comment-list.less
+++ b/src/main/resources/assets/styles/publish/issue-comment-list.less
@@ -1,7 +1,11 @@
 .issue-comments-list {
   .issue-comments-list-item {
     .clearfix();
-    margin-bottom: 30px;
+    margin-bottom: 20px;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
 
     .principal-viewer-compact {
       float: left;
@@ -48,6 +52,7 @@
         color: black;
         margin: 6px;
         white-space: normal;
+        overflow-wrap: break-word;
       }
       .inplace-area {
         font-size: 14px;

--- a/src/main/resources/assets/styles/publish/issue-details-dialog.less
+++ b/src/main/resources/assets/styles/publish/issue-details-dialog.less
@@ -6,7 +6,6 @@
   }
 
   .dialog-content {
-    padding: 5px 0;
     min-height: 200px;
     position: relative; // to be able to position empty text message absolutely
 
@@ -401,10 +400,6 @@
   &.tab-assignees {
     .dialog-content {
       min-height: 220px;
-    }
-
-    .modal-dialog-footer {
-      padding-top: 0;
     }
   }
 

--- a/src/main/resources/assets/styles/publish/issue-details-dialog.less
+++ b/src/main/resources/assets/styles/publish/issue-details-dialog.less
@@ -15,8 +15,16 @@
       & > .panel {
         overflow: visible;
 
-        .content-combo-box {
-          margin-top: 15px;
+        .content-combo-box,
+        .principal-combobox {
+          margin-top: 5px;
+        }
+
+        .principal-combobox {
+          .principal-selected-option-view:last-of-type {
+            height: 37px;
+            padding-bottom: 0;
+          }
         }
 
         input {
@@ -396,13 +404,6 @@
     }
   }
 
-
-  &.tab-assignees {
-    .dialog-content {
-      min-height: 220px;
-    }
-  }
-
   &.no-action {
     .dependants {
       display: none;
@@ -413,6 +414,7 @@
     position: relative;
     display: flex;
     justify-content: flex-end;
+    min-height: 36px;
   }
 
 }

--- a/src/main/resources/assets/styles/publish/issue-dialog.less
+++ b/src/main/resources/assets/styles/publish/issue-dialog.less
@@ -55,10 +55,6 @@
       }
     }
 
-    .principal-selected-options-view {
-      padding: 0 15px 0 0;
-    }
-
     .dependants {
       margin-top: 5px;
     }


### PR DESCRIPTION
* Updated padding in the footer of the IssueDetailsDialog on Assignees tab.

__In addition:__
* Decreased space between comments.
* Removed spacing on the right of the assignees' list, making it similar to the items list.
* Added word breaking, when comments overflow the comments section, e.g. when you comment with long words without the whitespaces (links, etc.).
* Fixed different height of the dialog buttons on each tab.