### PR TITLE
Publishing Wizard - items not updated after changing content in anoth…

### DIFF
--- a/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
+++ b/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
@@ -152,20 +152,11 @@ export abstract class BasePublishDialog
         if ((!needPublish || allPublishable) && allValid && !containsItemsInProgress) {
             this.publishIssuesStateBar.removeClass('has-issues');
             this.publishIssuesStateBar.reset();
-            return;
-        }
-
-        this.publishIssuesStateBar.addClass('has-issues');
-        if (containsItemsInProgress) {
-            this.publishIssuesStateBar.showContainsInProgress();
-        }
-
-        if (!allValid) {
-            this.publishIssuesStateBar.showContainsInvalid();
-        }
-
-        if (!allPublishable) {
-            this.publishIssuesStateBar.showContainsNotPublishable();
+        } else {
+            this.publishIssuesStateBar.addClass('has-issues');
+            this.publishIssuesStateBar.setContainsInProgressVisible(containsItemsInProgress);
+            this.publishIssuesStateBar.setContainsInvalidVisible(!allValid);
+            this.publishIssuesStateBar.setContainsNotPublishableVisible(!allPublishable);
         }
     }
 

--- a/src/main/resources/assets/js/app/dialog/DialogTogglableItemList.ts
+++ b/src/main/resources/assets/js/app/dialog/DialogTogglableItemList.ts
@@ -84,7 +84,7 @@ export class DialogTogglableItemList
 
     protected updateItemView(itemView: api.dom.Element, item: ContentSummaryAndCompareStatus) {
         const view = <TogglableStatusSelectionItem>itemView;
-        view.getViewer().setObject(item);
+        view.setObject(item);
     }
 
     protected createSelectionItem(viewer: ContentSummaryAndCompareStatusViewer,

--- a/src/main/resources/assets/js/app/dialog/StatusSelectionItem.ts
+++ b/src/main/resources/assets/js/app/dialog/StatusSelectionItem.ts
@@ -10,6 +10,7 @@ export class StatusSelectionItem
     private isRemovableFn: () => boolean;
     private clickTooltip: Tooltip;
     private removeClickTooltip: string = i18n('tooltip.list.itemRequired');
+    private status: api.dom.DivEl;
 
     constructor(viewer: api.ui.Viewer<ContentSummaryAndCompareStatus>, item: BrowseItem<ContentSummaryAndCompareStatus>) {
         super(viewer, item);
@@ -61,11 +62,20 @@ export class StatusSelectionItem
                 e.stopPropagation();
             });
 
-            let statusDiv = this.initStatusDiv(this.item.getModel());
-            this.appendChild(statusDiv);
+            this.status = this.initStatusDiv(this.item.getModel());
+            this.appendChild(this.status);
 
             return rendered;
         });
+    }
+
+    public setObject(obj: ContentSummaryAndCompareStatus) {
+        const viewer = this.getViewer();
+        this.status.removeClass(viewer.getObject().getStatusClass());
+
+        viewer.setObject(obj);
+        this.status.setHtml(obj.getStatusText());
+        this.status.addClass(obj.getStatusClass());
     }
 
     private initStatusDiv(content: ContentSummaryAndCompareStatus) {

--- a/src/main/resources/assets/js/app/publish/PublishIssuesStateBar.ts
+++ b/src/main/resources/assets/js/app/publish/PublishIssuesStateBar.ts
@@ -62,16 +62,16 @@ export class PublishIssuesStateBar
         });
     }
 
-    showContainsInvalid() {
-        this.containsInvalidElement.show();
+    setContainsInvalidVisible(flag: boolean) {
+        this.containsInvalidElement.setVisible(flag);
     }
 
-    showContainsInProgress() {
-        this.containsInProgressElement.show();
+    setContainsInProgressVisible(flag: boolean) {
+        this.containsInProgressElement.setVisible(flag);
     }
 
-    showContainsNotPublishable() {
-        this.containsNotPublishableElement.show();
+    setContainsNotPublishableVisible(flag: boolean) {
+        this.containsNotPublishableElement.setVisible(flag);
     }
 
     showLoadFailed() {

--- a/src/main/resources/assets/js/app/publish/PublishProcessor.ts
+++ b/src/main/resources/assets/js/app/publish/PublishProcessor.ts
@@ -204,7 +204,11 @@ export class PublishProcessor {
     }
 
     public containsInvalidItems() {
-        return this.containsInvalid;
+        return this.containsInvalid || this.itemList.getItems().some(this.isItemInvalid);
+    }
+
+    private isItemInvalid(item: ContentSummaryAndCompareStatus): boolean {
+        return !item.getContentSummary().isValid();
     }
 
     public setCheckPublishable(flag: boolean) {


### PR DESCRIPTION
…er tab #909

- also fixed the publishIssueStateBar not hiding old message if the content remained invalid, i.e. changing content from 'not ready' -> 'invalid' resulted in both messages visible in PublishDialog