### PR TITLE
Content Editor - after publishing, status is visually toggled to "in progress" and showing "unpublish" as default action #843

### DIFF
--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -989,6 +989,7 @@ export class ContentWizardPanel
                 return !!undeletedItem && this.getPersistedItem().getPath().equals(undeletedItem.getContentPath());
             }).some((undeletedItem) => {
                 this.updateContent(undeletedItem.getCompareStatus());
+                this.updatePublishStatusOnDataChange();
 
                 return true;
             });

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -56,6 +56,7 @@ import {PermissionHelper} from './PermissionHelper';
 import {XDataWizardStepForms} from './XDataWizardStepForms';
 import {AccessControlEntryView} from '../view/AccessControlEntryView';
 import {Access} from '../security/Access';
+import {WorkflowStateIconsManager} from './WorkflowStateIconsManager';
 import PropertyTree = api.data.PropertyTree;
 import FormView = api.form.FormView;
 import ContentId = api.content.ContentId;
@@ -90,6 +91,7 @@ import RoleKeys = api.security.RoleKeys;
 import PrincipalKey = api.security.PrincipalKey;
 import Workflow = api.content.Workflow;
 import WorkflowState = api.content.WorkflowState;
+import ContentIconUrlResolver = api.content.util.ContentIconUrlResolver;
 import i18n = api.util.i18n;
 
 export class ContentWizardPanel
@@ -190,6 +192,8 @@ export class ContentWizardPanel
 
     private isFirstUpdateAndRenameEventSkiped: boolean;
 
+    private workflowStateIconsManager: WorkflowStateIconsManager;
+
     public static debug: boolean = false;
 
     constructor(params: ContentWizardPanelParams) {
@@ -216,6 +220,8 @@ export class ContentWizardPanel
         this.displayNameResolver = new DisplayNameResolver();
 
         this.xDataWizardStepForms = new XDataWizardStepForms();
+
+        this.workflowStateIconsManager = new WorkflowStateIconsManager(this);
 
         this.initListeners();
         this.listenToContentEvents();
@@ -310,7 +316,11 @@ export class ContentWizardPanel
     }
 
     protected createMainToolbar(): Toolbar {
-        return new ContentWizardToolbar(this.contentParams.application, this.wizardActions);
+        return new ContentWizardToolbar({
+            application: this.contentParams.application,
+            actions: this.wizardActions,
+            workflowStateIconsManager: this.workflowStateIconsManager
+        });
     }
 
     public getMainToolbar(): ContentWizardToolbar {
@@ -326,7 +336,7 @@ export class ContentWizardPanel
         header.setPath(this.getWizardHeaderPath());
 
         const existing: Content = this.getPersistedItem();
-        if (!!existing) {
+        if (existing) {
             header.initNames(existing.getDisplayName(), existing.getName().toString(), false);
         }
 
@@ -449,10 +459,7 @@ export class ContentWizardPanel
 
                 const isThisValid: boolean = this.isValid();
                 this.isContentFormValid = isThisValid;
-                if (thumbnailUploader) {
-                    thumbnailUploader.toggleClass('invalid', !isThisValid);
-                }
-                this.getMainToolbar().toggleValid(isThisValid);
+                this.workflowStateIconsManager.updateIcons();
                 this.getContentWizardToolbarPublishControls()
                     .setContentCanBePublished(this.checkContentCanBePublished(), false)
                     .setIsValid(isThisValid);
@@ -592,19 +599,17 @@ export class ContentWizardPanel
 
             this.updateThumbnailWithContent(persistedContent);
 
-            let wizardHeader = this.getWizardHeader();
-
-            wizardHeader.setSimplifiedNameGeneration(persistedContent.getType().isDescendantOfMedia());
+            this.getWizardHeader().setSimplifiedNameGeneration(persistedContent.getType().isDescendantOfMedia());
 
             if (this.isRendered()) {
 
-                let viewedContent = this.assembleViewedContent(persistedContent.newBuilder()).build();
+                const viewedContent = this.assembleViewedContent(persistedContent.newBuilder()).build();
                 if (viewedContent.equals(persistedContent) || this.skipValidation) {
 
                     // force update wizard with server bounced values to erase incorrect ones
                     this.updateWizard(persistedContentCopy, false);
 
-                    let liveFormPanel = this.getLivePanel();
+                    const liveFormPanel = this.getLivePanel();
                     if (liveFormPanel) {
                         liveFormPanel.loadPage();
                     }
@@ -644,7 +649,7 @@ export class ContentWizardPanel
                         new ConfirmationDialog()
                             .setQuestion(i18n('dialog.confirm.contentDiffers'))
                             .setYesCallback(() => this.doLayoutPersistedItem(persistedContentCopy))
-                            .setNoCallback(() => { /* empty */
+                            .setNoCallback(() => {/* empty */
                             })
                             .show();
                     }
@@ -895,15 +900,9 @@ export class ContentWizardPanel
         this.currentContent = newContent;
         this.persistedContent = newContent;
         this.getMainToolbar().setItem(newContent);
-        this.updateWorkflowStateIcons();
+        this.workflowStateIconsManager.updateIcons();
 
         this.wizardActions.refreshPendingDeleteDecorations();
-    }
-
-    private updateWorkflowStateIcons() {
-        const hasUnsavedChanges: boolean = this.hasUnsavedChanges();
-        this.getMainToolbar().setHasUnsavedChanges(hasUnsavedChanges);
-        this.updateThumbnailStateIcon(hasUnsavedChanges);
     }
 
     private isOutboundDependencyUpdated(content: ContentSummaryAndCompareStatus): wemQ.Promise<boolean> {
@@ -1013,7 +1012,7 @@ export class ContentWizardPanel
                     this.currentContent = content;
                     this.persistedContent = content;
                     this.getMainToolbar().setItem(content);
-                    this.updateWorkflowStateIcons();
+                    this.workflowStateIconsManager.updateIcons();
                     this.refreshScheduleWizardStep();
 
                     this.getWizardHeader().toggleNameGeneration(content.getCompareStatus() !== CompareStatus.EQUAL);
@@ -1153,11 +1152,10 @@ export class ContentWizardPanel
         const isUpdatedAndRenamed = this.isContentUpdatedAndRenamed(updatedContent);
         this.currentContent = updatedContent;
         this.persistedContent = updatedContent;
-        this.getMainToolbar().setSkipNextIconStateUpdate(true);
         this.getMainToolbar().setItem(updatedContent);
         if (!isUpdatedAndRenamed || this.isFirstUpdateAndRenameEventSkiped) {
             this.isFirstUpdateAndRenameEventSkiped = false;
-            this.updateWorkflowStateIcons();
+            this.workflowStateIconsManager.updateIcons();
         }
         this.contextSplitPanel.setContent(updatedContent);
     }
@@ -1403,7 +1401,7 @@ export class ContentWizardPanel
             this.persistedContent = summaryAndStatus;
             this.getMainToolbar().setItem(summaryAndStatus);
             this.getWizardHeader().toggleNameGeneration(this.currentContent.getCompareStatus() === CompareStatus.NEW);
-            this.updateWorkflowStateIcons();
+            this.workflowStateIconsManager.updateIcons();
             new IsAuthenticatedRequest().sendAndParse().then((loginResult: LoginResult) => {
                 const userCanPublish: boolean = this.isContentPublishableByUser(loginResult);
                 this.getContentWizardToolbarPublishControls().setUserCanPublish(userCanPublish);
@@ -1428,26 +1426,13 @@ export class ContentWizardPanel
 
     private updateThumbnailWithContent(content: Content) {
         const thumbnailUploader: ThumbnailUploaderEl = this.getFormIcon();
+        const id = content.getContentId().toString();
 
         thumbnailUploader
-            .setParams({
-                id: content.getContentId().toString()
-            })
+            .setParams({id})
             .setEnabled(!content.isImage())
-            .setValue(new api.content.util.ContentIconUrlResolver().setContent(content).resolve());
-
-        thumbnailUploader.toggleClass('invalid', !content.isValid());
-    }
-
-    private updateThumbnailStateIcon(hasUnsavedChanges: boolean) {
-        const item: ContentSummaryAndCompareStatus = this.currentContent;
-        const thumbnailUploader: ThumbnailUploaderEl = this.getFormIcon();
-        const isReady: boolean = !item.isOnline() && !item.isPendingDelete() && !hasUnsavedChanges && item.getContentSummary().isReady();
-        const isInProgress: boolean =
-            !item.isOnline() && !item.isPendingDelete() && (hasUnsavedChanges || item.getContentSummary().isInProgress());
-
-        thumbnailUploader.toggleClass('ready', isReady);
-        thumbnailUploader.toggleClass('in-progress', isInProgress);
+            .setValue(new ContentIconUrlResolver().setContent(content).resolve());
+        this.workflowStateIconsManager.updateIcons();
     }
 
     private initLiveEditor(formContext: ContentFormContext, content: Content): wemQ.Promise<void> {
@@ -2382,8 +2367,7 @@ export class ContentWizardPanel
                 this.currentContent.setPublishStatus(this.scheduleWizardStepForm.getPublishStatus());
             }
             this.getMainToolbar().setItem(this.currentContent);
-            this.getMainToolbar().setHasUnsavedChanges(hasUnsavedChanges);
-            this.updateThumbnailStateIcon(hasUnsavedChanges);
+            this.workflowStateIconsManager.updateIcons();
         }
     }
 

--- a/src/main/resources/assets/js/app/wizard/ContentWizardToolbar.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardToolbar.ts
@@ -2,6 +2,7 @@ import {ContentWizardActions} from './action/ContentWizardActions';
 import {ContentWizardToolbarPublishControls} from './ContentWizardToolbarPublishControls';
 import {ContentStatusToolbar} from '../ContentStatusToolbar';
 import {ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
+import {WorkflowStateIconsManager, WorkflowStateStatus} from './WorkflowStateIconsManager';
 import TogglerButton = api.ui.button.TogglerButton;
 import CycleButton = api.ui.button.CycleButton;
 import AppIcon = api.app.bar.AppIcon;
@@ -9,6 +10,13 @@ import Application = api.app.Application;
 import Action = api.ui.Action;
 import i18n = api.util.i18n;
 import DivEl = api.dom.DivEl;
+
+export interface ContentWizardToolbarConfig {
+    application: Application;
+    actions: ContentWizardActions;
+    workflowStateIconsManager: WorkflowStateIconsManager;
+    item?: ContentSummaryAndCompareStatus;
+}
 
 export class ContentWizardToolbar
     extends ContentStatusToolbar {
@@ -21,48 +29,55 @@ export class ContentWizardToolbar
 
     private mobileItemStatisticsButton: TogglerButton;
 
-    private stateElement: api.dom.Element;
+    private stateIcon: DivEl;
 
-    private hasUnsavedChanges: boolean;
+    private workflowStateIconsManager: WorkflowStateIconsManager;
 
-    private isValid: boolean;
-
-    private skipNextIconStateUpdate: boolean;
-
-    constructor(application: Application, actions: ContentWizardActions, item?: ContentSummaryAndCompareStatus) {
+    constructor(config: ContentWizardToolbarConfig) {
         super('content-wizard-toolbar');
 
-        this.initElements(application, actions, item);
+        this.initElements(config);
+        this.initListeners();
     }
 
-    protected initElements(application: Application, actions: ContentWizardActions, item?: ContentSummaryAndCompareStatus) {
-        this.addHomeButton(application);
-        this.addActionButtons(actions);
-        this.addPublishMenuButton(actions);
+    protected initElements(config: ContentWizardToolbarConfig) {
+        this.workflowStateIconsManager = config.workflowStateIconsManager;
+
+        this.addHomeButton(config.application);
+        this.addActionButtons(config.actions);
+        this.addPublishMenuButton(config.actions);
         this.addMobileItemStatisticsButton();
-        this.addTogglerButtons(actions);
+        this.addTogglerButtons(config.actions);
+
         this.addStateIcon();
 
-        if (item) {
-            this.updateCanBeMarkedAsReadyControl(true);
-            this.setItem(item);
+        if (config.item) {
+            if (this.workflowStateIconsManager) {
+                const isInProgress = this.workflowStateIconsManager.getStatus().inProgress;
+                this.contentWizardToolbarPublishControls.setContentCanBeMarkedAsReady(isInProgress);
+            }
+            this.setItem(config.item);
         }
+    }
+
+    protected initListeners() {
+        this.workflowStateIconsManager.onStatusChanged((status: WorkflowStateStatus) => {
+            if (status.ready) {
+                this.stateIcon.getEl().setTitle(i18n('tooltip.state.ready'));
+            } else if (status.inProgress) {
+                this.stateIcon.getEl().setTitle(i18n('tooltip.state.in_progress'));
+            } else {
+                this.stateIcon.getEl().removeAttribute('title');
+            }
+
+            this.contentWizardToolbarPublishControls.setContentCanBeMarkedAsReady(status.inProgress, true);
+            this.toggleValid(!status.invalid);
+        });
     }
 
     setItem(item: ContentSummaryAndCompareStatus) {
         super.setItem(item);
-
         this.contentWizardToolbarPublishControls.setContent(item);
-    }
-
-    setHasUnsavedChanges(value: boolean) {
-        this.hasUnsavedChanges = value;
-        this.updateStateIconElement();
-        this.updateCanBeMarkedAsReadyControl();
-    }
-
-    setSkipNextIconStateUpdate(skipIconStateUpdate: boolean) {
-        this.skipNextIconStateUpdate = skipIconStateUpdate;
     }
 
     private addHomeButton(application: Application) {
@@ -92,8 +107,8 @@ export class ContentWizardToolbar
     }
 
     private addStateIcon() {
-        this.stateElement = new DivEl('toolbar-state-icon');
-        super.addElement(this.stateElement);
+        this.stateIcon = new DivEl('toolbar-state-icon');
+        super.addElement(this.stateIcon);
     }
 
     private addPublishMenuButton(actions: ContentWizardActions) {
@@ -125,59 +140,8 @@ export class ContentWizardToolbar
         super.addElement(this.cycleViewModeButton);
     }
 
-    toggleValid(isValid: boolean) {
-        super.toggleValid(isValid);
-
-        this.isValid = isValid;
-
-        if (!this.getItem()) {
-            return;
-        }
-
-        this.updateStateIconElement();
-        this.updateCanBeMarkedAsReadyControl();
-    }
-
-    private updateCanBeMarkedAsReadyControl(silent?: boolean) {
-        const isInProgress: boolean = this.isValid && (this.hasUnsavedChanges || this.isContentInProgress());
-        this.contentWizardToolbarPublishControls.setContentCanBeMarkedAsReady(isInProgress, !silent);
-    }
-
-    private updateStateIconElement() {
-        if (this.skipNextIconStateUpdate) {
-            this.skipNextIconStateUpdate = false;
-            return;
-        }
-
-        const isReady: boolean = this.isReadyState();
-        const isInProgress: boolean = this.isInProgressState();
-
-        this.stateElement.getEl().removeAttribute('title');
-        this.stateElement.toggleClass('invalid', !this.isValid);
-        this.stateElement.toggleClass('ready', isReady);
-        this.stateElement.toggleClass('in-progress', isInProgress);
-
-        if (isReady) {
-            this.stateElement.getEl().setTitle(i18n('tooltip.state.ready'));
-        } else if (isInProgress) {
-            this.stateElement.getEl().setTitle(i18n('tooltip.state.in_progress'));
-        }
-    }
-
-    private isReadyState(): boolean {
-        return this.isValid && !this.hasUnsavedChanges && !this.getItem().isPendingDelete() && this.isContentReady();
-    }
-
-    private isInProgressState(): boolean {
-        return this.isValid && !this.getItem().isPendingDelete() && (this.hasUnsavedChanges || this.isContentInProgress());
-    }
-
-    private isContentReady(): boolean {
-        return !this.getItem().isOnline() && this.getItem().getContentSummary().isReady();
-    }
-
-    private isContentInProgress(): boolean {
-        return !this.getItem().isOnline() && this.getItem().getContentSummary().isInProgress();
+    getStateIcon() {
+        return this.stateIcon;
     }
 
     getCycleViewModeButton(): CycleButton {

--- a/src/main/resources/assets/js/app/wizard/WorkflowStateIconsManager.ts
+++ b/src/main/resources/assets/js/app/wizard/WorkflowStateIconsManager.ts
@@ -1,0 +1,108 @@
+import {ContentWizardPanel} from './ContentWizardPanel';
+
+export interface WorkflowStateStatus {
+    invalid: boolean;
+    ready: boolean;
+    inProgress: boolean;
+}
+
+export class WorkflowStateIconsManager {
+
+    static INVALID_CLASS: string = 'invalid';
+
+    static READY_CLASS: string = 'ready';
+
+    static IN_PROGRESS_CLASS: string = 'in-progress';
+
+    private wizard: ContentWizardPanel;
+
+    private status: WorkflowStateStatus;
+
+    private statusChangedListeners: ((status: WorkflowStateStatus) => void)[];
+
+    constructor(wizard: ContentWizardPanel) {
+        this.wizard = wizard;
+        this.status = null;
+        this.statusChangedListeners = [];
+    }
+
+    updateIcons() {
+        const status = this.createWorkflowStateStatus();
+        const isStatusChanged = this.isWorkflowStateStatusChanged(status);
+
+        if (isStatusChanged) {
+            const toolbar = this.wizard.getMainToolbar();
+            const toolbarIcon = toolbar != null ? toolbar.getStateIcon() : toolbar;
+            const thumbnailUploader = this.wizard.getFormIcon();
+            const icons = [thumbnailUploader, toolbarIcon].filter(icon => icon != null);
+
+            icons.forEach(icon => WorkflowStateIconsManager.toggleWorkflowStateClasses(icon, status));
+
+            this.status = status;
+
+            this.notifyStatusChanged(status);
+        }
+    }
+
+    getStatus(): WorkflowStateStatus {
+        return this.status;
+    }
+
+    isWorkflowStateStatusChanged(status: WorkflowStateStatus) {
+        if (status == null && this.status == null) {
+            return false;
+        }
+
+        return this.status == null || status == null ||
+               this.status.inProgress !== status.inProgress ||
+               this.status.invalid !== status.invalid ||
+               this.status.ready !== status.ready;
+    }
+
+    createWorkflowStateStatus(): WorkflowStateStatus {
+        const content = this.wizard.getContent();
+
+        if (content == null) {
+            return {
+                invalid: false,
+                ready: false,
+                inProgress: false
+            };
+        }
+
+        const contentSummary = content.getContentSummary();
+
+        const isValid = this.wizard.isValid();
+        const isOnline = content.isOnline();
+        const isPendingDelete = content.isPendingDelete();
+        const isInWorkflow = isValid && !isOnline && !isPendingDelete;
+        const hasUnsavedChanges = this.wizard.hasUnsavedChanges();
+
+        const isReady: boolean = isInWorkflow && !hasUnsavedChanges && contentSummary.isReady();
+        const isInProgress: boolean = isInWorkflow && (hasUnsavedChanges || contentSummary.isInProgress());
+
+        return {
+            invalid: !isValid,
+            ready: isReady,
+            inProgress: isInProgress
+        };
+    }
+
+    static toggleWorkflowStateClasses(element: api.dom.Element, status: WorkflowStateStatus) {
+        element.toggleClass(WorkflowStateIconsManager.INVALID_CLASS, status.invalid);
+        element.toggleClass(WorkflowStateIconsManager.READY_CLASS, status.ready);
+        element.toggleClass(WorkflowStateIconsManager.IN_PROGRESS_CLASS, status.inProgress);
+    }
+
+    public onStatusChanged(listener: (status: WorkflowStateStatus) => void) {
+        this.statusChangedListeners.push(listener);
+    }
+
+    public unStatusChanged(listener: () => void) {
+        this.statusChangedListeners = this.statusChangedListeners.filter(curr => curr !== listener);
+    }
+
+    private notifyStatusChanged(status: WorkflowStateStatus) {
+        this.statusChangedListeners.forEach(listener => listener(status));
+    }
+}


### PR DESCRIPTION
* Moved icons status management in wizard and toolbar to a separate manager.
* Added icon state update, when changes were made to the content with "Pending delete", and the "Undo delete" was clicked.