### PR TITLE
Fetch component descriptors for all applications with one request #875

### DIFF
--- a/src/main/resources/assets/js/app/resource/GetLayoutDescriptorsByApplicationRequest.ts
+++ b/src/main/resources/assets/js/app/resource/GetLayoutDescriptorsByApplicationRequest.ts
@@ -30,11 +30,13 @@ export class GetLayoutDescriptorsByApplicationRequest
 
     sendAndParse(): wemQ.Promise<LayoutDescriptor[]> {
 
-        let cached = this.cache.getByApplication(this.applicationKey);
+        let cached = this.cache.getByApplications([this.applicationKey]);
         if (cached) {
             return wemQ(cached);
         } else {
             return this.send().then((response: api.rest.JsonResponse<LayoutDescriptorsJson>) => {
+                // mark applicationKeys as cached to prevent request when there are no descriptors defined in app
+                this.cache.putApplicationKeys([this.applicationKey]);
                 return response.getResult().descriptors.map((descriptorJson: LayoutDescriptorJson) => {
                     const descriptor = LayoutDescriptor.fromJson(descriptorJson);
                     this.cache.put(descriptor);

--- a/src/main/resources/assets/js/app/resource/GetPageDescriptorsByApplicationRequest.ts
+++ b/src/main/resources/assets/js/app/resource/GetPageDescriptorsByApplicationRequest.ts
@@ -29,12 +29,13 @@ export class GetPageDescriptorsByApplicationRequest
     }
 
     sendAndParse(): wemQ.Promise<PageDescriptor[]> {
-        const cached = this.cache.getByApplication(this.applicationKey);
+        const cached = this.cache.getByApplications([this.applicationKey]);
         if (cached) {
             return wemQ(cached);
         }
 
         return this.send().then((response: api.rest.JsonResponse<PageDescriptorsJson>) => {
+            this.cache.putApplicationKeys([this.applicationKey]);
             return response.getResult().descriptors.map((descriptorJson: PageDescriptorJson) => {
                 const pageDescriptor = api.content.page.PageDescriptor.fromJson(descriptorJson);
                 this.cache.put(pageDescriptor);

--- a/src/main/resources/assets/js/app/resource/GetPartDescriptorsByApplicationRequest.ts
+++ b/src/main/resources/assets/js/app/resource/GetPartDescriptorsByApplicationRequest.ts
@@ -29,7 +29,7 @@ export class GetPartDescriptorsByApplicationRequest
     }
 
     sendAndParse(): wemQ.Promise<PartDescriptor[]> {
-        const cached = this.cache.getByApplication(this.applicationKey);
+        const cached = this.cache.getByApplications([this.applicationKey]);
         if (cached) {
             return wemQ(cached);
         } else {

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/page/PageDescriptorDropdown.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/page/PageDescriptorDropdown.ts
@@ -44,11 +44,12 @@ export class PageDescriptorDropdown
     private initListeners() {
         this.onOptionSelected(this.handleOptionSelected.bind(this));
 
-        let onApplicationAddedHandler = () => {
+        // debounce it in case multiple apps were added at once using checkboxes
+        let onApplicationAddedHandler = api.util.AppHelper.debounce(() => {
             this.load();
-        };
+        }, 100);
 
-        let onApplicationRemovedHandler = (event: ApplicationRemovedEvent) => {
+        let onApplicationRemovedHandler = api.util.AppHelper.debounce((event: ApplicationRemovedEvent) => {
 
             let currentController = this.liveEditModel.getPageModel().getController();
             let removedApp = event.getApplicationKey();
@@ -58,7 +59,7 @@ export class PageDescriptorDropdown
             } else {
                 this.load();
             }
-        };
+        }, 100);
 
         this.liveEditModel.getSiteModel().onApplicationAdded(onApplicationAddedHandler);
 

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/DescriptorBasedComponentInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/DescriptorBasedComponentInspectionPanel.ts
@@ -59,27 +59,26 @@ export abstract class DescriptorBasedComponentInspectionPanel<COMPONENT extends 
 
         if (this.liveEditModel !== liveEditModel) {
 
-            const siteModelUpdatedHandler = () => this.reloadDescriptorsOnApplicationChange();
+            const debouncedReload = api.util.AppHelper.debounce(this.reloadDescriptorsOnApplicationChange.bind(this), 100);
             const applicationUnavailableHandler = () => this.applicationUnavailableHandler();
-            const applicationAddedHandler = () => this.reloadDescriptorsOnApplicationChange();
-            const applicationRemovedHandler = () => this.reloadDescriptorsOnApplicationChange();
+
 
             if (this.liveEditModel != null && this.liveEditModel.getSiteModel() != null) {
                 const siteModel = this.liveEditModel.getSiteModel();
 
-                liveEditModel.getSiteModel().unSiteModelUpdated(siteModelUpdatedHandler);
+                liveEditModel.getSiteModel().unSiteModelUpdated(debouncedReload);
                 siteModel.unApplicationUnavailable(applicationUnavailableHandler);
-                siteModel.unApplicationAdded(applicationAddedHandler);
-                siteModel.unApplicationRemoved(applicationRemovedHandler);
+                siteModel.unApplicationAdded(debouncedReload);
+                siteModel.unApplicationRemoved(debouncedReload);
             }
 
             super.setModel(liveEditModel);
             this.layout();
 
-            liveEditModel.getSiteModel().onSiteModelUpdated(siteModelUpdatedHandler);
+            liveEditModel.getSiteModel().onSiteModelUpdated(debouncedReload);
             liveEditModel.getSiteModel().onApplicationUnavailable(applicationUnavailableHandler);
-            liveEditModel.getSiteModel().onApplicationAdded(applicationAddedHandler);
-            liveEditModel.getSiteModel().onApplicationRemoved(applicationRemovedHandler);
+            liveEditModel.getSiteModel().onApplicationAdded(debouncedReload);
+            liveEditModel.getSiteModel().onApplicationRemoved(debouncedReload);
         }
     }
 

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetComponentDescriptorsByApplicationsRequest.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetComponentDescriptorsByApplicationsRequest.ts
@@ -1,31 +1,57 @@
 import Descriptor = api.content.page.Descriptor;
 import ApplicationKey = api.application.ApplicationKey;
-import ResourceRequest = api.rest.ResourceRequest;
+import JsonResponse = api.rest.JsonResponse;
+import {ApplicationBasedCache} from '../../../../../application/ApplicationBasedCache';
 
 export abstract class GetComponentDescriptorsByApplicationsRequest<JSON, DESCRIPTOR extends Descriptor>
     extends api.rest.ResourceRequest<JSON, DESCRIPTOR[]> {
 
     private applicationKeys: ApplicationKey[];
 
+    private cache: ApplicationBasedCache<DESCRIPTOR>;
+
+    constructor(applicationKey?: ApplicationKey[]) {
+        super();
+        super.setMethod('POST');
+        this.applicationKeys = applicationKey;
+        this.cache = this.registerCache();
+    }
+
+    getRequestPath(): api.rest.Path {
+        return api.rest.Path.fromParent(super.getRestPath(), 'content', 'page', this.getComponentPathName(), 'descriptor', 'list',
+            'by_applications');
+    }
+
     setApplicationKeys(applicationKeys: ApplicationKey[]) {
         this.applicationKeys = applicationKeys;
     }
 
-    sendAndParse(): wemQ.Promise<DESCRIPTOR[]> {
-
-        if (this.applicationKeys.length > 0) {
-
-            const request = (appKey: ApplicationKey) => this.createGetDescriptorsByApplicationRequest(appKey).sendAndParse();
-
-            const promises = this.applicationKeys.map(request);
-
-            return wemQ.all(promises).then((results: DESCRIPTOR[][]) => {
-                return results.reduce((prev: DESCRIPTOR[], curr: DESCRIPTOR[]) => prev.concat(curr), []);
-            });
-        }
-
-        return wemQ.resolve([]);
+    getParams(): Object {
+        return {
+            applicationKeys: this.applicationKeys ? this.applicationKeys.map(key => key.toString()) : []
+        };
     }
 
-    protected abstract createGetDescriptorsByApplicationRequest(applicationKey: ApplicationKey): ResourceRequest<JSON, DESCRIPTOR[]>;
+    sendAndParse(): wemQ.Promise<DESCRIPTOR[]> {
+
+        let cached = this.cache.getByApplications(this.applicationKeys);
+        if (cached) {
+            return wemQ(cached);
+        } else {
+            return this.send().then((response: JsonResponse<JSON>) => {
+                // mark applicationKeys as cached to prevent request when there are no descriptors defined in app
+                this.cache.putApplicationKeys(this.applicationKeys);
+                return this.parseResponse(response).map((descriptor: DESCRIPTOR) => {
+                    this.cache.put(descriptor);
+                    return descriptor;
+                });
+            });
+        }
+    }
+
+    protected abstract registerCache(): ApplicationBasedCache<DESCRIPTOR>;
+
+    protected abstract parseResponse(response: JsonResponse<JSON>): DESCRIPTOR[];
+
+    protected abstract getComponentPathName(): string;
 }

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetLayoutDescriptorsByApplicationsRequest.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetLayoutDescriptorsByApplicationsRequest.ts
@@ -1,13 +1,21 @@
-import ApplicationKey = api.application.ApplicationKey;
 import LayoutDescriptor = api.content.page.region.LayoutDescriptor;
 import LayoutDescriptorsJson = api.content.page.region.LayoutDescriptorsJson;
-import {GetLayoutDescriptorsByApplicationRequest} from '../../../../../resource/GetLayoutDescriptorsByApplicationRequest';
+import JsonResponse = api.rest.JsonResponse;
 import {GetComponentDescriptorsByApplicationsRequest} from './GetComponentDescriptorsByApplicationsRequest';
+import {ApplicationBasedCache} from '../../../../../application/ApplicationBasedCache';
 
 export class GetLayoutDescriptorsByApplicationsRequest
     extends GetComponentDescriptorsByApplicationsRequest<LayoutDescriptorsJson, LayoutDescriptor> {
 
-    protected createGetDescriptorsByApplicationRequest(applicationKey: ApplicationKey): GetLayoutDescriptorsByApplicationRequest {
-        return new GetLayoutDescriptorsByApplicationRequest(applicationKey);
+    protected parseResponse(response: JsonResponse<LayoutDescriptorsJson>): api.content.page.region.LayoutDescriptor[] {
+        return response.getResult().descriptors.map(LayoutDescriptor.fromJson);
+    }
+
+    protected registerCache(): ApplicationBasedCache<LayoutDescriptor> {
+        return ApplicationBasedCache.registerCache(LayoutDescriptor, GetLayoutDescriptorsByApplicationsRequest);
+    }
+
+    protected getComponentPathName(): string {
+        return 'layout';
     }
 }

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetPartDescriptorsByApplicationsRequest.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/GetPartDescriptorsByApplicationsRequest.ts
@@ -1,13 +1,21 @@
-import ApplicationKey = api.application.ApplicationKey;
 import PartDescriptor = api.content.page.region.PartDescriptor;
 import PartDescriptorsJson = api.content.page.region.PartDescriptorsJson;
-import {GetPartDescriptorsByApplicationRequest} from '../../../../../resource/GetPartDescriptorsByApplicationRequest';
+import JsonResponse = api.rest.JsonResponse;
 import {GetComponentDescriptorsByApplicationsRequest} from './GetComponentDescriptorsByApplicationsRequest';
+import {ApplicationBasedCache} from '../../../../../application/ApplicationBasedCache';
 
 export class GetPartDescriptorsByApplicationsRequest
     extends GetComponentDescriptorsByApplicationsRequest<PartDescriptorsJson, PartDescriptor> {
 
-    protected createGetDescriptorsByApplicationRequest(applicationKey: ApplicationKey): GetPartDescriptorsByApplicationRequest {
-        return new GetPartDescriptorsByApplicationRequest(applicationKey);
+    protected parseResponse(response: JsonResponse<PartDescriptorsJson>): api.content.page.region.PartDescriptor[] {
+        return response.getResult().descriptors.map(PartDescriptor.fromJson);
+    }
+
+    protected registerCache(): ApplicationBasedCache<PartDescriptor> {
+        return ApplicationBasedCache.registerCache(PartDescriptor, GetPartDescriptorsByApplicationsRequest);
+    }
+
+    protected getComponentPathName(): string {
+        return 'part';
     }
 }


### PR DESCRIPTION
- adapted ApplicationBasedCache to work with multiple app keys and cache requests with empty responses as well
- changed GetDescriptorsByApplication*S* requests for Page/Layout/Part to make requests to corresponding endpoints instead of doing multiple GetDescriptorsByApplication requests
- also debounced descriptors reload on applications change that reduced No of requests in case of selecting multiple applications with checkboxes