### PR TITLE
Page template config is not shown in the Inspect panel #947

### DIFF
--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/page/PageInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/page/PageInspectionPanel.ts
@@ -147,6 +147,7 @@ class BaseInspectionHandler {
 
         const root = config ? config.getRoot() : null;
         this.configForm = new FormView(context ? context : new FormContextBuilder().build(), pageDescriptor.getConfig(), root);
+        this.configForm.setLazyRender(false);
         this.pageInspectionPanel.appendChild(this.configForm);
         this.pageModel.setIgnorePropertyChanges(true);
         this.configForm.layout().catch((reason: any) => {


### PR DESCRIPTION
Disabled lazy render for the form view in the components widgets, since it may cause the ill-timed call of the render method, which is leading to `onRendered` parent listener not to be called in `FormItemLayer` and children items not added into the `FormView`.