### PR TITLE
Can't serialize Page with config and without the descriptor #1062

### DIFF
--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/page/PageInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/page/PageInspectionPanel.ts
@@ -136,7 +136,7 @@ class BaseInspectionHandler {
         const pageModel: PageModel = this.liveEditModel.getPageModel();
         const pageDescriptor: PageDescriptor = pageModel.getDescriptor();
 
-        if (!pageDescriptor || pageModel.getMode() === PageMode.FORCED_TEMPLATE || pageModel.getMode() === PageMode.FORCED_CONTROLLER) {
+        if (!pageDescriptor || pageModel.getMode() === PageMode.FORCED_TEMPLATE || pageModel.getMode() === PageMode.AUTOMATIC) {
             return;
         }
 

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/page/PageInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/page/PageInspectionPanel.ts
@@ -135,12 +135,13 @@ class BaseInspectionHandler {
 
         const pageModel: PageModel = this.liveEditModel.getPageModel();
         const pageDescriptor: PageDescriptor = pageModel.getDescriptor();
-        const config: PropertyTree = pageModel.getConfig();
-        const context: ContentFormContext = this.liveEditModel.getFormContext();
 
-        if (!pageDescriptor) {
+        if (!pageDescriptor || pageModel.getMode() === PageMode.FORCED_TEMPLATE || pageModel.getMode() === PageMode.FORCED_CONTROLLER) {
             return;
         }
+
+        const config: PropertyTree = pageModel.getConfig();
+        const context: ContentFormContext = this.liveEditModel.getFormContext();
 
         const root: PropertySet = config ? config.getRoot() : null;
         this.configForm = new FormView(context ? context : new FormContextBuilder().build(), pageDescriptor.getConfig(), root);

--- a/src/main/resources/assets/js/page-editor/PageModel.ts
+++ b/src/main/resources/assets/js/page-editor/PageModel.ts
@@ -405,10 +405,7 @@ export class PageModel {
             const defaultRegions = this.defaultTemplate.getRegions();
             const regionsUnchanged = defaultRegions != null && defaultRegions.equals(this.regions);
             const regions = regionsUnchanged ? null : this.regions;
-
-            const defaultConfig = this.defaultTemplate.getConfig();
-            const configUnchanged = defaultConfig != null && defaultConfig.equals(this.config);
-            const config = configUnchanged ? null : this.config;
+            const config = null;
 
             return new PageBuilder().setTemplate(this.getTemplateKey()).setRegions(regions).setConfig(config).setCustomized(
                 this.isCustomized()).setFragment(this.fragment).build();


### PR DESCRIPTION
NPE was occurring when saving page with template set that refers to controller(descriptor) that has config
-No config will be saved with content's page obj that has template set
-Not rendering template's controller's config in page inspection panel