### PR TITLE
Grid toolbar - Undo delete button should not be visible until deleted…

### DIFF
--- a/src/main/resources/assets/js/app/browse/ContentBrowseToolbar.ts
+++ b/src/main/resources/assets/js/app/browse/ContentBrowseToolbar.ts
@@ -6,6 +6,7 @@ export class ContentBrowseToolbar extends api.ui.toolbar.Toolbar {
     constructor(actions: ContentTreeGridActions) {
         super();
         this.addClass('content-browse-toolbar');
+        actions.getUndoPendingDeleteAction().setVisible(false);
         this.addActions(actions.getAllActionsNoPublish());
     }
 }


### PR DESCRIPTION
… content is selected #929

-Making UNDO invisible before adding toolbar buttons