### PR TITLE
Debounced update results in incorrect layout in the Issue Detail dialog

### DIFF
--- a/src/main/resources/assets/js/app/issue/view/IssueDetailsDialogSubTitle.ts
+++ b/src/main/resources/assets/js/app/issue/view/IssueDetailsDialogSubTitle.ts
@@ -6,7 +6,7 @@ import {IssueStatusInfoGenerator} from './IssueStatusInfoGenerator';
 import {IssueStatus} from '../IssueStatus';
 import {IssueTypeFormatter} from '../IssueType';
 
-export class DetailsDialogSubTitle
+export class IssueDetailsDialogSubTitle
     extends DivEl {
 
     private issue: Issue;
@@ -47,6 +47,10 @@ export class DetailsDialogSubTitle
 
     setStatus(status: IssueStatus, silent?: boolean) {
         this.issueStatusSelector.setValue(status, silent);
+    }
+
+    getStatus(): IssueStatus {
+        return this.issueStatusSelector.getValue();
     }
 
     doRender(): wemQ.Promise<boolean> {


### PR DESCRIPTION
-Issue's update is invoked via debounced function, in certain cases like adding assignees even call to a debounced function is async itself; So debounced issue update might be triggered after details dialog is closed and it's fields' values are reset, thus we end up with issue update request set with empty values. Solved by adding a flag that signalizes that update is going to be triggered and then on closing dialog we first invoke update immediately so it is run with actual values