### PR TITLE
Selection is not reset in in the Inspect panel's descriptor selector …

### DIFF
--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/DescriptorBasedDropdown.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/DescriptorBasedDropdown.ts
@@ -21,6 +21,8 @@ export class DescriptorBasedDropdown<DESCRIPTOR extends Descriptor>
     }
 
     setDescriptor(descriptor: Descriptor) {
+        this.resetActiveSelection();
+        this.resetSelected();
 
         if (descriptor) {
             let option = this.getOptionByValue(descriptor.getKey().toString());

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/FragmentDropdown.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/FragmentDropdown.ts
@@ -58,6 +58,8 @@ export class FragmentDropdown
     }
 
     setSelection(fragment: ContentSummary) {
+        this.resetActiveSelection();
+        this.resetSelected();
 
         if (fragment) {
             let option = this.getOptionByValue(fragment.getId().toString());


### PR DESCRIPTION
…#1103

-Grid is used for holding options in inspection panel selector, 'selected' and 'active' cell classes were not set correctly when switching between components of same kind