### PR TITLE
Page Component View loses selection after changes are saved #936

### DIFF
--- a/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
+++ b/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
@@ -45,6 +45,7 @@ export class PageComponentsView
     private modal: boolean;
     private floating: boolean;
     private draggable: boolean;
+    private selectedItemId: string;
 
     private beforeInsertActionListeners: { (event: any): void }[] = [];
 
@@ -166,6 +167,9 @@ export class PageComponentsView
 
             this.tree.setPageView(pageView).then(() => {
                 this.initLock();
+                if (this.selectedItemId) {
+                    this.selectItemById();
+                }
             });
         }
 
@@ -203,14 +207,14 @@ export class PageComponentsView
     private initLiveEditEvents() {
         this.liveEditPage.onItemViewSelected((event: ItemViewSelectedEvent) => {
             if (!event.isNewlyCreated() && !this.pageView.isLocked()) {
-                let selectedItemId = this.tree.getDataId(event.getItemView());
-                this.tree.selectNode(selectedItemId, true);
-                this.tree.getGrid().focus();
+                this.selectedItemId = this.tree.getDataId(event.getItemView());
+                this.selectItemById();
             }
         });
 
         this.liveEditPage.onItemViewDeselected((event: ItemViewDeselectedEvent) => {
             this.tree.deselectNodes([this.tree.getDataId(event.getItemView())]);
+            this.selectedItemId = null;
         });
 
         this.liveEditPage.onComponentAdded((event: ComponentAddedEvent) => {
@@ -514,6 +518,11 @@ export class PageComponentsView
     private selectItem(treeNode: TreeNode<ItemView>) {
         treeNode.getData().selectWithoutMenu();
         this.scrollToItem(treeNode.getDataId());
+    }
+
+    private selectItemById() {
+        this.tree.selectNode(this.selectedItemId, true);
+        this.tree.getGrid().focus();
     }
 
     isDraggable(): boolean {


### PR DESCRIPTION
-Setting pageView to PCV triggers PCV grid reload; during grid reload attempt to restore selection fails; Solved by saving selectedItemId and restoring selection in PCV after grid reload