### PR TITLE
Inspect Panel is not correctly rendered after inserting an image. #1176

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageContentComboBox.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageContentComboBox.ts
@@ -80,7 +80,7 @@ export class ImageContentComboBox
     }
 
     load() {
-        this.reload('');
+        this.reload(this.getComboBox().getInput().getValue());
     }
 
     public static create(): ImageContentComboBoxBuilder {

--- a/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/ImageInspectionPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/ImageInspectionPanel.ts
@@ -84,6 +84,7 @@ export class ImageInspectionPanel
                 this.setImage(image);
             } else {
                 new GetContentSummaryByIdRequest(contentId).sendAndParse().then((receivedImage: ContentSummary) => {
+                    this.imageSelector.clearSelection(true);
                     this.setImage(receivedImage);
                 }).catch((reason: any) => {
                     if (this.isNotFoundError(reason)) {


### PR DESCRIPTION
-Selected option in ImageInspectionPanel was not cleaned before updating it in case when content representing image was not loaded in first batch of data during update, thus it remained selected
-Solved by forcing selection cleanup during update when selected option content not found in dropdown options