### PR TITLE
Keyboard navigation inside Image selector gallery doesn't work correc…

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageContentComboboxKeyEventsHandler.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageContentComboboxKeyEventsHandler.ts
@@ -56,6 +56,11 @@ export class ImageContentComboboxKeyEventsHandler
             }
             return true;
         }
+
+        if (this.grid.getGrid().hasClass('reverted')) {
+            this.handleDown(e);
+            return true;
+        }
     }
 
     private handleRight(e: KeyboardEvent): boolean {


### PR DESCRIPTION
…tly when the dropdown is top-aligned #1211

-Invoking handleDown handlers when these conditions met:
1. Input itself is focused and no active cell in grid
2. Grid is shown above input
3. Arrow up is pressed