### PR TITLE
Publish Menu - incorrect default action after a site has been publish…

### DIFF
--- a/src/main/resources/assets/js/app/browse/ContentPublishMenuButton.ts
+++ b/src/main/resources/assets/js/app/browse/ContentPublishMenuButton.ts
@@ -52,6 +52,7 @@ export class ContentPublishMenuButton
     private activeClass: string;
 
     private initializedListeners: Function[] = [];
+    private actionUpdatedHandler: Function;
 
     protected publishAction: ContentPublishMenuAction;
     protected unpublishAction: ContentPublishMenuAction;
@@ -139,6 +140,10 @@ export class ContentPublishMenuButton
 
     setRefreshDisabled(value: boolean) {
         this.isRefreshDisabled = value;
+
+        if (!value) {
+            this.actionUpdatedHandler();
+        }
     }
 
     private notifyInitialized() {
@@ -171,13 +176,13 @@ export class ContentPublishMenuButton
     }
 
     private handleActionsUpdated() {
-        const actionUpdatedHandler = AppHelper.debounce(() => {
+        this.actionUpdatedHandler = AppHelper.debounce(() => {
             this.updateActiveClass();
         }, 50);
 
         this.getActions().forEach((action: Action) => action.onPropertyChanged(() => {
             if (!this.isRefreshDisabled) {
-                actionUpdatedHandler();
+                this.actionUpdatedHandler();
             }
         }));
     }


### PR DESCRIPTION
…ed and some child were excluded #991

-Issue origin: treegrid actions states are being stashed before heavy operation starts and unstashed after, so we skip publish menu button updates to prevent flickering, however due to async nature of heavy operations some actions might be updated while stashed, and after actions unstashed publish menu button might not be updated if no more updates on actions occur
-Solved: forcing menu button update after menu button enables refresh listener