### PR TITLE
Centered images in HTML Area become left-aligned in edit mode #1289

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -52,7 +52,7 @@ export class HtmlEditor {
         this.editor.on('widgetDefinition', (e: eventInfo) => {
             if (e.data.name === 'image') {
                 this.allowFigureHaveAnyClasses2(e);
-                this.modifyImagePluginUpcastFunction(e);
+                this.modifyImagePluginUpcastDowncastFunctions(e);
             }
         });
     }
@@ -63,7 +63,7 @@ export class HtmlEditor {
         e.data.allowedContent.img.styles = ['*'];
     }
 
-    private modifyImagePluginUpcastFunction(e: eventInfo) {
+    private modifyImagePluginUpcastDowncastFunctions(e: eventInfo) {
         const originalUpcastFunction: Function = e.data.upcast;
         const newUpcastFunction = function (el: CKEDITOR.htmlParser.element, data: any) {
             const result: CKEDITOR.htmlParser.element = originalUpcastFunction(el, data);
@@ -87,7 +87,17 @@ export class HtmlEditor {
             return result;
         };
 
+        const originalDowncastFunction: Function = e.data.downcast;
+        const newDowncastFunction = function (el: CKEDITOR.htmlParser.element) {
+            if (el.name === 'figure' && el.hasClass(StyleHelper.STYLE.ALIGNMENT.CENTER.CLASS)) {
+                return el;
+            }
+
+            return originalDowncastFunction.call(this, el);
+        };
+
         e.data.upcast = newUpcastFunction;
+        e.data.downcast = newDowncastFunction;
     }
 
     private transformTableAttrs() {


### PR DESCRIPTION
-Issue origin: image widget plugin wraps figure element that is centered with alignment
-Solved by overriding required function in image plugin code