### PR TITLE
CKEditor pasteModeSwitcher plugin is written for the old lib-admin-ui…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ jar {
     exclude 'assets/page-editor/lib/_include.js'
     exclude 'assets/page-editor/lib/jquery*.js'
     exclude 'assets/icons/fonts/*.*'
+    exclude 'assets/lib/ckeditor/**/plugin.raw.js'
     if (isProd()) {
         exclude 'assets/**/*.map'
     }

--- a/src/main/resources/assets/lib/ckeditor/plugins/pasteModeSwitcher/plugin.raw.js
+++ b/src/main/resources/assets/lib/ckeditor/plugins/pasteModeSwitcher/plugin.raw.js
@@ -1,3 +1,9 @@
+import {StyleHelper} from 'lib-admin-ui/StyleHelper';
+import {i18n} from 'lib-admin-ui/util/Messages';
+import {Store} from 'lib-admin-ui/store/Store';
+// get jQuery from the global scope
+var $ = Store.instance().get('$');
+
 CKEDITOR.plugins.add('pasteModeSwitcher', {
     init: function (editor) {
 
@@ -8,13 +14,12 @@ CKEDITOR.plugins.add('pasteModeSwitcher', {
             exec: function (editor) {
                 pasteTextOnly = !pasteTextOnly;
                 editor.getCommand('switchPasteMode').setState(pasteTextOnly ? CKEDITOR.TRISTATE_ON : CKEDITOR.TRISTATE_OFF);
-                var tooltipText = pasteTextOnly ? api.util.i18n('tooltip.editor.pastemode.plain') :
-                                                    api.util.i18n('tooltip.editor.pastemode.formatted');
+                var tooltipText = pasteTextOnly ? i18n('tooltip.editor.pastemode.plain') :
+                                  i18n('tooltip.editor.pastemode.formatted');
                 replaceTooltip(tooltipText);
 
                 return true;
             },
-
             contextSensitive: false
         });
 
@@ -25,16 +30,16 @@ CKEDITOR.plugins.add('pasteModeSwitcher', {
                 toolbarButton.title = tooltipText;
             }
 
-            var tooltipId = '#' + api.StyleHelper.getCls('tooltip', api.StyleHelper.COMMON_PREFIX);
-            if (!wemjq(tooltipId).length) {
-                return;
+            var tooltipId = '#' + StyleHelper.getCls('tooltip', StyleHelper.COMMON_PREFIX);
+
+            if ($(tooltipId).length > 0) {
+                $(toolbarButton).data('_tooltip', tooltipText);
+                $(tooltipId).text(tooltipText);
             }
-            wemjq(toolbarButton).data('_tooltip', tooltipText);
-            wemjq(tooltipId).text(tooltipText);
         }
 
         editor.ui.addButton('PasteModeSwitcher', {
-            label: api.util.i18n('tooltip.editor.pastemode.formatted'),
+            label: i18n('tooltip.editor.pastemode.formatted'),
             toolbar: 'tools,10',
             command: 'switchPasteMode',
             icon: 'pastetext'
@@ -51,7 +56,6 @@ CKEDITOR.plugins.add('pasteModeSwitcher', {
                     evt.editor.disableNotification = true;
                     evt.editor.execCommand('pastetext', evt.data);
                     evt.editor.disableNotification = false;
-                    return;
                 } else {
                     skipNextBeforePasteEvent = false;
                 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
         'js/main': './js/main.ts',
         'lib/vendors': './lib/index.js',
         'styles/main': './styles/main.less',
+        'lib/ckeditor/plugins/pasteModeSwitcher/plugin': './lib/ckeditor/plugins/pasteModeSwitcher/plugin.raw.js',
         'page-editor/js/editor': './js/page-editor.ts',
         'page-editor/lib/vendors': './page-editor/lib/index.js',
         'page-editor/styles/main': './page-editor/styles/main.less',


### PR DESCRIPTION
… #1308

Made pasteModeSwitcher plugin compilable.
Renamed `plugin.js` to `plugin.raw.js` to prevent loading error in dev mode, when resources loading from the src.