### PR TITLE
Incorrect behaviour when uploading more attachments than allowed by c…

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/selector/ImageSelector.ts
+++ b/src/main/resources/assets/js/app/inputtype/selector/ImageSelector.ts
@@ -20,7 +20,6 @@ import {ImageSelectorSelectedOptionView} from '../ui/selector/image/ImageSelecto
 import {ImageOptionDataLoader} from '../ui/selector/image/ImageOptionDataLoader';
 import {MediaTreeSelectorItem} from '../ui/selector/media/MediaTreeSelectorItem';
 import {ContentInputTypeViewContext} from '../ContentInputTypeViewContext';
-import {MediaUploaderElOperation} from '../ui/upload/MediaUploaderEl';
 import {Content} from '../../content/Content';
 import {ContentPath} from 'lib-admin-ui/content/ContentPath';
 import {InputValidationRecording} from 'lib-admin-ui/form/inputtype/InputValidationRecording';
@@ -158,19 +157,7 @@ export class ImageSelector
     }
 
     protected createUploader(): Q.Promise<ImageUploaderEl> {
-        let multiSelection = (this.getInput().getOccurrences().getMaximum() !== 1);
-
-        const uploader = new ImageUploaderEl({
-            params: {
-                parent: this.config.content.getContentId().toString()
-            },
-            operation: MediaUploaderElOperation.create,
-            name: 'image-selector-upload-dialog',
-            showCancel: false,
-            showResult: false,
-            maximumOccurrences: this.getRemainingOccurrences(),
-            allowMultiSelection: multiSelection
-        });
+        const uploader: ImageUploaderEl = new ImageUploaderEl(this.createUploaderConfig());
 
         this.doInitUploader(uploader);
 
@@ -210,8 +197,6 @@ export class ImageSelector
             if (!!selectedOption) {
                 this.getSelectedOptionsView().removeSelectedOptions([selectedOption]);
             }
-
-            uploader.setMaximumOccurrences(this.getRemainingOccurrences());
         });
     }
 

--- a/src/main/resources/assets/js/app/inputtype/ui/text/dialog/LinkModalDialog.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/dialog/LinkModalDialog.ts
@@ -415,7 +415,6 @@ export class LinkModalDialog
             name: 'media-selector-upload-el',
             showCancel: false,
             showResult: false,
-            maximumOccurrences: 1,
             allowMultiSelection: false
         });
 

--- a/src/main/resources/assets/js/app/inputtype/ui/text/dialog/image/ImageModalDialog.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/dialog/image/ImageModalDialog.ts
@@ -457,7 +457,6 @@ export class ImageModalDialog
             operation: MediaUploaderElOperation.create,
             name: 'image-selector-upload-dialog',
             showResult: false,
-            maximumOccurrences: 1,
             allowMultiSelection: false,
             deferred: true,
             showCancel: false,

--- a/src/main/resources/assets/js/app/inputtype/ui/upload/AttachmentUploaderEl.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/upload/AttachmentUploaderEl.ts
@@ -7,6 +7,14 @@ import {Attachment, AttachmentBuilder} from '../../../attachment/Attachment';
 import {AttachmentJson} from '../../../attachment/AttachmentJson';
 import {UriHelper} from 'lib-admin-ui/util/UriHelper';
 
+export interface AttachmentUploaderElConfig
+    extends api.ui.uploader.UploaderElConfig {
+
+    attachmentAddCallback?: (value: string) => void;
+
+    attachmentRemoveCallback?: (value: any) => void;
+}
+
 export class AttachmentUploaderEl
     extends FileUploaderEl<Attachment> {
 
@@ -15,7 +23,7 @@ export class AttachmentUploaderEl
     private removeCallback: (value: string) => void;
     private addCallback: (value: string) => void;
 
-    constructor(config: any) {
+    constructor(config: AttachmentUploaderElConfig) {
 
         if (config.url == null) {
             config.url = UriHelper.getRestUri('content/createAttachment');
@@ -83,10 +91,7 @@ export class AttachmentUploaderEl
         return attachmentItem;
     }
 
-    maximumOccurrencesReached(): boolean {
-        if (this.config.maximumOccurrences) {
-            return this.attachmentItems.length >= this.config.maximumOccurrences;
-        }
-        return false;
+    getTotalItems(): number {
+        return this.attachmentItems.length;
     }
 }

--- a/src/main/resources/assets/js/app/inputtype/upload/AttachmentUploader.ts
+++ b/src/main/resources/assets/js/app/inputtype/upload/AttachmentUploader.ts
@@ -7,7 +7,6 @@ import {ValueTypes} from 'lib-admin-ui/data/ValueTypes';
 import {UploadedEvent} from 'lib-admin-ui/ui/uploader/UploadedEvent';
 import {FileUploader} from './FileUploader';
 import {FileUploaderEl} from '../ui/upload/FileUploaderEl';
-import {MediaUploaderElOperation} from '../ui/upload/MediaUploaderEl';
 import {AttachmentUploaderEl} from '../ui/upload/AttachmentUploaderEl';
 import {ContentInputTypeViewContext} from '../ContentInputTypeViewContext';
 import {ContentRequiresSaveEvent} from '../../event/ContentRequiresSaveEvent';
@@ -85,15 +84,14 @@ export class AttachmentUploader
             params: {
                 id: this.getContext().content.getContentId().toString()
             },
-            operation: MediaUploaderElOperation.update,
             name: this.getContext().input.getName(),
             showCancel: false,
             allowMultiSelection: this.getInput().getOccurrences().getMaximum() !== 1,
             hideDefaultDropZone: !!(<any>(this.config.inputConfig)).hideDropZone,
             deferred: true,
-            maximumOccurrences: this.getInput().getOccurrences().getMaximum(),
             attachmentRemoveCallback: this.removeItemCallback.bind(this),
             attachmentAddCallback: this.addItemCallback.bind(this),
+            getTotalAllowedToUpload: this.getTotalAllowedToUpload.bind(this),
             hasUploadButton: false
         });
     }
@@ -123,9 +121,16 @@ export class AttachmentUploader
     }
 
     private updateOccurrences() {
-        this.uploadButton.setVisible(!(<AttachmentUploaderEl>this.uploaderEl).maximumOccurrencesReached());
+        this.uploadButton.setVisible(this.isUploadAllowed());
     }
 
+    private isUploadAllowed(): boolean {
+        return this.getTotalAllowedToUpload() > 0;
+    }
+
+    private getTotalAllowedToUpload(): number {
+        return this.getInput().getOccurrences().getMaximum() - (<AttachmentUploaderEl>this.uploaderEl).getTotalItems();
+    }
 }
 
 InputTypeManager.register(new Class('AttachmentUploader', AttachmentUploader));

--- a/src/main/resources/assets/js/app/inputtype/upload/ImageUploader.ts
+++ b/src/main/resources/assets/js/app/inputtype/upload/ImageUploader.ts
@@ -47,7 +47,6 @@ export class ImageUploader
             },
             operation: MediaUploaderElOperation.update,
             name: config.input.getName(),
-            maximumOccurrences: 1,
             hideDefaultDropZone: true,
             selfIsDropzone: false
         });

--- a/src/main/resources/assets/js/app/inputtype/upload/MediaUploader.ts
+++ b/src/main/resources/assets/js/app/inputtype/upload/MediaUploader.ts
@@ -237,7 +237,6 @@ export class MediaUploader
             operation: MediaUploaderElOperation.update,
             allowExtensions: allowExtensions,
             name: this.getContext().input.getName(),
-            maximumOccurrences: 1,
             allowMultiSelection: false,
             hideDefaultDropZone: hideDropZone != null ? hideDropZone : true,
             deferred: true,


### PR DESCRIPTION
…ontent type #994

-Input types can limit occurrences of items, however uploader is not checking how many items we're uploading and we might upload more items than input allows
-Added mechanism for uploader that checks on demand if item to be uploaded (have to return 'false' from FineUploader's sumbitCallback to reject)
-Adjusted CS files to correspond to latest uploaderEL changes