### PR TITLE
Keep cursor position inside HTML editor after content is saved #1426

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
+++ b/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
@@ -128,7 +128,7 @@ export class HtmlArea
         const textArea = <TextArea> occurrence;
         const id = textArea.getId();
 
-        this.setEditorContent(id, property);
+        this.setEditorContent(id, property, true);
     }
 
     resetInputOccurrenceElement(occurrence: Element) {
@@ -383,12 +383,12 @@ export class HtmlArea
         return HtmlEditor.getData(editor.id);
     }
 
-    private setEditorContent(editorId: string, property: Property): void {
+    private setEditorContent(editorId: string, property: Property, internal: boolean = false): void {
         const content: string = property.hasNonNullValue() ?
                                     HTMLAreaHelper.convertRenderSrcToPreviewSrc(property.getString(), this.content.getId()) : '';
 
         if (HtmlEditor.exists(editorId)) {
-            HtmlEditor.setData(editorId, content);
+            HtmlEditor.setData(editorId, content, internal);
         } else {
             console.log(`Editor with id '${editorId}' not found`);
         }

--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -21,6 +21,12 @@ import {UriHelper} from 'lib-admin-ui/util/UriHelper';
 import eventInfo = CKEDITOR.eventInfo;
 import widget = CKEDITOR.plugins.widget;
 
+export interface HtmlEditorCursorPosition {
+    selectionIndexes: number[];
+    indexOfSelectedElement: number;
+    startOffset: number;
+}
+
 /**
  * NB: Using inline styles for editor's inline mode; Inline styles apply same alignment styles as alignment classes
  * in xp/styles.css, thus don't forget to update inline styles when styles.css modified
@@ -582,16 +588,10 @@ export class HtmlEditor {
                     return;
                 }
 
-                const selection: CKEDITOR.dom.selection = editor.getSelection();
-                const range: CKEDITOR.dom.range = selection.getRanges()[0];
-                const isCursorSetOnText: boolean = (!!range && !!range.startContainer && range.startContainer.$.nodeName === '#text');
-
                 const config: any = {
                     editor: editor,
                     editorParams: this.editorParams,
-                    selectionIndexes: editor.elementPath().elements.map(e => e.getIndex()).reverse().slice(1),
-                    indexOfSelectedElement: isCursorSetOnText ? range.startContainer.getIndex() : -1,
-                    cursorPosition: isCursorSetOnText ? range.startOffset : null
+                    cursorPosition: this.getCursorPosition(editor)
                 };
 
                 this.notifyFullscreenDialog(config);
@@ -633,6 +633,18 @@ export class HtmlEditor {
                 break;
             }
         });
+    }
+
+    private getCursorPosition(editor: CKEDITOR.editor): HtmlEditorCursorPosition {
+        const selection: CKEDITOR.dom.selection = editor.getSelection();
+        const range: CKEDITOR.dom.range = selection.getRanges()[0];
+        const isCursorSetOnText: boolean = (!!range && !!range.startContainer && range.startContainer.$.nodeName === '#text');
+
+        return {
+            selectionIndexes: editor.elementPath().elements.map(e => e.getIndex()).reverse().slice(1),
+            indexOfSelectedElement: isCursorSetOnText ? range.startContainer.getIndex() : -1,
+            startOffset: isCursorSetOnText ? range.startOffset : null
+        };
     }
 
     private setupKeyboardShortcuts() {
@@ -790,8 +802,8 @@ export class HtmlEditor {
         return CKEDITOR.instances[id].getData();
     }
 
-    public static setData(id: string, data: string) {
-        CKEDITOR.instances[id].setData(data);
+    public static setData(id: string, data: string, internal: boolean = false) {
+        CKEDITOR.instances[id].setData(data, {internal: internal});
     }
 
     public static focus(id: string) {
@@ -853,19 +865,19 @@ export class HtmlEditor {
         this.editor.on(eventName, handler);
     }
 
-    public setSelectionByCursorPosition(selectionIndexes: number[], indexOfSelectedElement: number, cursorPosition: number) {
+    public setSelectionByCursorPosition(cursorPositon: HtmlEditorCursorPosition) {
         let elementContainer: CKEDITOR.dom.element = this.editor.document.getBody();
-        selectionIndexes.forEach((index: number) => {
+        cursorPositon.selectionIndexes.forEach((index: number) => {
             elementContainer = <CKEDITOR.dom.element>elementContainer.getChild(index);
         });
 
         elementContainer.scrollIntoView();
 
         const selectedElement: CKEDITOR.dom.node =
-            indexOfSelectedElement > -1 ? elementContainer.getChild(indexOfSelectedElement) : elementContainer;
+            cursorPositon.indexOfSelectedElement > -1 ? elementContainer.getChild(cursorPositon.indexOfSelectedElement) : elementContainer;
 
         const range: CKEDITOR.dom.range = this.editor.createRange();
-        range.setStart(selectedElement, cursorPosition || 0);
+        range.setStart(selectedElement, cursorPositon.startOffset || 0);
         range.select();
     }
 }

--- a/src/main/resources/assets/js/app/inputtype/ui/text/dialog/FullscreenDialog.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/dialog/FullscreenDialog.ts
@@ -2,16 +2,14 @@ import {TextArea} from 'lib-admin-ui/ui/text/TextArea';
 import {i18n} from 'lib-admin-ui/util/Messages';
 import {HtmlAreaModalDialogConfig, ModalDialog} from './ModalDialog';
 import {HtmlEditorParams} from '../HtmlEditorParams';
-import {HtmlEditor} from '../HtmlEditor';
+import {HtmlEditor, HtmlEditorCursorPosition} from '../HtmlEditor';
 
 declare var CONFIG;
 
 export interface FullscreenDialogConfig
     extends HtmlAreaModalDialogConfig {
     editorParams: HtmlEditorParams;
-    selectionIndexes: number[];
-    indexOfSelectedElement: number;
-    cursorPosition: number;
+    cursorPosition: HtmlEditorCursorPosition;
 }
 
 export class FullscreenDialog
@@ -29,8 +27,6 @@ export class FullscreenDialog
         super(<FullscreenDialogConfig>{
             editor: config.editor,
             editorParams: config.editorParams,
-            indexOfSelectedElement: config.indexOfSelectedElement,
-            selectionIndexes: config.selectionIndexes,
             cursorPosition: config.cursorPosition,
             title: i18n('dialog.fullscreen.title'),
             class: 'fullscreen-modal-dialog'
@@ -91,8 +87,7 @@ export class FullscreenDialog
             this.fseditor = htmlEditor;
             htmlEditor.onReady(() => {
                 setTimeout(() => {
-                    htmlEditor.setSelectionByCursorPosition(this.config.selectionIndexes,
-                        this.config.indexOfSelectedElement, this.config.cursorPosition);
+                    htmlEditor.setSelectionByCursorPosition(this.config.cursorPosition);
                 }, 100);
 
                 this.fseditor.on('closeFullscreenDialog', () => {


### PR DESCRIPTION
-Using editor setData with option 'internal' set to 'true' when updating editor, that suppresses any event fired by cke when copying data internally inside the editor - one of this events was triggering changing scrollTop