### PR TITLE
Issues with mid-aligning images in html-area #1444

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -74,6 +74,10 @@ export class HtmlEditor {
         const newUpcastFunction = function (el: CKEDITOR.htmlParser.element, data: any) {
             const result: CKEDITOR.htmlParser.element = originalUpcastFunction(el, data);
 
+            if (el.name === 'figure' && el.hasClass(StyleHelper.STYLE.ALIGNMENT.CENTER.CLASS)) {
+                data.align = 'center';
+            }
+
             if (result && result.name === 'img') { // standalone image
                 return null;
             }


### PR DESCRIPTION
-cke's image plugin logic doesn't expect figure to be topmost widget element and doesn't set internally alignment to be 'center', thus alignment classes are getting wiped out during init
-Fixed by setting image widget's internal data.align = 'center' for a center image when upcasting figure to an image widget