### PR TITLE
Html Area is not updated after reverting a version #1500

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
+++ b/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
@@ -128,7 +128,7 @@ export class HtmlArea
         const textArea = <TextArea> occurrence;
         const id = textArea.getId();
 
-        this.setEditorContent(id, property, true);
+        this.setEditorContent(id, property);
     }
 
     resetInputOccurrenceElement(occurrence: Element) {
@@ -383,12 +383,16 @@ export class HtmlArea
         return HtmlEditor.getData(editor.id);
     }
 
-    private setEditorContent(editorId: string, property: Property, internal: boolean = false): void {
+    private setEditorContent(editorId: string, property: Property): void {
         const content: string = property.hasNonNullValue() ?
                                     HTMLAreaHelper.convertRenderSrcToPreviewSrc(property.getString(), this.content.getId()) : '';
 
         if (HtmlEditor.exists(editorId)) {
-            HtmlEditor.setData(editorId, content, internal);
+            const currentData: string = HtmlEditor.getData(editorId);
+            // invoke setData only if data changed
+            if (content !== currentData) {
+                HtmlEditor.setData(editorId, content);
+            }
         } else {
             console.log(`Editor with id '${editorId}' not found`);
         }

--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -806,8 +806,8 @@ export class HtmlEditor {
         return CKEDITOR.instances[id].getData();
     }
 
-    public static setData(id: string, data: string, internal: boolean = false) {
-        CKEDITOR.instances[id].setData(data, {internal: internal});
+    public static setData(id: string, data: string) {
+        CKEDITOR.instances[id].setData(data);
     }
 
     public static focus(id: string) {


### PR DESCRIPTION
-Removed usage of 'internal' property in setData, it prevents immediate update of editor content
-Updated setEditorContent() function in HtmlArea: invoking setData only when data changed, thus focus won't be lost after editor's updated on save