### PR TITLE
ui-tests for generated names for Fragments issue#1452

### DIFF
--- a/testing/libs/elements.js
+++ b/testing/libs/elements.js
@@ -49,5 +49,6 @@ module.exports = Object.freeze({
     DETAILS_PANEL_TOGGLE_BUTTON: `//button[contains(@id,'NonMobileContextPanelToggleButton')]`,
     ACTION_BUTTON: `//button[contains(@id,'ActionButton')]`,
     SHOW_DEPENDENT_ITEM_LINK: `//h6[@class='dependants-header' and contains(.,'Show dependent items')]`,
-    COMPARE_WITH_CURRENT_VERSION:`//button[contains(@id,'ActionButton') and @title='Compare with current version']`
+    COMPARE_WITH_CURRENT_VERSION:`//button[contains(@id,'ActionButton') and @title='Compare with current version']`,
+    LIVE_EDIT_FRAME: "//iframe[contains(@class,'live-edit-frame shown')]",
 });

--- a/testing/libs/studio.utils.js
+++ b/testing/libs/studio.utils.js
@@ -66,27 +66,20 @@ module.exports = {
         let script = `return CKEDITOR.instances['${id}'].getData()`;
         return webDriverHelper.browser.execute(script);
     },
-    insertUrlLinkInCke: function (text, url) {
+    async insertUrlLinkInCke(text, url) {
         let insertLinkDialog = new InsertLinkDialog();
-        return insertLinkDialog.typeText(text).then(() => {
-            return insertLinkDialog.typeUrl(url);
-        }).then(() => {
-            return insertLinkDialog.clickOnInsertButtonAndWaitForClosed();
-        }).then(() => {
-            return webDriverHelper.browser.pause(500);
-        });
+        await insertLinkDialog.typeText(text);
+        await insertLinkDialog.typeUrl(url);
+        await insertLinkDialog.clickOnInsertButtonAndWaitForClosed();
+        return await webDriverHelper.browser.pause(500);
     },
-    insertDownloadLinkInCke: function (text, contentDisplayName) {
+    async insertDownloadLinkInCke(text, contentDisplayName) {
         let insertLinkDialog = new InsertLinkDialog();
-        return insertLinkDialog.typeText(text).then(() => {
-            return insertLinkDialog.selectTargetInDownloadTab(contentDisplayName);
-        }).then(() => {
-            this.saveScreenshot('download_link_dialog');
-            return insertLinkDialog.clickOnInsertButton();
-        }).then(() => {
-            return insertLinkDialog.pause(700);
-        });
-
+        await insertLinkDialog.typeText(text);
+        await insertLinkDialog.selectTargetInDownloadTab(contentDisplayName);
+        this.saveScreenshot('download_link_dialog');
+        await insertLinkDialog.clickOnInsertButton();
+        return await insertLinkDialog.pause(700);
     },
     async insertEmailLinkInCke(text, email) {
         let insertLinkDialog = new InsertLinkDialog();
@@ -97,16 +90,13 @@ module.exports = {
         return await insertLinkDialog.pause(700);
     },
 
-    insertContentLinkInCke: function (text, contentDisplayName) {
+    async insertContentLinkInCke(text, contentDisplayName) {
         let insertLinkDialog = new InsertLinkDialog();
-        return insertLinkDialog.typeText(text).then(() => {
-            return insertLinkDialog.selectTargetInContentTab(contentDisplayName);
-        }).then(() => {
-            this.saveScreenshot('content_link_dialog');
-            return insertLinkDialog.clickOnInsertButton();
-        }).then(() => {
-            return insertLinkDialog.pause(700);
-        });
+        await insertLinkDialog.typeText(text);
+        await insertLinkDialog.selectTargetInContentTab(contentDisplayName);
+        this.saveScreenshot('content_link_dialog');
+        await insertLinkDialog.clickOnInsertButton();
+        return await insertLinkDialog.pause(700);
     },
     doCloseCurrentBrowserTab: function () {
         return webDriverHelper.browser.getTitle().then(title => {

--- a/testing/page_objects/wizardpanel/content.wizard.panel.js
+++ b/testing/page_objects/wizardpanel/content.wizard.panel.js
@@ -38,7 +38,6 @@ const XPATH = {
     componentViewToggler: "//button[contains(@id, 'TogglerButton')  and contains(@class,'icon-clipboard')]",
     hideComponentViewToggler: "//button[contains(@id, 'TogglerButton') and @title='Hide Component View']",
     thumbnailUploader: "//div[contains(@id,'ThumbnailUploaderEl')]",
-    liveEditFrame: "//iframe[contains(@class,'live-edit-frame shown')]",
     pageDescriptorViewer: `//div[contains(@id,'PageDescriptorViewer')]`,
     accessTabBarItem: `//li[contains(@id,'ContentTabBarItem') and @title='Access']`,
     scheduleTabBarItem: `//li[contains(@id,'ContentTabBarItem') and @title='Schedule']`,
@@ -363,11 +362,11 @@ class ContentWizardPanel extends Page {
     }
 
     switchToLiveEditFrame() {
-        return this.switchToFrame(XPATH.liveEditFrame);
+        return this.switchToFrame(lib.LIVE_EDIT_FRAME);
     }
 
     async getLiveFramePosition() {
-        let el = await this.findElement(XPATH.liveEditFrame);
+        let el = await this.findElement(lib.LIVE_EDIT_FRAME);
         let xValue = parseInt(await el.getLocation('x'));
         let yValue = parseInt(await el.getLocation('y'));
         return {x: xValue, y: yValue};

--- a/testing/specs/page-editor/generate.name.for.fragments.spec.js
+++ b/testing/specs/page-editor/generate.name.for.fragments.spec.js
@@ -1,0 +1,118 @@
+/**
+ * Created on 25.02.2020.
+ */
+const chai = require('chai');
+const assert = chai.assert;
+const webDriverHelper = require('../../libs/WebDriverHelper');
+const appConstant = require('../../libs/app_const');
+const ImageInspectPanel = require('../../page_objects/wizardpanel/liveform/inspection/image.inspection.panel');
+const LayoutInspectPanel = require('../../page_objects/wizardpanel/liveform/inspection/layout.inspection.panel');
+const studioUtils = require('../../libs/studio.utils.js');
+const ContentWizard = require('../../page_objects/wizardpanel/content.wizard.panel');
+const contentBuilder = require("../../libs/content.builder");
+const PageComponentView = require("../../page_objects/wizardpanel/liveform/page.components.view");
+const TextComponentCke = require('../../page_objects/components/text.component');
+const InsertImageDialog = require('../../page_objects/wizardpanel/insert.image.dialog.cke');
+
+describe('Generate name for fragments  specification', function () {
+    this.timeout(appConstant.SUITE_TIMEOUT);
+    webDriverHelper.setupBrowser();
+
+    let SITE;
+    let CONTROLLER_NAME = 'main region';
+    let TEST_IMAGE_NAME = appConstant.TEST_IMAGES.FOSS;
+
+
+    it(`Preconditions: new site should be created`,
+        async () => {
+            let displayName = contentBuilder.generateRandomName('site');
+            SITE = contentBuilder.buildSite(displayName, 'description', [appConstant.SIMPLE_SITE_APP], CONTROLLER_NAME);
+            await studioUtils.doAddSite(SITE);
+        });
+
+    //Verifies https://github.com/enonic/app-contentstudio/issues/1455 Text component name should be sanitised
+    it(`GIVEN an image is inserted in text-component WHEN the component has been saved as fragment THEN expected fragment-name should be generated`,
+        async () => {
+            let contentWizard = new ContentWizard();
+            let textComponentCke = new TextComponentCke();
+            let pageComponentView = new PageComponentView();
+            let insertImageDialog = new InsertImageDialog();
+            //1. Open existing site:
+            await studioUtils.selectContentAndOpenWizard(SITE.displayName);
+            await contentWizard.clickOnShowComponentViewToggler();
+            //2. Insert new text-component
+            await pageComponentView.openMenu("main");
+            await pageComponentView.selectMenuItemAndCloseDialog(["Insert", "Text"]);
+            await textComponentCke.switchToLiveEditFrame();
+            //3. Open 'Insert Image' dialog and insert an image in htmlArea:
+            await textComponentCke.clickOnInsertImageButton();
+            await insertImageDialog.waitForDialogVisible();
+            await insertImageDialog.filterAndSelectImage(TEST_IMAGE_NAME);
+            await insertImageDialog.clickOnInsertButton();
+            //4. Save the text-component as fragment:
+            await contentWizard.clickOnShowComponentViewToggler();
+            await pageComponentView.openMenu("Text");
+            await pageComponentView.clickOnMenuItem(appConstant.MENU_ITEMS.SAVE_AS_FRAGMENT);
+            await contentWizard.pause(700);
+            studioUtils.doSwitchToNewWizard();
+            //5. Verify the generated display name:
+            let fragmentContent = await contentWizard.getDisplayName();
+            assert.equal(fragmentContent, "Text", "Expected display name should be generated in Fragment-Wizard");
+        });
+
+    //Verifies -  xp/issues/7831, Component Names - generate proper names for Fragment component #7831
+    it(`GIVEN an image component is inserted WHEN the component has been saved as fragment THEN expected fragment-name should be generated`,
+        async () => {
+            let contentWizard = new ContentWizard();
+            let imageInspectPanel = new ImageInspectPanel();
+            let pageComponentView = new PageComponentView();
+            let insertImageDialog = new InsertImageDialog();
+            //1. Open existing site:
+            await studioUtils.selectContentAndOpenWizard(SITE.displayName);
+            await contentWizard.clickOnShowComponentViewToggler();
+            //2. Insert new image-component
+            await pageComponentView.openMenu("main");
+            await pageComponentView.selectMenuItemAndCloseDialog(["Insert", "Image"]);
+            //3. Select the image in Inspect Panel:
+            await imageInspectPanel.typeNameAndSelectImage(TEST_IMAGE_NAME);
+            //4. Save the image-component as fragment:
+            await contentWizard.clickOnShowComponentViewToggler();
+            await pageComponentView.openMenu(TEST_IMAGE_NAME);
+            await pageComponentView.clickOnMenuItem(appConstant.MENU_ITEMS.SAVE_AS_FRAGMENT);
+            await contentWizard.pause(700);
+            studioUtils.doSwitchToNewWizard();
+            //5. Verify the generated display name:
+            let fragmentContent = await contentWizard.getDisplayName();
+            assert.equal(fragmentContent, TEST_IMAGE_NAME, "Expected display name should be generated in Fragment-Wizard");
+        });
+
+    //Verifies -  xp/issues/7831, Component Names - generate proper names for Fragment component #7831
+    it(`GIVEN an layout component is inserted WHEN the empty layout has been saved as fragment THEN expected fragment-name should be generated`,
+        async () => {
+            let contentWizard = new ContentWizard();
+            let layoutInspectPanel = new LayoutInspectPanel();
+            let pageComponentView = new PageComponentView();
+            let insertImageDialog = new InsertImageDialog();
+            //1. Open existing site:
+            await studioUtils.selectContentAndOpenWizard(SITE.displayName);
+            await contentWizard.clickOnShowComponentViewToggler();
+            //2. Insert new layout-component
+            await pageComponentView.openMenu("main");
+            await pageComponentView.selectMenuItem(["Insert", "Layout"]);
+            //3. Save the empty layout-component as fragment:
+            await pageComponentView.openMenu("Layout");
+            await pageComponentView.clickOnMenuItem(appConstant.MENU_ITEMS.SAVE_AS_FRAGMENT);
+            await contentWizard.pause(700);
+            studioUtils.doSwitchToNewWizard();
+            //4. Verify the generated display name(should be 'Layout'):
+            let fragmentContent = await contentWizard.getDisplayName();
+            assert.equal(fragmentContent, "Layout", "Expected display name should be generated in Fragment-Wizard");
+        });
+
+
+    beforeEach(() => studioUtils.navigateToContentStudioApp());
+    afterEach(() => studioUtils.doCloseAllWindowTabsAndSwitchToHome());
+    before(() => {
+        return console.log('specification starting: ' + this.title);
+    });
+});

--- a/testing/specs/page-editor/image.component.inspect.panel.spec.js
+++ b/testing/specs/page-editor/image.component.inspect.panel.spec.js
@@ -5,8 +5,6 @@
  * Incorrect behavior after applying changes in Inspection Panel
  */
 const chai = require('chai');
-chai.use(require('chai-as-promised'));
-const expect = chai.expect;
 const assert = chai.assert;
 const webDriverHelper = require('../../libs/WebDriverHelper');
 const appConstant = require('../../libs/app_const');
@@ -16,7 +14,6 @@ const contentBuilder = require("../../libs/content.builder");
 const PageComponentView = require("../../page_objects/wizardpanel/liveform/page.components.view");
 const LiveFormPanel = require("../../page_objects/wizardpanel/liveform/live.form.panel");
 const ImageInspectPanel = require('../../page_objects/wizardpanel/liveform/inspection/image.inspection.panel');
-
 
 describe("image.component.inspect.panel.spec: Inserts a image component and checks 'Inspect Panel' on the Context Window ",
     function () {
@@ -35,66 +32,55 @@ describe("image.component.inspect.panel.spec: Inserts a image component and chec
             });
 
         it(`GIVEN existing site is opened AND an image has been inserted WHEN a caption has been typed AND 'Apply' button pressed THEN the site is getting 'saved'`,
-            () => {
+            async () => {
                 let pageComponentView = new PageComponentView();
                 let liveFormPanel = new LiveFormPanel();
                 let contentWizard = new ContentWizard();
                 let imageInspectPanel = new ImageInspectPanel();
-                return studioUtils.selectContentAndOpenWizard(SITE.displayName).then(() => {
-                    //automatic template does not exist, so no need to unlock the editor
-                    return contentWizard.clickOnShowComponentViewToggler();
-                }).then(() => {
-                    return pageComponentView.openMenu("main");
-                }).then(() => {
-                    return pageComponentView.selectMenuItemAndCloseDialog(["Insert", "Image"]);
-                }).then(() => {
-                    return liveFormPanel.selectImageByDisplayName(IMAGE_DISPLAY_NAME);
-                }).then(() => {
-                    return contentWizard.switchToMainFrame();
-                }).then(() => {
-                    return imageInspectPanel.typeCaption("test image");
-                }).then(() => {
-                    return imageInspectPanel.clickOnApplyButton();
-                }).then(() => {
-                    return contentWizard.switchToMainFrame();
-                }).then(() => {
-                    // the site should be automatically saved, because Apply button was pressed
-                    return contentWizard.waitForNotificationMessage();
-                }).then(message => {
-                    studioUtils.saveScreenshot('inspect_image_panel_applied');
-                    let expectedMessage = appConstant.itemSavedNotificationMessage(SITE.displayName);
-                    assert.equal(message, expectedMessage, "expected notification message should appear")
-                })
+                //1. Open existing site:
+                await studioUtils.selectContentAndOpenWizard(SITE.displayName);
+                //automatic template does not exist, so no need to unlock the editor
+                await contentWizard.clickOnShowComponentViewToggler();
+                //2. Insert image component, select an image and set a caption:
+                await pageComponentView.openMenu("main");
+                await pageComponentView.selectMenuItemAndCloseDialog(["Insert", "Image"]);
+                await liveFormPanel.selectImageByDisplayName(IMAGE_DISPLAY_NAME);
+                await contentWizard.switchToMainFrame();
+                await imageInspectPanel.typeCaption("test image");
+                //3. Click on Apply button:
+                await imageInspectPanel.clickOnApplyButton();
+                await contentWizard.switchToMainFrame();
+                //4. Verify - the site should be automatically saved, because Apply button was pressed
+                let actualMessage = await contentWizard.waitForNotificationMessage();
+                //5. Verify the notification message:
+                studioUtils.saveScreenshot('inspect_image_panel_applied');
+                let expectedMessage = appConstant.itemSavedNotificationMessage(SITE.displayName);
+                assert.equal(actualMessage, expectedMessage, "expected notification message should appear")
             });
 
         //verifies https://github.com/enonic/app-contentstudio/issues/77
-        it(`GIVEN existing site with image-component is opened WHEN the caption in inspection panel has been updated THEN expected caption should be present in the text area`,
-            () => {
+        it(`GIVEN existing site with image-component is opened WHEN the caption in inspection panel has been updated THEN updated caption should be present in the text area`,
+            async () => {
                 let contentWizard = new ContentWizard();
                 let pageComponentView = new PageComponentView();
                 let imageInspectPanel = new ImageInspectPanel();
-                return studioUtils.selectContentAndOpenWizard(SITE.displayName).then(() => {
-                    return contentWizard.clickOnShowComponentViewToggler();
-                }).then(() => {
-                    return pageComponentView.clickOnComponent(IMAGE_DISPLAY_NAME);
-                }).then(() => {
-                    // image inspection panel should be loaded automatically
-                    return imageInspectPanel.waitForOpened();
-                }).then(() => {
-                    return imageInspectPanel.typeCaption("new caption");
-                }).then(() => {
-                    return imageInspectPanel.clickOnApplyButton();
-                }).then(() => {
-                    return imageInspectPanel.typeCaption("test caption");
-                }).then(() => {
-                    return imageInspectPanel.clickOnApplyButton();
-                }).then(() => {
-                    return imageInspectPanel.pause(1000);
-                }).then(() => {
-                    return imageInspectPanel.getCaptionText();
-                }).then(result => {
-                    assert.equal(result, "test caption", "caption should be updated successfully");
-                })
+                //1. Open existing site and open Page Component View:
+                await studioUtils.selectContentAndOpenWizard(SITE.displayName);
+                await contentWizard.clickOnShowComponentViewToggler();
+                await pageComponentView.clickOnComponent(IMAGE_DISPLAY_NAME);
+                //2. Verify that image inspection panel should be loaded automatically
+                await imageInspectPanel.waitForOpened();
+                //3. Type the text in caption area:
+                await imageInspectPanel.typeCaption("new caption");
+                //4. click on Apply button:
+                await imageInspectPanel.clickOnApplyButton();
+                //5. Update the caption:
+                await imageInspectPanel.typeCaption("test caption");
+                await imageInspectPanel.clickOnApplyButton();
+                await imageInspectPanel.pause(1000);
+                //6. Verify the text in caption-area:
+                let actualCaption = await imageInspectPanel.getCaptionText();
+                assert.equal(actualCaption, "test caption", "caption should be updated successfully");
             });
 
         beforeEach(() => studioUtils.navigateToContentStudioApp());

--- a/testing/specs/wizard.tag.allowpath.spec.js
+++ b/testing/specs/wizard.tag.allowpath.spec.js
@@ -2,8 +2,6 @@
  * Created on 23.03.2019.
  */
 const chai = require('chai');
-chai.use(require('chai-as-promised'));
-const expect = chai.expect;
 const assert = chai.assert;
 const webDriverHelper = require('../libs/WebDriverHelper');
 const appConstant = require('../libs/app_const');
@@ -32,80 +30,66 @@ describe('wizard.tag.allowpath.spec: check allowPath for tags`', function () {
         });
 
     it(`Precondition, new tag should be added in the root of the site: tag-content wizard has been opened and tag with text 'enonic' has been saved`,
-        () => {
+        async () => {
             let contentWizard = new ContentWizard();
             let tagForm = new TagForm();
-            //do add new tag-content in the root of the site
-            return studioUtils.selectSiteAndOpenNewWizard(SITE.displayName, 'tag0_5').then(() => {
-                return contentWizard.typeDisplayName("test-tag1");
-            }).then(() => {
-                //type 'enonic' in the input and save this tag
-                return tagForm.doAddTag(TAG_TEXT1);
-            }).then(() => {
-                return contentWizard.waitAndClickOnSave();
-            }).then(() => {
-                studioUtils.saveScreenshot('tag1_added');
-                return contentWizard.waitForNotificationMessage();
-            });
+            //1. Select the site and open new wizard for child content:
+            await studioUtils.selectSiteAndOpenNewWizard(SITE.displayName, 'tag0_5');
+            await contentWizard.typeDisplayName("test-tag1");
+            //2. type 'enonic' in the input and save this tag:
+            await tagForm.doAddTag(TAG_TEXT1);
+            await contentWizard.waitAndClickOnSave();
+            //3. Verify that new content is saved:
+            studioUtils.saveScreenshot('tag1_added');
+            await contentWizard.waitForNotificationMessage();
         });
 
     it(`Precondition: new tag-content should be added in the folder that specified in 'allowPath'`,
-        () => {
+        async () => {
             let tagForm = new TagForm();
             let contentWizard = new ContentWizard();
             //select 'mytags' folder and open wizard for tag-content
-            return studioUtils.selectSiteAndOpenNewWizard(MY_TAGS_FOLDER, 'tag0_5').then(() => {
-                return contentWizard.typeDisplayName("test-tag2");
-            }).then(() => {
-                //type 'test-enonic' in the input and save this tag
-                return tagForm.doAddTag(TAG_TEXT2);
-            }).then(() => {
-                return contentWizard.waitAndClickOnSave();
-            }).then(() => {
-                studioUtils.saveScreenshot('tag2_added');
-                return contentWizard.waitForNotificationMessage();
-            });
+            await studioUtils.selectSiteAndOpenNewWizard(MY_TAGS_FOLDER, 'tag0_5');
+            await contentWizard.typeDisplayName("test-tag2");
+            //type 'test-enonic' in the input and save this tag:
+            await tagForm.doAddTag(TAG_TEXT2);
+            await contentWizard.waitAndClickOnSave();
+            studioUtils.saveScreenshot('tag2_added');
+            //verify that new content is saved:
+            await contentWizard.waitForNotificationMessage();
         });
 
-//<allowPath>${site}/mytags/</allowPath>
+    //<allowPath>${site}/mytags/</allowPath>
     it(`GIVEN wizard for new tag-content is opened WHEN part of the tag that is not in 'allowPath' has been typed THEN tag-suggestion should not appear`,
-        () => {
+        async () => {
             let tagForm = new TagForm();
             let contentWizard = new ContentWizard();
-            //open new wizard in "${site}/mytags/"
-            return studioUtils.selectSiteAndOpenNewWizard(MY_TAGS_FOLDER, 'tag0_5').then(() => {
-                //type a name
-                return contentWizard.typeDisplayName("test-tag3");
-            }).then(() => {
-                //type the text-part of existing tag(the tag is not in allowed folder)
-                return tagForm.typeInTagInput("enon");
-            }).then(() => {
-                // suggestion is not visible because 'allowPath' is "${site}/mytags"
-                return tagForm.getTagSuggestions();
-            }).then(result => {
-                studioUtils.saveScreenshot('no_tag_suggestion');
-                assert.isTrue(result === "", "Tag Suggestion should not be visible");
-            });
+            //1. open new wizard in "${site}/mytags/"
+            await studioUtils.selectSiteAndOpenNewWizard(MY_TAGS_FOLDER, 'tag0_5');
+            //2. type a name
+            await contentWizard.typeDisplayName("test-tag3");
+            //3. type the text-part of existing tag(the tag is not in allowed folder)
+            await tagForm.typeInTagInput("enon");
+            //Verify that the suggestion is not visible because tag is not in 'allowPath'
+            let actualSuggestion = await tagForm.getTagSuggestions();
+            studioUtils.saveScreenshot('no_tag_suggestion');
+            assert.equal(actualSuggestion, "", "Tag Suggestion should not be visible");
         });
 
     it(`GIVEN wizard for new tag-content is opened WHEN part of the tag that in 'allowed' folder has been typed THEN tag-suggestion should appear`,
-        () => {
+        async () => {
             let tagForm = new TagForm();
             let contentWizard = new ContentWizard();
-            //open new wizard in "${site}/mytags/"
-            return studioUtils.selectSiteAndOpenNewWizard(MY_TAGS_FOLDER, 'tag0_5').then(() => {
-                //type a name
-                return contentWizard.typeDisplayName("test-tag3");
-            }).then(() => {
-                //type the part of text of existing tag(the tag is in allowed folder)
-                return tagForm.typeInTagInput("test");
-            }).then(() => {
-                // suggestion should be visible because allowPath is "${site}/mytags"
-                return tagForm.getTagSuggestions();
-            }).then(result => {
-                studioUtils.saveScreenshot('tag_suggestion');
-                assert.isTrue(result === TAG_TEXT2, "Tag- Suggestion should appear")
-            });
+            //1. open new wizard in "${site}/mytags/"
+            await studioUtils.selectSiteAndOpenNewWizard(MY_TAGS_FOLDER, 'tag0_5');
+            //2. type a name:
+            await contentWizard.typeDisplayName("test-tag3");
+            //3. type the part of text of existing tag(the tag is in allowed folder)
+            await tagForm.typeInTagInput("test");
+            //Verify : suggestion should be visible because allowPath is "${site}/mytags"
+            let actualSuggestion = await tagForm.getTagSuggestions();
+            studioUtils.saveScreenshot('tag_suggestion');
+            assert.equal(actualSuggestion, TAG_TEXT2, "Expected tag-suggestion should appear")
         });
 
     beforeEach(() => studioUtils.navigateToContentStudioApp());


### PR DESCRIPTION
Verifies
1)  https://github.com/enonic/app-contentstudio/issues/1455 Text component name should be sanitised
2) xp/issues/7831, Component Names - generate proper names for Fragment component #7831