### PR TITLE
Status is not refreshed in browse panel #1560

### DIFF
--- a/src/main/resources/assets/js/app/event/ContentServerEventsHandler.ts
+++ b/src/main/resources/assets/js/app/event/ContentServerEventsHandler.ts
@@ -11,6 +11,7 @@ import {ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompar
 import {CompareStatusChecker} from '../content/CompareStatus';
 import {ContentIds} from '../ContentIds';
 import {Branch} from '../versioning/Branch';
+import {DefaultErrorHandler} from 'lib-admin-ui/DefaultErrorHandler';
 
 /**
  * Class that listens to server events and fires UI events
@@ -459,7 +460,7 @@ export class ContentServerEventsHandler {
                     default:
                         //
                     }
-                });
+                }).catch(DefaultErrorHandler.handle);
         }
     }
 

--- a/src/main/resources/assets/js/app/view/MobileContentItemStatisticsPanel.ts
+++ b/src/main/resources/assets/js/app/view/MobileContentItemStatisticsPanel.ts
@@ -58,9 +58,12 @@ export class MobileContentItemStatisticsPanel
     private initListeners() {
 
         let reloadItemPublishStateChange = (contents: ContentSummaryAndCompareStatus[]) => {
-            let thisContentId = this.getItem().getModel().getId();
+            if (!this.getItem()) {
+                return;
+            }
+            const thisContentId: string = this.getItem().getModel().getId();
 
-            let contentSummary: ContentSummaryAndCompareStatus = contents.filter((content) => {
+            const contentSummary: ContentSummaryAndCompareStatus = contents.filter((content) => {
                 return thisContentId === content.getId();
             })[0];
 

--- a/src/main/resources/assets/js/app/view/MobileContentItemStatisticsPanel.ts
+++ b/src/main/resources/assets/js/app/view/MobileContentItemStatisticsPanel.ts
@@ -63,9 +63,7 @@ export class MobileContentItemStatisticsPanel
             }
             const thisContentId: string = this.getItem().getModel().getId();
 
-            const contentSummary: ContentSummaryAndCompareStatus = contents.filter((content) => {
-                return thisContentId === content.getId();
-            })[0];
+            const contentSummary: ContentSummaryAndCompareStatus = contents.find(content => thisContentId === content.getId());
 
             if (contentSummary) {
                 this.setItem(ContentHelper.createView(contentSummary));


### PR DESCRIPTION
Unhandled error occurred in MobileContentItemStatisticsPanel, so
1. Fixed error
2. Added catch() clause on event handling promise, thus error is displayed in console