### PR TITLE
Task Details Dialog switches to the Comments tab after save #1571

### DIFF
--- a/src/main/resources/assets/js/app/issue/view/IssueDetailsDialog.ts
+++ b/src/main/resources/assets/js/app/issue/view/IssueDetailsDialog.ts
@@ -23,7 +23,10 @@ import {PublishRequestItem} from '../PublishRequestItem';
 import {IssueDetailsDialogButtonRow} from './IssueDetailsDialogDropdownButtonRow';
 import {IssueDetailsDialogSubTitle} from './IssueDetailsDialogSubTitle';
 import {PublishProcessor} from '../../publish/PublishProcessor';
-import {DependantItemsWithProgressDialog, DependantItemsWithProgressDialogConfig} from '../../dialog/DependantItemsWithProgressDialog';
+import {
+    DependantItemsWithProgressDialog,
+    DependantItemsWithProgressDialogConfig
+} from '../../dialog/DependantItemsWithProgressDialog';
 import {IssueCommentsList} from './IssueCommentsList';
 import {IssueCommentTextArea} from './IssueCommentTextArea';
 import {CreateIssueCommentRequest} from '../resource/CreateIssueCommentRequest';
@@ -719,8 +722,6 @@ export class IssueDetailsDialog
 
         if (shouldUpdateDialog) {
             this.updateLabels();
-
-            this.tabBar.selectNavigationItem(isPublishRequest ? 1 : 0);
         }
 
         return this;


### PR DESCRIPTION
-Removed switching to comments tab on issue details dialog's setIssue