### PR TITLE
Page Component View - incorrect description of a fragment #1534

### DIFF
--- a/src/main/resources/assets/js/app/wizard/PageComponentsTreeGrid.ts
+++ b/src/main/resources/assets/js/app/wizard/PageComponentsTreeGrid.ts
@@ -28,6 +28,8 @@ import {TreeGridBuilder} from 'lib-admin-ui/ui/treegrid/TreeGridBuilder';
 import {Descriptor} from 'lib-admin-ui/content/page/Descriptor';
 import {ApplicationKey} from 'lib-admin-ui/application/ApplicationKey';
 import {SpanEl} from 'lib-admin-ui/dom/SpanEl';
+import {FragmentItemType} from '../../page-editor/fragment/FragmentItemType';
+import {FragmentComponentView} from '../../page-editor/fragment/FragmentComponentView';
 
 export class PageComponentsTreeGrid
     extends TreeGrid<ItemView> {
@@ -88,6 +90,32 @@ export class PageComponentsTreeGrid
 
         // tslint:disable-next-line:no-unused-expression
         (new PageComponentsGridDragHandler(this));
+    }
+
+    dataToTreeNode(data: ItemView, parent: TreeNode<ItemView>, expandAllowed?: boolean): TreeNode<ItemView> {
+        const node: TreeNode<ItemView> = super.dataToTreeNode(data, parent, expandAllowed);
+
+        if (ObjectHelper.iFrameSafeInstanceOf(data.getType(), FragmentItemType)) {
+            this.updateTreeNodeWithFragmentsOnLoad(node);
+        }
+
+        return node;
+    }
+
+    private updateTreeNodeWithFragmentsOnLoad(node: TreeNode<ItemView>) {
+        const fragmentView: FragmentComponentView = <FragmentComponentView>node.getData();
+
+        if (fragmentView.isLoaded()) {
+            return;
+        }
+
+        const loadedListener = () => {
+            // this.invalidateNodes([node]);
+            node.getViewer('name')
+            fragmentView.unFragmentContentLoaded(loadedListener);
+        };
+
+        fragmentView.onFragmentContentLoaded(loadedListener);
     }
 
     toggleCompact(flag: boolean) {


### PR DESCRIPTION
-FragmentComponentView's content is loaded async and is not there yet by the time when Page Components grid is creating its nodes, thus subname is generated without knowing type of fragment's content. Also due to the way how nodes are being generated - by triggering toString on viewer and making new Element from that string - original viewer is not reachable, thus have to invalidate fragment's node to trigger node rerender after fragment's content loaded