### PR TITLE
Settings page gives error 403 for users who have access only to a non…

### DIFF
--- a/src/main/resources/admin/tools/settings/settings.xml
+++ b/src/main/resources/admin/tools/settings/settings.xml
@@ -6,5 +6,6 @@
     <principal>role:system.admin</principal>
     <principal>role:cms.admin</principal>
     <principal>role:cms.cm.app</principal>
+      <principal>role:system.admin.login</principal>
   </allow>
 </tool>


### PR DESCRIPTION
…-default project #1705

-Allowed user with only admin console access to open settings page