### PR TITLE
Keyboard navigation in the Content grid stops working after project s…

### DIFF
--- a/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -224,8 +224,10 @@ export class ContentTreeGrid
 
         if (this.state === State.ENABLED) {
             this.getToolbar().enable();
+            this.enableKeys();
         } else {
             this.getToolbar().disable();
+            this.disableKeys();
         }
     }
 

--- a/src/main/resources/assets/js/app/settings/browse/SettingsBrowsePanel.ts
+++ b/src/main/resources/assets/js/app/settings/browse/SettingsBrowsePanel.ts
@@ -6,11 +6,32 @@ import {SettingsBrowseItemPanel} from './SettingsBrowseItemPanel';
 import {TreeNode} from 'lib-admin-ui/ui/treegrid/TreeNode';
 import {BrowseItem} from 'lib-admin-ui/app/browse/BrowseItem';
 import {SettingsViewItem} from '../view/SettingsViewItem';
+import {ProjectContext} from '../../project/ProjectContext';
+import {ProjectChangedEvent} from '../../project/ProjectChangedEvent';
 
 export class SettingsBrowsePanel
     extends BrowsePanel<SettingsViewItem> {
 
     protected treeGrid: SettingsItemsTreeGrid;
+
+    protected initElements(): void {
+        super.initElements();
+
+        if (!ProjectContext.get().isInitialized()) {
+            this.handleProjectNotSet();
+        }
+    }
+
+    private handleProjectNotSet() {
+        this.treeGrid.disableKeys();
+
+        const projectSetHandler = () => {
+            this.treeGrid.enableKeys();
+            ProjectChangedEvent.un(projectSetHandler);
+        };
+
+        ProjectChangedEvent.on(projectSetHandler);
+    }
 
     protected createTreeGrid(): SettingsItemsTreeGrid {
         return new SettingsItemsTreeGrid();


### PR DESCRIPTION
…elected #1733

-Keybindings are being shelved/unshelved in wrong order when project selection dialogs is open, thus closing it doesn't bring treegrid's key events back
-Now binding treegrid's key events AFTER project selection dialog is open