### PR TITLE
HTML Area fields are cleared on concurrent content update #1692

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -806,8 +806,8 @@ export class HtmlEditor {
         return CKEDITOR.instances[id].getData();
     }
 
-    public static setData(id: string, data: string) {
-        CKEDITOR.instances[id].setData(data);
+    public static setData(id: string, data: string, callback?: () => void) {
+        CKEDITOR.instances[id].setData(data, !!callback ? {callback: callback} : null);
     }
 
     public static focus(id: string) {


### PR DESCRIPTION
-all update related attributes( like dirty flag, original value etc.) are stored in hidden TextArea element, thus need to duplicate editor's content in TextArea element for updates to be received and handled correctly
-added 'callback' param for editor's setData method to differentiate between user input and update events that must be handled differently