### PR TITLE
Components Widget - html area becomes uneditable after the Context pa…

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
+++ b/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
@@ -67,6 +67,10 @@ export class HtmlArea
             return Q(null);
         });
 
+        this.onAdded(() => {
+            this.refresh();
+        });
+
         this.setupEventListeners();
     }
 


### PR DESCRIPTION
…nel switches to floating mode #963

-Detaching and reattaching editor's iframe to DOM breaks it (that what happens when switching between floating/docked mode, ContextView gets reattached to active panel), have to reinit editor instances after