### PR TITLE
Page Component View - error in console after DnD swapping component #…

### DIFF
--- a/src/main/resources/assets/js/app/wizard/PageComponentsGridDragHandler.ts
+++ b/src/main/resources/assets/js/app/wizard/PageComponentsGridDragHandler.ts
@@ -128,8 +128,8 @@ export class PageComponentsGridDragHandler
 
         (<ComponentView<Component>>item.getData()).moveToRegion(<RegionView>newParent.getData(), insertIndex);
 
-        item.getData().select(null, ItemViewContextMenuPosition.NONE);
         this.contentGrid.refresh();
+        item.getData().select(null, ItemViewContextMenuPosition.NONE);
 
         return data[regionPosition];
     }


### PR DESCRIPTION
…1824

-Selecting dragged node after grid refreshed (not before as now)