### PR TITLE
Image Selector with deleted image is not properly validated #1479

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/selector/ImageSelector.ts
+++ b/src/main/resources/assets/js/app/inputtype/selector/ImageSelector.ts
@@ -65,7 +65,15 @@ export class ImageSelector
 
         selectedOptionsView.onRemoveSelectedOptions((options: SelectedOption<MediaTreeSelectorItem>[]) => {
             options.forEach((option: SelectedOption<MediaTreeSelectorItem>) => {
-                this.contentComboBox.deselect(option.getOption().displayValue);
+                const item: MediaTreeSelectorItem = option.getOption().displayValue;
+
+                if (item.isEmptyContent()) {
+                    selectedOptionsView.removeOption(option.getOption());
+                    this.handleDeselected(option.getIndex());
+                } else {
+                    this.contentComboBox.deselect(item);
+                }
+
             });
             this.validate(false);
         });
@@ -91,13 +99,14 @@ export class ImageSelector
             .build();
 
         const contentComboBox: ImageContentComboBox
-            = ImageContentComboBox.create()
+            = <ImageContentComboBox>ImageContentComboBox.create()
             .setMaximumOccurrences(input.getOccurrences().getMaximum())
             .setLoader(optionDataLoader)
             .setSelectedOptionsView(this.createSelectedOptionsView())
             .setValue(value)
             .setTreegridDropdownEnabled(this.treeMode)
             .setTreeModeTogglerAllowed(!this.hideToggleIcon)
+            .setDisplayMissingSelectedOptions(true)
             .build();
 
         let comboBox: ComboBox<MediaTreeSelectorItem> = contentComboBox.getComboBox();

--- a/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageContentLoader.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageContentLoader.ts
@@ -3,7 +3,7 @@ import {AppHelper} from 'lib-admin-ui/util/AppHelper';
 import {ContentId} from 'lib-admin-ui/content/ContentId';
 import {ContentSummary} from 'lib-admin-ui/content/ContentSummary';
 import {GetContentSummaryByIds} from '../../../../resource/GetContentSummaryByIds';
-import {DefaultErrorHandler} from '../../../../../../../../../../../lib-admin-ui/src/main/resources/assets/admin/common/js/DefaultErrorHandler';
+import {DefaultErrorHandler} from 'lib-admin-ui/DefaultErrorHandler';
 
 type RequestToken = {
     contentId: ContentId;

--- a/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageContentLoader.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageContentLoader.ts
@@ -3,6 +3,7 @@ import {AppHelper} from 'lib-admin-ui/util/AppHelper';
 import {ContentId} from 'lib-admin-ui/content/ContentId';
 import {ContentSummary} from 'lib-admin-ui/content/ContentSummary';
 import {GetContentSummaryByIds} from '../../../../resource/GetContentSummaryByIds';
+import {DefaultErrorHandler} from '../../../../../../../../../../../lib-admin-ui/src/main/resources/assets/admin/common/js/DefaultErrorHandler';
 
 type RequestToken = {
     contentId: ContentId;
@@ -46,23 +47,18 @@ export class ImageContentLoader {
     }
 
     private static doLoadContent() {
-        const contentIds = ImageContentLoader.requestTokens.map(requestToken => requestToken.contentId);
-        const requestTokens = ImageContentLoader.requestTokens;
-        const tokenIds = requestTokens.map(token => token.contentId.toString());
+        const contentIds: ContentId[] = ImageContentLoader.requestTokens.map(requestToken => requestToken.contentId);
+        const requestTokens: RequestToken[] = ImageContentLoader.requestTokens;
 
         ImageContentLoader.requestTokens = [];
 
         new GetContentSummaryByIds(contentIds).sendAndParse().then((contents: ContentSummary[]) => {
+            requestTokens.forEach((requestToken: RequestToken) => {
+                const loadedContent: ContentSummary = contents
+                    .find((item: ContentSummary) => item.getContentId().equals(requestToken.contentId));
 
-            contents.map((content: ContentSummary) => {
-                const tokenIndex = tokenIds.indexOf(content.getContentId().toString());
-                const requestToken = requestTokens.splice(tokenIndex, 1)[0];
-                tokenIds.splice(tokenIndex, 1);
-
-                if (requestToken) {
-                    requestToken.promises.map(promise => promise.resolve(content));
-                }
+                requestToken.promises.forEach(promise => promise.resolve(loadedContent));
             });
-        });
+        }).catch(DefaultErrorHandler.handle);
     }
 }

--- a/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageSelectorSelectedOptionView.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageSelectorSelectedOptionView.ts
@@ -45,8 +45,6 @@ export class ImageSelectorSelectedOptionView
             this.label.getEl().setInnerHtml(displayValue.getDisplayName());
             this.icon.getEl().setAttribute('title',
                 isMissingContent ? option.value : option.displayValue.getPath() ? option.displayValue.getPath().toString() : '');
-        } else {
-            this.showProgress();
         }
     }
 
@@ -122,6 +120,10 @@ export class ImageSelectorSelectedOptionView
 
             ResponsiveManager.fireResizeEvent();
         });
+
+        if (this.getOption().displayValue.isEmptyContent()) {
+            this.addClass('missing');
+        }
 
         return Q(true);
     }

--- a/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageSelectorSelectedOptionsView.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageSelectorSelectedOptionsView.ts
@@ -10,6 +10,7 @@ import {SelectionToolbar} from './SelectionToolbar';
 import {MediaTreeSelectorItem} from '../media/MediaTreeSelectorItem';
 import {MediaSelectorDisplayValue} from '../media/MediaSelectorDisplayValue';
 import {BaseSelectedOptionsView} from 'lib-admin-ui/ui/selector/combobox/BaseSelectedOptionsView';
+import {i18n} from 'lib-admin-ui/util/Messages';
 
 export class ImageSelectorSelectedOptionsView
     extends BaseSelectedOptionsView<MediaTreeSelectorItem> {
@@ -163,9 +164,13 @@ export class ImageSelectorSelectedOptionsView
     }
 
     makeEmptyOption(id: string): Option<MediaTreeSelectorItem> {
+        const item: MediaTreeSelectorItem = new MediaTreeSelectorItem(null)
+            .setDisplayValue(MediaSelectorDisplayValue.makeEmpty())
+            .setMissingItemId(id);
+
         return <Option<MediaTreeSelectorItem>>{
             value: id,
-            displayValue: new MediaTreeSelectorItem(null).setDisplayValue(MediaSelectorDisplayValue.makeEmpty()),
+            displayValue: item,
             empty: true
         };
     }
@@ -252,7 +257,8 @@ export class ImageSelectorSelectedOptionsView
         optionView.getIcon().onLoaded(() => this.handleOptionViewImageLoaded(optionView));
 
         if (option.getOption().displayValue.isEmptyContent()) {
-            optionView.showError('No access to image.');
+            const missingItemId: string = option.getOption().displayValue.getMissingItemId();
+            optionView.showError(!!missingItemId ? i18n('text.image.id.notavailable', missingItemId) : i18n('text.image.notavailable'));
         }
     }
 

--- a/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageSelectorViewer.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageSelectorViewer.ts
@@ -26,7 +26,7 @@ export class ImageSelectorViewer
     }
 
     resolveHint(object: MediaTreeSelectorItem): string {
-        return object.getPath().toString();
+        return object.getPath() ? object.getPath().toString() : '';
     }
 
     protected getHintTargetEl(): ElementHelper {

--- a/src/main/resources/assets/js/app/inputtype/ui/selector/media/MediaSelectorDisplayValue.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/media/MediaSelectorDisplayValue.ts
@@ -16,6 +16,8 @@ export class MediaSelectorDisplayValue {
 
     private empty: boolean;
 
+    private missingItemId: string;
+
     static fromUploadItem(item: UploadItem<ContentSummary>): MediaSelectorDisplayValue {
         return new MediaSelectorDisplayValue().setUploadItem(item);
     }
@@ -47,6 +49,11 @@ export class MediaSelectorDisplayValue {
         return this;
     }
 
+    setMissingItemId(value: string): MediaSelectorDisplayValue {
+        this.missingItemId = value;
+        return this;
+    }
+
     getUploadItem(): UploadItem<ContentSummary> {
         return this.uploadItem;
     }
@@ -56,11 +63,15 @@ export class MediaSelectorDisplayValue {
     }
 
     getId(): string {
-        return this.content ? this.content.getId() : this.uploadItem.getId();
+        return this.content ? this.content.getId() : this.uploadItem ? this.uploadItem.getId() : this.missingItemId;
     }
 
     getContentId(): ContentId {
         return this.content ? this.content.getContentId() : null;
+    }
+
+    getMissingItemId(): string {
+        return this.missingItemId;
     }
 
     getContentPath(): ContentPath {

--- a/src/main/resources/assets/js/app/inputtype/ui/selector/media/MediaTreeSelectorItem.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/media/MediaTreeSelectorItem.ts
@@ -23,6 +23,11 @@ export class MediaTreeSelectorItem
         return this;
     }
 
+    setMissingItemId(value: string): MediaTreeSelectorItem {
+        this.mediaSelectorDisplayValue.setMissingItemId(value);
+        return this;
+    }
+
     getDisplayValue(): MediaSelectorDisplayValue {
         return this.mediaSelectorDisplayValue;
     }
@@ -49,6 +54,10 @@ export class MediaTreeSelectorItem
 
     getContentId(): ContentId {
         return this.mediaSelectorDisplayValue.getContentId();
+    }
+
+    getMissingItemId(): string {
+        return this.mediaSelectorDisplayValue.getMissingItemId();
     }
 
     getContentPath(): ContentPath {

--- a/src/main/resources/assets/styles/inputtype/selector/image-selector.less
+++ b/src/main/resources/assets/styles/inputtype/selector/image-selector.less
@@ -136,6 +136,15 @@
         }
       }
 
+
+      &.missing {
+        .squared-content {
+          .error {
+            margin-top: 30%;
+          }
+        }
+      }
+
     }
   }
   .selection-toolbar {

--- a/src/main/resources/i18n/phrases.properties
+++ b/src/main/resources/i18n/phrases.properties
@@ -458,6 +458,8 @@ live.view.device.highDefinitionTV=High Definition TV
 # Texts
 #
 text.noDescription=No description
+text.image.notavailable=Image is not available
+text.image.id.notavailable=Image with id "{0}" is not available
 
 #
 # Widget


### PR DESCRIPTION
-First problem solved: ImageContentLoader was NOT RESOLVING promises for content ids that were not found (deleted), thus .then block for missing ids was never invoked (now returning null for that case when resolving)
-Second promblem solved: Deleted images remain in content's data, thus in content wizard these values were not shown as selected but silently influence on viewed and persisted content comparison. Now showing missing selected ImageSelector items so user could see what and where is missing and manually delete them.

There's second option available for missing images, same as for ContentSelector - delete missing images ids from data after opening wizard and notifying user that reference to be removed on save.