### PR TITLE
Html Area content - previous text is restored after swapping html-are…

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
+++ b/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
@@ -131,6 +131,11 @@ export class HtmlArea
     }
 
     protected updateFormInputElValue(occurrence: FormInputEl, property: Property) {
+        const editor: HtmlAreaOccurrenceInfo = this.getEditorInfo(occurrence.getId());
+        if (editor) {
+            editor.property = property;
+        }
+
         this.setEditorContent(<TextArea>occurrence, property);
     }
 


### PR DESCRIPTION
…as #1836

-Updating saved editors property field on content update