### PR TITLE
Page Components View - custom part icon is not working inside a fragm…

### DIFF
--- a/src/main/resources/assets/js/app/wizard/PageComponentsTreeGrid.ts
+++ b/src/main/resources/assets/js/app/wizard/PageComponentsTreeGrid.ts
@@ -176,7 +176,9 @@ export class PageComponentsTreeGrid
 
     fetchRoot(): Q.Promise<ItemView[]> {
         if (this.pageView.getFragmentView()) {
-            return Q([this.pageView.getFragmentView()]);
+            return this.fetchDescriptions([this.pageView.getFragmentView()]).then(items => {
+                return items;
+            });
         } else {
             return Q([this.pageView]);
         }


### PR DESCRIPTION
…ent #1523

-Fetching grid items description for fragment page view root element (was loaded only for children)