### PR TITLE
Existing projects disappear from the grid after a new project is crea…

### DIFF
--- a/src/main/resources/assets/js/app/settings/SettingsAppPanel.ts
+++ b/src/main/resources/assets/js/app/settings/SettingsAppPanel.ts
@@ -130,6 +130,10 @@ export class SettingsAppPanel
     }
 
     private handleItemUpdated(projectName: string) {
+        if (!this.browsePanel.hasItemsLoaded()) {
+            return;
+        }
+
         new ProjectListRequest().sendAndParse()
             .then((projects: Project[]) => {
 

--- a/src/main/resources/assets/js/app/settings/browse/SettingsBrowsePanel.ts
+++ b/src/main/resources/assets/js/app/settings/browse/SettingsBrowsePanel.ts
@@ -68,4 +68,8 @@ export class SettingsBrowsePanel
         this.treeGrid.deleteSettingsItemNode(id);
     }
 
+    hasItemsLoaded(): boolean {
+        return this.treeGrid.getCurrentTotal() > 1;
+    }
+
 }


### PR DESCRIPTION
…ted #1897

-Skipping grid items update when root item was not loaded yet (will be loaded on first expand)