### PR TITLE
Console errors when uploading an image inside the Image Editor #1971

### DIFF
--- a/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageEditor.ts
+++ b/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageEditor.ts
@@ -64,10 +64,10 @@ export class ImageEditor
     private focusClipPath: Element;
     private cropClipPath: Element;
 
-    private focusData: FocusData = {x: 0, y: 0, r: 0.25, auto: null};
+    private focusData: FocusData = {x: 0, y: 0, r: 0.25, auto: true};
     private revertFocusData: FocusData;
 
-    private cropData: CropData = {x: 0, y: 0, w: 0, h: 0, auto: null};
+    private cropData: CropData = {x: 0, y: 0, w: 0, h: 0, auto: true};
     private revertCropData: CropData;
 
     private zoomData: ZoomData = {x: 0, y: 0, w: 0, h: 0};
@@ -131,7 +131,7 @@ export class ImageEditor
     public static debug: boolean = false;
 
     constructor() {
-        super('image-editor');
+        super('image-editor autofocused');
 
         this.frame = new DivEl('image-frame');
         this.canvas = new DivEl('image-canvas');


### PR DESCRIPTION
-focus and crop data must have auto value set to 'true' by default; Error occurred on image update when values were not set correctly due to 'auto' prop in crop and focus data being 'null'