### PR TITLE
Implement modal dialog with layer-specific item details in the Content Wizard

### DIFF
--- a/src/main/resources/assets/js/app/project/ProjectContext.ts
+++ b/src/main/resources/assets/js/app/project/ProjectContext.ts
@@ -12,7 +12,7 @@ export class ProjectContext {
     private state: State = State.NOT_INITIALIZED;
 
     private constructor() {
-    //
+        //
     }
 
     static get(): ProjectContext {
@@ -28,9 +28,13 @@ export class ProjectContext {
     }
 
     setProject(project: Project) {
+        const projectChanged: boolean = this.state === State.NOT_INITIALIZED || !project.equals(this.currentProject);
         this.currentProject = project;
         this.state = State.INITIALIZED;
-        new ProjectChangedEvent().fire();
+
+        if (projectChanged) {
+            new ProjectChangedEvent().fire();
+        }
     }
 
     updateDefaultProject(project: Project) {

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -356,7 +356,8 @@ export class ContentWizardPanel
         return new ContentWizardToolbar({
             application: this.contentParams.application,
             actions: this.wizardActions,
-            workflowStateIconsManager: this.workflowStateIconsManager
+            workflowStateIconsManager: this.workflowStateIconsManager,
+            contentId: this.contentParams.contentId
         });
     }
 

--- a/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -1,4 +1,5 @@
 .content-wizard-panel {
+  top: 0px !important;
 
   &:not(.rendered) {
     .content-wizard-toolbar {

--- a/src/main/resources/assets/styles/wizard/content-wizard-toolbar.less
+++ b/src/main/resources/assets/styles/wizard/content-wizard-toolbar.less
@@ -154,6 +154,7 @@
         height: @app-header-height-inner;
         line-height: @app-header-height-inner;
         font-size: 16px;
+        cursor: pointer;
       }
     }
   }


### PR DESCRIPTION
Requires review, important things to notice:

- Showing project selection dialog for selection
- We had project icon click opening studio, and now it is confusing (especially when there is custom icon on project) when click on project name opens selection dialog. Need a separate icon for opening studio?