### PR TITLE
Visualize missing language in the Content grid

### DIFF
--- a/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatusViewer.ts
+++ b/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatusViewer.ts
@@ -91,14 +91,20 @@ export class ContentSummaryAndCompareStatusViewer
     }
 
     protected resolveSecondaryName(object: ContentSummaryAndCompareStatus): string {
-        const itemLang: string = object.getContentSummary() ? object.getContentSummary().getLanguage() : null;
+        const projectLang: string = ProjectContext.get().getProject().getLanguage();
 
-        if (itemLang) {
-            const projectLang: string = ProjectContext.get().getProject().getLanguage();
+        if (!projectLang) {
+            return '';
+        }
 
-            if (projectLang !== itemLang) {
-                return `(${object.getContentSummary().getLanguage()})`;
-            }
+        const itemLang: string = object.getContentSummary()?.getLanguage();
+
+        if (!itemLang) {
+            return '(?)';
+        }
+
+        if (projectLang !== itemLang) {
+            return `(${itemLang})`;
         }
 
         return '';


### PR DESCRIPTION
The new logic is as follows:

1) If current project/layer does **not** have a default language set, we assume that language is not used/not important for this project/layer. In this case no language will be displayed in the Grid for the content item (no matter if it has the language or not).
2) If default project is **set** for the current project/layer and the item's language is **not set**, "(?)" will be displayed after display name
3) If default project is **set** for the current project/layer and the item's language is different, then the item's language will be shown in brackets to visualise that the item's language is different from the default language of the project/layer.
4) If the item's language is the same as default language of the current project/layer, no language will be displayed