### PR TITLE
Localisation should work only in the current layer #2298

### DIFF
--- a/src/main/resources/assets/js/app/ContentAppPanel.ts
+++ b/src/main/resources/assets/js/app/ContentAppPanel.ts
@@ -55,6 +55,7 @@ export class ContentAppPanel
         const type = path ? path.getElement(3) : null;
 
         switch (actionAsTabMode) {
+        case UrlAction.LOCALIZE:
         case UrlAction.EDIT:
             if (id) {
                 ContentSummaryAndCompareStatusFetcher.fetch(new ContentId(id)).done(

--- a/src/main/resources/assets/js/app/ContentEventsProcessor.ts
+++ b/src/main/resources/assets/js/app/ContentEventsProcessor.ts
@@ -66,11 +66,14 @@ export class ContentEventsProcessor {
             const contentSummary: ContentSummary = content.getContentSummary();
             const contentTypeName: ContentTypeName = contentSummary.getType();
             const tabId: ContentAppBarTabId = ContentAppBarTabId.forEdit(`${event.getProject().getName()}/${contentSummary.getId()}`);
+            const isLocalize: boolean = content.isDataInherited() && event.getProject().getName() ===
+                                        ProjectContext.get().getProject().getName();
 
             const wizardParams: ContentWizardPanelParams = new ContentWizardPanelParams()
                 .setTabId(tabId)
                 .setContentTypeName(contentTypeName)
                 .setProject(event.getProject())
+                .setLocalize(isLocalize)
                 .setContentId(contentSummary.getContentId());
 
             const win: Window = ContentEventsProcessor.openWizardTab(wizardParams);
@@ -117,7 +120,8 @@ export class ContentEventsProcessor {
         }
 
         if (!!params.contentId) {
-            return `${project}/${UrlAction.EDIT}/${params.contentId.toString()}`;
+            const action: string = params.localize ? UrlAction.LOCALIZE : UrlAction.EDIT;
+            return `${project}/${action}/${params.contentId.toString()}`;
         }
 
         if (params.parentContentId) {

--- a/src/main/resources/assets/js/app/UrlAction.ts
+++ b/src/main/resources/assets/js/app/UrlAction.ts
@@ -2,6 +2,7 @@ export enum UrlAction {
     BROWSE = 'browse',
     NEW = 'new',
     EDIT = 'edit',
+    LOCALIZE = 'localize',
     ISSUE = 'issue',
     OUTBOUND = 'outbound',
     INBOUND = 'inbound',

--- a/src/main/resources/assets/js/app/wizard/ContentAppHelper.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentAppHelper.ts
@@ -13,7 +13,7 @@ export class ContentAppHelper {
         const path: Path = app.getPath();
         const action: string = path.getElement(1);
 
-        return action === UrlAction.NEW || action === UrlAction.EDIT;
+        return action === UrlAction.NEW || action === UrlAction.EDIT || action === UrlAction.LOCALIZE;
     }
 
     static createWizardParamsFromApp(app: Application): ContentWizardPanelParams {

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanelParams.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanelParams.ts
@@ -21,6 +21,8 @@ export class ContentWizardPanelParams {
 
     project: Project;
 
+    localize: boolean = false;
+
     constructor() {
         this.project = ProjectContext.get().getProject();
     }
@@ -57,6 +59,11 @@ export class ContentWizardPanelParams {
 
     setProject(value: Project): ContentWizardPanelParams {
         this.project = value;
+        return this;
+    }
+
+    setLocalize(value: boolean): ContentWizardPanelParams {
+        this.localize = value;
         return this;
     }
 


### PR DESCRIPTION
-Added 'localize' url action
-When opening inherited item in current layer from browse panel url will be constructed with 'localize'
-Layer language for inherited item in wizard panel will only be set only if 'localize' presents in url
-'localize' in url will be replaced with 'edit' after item is saved or if item is initially not inherited