### PR TITLE
Errors when trying to open content wizard for multiple content items …

### DIFF
--- a/src/main/resources/assets/js/main.ts
+++ b/src/main/resources/assets/js/main.ts
@@ -320,20 +320,23 @@ function preLoadApplication() {
 
         if (!body.isRendered() && !body.isRendering()) {
             dataPreloaded = true;
+            const projectName: string = application.getPath().getElement(0);
             // body is not rendered if the tab is in background
             if (wizardParams.contentId) {
-                new GetContentByIdRequest(wizardParams.contentId).sendAndParse().then((content: Content) => {
-                    refreshTab(content);
+                new GetContentByIdRequest(wizardParams.contentId).setRequestProjectName(projectName).sendAndParse().then(
+                    (content: Content) => {
+                        refreshTab(content);
 
-                    if (shouldUpdateFavicon(content.getType())) {
-                        refreshTabOnContentUpdate(content);
-                    }
+                        if (shouldUpdateFavicon(content.getType())) {
+                            refreshTabOnContentUpdate(content);
+                        }
 
-                });
+                    });
             } else {
-                new GetContentTypeByNameRequest(wizardParams.contentTypeName).sendAndParse().then((contentType) => {
-                    updateTabTitle(ContentUnnamed.prettifyUnnamed(contentType.getDisplayName()));
-                });
+                new GetContentTypeByNameRequest(wizardParams.contentTypeName).setRequestProjectName(projectName).sendAndParse().then(
+                    (contentType) => {
+                        updateTabTitle(ContentUnnamed.prettifyUnnamed(contentType.getDisplayName()));
+                    });
             }
         }
     }


### PR DESCRIPTION
…#2284

-Project context is not initialized when wizard content is preloaded in background, thus content load fails to get current context. Using project name from url for preload.