### PR TITLE
Let readonly content be open in content wizard tab #2328

### DIFF
--- a/src/main/resources/assets/js/app/ContentEventsProcessor.ts
+++ b/src/main/resources/assets/js/app/ContentEventsProcessor.ts
@@ -66,7 +66,7 @@ export class ContentEventsProcessor {
             const contentSummary: ContentSummary = content.getContentSummary();
             const contentTypeName: ContentTypeName = contentSummary.getType();
             const tabId: ContentAppBarTabId = ContentAppBarTabId.forEdit(`${event.getProject().getName()}/${contentSummary.getId()}`);
-            const isLocalize: boolean = content.isDataInherited() && event.getProject().getName() ===
+            const isLocalize: boolean = !content.isReadOnly() && content.isDataInherited() && event.getProject().getName() ===
                                         ProjectContext.get().getProject().getName();
 
             const wizardParams: ContentWizardPanelParams = new ContentWizardPanelParams()

--- a/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -802,10 +802,6 @@ export class ContentTreeGrid
             return {cssClasses: 'empty-node'};
         }
 
-        if (node.getData().isReadOnly()) {
-            return {cssClasses: `readonly' title='${i18n('field.readOnly')}'`};
-        }
-
         let cssClasses: string = '';
 
         if (!!node.getData().getContentSummary() && node.getData().getContentSummary().isDataInherited()) {
@@ -814,6 +810,10 @@ export class ContentTreeGrid
 
         if (!!node.getData().getContentSummary() && node.getData().getContentSummary().isSortInherited()) {
             cssClasses += ' sort-inherited';
+        }
+
+        if (node.getData().isReadOnly()) {
+            cssClasses += `readonly' title='${i18n('field.readOnly')}'`;
         }
 
         return {cssClasses: cssClasses};

--- a/src/main/resources/assets/js/app/browse/action/ContentTreeGridItemsState.ts
+++ b/src/main/resources/assets/js/app/browse/action/ContentTreeGridItemsState.ts
@@ -47,6 +47,8 @@ export class ContentTreeGridItemsState {
 
     private anyInProgress: boolean = false;
 
+    private allReadOnly: boolean = false;
+
     private managedActionExecuting: boolean = false;
 
     constructor(items: ContentSummaryAndCompareStatus[], allowedPermissions: Permission[]) {
@@ -76,6 +78,7 @@ export class ContentTreeGridItemsState {
         this.anyCanBeMarkedAsReady = false;
         this.anyCanBeRequestedToPublish = false;
         this.anyInProgress = false;
+        this.allReadOnly = true;
         this.managedActionExecuting = ManagedActionManager.instance().isExecuting();
     }
 
@@ -102,7 +105,7 @@ export class ContentTreeGridItemsState {
                 this.allValid = false;
             }
 
-            if (!content.isReadOnly() && content.isEditable()) {
+            if (content.isEditable()) {
                 this.anyEditable = true;
             }
 
@@ -138,6 +141,10 @@ export class ContentTreeGridItemsState {
 
             if (content.getContentSummary().isInProgress()) {
                 this.anyInProgress = true;
+            }
+
+            if (!content.isReadOnly()) {
+                this.allReadOnly = false;
             }
 
         });
@@ -245,6 +252,10 @@ export class ContentTreeGridItemsState {
 
     hasAnyInProgress(): boolean {
         return this.anyInProgress;
+    }
+
+    hasAllReadOnly(): boolean {
+        return this.allReadOnly;
     }
 
     isManagedActionExecuting(): boolean {

--- a/src/main/resources/assets/js/app/browse/action/EditContentAction.ts
+++ b/src/main/resources/assets/js/app/browse/action/EditContentAction.ts
@@ -17,8 +17,7 @@ export class EditContentAction extends ContentTreeGridAction {
     }
 
     protected handleExecuted() {
-        const contents: ContentSummaryAndCompareStatus[]
-            = this.grid.getSelectedDataList().filter((content) => !content.isReadOnly());
+        const contents: ContentSummaryAndCompareStatus[] = this.grid.getSelectedDataList();
 
         if (contents.length > EditContentAction.MAX_ITEMS_TO_EDIT) {
             showWarning(i18n('notify.edit.tooMuch'));
@@ -32,8 +31,10 @@ export class EditContentAction extends ContentTreeGridAction {
     }
 
     updateLabel(state: ContentTreeGridItemsState) {
-        if (state.hasAllInherited()) {
-            this.setLabel( i18n('action.translate'));
+        if (state.hasAllReadOnly()) {
+            this.setLabel( i18n('action.open'));
+        } else if (state.hasAllInherited()) {
+            this.setLabel(i18n('action.translate'));
         } else {
             this.setLabel(i18n('action.edit'));
         }

--- a/src/main/resources/assets/js/app/project/tree/LayersContentActionButton.ts
+++ b/src/main/resources/assets/js/app/project/tree/LayersContentActionButton.ts
@@ -28,8 +28,9 @@ export class LayersContentActionButton extends ActionButton {
     private getLabelText(): string {
         const isCurrentProject: boolean = this.item.getProject().getName() === ProjectContext.get().getProject().getName();
         const isInherited: boolean = this.item.getItem().isDataInherited();
+        const isReadOnly: boolean = this.item.getItem().isReadOnly();
 
-        if (isCurrentProject) {
+        if (!isReadOnly && isCurrentProject) {
             return isInherited ? i18n('action.translate') : i18n('action.edit');
         }
 

--- a/src/main/resources/assets/js/app/resource/ContentSummaryAndCompareStatusFetcher.ts
+++ b/src/main/resources/assets/js/app/resource/ContentSummaryAndCompareStatusFetcher.ts
@@ -66,7 +66,12 @@ export class ContentSummaryAndCompareStatusFetcher {
             return CompareContentRequest.fromContentSummaries([content], projectName).sendAndParse()
                 .then((compareResults: CompareContentResults) => {
 
-                    return ContentSummaryAndCompareStatusFetcher.updateCompareStatus([content], compareResults)[0];
+                    const result: ContentSummaryAndCompareStatus = ContentSummaryAndCompareStatusFetcher.updateCompareStatus([content],
+                        compareResults)[0];
+
+                    return ContentSummaryAndCompareStatusFetcher.updateReadOnly([result]).then(() => {
+                        return result;
+                    });
                 });
         });
 

--- a/src/main/resources/assets/js/app/view/context/widget/layers/LayerContentView.ts
+++ b/src/main/resources/assets/js/app/view/context/widget/layers/LayerContentView.ts
@@ -46,6 +46,10 @@ export class LayerContentView extends LiEl {
                 this.addClass(LayerContentView.INHERITED_CLASS);
             }
 
+            if (this.item.getItem().isReadOnly()) {
+                this.addClass('readonly');
+            }
+
             return rendered;
         });
     }

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -821,15 +821,7 @@ export class ContentWizardPanel
     private initListeners() {
 
         let shownAndLoadedHandler = () => {
-            if (this.getPersistedItem()) {
-                const action: string = (this.getPersistedItem().isDataInherited() && this.isLocalizeInUrl())
-                                       ? UrlAction.LOCALIZE
-                                       : UrlAction.EDIT;
-                Router.get().setHash(`${action}/${this.getPersistedItem().getId()}`);
-                if (!window.name) {
-                    window.name = `${action}:${this.getPersistedItem().getId()}`;
-                }
-            } else {
+            if (!this.getPersistedItem()) {
                 Router.get().setHash(`${UrlAction.NEW}/${this.contentType.getName()}`);
             }
         };
@@ -1711,6 +1703,11 @@ export class ContentWizardPanel
                         new IsAuthenticatedRequest().sendAndParse().then((loginResult: LoginResult) => {
                             this.setModifyPermissions(loginResult);
                             this.toggleStepFormsVisibility(loginResult);
+                            this.updateUrlAction();
+
+                            if (this.isLocalizeInUrl()) {
+                                this.settingsWizardStepForm.updateInitialLanguage();
+                            }
                         });
 
                         this.syncPersistedItemWithContentData(content.getContentData());
@@ -1736,10 +1733,6 @@ export class ContentWizardPanel
                         this.onLiveModelChanged(() => {
                             setTimeout(this.updatePublishStatusOnDataChange.bind(this), 100);
                         });
-
-                        if (this.isLocalizeInUrl()) {
-                            this.settingsWizardStepForm.updateInitialLanguage();
-                        }
 
                         return Q(null);
                     });
@@ -2602,5 +2595,16 @@ export class ContentWizardPanel
     private canEveryoneRead(content: Content): boolean {
         const entry: AccessControlEntry = content.getPermissions().getEntry(RoleKeys.EVERYONE);
         return !!entry && entry.isAllowed(Permission.READ);
+    }
+
+    private updateUrlAction() {
+        const action: string = (this.modifyPermissions && this.getPersistedItem().isDataInherited() &&
+                                this.isLocalizeInUrl())
+                               ? UrlAction.LOCALIZE
+                               : UrlAction.EDIT;
+        Router.get().setHash(`${action}/${this.getPersistedItem().getId()}`);
+        if (!window.name) {
+            window.name = `${action}:${this.getPersistedItem().getId()}`;
+        }
     }
 }

--- a/src/main/resources/assets/styles/view/context/widget-layers.less
+++ b/src/main/resources/assets/styles/view/context/widget-layers.less
@@ -97,7 +97,7 @@
             }
           }
 
-          &.layer-current {
+          &.layer-current:not(.readonly) {
             .layers-item-view-data-footer {
               .action-button {
                 background-color: @admin-button-blue2;


### PR DESCRIPTION
-Enabling edit button in toolbar for readonly content
-Replacing 'Edit' text with 'Open' for readonly content both in grid and layers widget
-Not trying to set language for inherited readonly content in wizard, updating url localize->edit in that case