### PR TITLE
Path for Moved content should not be truncated in wizard #2434

### DIFF
--- a/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
@@ -53,6 +53,7 @@ export class ContentWizardHeader
                 this.renameDialog = new RenameContentDialog();
 
                 this.renameDialog.onRenamed((newName: string) => {
+                    this.setOnline(false);
                     this.setName(newName);
 
                     const contentName: ContentName = StringHelper.isBlank(newName) ? ContentUnnamed.newUnnamed() : new ContentName(newName);


### PR DESCRIPTION
-AutosizeTextInput won't update it's size if it is invisible, so need first make it visible on renaming and then set it's new name