### PR TITLE
Responsive header in the Content Wizard

### DIFF
--- a/src/main/resources/assets/js/app/settings/wizard/panel/SettingsDataItemWizardPanel.ts
+++ b/src/main/resources/assets/js/app/settings/wizard/panel/SettingsDataItemWizardPanel.ts
@@ -6,7 +6,7 @@ import {WizardStep} from 'lib-admin-ui/app/wizard/WizardStep';
 import {i18n} from 'lib-admin-ui/util/Messages';
 import {
     WizardHeaderWithDisplayNameAndName,
-    WizardHeaderWithDisplayNameAndNameBuilder
+    WizardHeaderWithDisplayNameAndNameOptions
 } from 'lib-admin-ui/app/wizard/WizardHeaderWithDisplayNameAndName';
 import {ResponsiveManager} from 'lib-admin-ui/ui/responsive/ResponsiveManager';
 import {FormIcon} from 'lib-admin-ui/app/wizard/FormIcon';
@@ -328,9 +328,8 @@ export abstract class SettingsDataItemWizardPanel<ITEM extends SettingsDataViewI
     }
 
     protected createWizardHeader(): WizardHeaderWithDisplayNameAndName {
-        const wizardHeader: WizardHeaderWithDisplayNameAndName = new WizardHeaderWithDisplayNameAndNameBuilder()
-            .setDisplayNameLabel(this.type.getDisplayNamePlaceholder()).build();
-
+        const wizardHeader: WizardHeaderWithDisplayNameAndName = new WizardHeaderWithDisplayNameAndName(
+            {displayNameLabel: this.type.getDisplayNamePlaceholder()});
         const existing: ITEM = this.getPersistedItem();
         const displayName: string = !!existing ? existing.getDisplayName() : '';
 

--- a/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
@@ -31,7 +31,7 @@ export class ContentWizardHeader
 
     private debouncedNameUniqueChecker: () => void;
 
-    private lockElem: ButtonEl = new ButtonEl();
+    private lockElem: ButtonEl;
 
     constructor(options?: WizardHeaderWithDisplayNameAndNameOptions) {
         super(options);
@@ -56,6 +56,8 @@ export class ContentWizardHeader
         });
 
         this.lockElem.onClicked(() => {
+            console.log('clickz');
+
             if (!this.renameDialog) {
                 this.renameDialog = new RenameContentDialog();
 

--- a/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -76,7 +76,6 @@ import {ContentTypeName} from 'lib-admin-ui/schema/content/ContentTypeName';
 import {ConfirmationDialog} from 'lib-admin-ui/ui/dialog/ConfirmationDialog';
 import {ResponsiveRanges} from 'lib-admin-ui/ui/responsive/ResponsiveRanges';
 import {TogglerButton} from 'lib-admin-ui/ui/button/TogglerButton';
-import {WizardHeaderWithDisplayNameAndNameBuilder} from 'lib-admin-ui/app/wizard/WizardHeaderWithDisplayNameAndName';
 import {Application} from 'lib-admin-ui/application/Application';
 import {ApplicationKey} from 'lib-admin-ui/application/ApplicationKey';
 import {ApplicationEvent} from 'lib-admin-ui/application/ApplicationEvent';
@@ -124,6 +123,7 @@ import {UrlAction} from '../UrlAction';
 import {ContentWizardHeader} from './ContentWizardHeader';
 import {NotifyManager} from 'lib-admin-ui/notify/NotifyManager';
 import {ContentIconUrlResolver} from '../content/ContentIconUrlResolver';
+import { WizardHeaderWithDisplayNameAndNameOptions } from 'lib-admin-ui/app/wizard/WizardHeaderWithDisplayNameAndName';
 
 export class ContentWizardPanel
     extends WizardPanel<Content> {
@@ -365,9 +365,12 @@ export class ContentWizardPanel
     }
 
     protected createWizardHeader(): WizardHeader {
-        const header: ContentWizardHeader = new ContentWizardHeader(new WizardHeaderWithDisplayNameAndNameBuilder()
-            .setDisplayNameGenerator(this.displayNameResolver)
-            .setDisplayNameLabel(this.contentType ? this.contentType.getDisplayNameLabel() : null));
+        const headerOptions: WizardHeaderWithDisplayNameAndNameOptions = {
+            displayNameGenerator: this.displayNameResolver,
+            displayNameLabel: this.contentType ? this.contentType.getDisplayNameLabel() : null
+        };
+
+        const header: ContentWizardHeader = new ContentWizardHeader(headerOptions);
 
         header.setPersistedPath(this.isItemPersisted() ? this.getPersistedItem() : null);
         header.setPath(this.getWizardHeaderPath());

--- a/src/main/resources/assets/styles/settings/wizard/settings-item-wizard-panel.less
+++ b/src/main/resources/assets/styles/settings/wizard/settings-item-wizard-panel.less
@@ -1,9 +1,6 @@
 .settings-item-wizard-panel {
 
   .wizard-header {
-    height: 64px;
-    display: flex;
-    align-items: center;
 
     input:first-child:disabled {
       color: @admin-dark-gray;
@@ -15,6 +12,10 @@
   }
 
   .header-and-navigator-container {
+
+    .wizard-header {
+      margin-top: 35px;
+    }
 
     .@{_COMMON_PREFIX}form-icon {
       &.not-empty {
@@ -68,21 +69,23 @@
     }
   }
 
+
   ._0-240 &,
   ._240-360 &,
-  ._360-540 &,
-  ._540-720 & {
+  ._360-540 & {
 
     .header-and-navigator-container {
 
       .wizard-header {
-        margin-left: 46px;
-      }
-
-      .@{_COMMON_PREFIX}form-icon {
-        margin: 5px;
+        margin-top: 20px;
       }
     }
+  }
+
+  ._0-240 &,
+  ._240-360 &,
+  ._360-540 &,
+  ._540-720 & {
 
     .wizard-step-form {
 

--- a/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -7,19 +7,22 @@
       display: none;
     }
 
-    input:last-of-type {
-      display: inline-block;
-      margin-right: 10px;
+    .bottom {
+      input {
+        display: inline-block;
+      }
     }
 
     &.path-exists {
-      .path-error {
-        display: inline-block;
-      }
+      .bottom {
+        .path-error {
+          display: inline-block;
+        }
 
-      input:last-of-type {
-        border: 1px solid @admin-input-red;
-        box-shadow: 0 0 3px 1px darken(@admin-input-red, 10%);
+        input {
+          border: 1px solid @admin-input-red;
+          box-shadow: 0 0 3px 1px darken(@admin-input-red, 10%);
+        }
       }
     }
 
@@ -27,32 +30,22 @@
       display: none;
     }
 
-    .name-static {
-      display: none;
-    }
-
     &.locked {
       .lock-name {
         display: inline;
         cursor: pointer;
-        position: relative;
-        top: -7px;
         background: none;
         border: none;
+        position: relative;
+        top: 3px;
       }
 
-      input:last-of-type {
-        display: none;
-      }
+      .@{_COMMON_PREFIX}text-input:disabled {
+        color: @admin-black;
 
-      .name-static {
-        display: inline-block;
-        font-size: 16px;
-        height: 28px;
-        line-height: 28px;
-        margin-right: 15px;
-        max-width: 80%;
-        .ellipsis();
+        &:hover {
+          cursor: text;
+        }
       }
     }
   }

--- a/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -55,9 +55,6 @@
     &._0-240,
     &._240-360,
     &._360-540 {
-      .wizard-header {
-        max-width: calc(100% - 105px);
-      }
 
       .thumbnail-uploader-el {
         .dropzone-container .dropzone {

--- a/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -1,4 +1,20 @@
 .content-wizard-panel {
+
+  &--live {
+    .split-panel .minimize-edit {
+      display: block;
+    }
+
+    .wizard-step-navigator-and-toolbar.pre-scroll-stick {
+      &.has-help-text-button {
+        .help-text-button {
+          padding-right: 38px;
+        }
+      }
+
+    }
+  }
+
   .wizard-header {
     padding-left: 70px;
 
@@ -51,24 +67,15 @@
   }
 
   .form-panel {
-    .thumbnail-uploader-el {
-      float: left;
-    }
 
     &._0-240,
     &._240-360,
     &._360-540 {
       .wizard-header {
         max-width: calc(100% - 105px);
-        margin: 15px 0;
-        padding-left: 65px;
       }
 
       .thumbnail-uploader-el {
-        width: 32px;
-        height: 32px;
-        margin: 5px 10px 5px 15px;
-
         .dropzone-container .dropzone {
           min-height: auto;
         }

--- a/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -1,22 +1,6 @@
 .content-wizard-panel {
 
-  &--live {
-    .split-panel .minimize-edit {
-      display: block;
-    }
-
-    .wizard-step-navigator-and-toolbar.pre-scroll-stick {
-      &.has-help-text-button {
-        .help-text-button {
-          padding-right: 38px;
-        }
-      }
-
-    }
-  }
-
   .wizard-header {
-    padding-left: 70px;
 
     .path-error {
       color: @admin-level-3;

--- a/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -268,11 +268,10 @@
 
         .minimize-edit {
           .icon-arrow-right;
-          position: absolute;
-          left: 40px !important;
-          top: 0;
-          height: 35px;
           font-weight: bold;
+          position: absolute;
+          left: 5px;
+          top: 5px;
         }
       }
     }
@@ -283,14 +282,9 @@
     font-size: 30px;
     font-weight: 800;
     display: none;
-    position: fixed;
-    height: 40px;
-    width: 40px;
-    margin-left: -40px;
     text-align: center;
     line-height: 40px;
     overflow: hidden;
-    z-index: @z-index-mask - 1;
     cursor: pointer;
     color: @admin-font-gray2;
 

--- a/src/main/resources/assets/styles/wizard/thumbnail-uploader-el.less
+++ b/src/main/resources/assets/styles/wizard/thumbnail-uploader-el.less
@@ -40,6 +40,7 @@
   }
 
   .result-container {
+    display: flex;
     height: 100%;
     width: 100%;
     line-height: 64px;

--- a/src/main/resources/assets/styles/wizard/thumbnail-uploader-el.less
+++ b/src/main/resources/assets/styles/wizard/thumbnail-uploader-el.less
@@ -1,7 +1,4 @@
 .thumbnail-uploader-el {
-  width: 64px;
-  height: 64px;
-  margin: 5px 20px;
 
   .dropzone-container {
     position: absolute;


### PR DESCRIPTION
To avoid overcomplicated logic of wrapping/unwrapping static path part and calculating it's length on value change/resize:
1. Using flex styling and showing static part with title 
2. Removed redundant elements
3. Letting dynamic input grow as much as needed and static path shrink down to zero

@alansemenov please check if this approach is appropriate

Requires https://github.com/enonic/lib-admin-ui/pull/1802

