### PR TITLE
Cant double click / open macro inside the html area #3013

### DIFF
--- a/modules/app/src/main/resources/assets/lib/ckeditor/plugins/macro/plugin.js
+++ b/modules/app/src/main/resources/assets/lib/ckeditor/plugins/macro/plugin.js
@@ -80,7 +80,7 @@ CKEDITOR.plugins.add('macro', {
         }
 
         function makeMakroObject(regexResult) {
-            var regexMacroAttributes = /([\w]+)(?:\s*=\s*")([^"]+)(?:")/g;
+            var regexMacroAttributes = /(\w+(?:-?\w+)*)(?:\s*=\s*")([^"]+)(?:")/g;
             var attributes = [];
             var attributesString = regexResult[0].match(/\[(.*?)\]/)[1];
 
@@ -100,7 +100,7 @@ CKEDITOR.plugins.add('macro', {
         }
 
         function checkMacroWithBodySelected() {
-            var regexMacroWithBody = /\[(\w+)\s?.*?\](.+?)\[\/(\w+)\]/g;
+            var regexMacroWithBody = /\[(\w+(?:-?\w+)*)\s?.*?\](.+?)\[\/(\w+(?:-?\w+)*)\]/g;
 
             var result;
             while (result = regexMacroWithBody.exec(selectedElement.getText())) {
@@ -113,7 +113,7 @@ CKEDITOR.plugins.add('macro', {
         }
 
         function checkMacroNoBodySelected() {
-            var regexMacroNoBody = /\[(\w+)\s.+?\/\]/g;
+            var regexMacroNoBody = /\[(\w+(?:-?\w+)*)(?:\s.+)?\/\]/g;
 
             var result;
             while (result = regexMacroNoBody.exec(selectedElement.getText())) {


### PR DESCRIPTION
-modified macro regex to allow:
1. Dash in the macro name
2. Macro with empty body and no attributes