### PR TITLE
<include>*</include> includes non-default tools #3074

### DIFF
--- a/modules/app/src/main/resources/assets/styles/inputtype/text/htmlarea/html-area.less
+++ b/modules/app/src/main/resources/assets/styles/inputtype/text/htmlarea/html-area.less
@@ -125,23 +125,7 @@
 }
 
 .wizard-step-form .html-area {
-
   .cke_top {
     top: @toolbar-height;
-
-    .cke_button__bold,
-    .cke_button__italic,
-    .cke_button__underline {
-      display: none;
-    }
-  }
-
-  .customized-toolbar {
-
-    .cke_button__bold,
-    .cke_button__italic,
-    .cke_button__underline {
-      display: inline-block;
-    }
   }
 }

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
@@ -103,10 +103,6 @@ export class HtmlArea
 
         const textAreaWrapper = new TextAreaWrapper();
 
-        if (this.inputConfig['include']) {
-            textAreaWrapper.addClass('customized-toolbar');
-        }
-
         textAreaEl.onRendered(() => {
             this.authRequest.then(() => {
                 this.initEditor(editorId, property, textAreaWrapper).then(() => {

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -920,7 +920,7 @@ class HtmlEditorConfigBuilder {
     private enabledTools: string[] = [];
 
     private tools: any[] = [
-        ['Styles', 'Bold', 'Italic', 'Underline'],
+        ['Styles'],
         ['JustifyBlock', 'JustifyLeft', 'JustifyCenter', 'JustifyRight'],
         ['BulletedList', 'NumberedList', 'Outdent', 'Indent'],
         ['SpecialChar', 'Anchor', 'Image', 'Macro', 'Link', 'Unlink'],
@@ -975,11 +975,21 @@ class HtmlEditorConfigBuilder {
             this.includeTool('Fullscreen');
         }
 
+        const toolsToAdd: string[] = [];
+
+        this.enabledTools.forEach((tool: string) => {
+            if (tool === 'Bold' || tool === 'Italic' || tool === 'Underline') {
+                this.tools[0].push(tool);
+            } else {
+                toolsToAdd.push(tool);
+            }
+        });
+
         if (this.editorParams.isInline()) {
             this.tools[0].push('Strike', 'Superscript', 'Subscript');
         }
 
-        this.tools.push(this.enabledTools);
+        this.tools.push(toolsToAdd);
     }
 
     public static createEditorConfig(htmlEditorParams: HtmlEditorParams): Q.Promise<CKEDITOR.config> {


### PR DESCRIPTION
-Removed Bold,Italic and Underline from default tools
-Adding BIU tools only when added in config, to the same place where they used to be found in toolbar before