### PR TITLE
Site/Provider configurator -Apply button should not submit invalid co…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
@@ -16,6 +16,8 @@ import {ContentRequiresSaveEvent} from '../../event/ContentRequiresSaveEvent';
 import {BaseSelectedOptionView} from 'lib-admin-ui/ui/selector/combobox/BaseSelectedOptionView';
 import {FormValidityChangedEvent} from 'lib-admin-ui/form/FormValidityChangedEvent';
 import {NamesAndIconViewSize} from 'lib-admin-ui/app/NamesAndIconViewSize';
+import {FormContext} from 'lib-admin-ui/form/FormContext';
+import {FormState} from 'lib-admin-ui/app/wizard/WizardPanel';
 
 export class SiteConfiguratorSelectedOptionView
     extends BaseSelectedOptionView<Application> {
@@ -204,7 +206,8 @@ export class SiteConfiguratorSelectedOptionView
     }
 
     private createFormView(siteConfig: ApplicationConfig): FormView {
-        let formView = new FormView(this.formContext, this.application.getForm(), siteConfig.getConfig());
+        const context: FormContext = FormContext.create().setFormState(new FormState(false)).build();
+        const formView: FormView = new FormView(context, this.application.getForm(), siteConfig.getConfig());
         formView.addClass('site-form');
 
         formView.onLayoutFinished(() => {


### PR DESCRIPTION
…nfig form #3097

In addition to lib-admin-ui-changes:
-Not using wizard panel's form context since configurator dialog form and items to be handled separately: even if wizard panel is rendered for a new content/item and validation errors won't be shown until item saved, configurator dialog form should show validation errors