### PR TITLE
Changes in the Content wizard form don't enable Save button after the…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -557,8 +557,10 @@ export class ContentWizardPanel
 
         if (!viewedContent.equals(newPersistedContent, true)) {
             this.setPersistedItem(newPersistedContent);
-            this.initFormContext(newPersistedContent);
-            this.updateWizard(newPersistedContent, true);
+
+            const contentClone: Content = newPersistedContent.clone();
+            this.initFormContext(contentClone);
+            this.updateWizard(contentClone, true);
 
             if (!this.isDisplayNameUpdated()) {
                 this.getWizardHeader().resetBaseValues();


### PR DESCRIPTION
… content has been published #3100

-Issue was that same object was used as a persisted item and a source for a wizard forms data, thus changing data in forms was resulting in changing data in persisted item. After that comparing persisted item and item assembled with form data always resulted in their equality