### PR TITLE
Page Template wizard - Save button remains enabled after selecting a …

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -555,7 +555,7 @@ export class ContentWizardPanel
     private updateModifiedPersistedContent(newPersistedContent: Content) {
         const viewedContent = this.assembleViewedContent(new ContentBuilder(this.getPersistedItem()), true).build();
 
-        if (!viewedContent.equals(newPersistedContent, true)) {
+        if (!viewedContent.equals(newPersistedContent)) {
             this.setPersistedItem(newPersistedContent);
 
             const contentClone: Content = newPersistedContent.clone();


### PR DESCRIPTION
…controller in unnamed template #3091

-When rendering form items we might spawn default empty property arrays for them to store data. In a specific case with a new content where it's data is not saved yet with default/empty values we can trigger content's page create/update that will change page data only on a backend, after that we receive and process content update event with content that doesn't have default data values set yet; form items are not getting updated because on update event when comparing new data and current form data we treat empty property and null as equal and form data update is skipped, however nulls are not ignored in other checks and comparing persisted item data with current form data will see the change and enable save button
-Fixing this by handling null and empty property as not equal