### PR TITLE
Insert macro dialog does not retain focus when switching tabs/windows…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/MacroModalDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/MacroModalDialog.ts
@@ -217,6 +217,18 @@ export class MacroModalDialog
     isDirty(): boolean {
         return (<MacroComboBox>this.macroFormItem.getInput()).isDirty();
     }
+
+    open(): void {
+        super.open();
+
+        this.getEditor().focusManager.lock();
+    }
+
+    close() {
+        super.close();
+
+        this.getEditor().focusManager.unlock();
+    }
 }
 
 export interface SelectedMacro {


### PR DESCRIPTION
… #3096

-Most of HtmlArea dialogs are backed up by hidden original cke dialog that prevents losing focus, but MacroModalDialog is our original dialog so by some internal cke logic it's editor loses focus on clicking outside of dialog
-Fixed by using internal cke focusManager functionality that prevents losing focus