### PR TITLE
Content Selector - path is not updated in selected option after updat…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/ContentFormContext.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentFormContext.ts
@@ -26,6 +26,7 @@ export class ContentFormContext
         this.site = builder.site;
         this.parentContent = builder.parentContent;
         this.persistedContent = builder.persistedContent;
+
         if (builder.contentTypeName) {
             this.contentTypeName = builder.contentTypeName;
         } else if (builder.persistedContent) {
@@ -35,6 +36,11 @@ export class ContentFormContext
 
     getSite(): Site {
         return this.site;
+    }
+
+    setSite(site: Site): ContentFormContext {
+        this.site = site;
+        return this;
     }
 
     getContentId(): ContentId {
@@ -54,13 +60,19 @@ export class ContentFormContext
         return this.parentContent.getPath();
     }
 
+    setParentContent(content: Content): ContentFormContext {
+        this.parentContent = content;
+        return this;
+    }
+
     getPersistedContent(): Content {
         return this.persistedContent;
     }
 
-    updatePersistedContent(content: Content) {
+    setPersistedContent(content: Content): ContentFormContext {
         this.persistedContent = content;
         this.contentUpdatedListeners.forEach(listener => listener(content));
+        return this;
     }
 
     getContentTypeName(): ContentTypeName {

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentSelector.ts
@@ -25,6 +25,8 @@ import {NotifyManager} from 'lib-admin-ui/notify/NotifyManager';
 import {ContentSummary} from '../../content/ContentSummary';
 import {ContentId} from '../../content/ContentId';
 import {ContentPath} from '../../content/ContentPath';
+import {ContentServerEventsHandler} from '../../event/ContentServerEventsHandler';
+import {ContentSummaryAndCompareStatus} from '../../content/ContentSummaryAndCompareStatus';
 
 export class ContentSelector
     extends ContentInputTypeManagingAdd<ContentTreeSelectorItem> {
@@ -47,10 +49,39 @@ export class ContentSelector
 
     constructor(config?: ContentInputTypeViewContext) {
         super('content-selector', config);
+        this.initEventsListeners();
+    }
+
+    private initEventsListeners() {
+        const contentId: string = this.config.content.getId();
+
+        ContentServerEventsHandler.getInstance().onContentRenamed((data: ContentSummaryAndCompareStatus[]) => {
+            const isCurrentContentRenamed: boolean = data.some((item: ContentSummaryAndCompareStatus) => item.getId() === contentId);
+
+            if (isCurrentContentRenamed) {
+                this.handleContentRenamed();
+            }
+        });
+    }
+
+    protected handleContentRenamed() {
+        const selectedIds: ContentId[] = this.getSelectedOptions().map(
+            (option: SelectedOption<ContentTreeSelectorItem>) => option.getOption().getDisplayValue().getContentId());
+
+        this.doLoadContent(selectedIds).then((contents: ContentSummary[]) => {
+            this.contentComboBox.clearSelection(true, false);
+
+            contents.forEach((content: ContentSummary) => {
+                this.contentComboBox.select(this.createSelectorItem(content));
+            });
+        });
+    }
+
+    protected createSelectorItem(content: ContentSummary): ContentTreeSelectorItem {
+        return new ContentTreeSelectorItem(content);
     }
 
     protected readConfig(inputConfig: { [element: string]: { [name: string]: string }[]; }): void {
-
         const isTreeModeConfig = inputConfig['treeMode'] ? inputConfig['treeMode'][0] : {};
         this.treeMode = !StringHelper.isBlank(isTreeModeConfig['value']) ? isTreeModeConfig['value'].toLowerCase() === 'true' : false;
 
@@ -95,25 +126,25 @@ export class ContentSelector
         if (!ValueTypes.REFERENCE.equals(propertyArray.getType())) {
             propertyArray.convertValues(ValueTypes.REFERENCE, ValueTypeConverter.convertTo);
         }
+
         return super.layout(input, propertyArray).then(() => {
             this.contentComboBox = this.createContentComboBox(input, propertyArray);
-
             this.comboBoxWrapper = new DivEl('combobox-wrapper');
             this.comboBoxWrapper.appendChild(this.contentComboBox);
 
             this.appendChild(this.comboBoxWrapper);
 
             return this.doLayout(propertyArray);
-
         });
     }
 
     protected doLayout(propertyArray: PropertyArray): Q.Promise<void> {
-
         const contentIds: ContentId[] = [];
+
         propertyArray.forEach((property: Property) => {
             if (property.hasNonNullValue()) {
-                let referenceValue = property.getReference();
+                const referenceValue: Reference = property.getReference();
+
                 if (ObjectHelper.iFrameSafeInstanceOf(referenceValue, Reference)) {
                     contentIds.push(ContentId.fromReference(referenceValue));
                 }
@@ -121,7 +152,6 @@ export class ContentSelector
         });
 
         return this.doLoadContent(contentIds).then((contents: ContentSummary[]) => {
-
             this.setupSortable();
 
             //TODO: original value doesn't work because of additional request, so have to select manually
@@ -154,8 +184,8 @@ export class ContentSelector
     }
 
     protected createContentComboBoxBuilder(input: Input, propertyArray: PropertyArray): ContentComboBoxBuilder<ContentTreeSelectorItem> {
-        const optionDataLoader = this.createOptionDataLoader();
-        const comboboxValue = this.getValueFromPropertyArray(propertyArray);
+        const optionDataLoader: ContentSummaryOptionDataLoader<ContentTreeSelectorItem> = this.createOptionDataLoader();
+        const comboboxValue: string = this.getValueFromPropertyArray(propertyArray);
 
         return this.doCreateContentComboBoxBuilder()
                 .setComboBoxName(input.getName())
@@ -172,7 +202,6 @@ export class ContentSelector
     }
 
     protected initEvents(contentComboBox: ContentComboBox<ContentTreeSelectorItem>) {
-
         contentComboBox.getComboBox().onContentMissing((ids: string[]) => {
             ids.forEach(id => this.removePropertyWithId(id));
             this.validate(false);
@@ -195,7 +224,6 @@ export class ContentSelector
         });
 
         contentComboBox.onOptionDeselected((event: SelectedOptionEvent<ContentTreeSelectorItem>) => {
-
             this.handleDeselected(event.getSelectedOption().getIndex());
             this.updateSelectedOptionStyle();
             this.validate(false);
@@ -205,7 +233,7 @@ export class ContentSelector
     }
 
     protected createContentComboBox(input: Input, propertyArray: PropertyArray): ContentComboBox<ContentTreeSelectorItem> {
-        const contentComboBox = this.doCreateContentComboBox(input, propertyArray);
+        const contentComboBox: ContentComboBox<ContentTreeSelectorItem> = this.doCreateContentComboBox(input, propertyArray);
 
         this.initEvents(contentComboBox);
 
@@ -213,7 +241,8 @@ export class ContentSelector
     }
 
     protected removePropertyWithId(id: string) {
-        let length = this.getPropertyArray().getSize();
+        const length: number = this.getPropertyArray().getSize();
+
         for (let i = 0; i < length; i++) {
             if (this.getPropertyArray().get(i).getValue().getString() === id) {
                 this.getPropertyArray().remove(i);
@@ -228,6 +257,7 @@ export class ContentSelector
         if (ContentSelector.debug) {
             console.log('update(' + propertyArray.toJson() + ')');
         }
+
         return super.update(propertyArray, unchangedOnly).then(() => {
             /*let value = this.getValueFromPropertyArray(propertyArray);
             this.contentComboBox.setValue(value);*/
@@ -251,13 +281,14 @@ export class ContentSelector
     }
 
     private isResetRequired(): boolean {
-        const values = this.contentComboBox.getSelectedDisplayValues();
+        const values: ContentTreeSelectorItem[] = this.contentComboBox.getSelectedDisplayValues();
+
         if (this.getPropertyArray().getSize() !== values.length) {
             return true;
         }
 
         return !values.every((value: ContentTreeSelectorItem, index: number) => {
-            const property = this.getPropertyArray().get(index);
+            const property: Property = this.getPropertyArray().get(index);
             return property?.getString() === value.getId();
         });
     }
@@ -266,10 +297,12 @@ export class ContentSelector
         if (ContentSelector.debug) {
             console.log('resetPropertyValues()');
         }
+
         if (!this.isResetRequired()) {
             return;
         }
-        const values = this.contentComboBox.getSelectedDisplayValues();
+
+        const values: ContentTreeSelectorItem[] = this.contentComboBox.getSelectedDisplayValues();
 
         this.ignorePropertyChange(true);
 
@@ -293,7 +326,6 @@ export class ContentSelector
     }
 
     protected doLoadContent(contentIds: ContentId[]): Q.Promise<ContentSummary[]> {
-
         ContentSelector.contentIdBatch = ContentSelector.contentIdBatch.concat(contentIds);
 
         if (!ContentSelector.loadSummariesResult) {
@@ -303,15 +335,14 @@ export class ContentSelector
         ContentSelector.loadSummaries();
 
         return ContentSelector.loadSummariesResult.promise.then((result: ContentSummary[]) => {
-            let contentIdsStr = contentIds.map(id => id.toString());
+            const contentIdsStr: string[] = contentIds.map((id: ContentId) => id.toString());
             return result.filter(content => contentIdsStr.indexOf(content.getId()) >= 0);
         });
     }
 
     protected setContentIdProperty(contentId: ContentId) {
-        let reference = new Reference(contentId.toString());
-
-        let value = new Value(reference, ValueTypes.REFERENCE);
+        const reference: Reference = new Reference(contentId.toString());
+        const value: Value = new Value(reference, ValueTypes.REFERENCE);
 
         if (!this.getPropertyArray().containsValue(value)) {
             this.ignorePropertyChange(true);
@@ -350,8 +381,8 @@ export class ContentSelector
     }
 
     protected updateSelectedOptionIsEditable(selectedOption: SelectedOption<ContentTreeSelectorItem>) {
-        let selectedContentId = selectedOption.getOption().getDisplayValue().getContentId();
-        let refersToItself = selectedContentId.toString() === this.config.content.getId();
+        const selectedContentId: ContentId = selectedOption.getOption().getDisplayValue().getContentId();
+        const refersToItself: boolean = selectedContentId.toString() === this.config.content.getId();
         selectedOption.getOptionView().toggleClass('non-editable', refersToItself);
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/selector/MediaSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/selector/MediaSelector.ts
@@ -17,6 +17,7 @@ import {ContentTreeSelectorItem} from '../../item/ContentTreeSelectorItem';
 import {GetMimeTypesByContentTypeNamesRequest} from '../../resource/GetMimeTypesByContentTypeNamesRequest';
 import {Content} from '../../content/Content';
 import {UploadItem} from 'lib-admin-ui/ui/uploader/UploadItem';
+import {ContentSummary} from '../../content/ContentSummary';
 
 export class MediaSelector
     extends ContentSelector {
@@ -102,7 +103,7 @@ export class MediaSelector
 
             const option = Option.create<MediaTreeSelectorItem>()
                     .setValue(createdContent.getContentId().toString())
-                    .setDisplayValue(new MediaTreeSelectorItem(createdContent))
+                    .setDisplayValue(this.createSelectorItem(createdContent))
                     .build();
 
             this.contentComboBox.selectOption(option);
@@ -147,6 +148,10 @@ export class MediaSelector
         });
 
         return uploader;
+    }
+
+    protected createSelectorItem(content: ContentSummary): MediaTreeSelectorItem {
+        return new MediaTreeSelectorItem(content);
     }
 
     protected selectedOptionHandler(_selectedOption: SelectedOption<ContentTreeSelectorItem>) {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -1290,7 +1290,6 @@ export class ContentWizardPanel
 
         const versionChangeHandler = () => {
             this.handleCUD();
-
             this.updateButtonsState();
         };
 
@@ -1982,26 +1981,21 @@ export class ContentWizardPanel
     }
 
     private produceCreateContentRequest(): Q.Promise<CreateContentRequest> {
-        let deferred = Q.defer<CreateContentRequest>();
+        return this.contentType.getContentTypeName().isMedia() ? Q(null) : this.doCreateContentRequest();
+    }
 
-        let parentPath = this.parentContent != null ? this.parentContent.getPath() : ContentPath.ROOT;
+    private doCreateContentRequest(): Q.Promise<CreateContentRequest> {
+        const parentPath: ContentPath = this.parentContent != null ? this.parentContent.getPath() : ContentPath.ROOT;
 
-        if (this.contentType.getContentTypeName().isMedia()) {
-            deferred.resolve(null);
-        } else {
-            deferred.resolve(
-                new CreateContentRequest()
-                    .setRequireValid(this.requireValid)
-                    .setName(ContentUnnamed.newUnnamed())
-                    .setParent(parentPath)
-                    .setContentType(this.contentType.getContentTypeName())
-                    .setDisplayName('')     // new content is created on wizard open so display name is always empty
-                    .setData(new PropertyTree())
-                    .setExtraData([])
-                    .setWorkflow(Workflow.create().setState(WorkflowState.IN_PROGRESS).build()));
-        }
-
-        return deferred.promise;
+        return Q(new CreateContentRequest()
+            .setRequireValid(this.requireValid)
+            .setName(ContentUnnamed.newUnnamed())
+            .setParent(parentPath)
+            .setContentType(this.contentType.getContentTypeName())
+            .setDisplayName('')     // new content is created on wizard open so display name is always empty
+            .setData(new PropertyTree())
+            .setExtraData([])
+            .setWorkflow(Workflow.create().setState(WorkflowState.IN_PROGRESS).build()));
     }
 
     updatePersistedItem(): Q.Promise<Content> {
@@ -2014,7 +2008,7 @@ export class ContentWizardPanel
             .setWorkflowState(this.isMarkedAsReady ? WorkflowState.READY : WorkflowState.IN_PROGRESS);
 
         return updateContentRoutine.execute().then((context: RoutineContext) => {
-            const content = context.content;
+            const content: Content = context.content;
             this.wizardFormUpdatedDuringSave = context.dataUpdated;
             this.pageEditorUpdatedDuringSave = context.pageUpdated;
 
@@ -2310,14 +2304,14 @@ export class ContentWizardPanel
             console.debug('ContentWizardPanel.initFormContext');
         }
 
-        this.formContext = <ContentFormContext>ContentFormContext.create()
-            .setSite(this.site)
-            .setParentContent(this.parentContent)
-            .setPersistedContent(content)
-            .setContentTypeName(this.contentType ? this.contentType.getContentTypeName() : undefined)
-            .setFormState(this.formState)
-            .setShowEmptyFormItemSetOccurrences(this.isItemPersisted())
-            .build();
+        if (!this.formContext) {
+            this.formContext =
+                ContentFormContext.create().setPersistedContent(content).setContentTypeName(this.contentType?.getContentTypeName()).build();
+        }
+
+        this.formContext.setSite(this.site).setParentContent(this.parentContent).setPersistedContent(content);
+        this.formContext.setFormState(this.formState);
+        this.formContext.setShowEmptyFormItemSetOccurrences(this.isItemPersisted());
     }
 
     private setModifyPermissions() {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardStepForm.ts
@@ -1,3 +1,4 @@
+import * as Q from 'q';
 import {BeforeContentSavedEvent} from '../event/BeforeContentSavedEvent';
 import {Form} from 'lib-admin-ui/form/Form';
 import {FormContext} from 'lib-admin-ui/form/FormContext';
@@ -7,6 +8,7 @@ import {WizardStepValidityChangedEvent} from 'lib-admin-ui/app/wizard/WizardStep
 import {WizardStepForm} from 'lib-admin-ui/app/wizard/WizardStepForm';
 import {FormValidityChangedEvent} from 'lib-admin-ui/form/FormValidityChangedEvent';
 import {ValidationRecording} from 'lib-admin-ui/form/ValidationRecording';
+import {ContentFormContext} from '../ContentFormContext';
 
 export class ContentWizardStepForm
     extends WizardStepForm {
@@ -38,26 +40,26 @@ export class ContentWizardStepForm
         return this.formView.reset();
     }
 
-    layout(formContext: FormContext, data: PropertyTree, form: Form): Q.Promise<void> {
-
+    layout(formContext: ContentFormContext, data: PropertyTree, form: Form): Q.Promise<void> {
         this.formContext = formContext;
         this.form = form;
         this.data = data;
+
         return this.doLayout(form, data);
     }
 
     protected doLayout(form: Form, data: PropertyTree): Q.Promise<void> {
-
         if (this.formView) {
             this.formView.remove();
         }
 
         this.formView = new FormView(this.formContext, form, data.getRoot());
-        return this.formView.layout().then(() => {
 
+        return this.formView.layout().then(() => {
             this.formView.onFocus((event) => {
                 this.notifyFocused(event);
             });
+
             this.formView.onBlur((event) => {
                 this.notifyBlurred(event);
             });
@@ -72,6 +74,8 @@ export class ContentWizardStepForm
             if (form.getFormItems().length === 0) {
                 this.hide();
             }
+
+            return Q(null);
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/XDataWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/XDataWizardStepForm.ts
@@ -5,7 +5,7 @@ import {XData} from '../content/XData';
 import {Form} from 'lib-admin-ui/form/Form';
 import {FormView} from 'lib-admin-ui/form/FormView';
 import {PropertyTree} from 'lib-admin-ui/data/PropertyTree';
-import {FormContext} from 'lib-admin-ui/form/FormContext';
+import {ContentFormContext} from '../ContentFormContext';
 
 export class XDataWizardStepForm
     extends ContentWizardStepForm {
@@ -64,7 +64,7 @@ export class XDataWizardStepForm
         return this.enabled ? this.doLayout(this.form, this.data) : Q(null);
     }
 
-    layout(formContext: FormContext, data: PropertyTree, form: Form): Q.Promise<void> {
+    layout(formContext: ContentFormContext, data: PropertyTree, form: Form): Q.Promise<void> {
         this.enabled = !this.isOptional() || data.getRoot().getPropertyArrays().length > 0;
         return super.layout(formContext, data, form);
     }


### PR DESCRIPTION
…ing a name of content #1972

-Listening current content rename event and reloading selected options
-ContentWizardPanel: not recreating form context, using single instance and updating it props on update and other events so all forms will have actual data (otherwise stale content data will present in ContentFormContext )