### PR TITLE
User is switched to default context after current context/project is …

### DIFF
--- a/modules/app/src/main/resources/assets/js/main.ts
+++ b/modules/app/src/main/resources/assets/js/main.ts
@@ -601,6 +601,10 @@ function initProjectContext(application: Application): Q.Promise<void> {
             return Q(null);
         }
 
+        if (projects.length === 0) {
+            ProjectContext.get().setNoProjects();
+        }
+
         ProjectSelectionDialog.get().open();
 
         return Q(null);

--- a/modules/app/src/main/resources/assets/js/main.ts
+++ b/modules/app/src/main/resources/assets/js/main.ts
@@ -602,7 +602,7 @@ function initProjectContext(application: Application): Q.Promise<void> {
         }
 
         if (projects.length === 0) {
-            ProjectContext.get().setNoProjects();
+            ProjectContext.get().setNotAvailable();
         }
 
         ProjectSelectionDialog.get().open();

--- a/modules/lib/src/main/resources/assets/js/app/ContentAppContainer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentAppContainer.ts
@@ -90,7 +90,7 @@ export class ContentAppContainer
     private handleNoProjectsAvailable() {
         this.appBar.disable();
 
-        ProjectContext.get().setNoProjects();
+        ProjectContext.get().setNotAvailable();
     }
 
     private initSearchPanelListener(panel: ContentAppPanel) {

--- a/modules/lib/src/main/resources/assets/js/app/ContentAppContainer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentAppContainer.ts
@@ -88,7 +88,9 @@ export class ContentAppContainer
     }
 
     private handleNoProjectsAvailable() {
-    //
+        this.appBar.disable();
+
+        ProjectContext.get().setNoProjects();
     }
 
     private initSearchPanelListener(panel: ContentAppPanel) {

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -38,6 +38,8 @@ import {IsRenderableRequest} from '../resource/IsRenderableRequest';
 import {ContentSummary} from '../content/ContentSummary';
 import {ContentId} from '../content/ContentId';
 import {ContentPath} from '../content/ContentPath';
+import {NotifyManager} from 'lib-admin-ui/notify/NotifyManager';
+import {i18n} from 'lib-admin-ui/util/Messages';
 
 export class ContentBrowsePanel
     extends BrowsePanel {
@@ -242,7 +244,6 @@ export class ContentBrowsePanel
         });
 
         ToggleSearchPanelWithDependenciesEvent.on((event: ToggleSearchPanelWithDependenciesEvent) => {
-
             if (this.treeGrid.getToolbar().getSelectionPanelToggler().isActive()) {
                 this.treeGrid.getToolbar().getSelectionPanelToggler().setActive(false);
             }
@@ -277,10 +278,17 @@ export class ContentBrowsePanel
                 this.treeGrid.reload();
             });
         });
+
+        ProjectContext.get().onNoProjectsAvailable(() => {
+            this.handleProjectNotSet();
+            this.treeGrid.clean();
+            NotifyManager.get().showWarning(i18n('notify.settings.project.notInitialized'));
+        });
     }
 
     private selectInlinedContentInGrid(contentInlinePath: string) {
         const path: string = this.getPathFromInlinePath(contentInlinePath);
+
         if (path) {
             this.treeGrid.selectInlinedContentInGrid(ContentPath.fromString(path));
         }

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -234,6 +234,11 @@ export class ContentTreeGrid
         }
     }
 
+    clean() {
+        this.deselectAll();
+        this.getGridData().setItems([]);
+    }
+
     reload(): Q.Promise<void> {
         if (this.state === State.DISABLED) {
             return Q(null);

--- a/modules/lib/src/main/resources/assets/js/app/project/ProjectContext.ts
+++ b/modules/lib/src/main/resources/assets/js/app/project/ProjectContext.ts
@@ -37,9 +37,9 @@ export class ProjectContext {
         this.notifyProjectChanged();
     }
 
-    setNoProjects() {
+    setNotAvailable() {
         this.currentProject = null;
-        this.state = State.NO_AVAILABLE;
+        this.state = State.NOT_AVAILABLE;
         localStorage.removeItem(ProjectContext.LOCAL_STORAGE_KEY);
         this.notifyNoProjectsAvailable();
     }
@@ -82,5 +82,5 @@ export class ProjectContext {
 }
 
 enum State {
-    INITIALIZED, NOT_INITIALIZED, NO_AVAILABLE
+    INITIALIZED, NOT_INITIALIZED, NOT_AVAILABLE
 }

--- a/modules/lib/src/main/resources/assets/js/app/project/ProjectContext.ts
+++ b/modules/lib/src/main/resources/assets/js/app/project/ProjectContext.ts
@@ -12,6 +12,8 @@ export class ProjectContext {
 
     private projectChangedEventListeners: { (project: Project): void }[] = [];
 
+    private noProjectsAvailableListeners: { (): void }[] = [];
+
     private constructor() {
     //
     }
@@ -35,6 +37,13 @@ export class ProjectContext {
         this.notifyProjectChanged();
     }
 
+    setNoProjects() {
+        this.currentProject = null;
+        this.state = State.NO_AVAILABLE;
+        localStorage.removeItem(ProjectContext.LOCAL_STORAGE_KEY);
+        this.notifyNoProjectsAvailable();
+    }
+
     isInitialized(): boolean {
         return this.state === State.INITIALIZED;
     }
@@ -54,8 +63,24 @@ export class ProjectContext {
             handler(this.currentProject);
         });
     }
+
+    onNoProjectsAvailable(handler: () => void) {
+        this.noProjectsAvailableListeners.push(handler);
+    }
+
+    unNoProjectsAvailable(handler: (project: Project) => void) {
+        this.noProjectsAvailableListeners = this.noProjectsAvailableListeners.filter((curr: () => void) => {
+            return handler !== curr;
+        });
+    }
+
+    private notifyNoProjectsAvailable() {
+        this.noProjectsAvailableListeners.forEach((handler: () => void) => {
+            handler();
+        });
+    }
 }
 
 enum State {
-    INITIALIZED, NOT_INITIALIZED
+    INITIALIZED, NOT_INITIALIZED, NO_AVAILABLE
 }


### PR DESCRIPTION
…deleted #1967

-Handling deleting of the only available project for a user:
1. Introduced new project context state NOT_AVAILABLE
2. Added listeners for a case when single project in use becomes unavailable
3. Cleaning TreeGrid in that case and disabling toolbars and buttons