### PR TITLE
Error message should not be shown before new X-data form is validated…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -256,10 +256,8 @@ export class ContentWizardPanel
         this.contentUpdateDisabled = false;
         this.applicationLoadCount = 0;
         this.isFirstUpdateAndRenameEventSkiped = false;
-
         this.displayNameResolver = new DisplayNameResolver();
         this.xDataWizardStepForms = new XDataWizardStepForms();
-
         this.workflowStateIconsManager = new WorkflowStateIconsManager(this);
 
         this.listenToContentEvents();
@@ -2030,14 +2028,16 @@ export class ContentWizardPanel
             this.getWizardHeader().resetBaseValues();
 
             return content;
-        }).then((content: Content) => {
-            this.formState.setIsNew(false);
-            this.contentWizardStepForm.validate();
-            this.xDataWizardStepForms.validate(false, true);
-            this.displayValidationErrors(!this.isValid());
-
-            return content;
         });
+    }
+
+    postUpdatePersistedItem(persistedItem: Content): Q.Promise<Content> {
+        this.initFormContext(persistedItem);
+        this.contentWizardStepForm.validate();
+        this.xDataWizardStepForms.validate();
+        this.displayValidationErrors(!this.isValid());
+
+        return Q(persistedItem);
     }
 
     private showFeedbackContentSaved(content: Content, wasInherited: boolean = false) {
@@ -2302,7 +2302,9 @@ export class ContentWizardPanel
         });
     }
 
-    private initFormContext(content: Content) {
+    private initFormContext(persistedItem: Content) {
+        const content: Content = persistedItem.clone();
+
         if (ContentWizardPanel.debug) {
             console.debug('ContentWizardPanel.initFormContext');
         }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/XDataWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/XDataWizardStepForm.ts
@@ -6,11 +6,12 @@ import {Form} from 'lib-admin-ui/form/Form';
 import {FormView} from 'lib-admin-ui/form/FormView';
 import {PropertyTree} from 'lib-admin-ui/data/PropertyTree';
 import {ContentFormContext} from '../ContentFormContext';
+import {ExtraData} from '../content/ExtraData';
 
 export class XDataWizardStepForm
     extends ContentWizardStepForm {
 
-    private xData: XData;
+    private readonly xData: XData;
 
     private enabled: boolean = false;
 
@@ -120,7 +121,7 @@ export class XDataWizardStepForm
                 }
 
                 promise = this.doLayout(this.form, this.data).then(() => {
-                   this.validate(true);
+                   this.validate();
                    return Q(null);
                 });
             }
@@ -161,5 +162,30 @@ export class XDataWizardStepForm
         this.enableChangedListeners.forEach((listener) => {
             listener(value);
         });
+    }
+
+    displayValidationErrors(display: boolean) {
+        if (this.isValidationErrorToBeRendered()) {
+            super.displayValidationErrors(display);
+        }
+    }
+
+    private isValidationErrorToBeRendered(): boolean {
+        if (this.formContext?.getFormState().isNew()) {
+            return false;
+        }
+
+        if (!this.isOptional()) {
+            return true;
+        }
+
+        return this.isEnabled() && this.isSaved();
+    }
+
+    private isSaved(): boolean {
+        const persistedXData: ExtraData =
+            (<ContentFormContext>this.formContext).getPersistedContent().getExtraDataByName(this.getXDataName());
+
+        return persistedXData?.getData()?.getRoot()?.getPropertyArrays().length > 0;
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/XDataWizardStepForms.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/XDataWizardStepForms.ts
@@ -64,9 +64,9 @@ export class XDataWizardStepForms {
         });
     }
 
-    validate(silent: boolean = false, forceNotify: boolean = false) {
+    validate() {
         this.forEach((form: XDataWizardStepForm) => {
-            form.validate(silent, forceNotify);
+            form.validate();
         });
     }
 }


### PR DESCRIPTION
… #3178

-Controlling x-data validation errors displaying: showing only when content is saved and for optional x-data only when x-data present in persisted item data
-Instantiating form context once
-Setting cloned persisted content to form context instead of same object that is set to content data forms, otherwise this object's data and x-data is modified in wizard data forms