### PR TITLE
allowHeadings config not respected when used with exclude/include #3254

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -955,14 +955,19 @@ class HtmlEditorConfigBuilder {
         const disabledTools = tools['exclude'];
 
         if (disabledTools && disabledTools instanceof Array) {
-            this.disabledTools = disabledTools.map(tool => tool.value).join().replace(/\s+/g, ',');
+            this.disabledTools = disabledTools.map(tool => tool.value).join().replace('Format', 'Styles').replace(/\s+/g, ',');
             if (this.disabledTools === '*') {
                 this.tools = [[]];
             }
         }
 
         if (enabledTools && enabledTools instanceof Array) {
-            this.includeTools(enabledTools.map(tool => tool.value).join().replace(/\|/g, '-').split(/\s+/));
+            this.includeTools(enabledTools.map(tool => tool.value)
+                .join()
+                .replace('Format', 'Styles') // Styles plugin is used instead of Format
+                .replace(/\|/g, '-')
+                .split(/\s+/)
+                .filter((tool: string) => !this.isDefaultTool(tool)));
         }
     }
 
@@ -1097,6 +1102,10 @@ class HtmlEditorConfigBuilder {
 
     private isToolDisabled(tool: string): boolean {
         return this.disabledTools.indexOf(tool) > -1;
+    }
+
+    private isDefaultTool(tool: string): boolean {
+        return this.tools.some((toolgroup: string[]) => toolgroup.some((defaultTool: string) => defaultTool === tool));
     }
 }
 


### PR DESCRIPTION
-We replaced usage of basic Format plugin with more customizable Styles plugin some time ago, however in docs we have Format plugin mentioned in a list of plugins, thus need to replace Format->Styles when parsing include/exclude items
-Also found an issue: need to filter default toolbar items from the list of include items so they don't appear twice in the toolbar