### PR TITLE
Fix build order #3354 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,13 +7,16 @@ plugins {
     id 'org.aim42.htmlSanityCheck' version '1.1.6'
 }
 
+allprojects {
+    apply from: "$rootDir/gradle/env.gradle"
+    apply from: "$rootDir/gradle/node.gradle"
+    apply from: "$rootDir/gradle/lib-admin.gradle"
+}
+
 subprojects {
     apply plugin: 'java'
     apply plugin: 'com.enonic.defaults'
     apply plugin: 'com.enonic.xp.base'
-    apply from: "$rootDir/gradle/env.gradle"
-    apply from: "$rootDir/gradle/node.gradle"
-    apply from: "$rootDir/gradle/lib-admin.gradle"
 
     dependencies {
         testImplementation 'junit:junit:4.13.2'

--- a/build.gradle
+++ b/build.gradle
@@ -7,16 +7,13 @@ plugins {
     id 'org.aim42.htmlSanityCheck' version '1.1.6'
 }
 
-allprojects {
-    apply from: "$rootDir/gradle/env.gradle"
-    apply from: "$rootDir/gradle/node.gradle"
-    apply from: "$rootDir/gradle/lib-admin.gradle"
-}
-
 subprojects {
     apply plugin: 'java'
     apply plugin: 'com.enonic.defaults'
     apply plugin: 'com.enonic.xp.base'
+    apply from: "$rootDir/gradle/env.gradle"
+    apply from: "$rootDir/gradle/node.gradle"
+    apply from: "$rootDir/gradle/lib-admin.gradle"
 
     dependencies {
         testImplementation 'junit:junit:4.13.2'

--- a/gradle/lib-admin.gradle
+++ b/gradle/lib-admin.gradle
@@ -25,15 +25,15 @@ def applyBuildTaskDependencies()
     def libAdminBuildTask = gradle.includedBuild( 'lib-admin-ui' ).task( ':build' )
 
     if ( hasTask( 'copyDevResources' ) ) {
-        copyDevResources.dependsOn += libAdminBuildTask
+        copyDevResources.dependsOn libAdminBuildTask
     }
     if ( hasTask( 'typescript' ) ) {
-        typescript.dependsOn += libAdminBuildTask
+        typescript.dependsOn libAdminBuildTask
         typescript.mustRunAfter(libAdminBuildTask)
 
     }
     if ( hasTask( 'webpack' ) ) {
-        webpack.dependsOn += libAdminBuildTask
+        webpack.dependsOn libAdminBuildTask
         webpack.mustRunAfter(libAdminBuildTask)
     }
 }

--- a/gradle/lib-admin.gradle
+++ b/gradle/lib-admin.gradle
@@ -20,18 +20,12 @@ def applyExcludedTasks()
     gradle.includedBuild( 'lib-admin-ui' ).getLoadedSettings().getStartParameter().setExcludedTaskNames( excludedTasks )
 }
 
-def applyBuildTaskDependencies()
+def applyResourcesTaskDependencies()
 {
-    def libAdminBuildTask = gradle.includedBuild( 'lib-admin-ui' ).task( ':build' )
+    def libAdminDevJarTask = gradle.includedBuild( 'lib-admin-ui' ).task( ':devJar' )
 
     if ( hasTask( 'copyDevResources' ) ) {
-        copyDevResources.dependsOn libAdminBuildTask
-    }
-    if ( hasTask( 'typescript' ) ) {
-        typescript.dependsOn libAdminBuildTask
-    }
-    if ( hasTask( 'webpack' ) ) {
-        webpack.dependsOn libAdminBuildTask
+        copyDevResources.dependsOn libAdminDevJarTask
     }
 }
 
@@ -39,7 +33,7 @@ if ( hasLibAdminUi() )
 {
     afterEvaluate {
         applyExcludedTasks()
-        applyBuildTaskDependencies()
+        applyResourcesTaskDependencies()
     }
 }
 

--- a/gradle/lib-admin.gradle
+++ b/gradle/lib-admin.gradle
@@ -20,19 +20,42 @@ def applyExcludedTasks()
     gradle.includedBuild( 'lib-admin-ui' ).getLoadedSettings().getStartParameter().setExcludedTaskNames( excludedTasks )
 }
 
+def applyBuildTaskDependencies()
+{
+    def libAdminBuildTask = gradle.includedBuild( 'lib-admin-ui' ).task( ':build' )
+
+    if ( hasTask( 'copyDevResources' ) ) {
+        copyDevResources.dependsOn += libAdminBuildTask
+    }
+    if ( hasTask( 'typescript' ) ) {
+        typescript.dependsOn += libAdminBuildTask
+        typescript.mustRunAfter(libAdminBuildTask)
+
+    }
+    if ( hasTask( 'webpack' ) ) {
+        webpack.dependsOn += libAdminBuildTask
+        webpack.mustRunAfter(libAdminBuildTask)
+    }
+}
+
 if ( hasLibAdminUi() )
 {
-    applyExcludedTasks()
+    afterEvaluate {
+        applyExcludedTasks()
+        applyBuildTaskDependencies()
+    }
 }
 
 ext {
     hasLibAdminUi = this.&hasLibAdminUi
 }
 
-if ( hasTask( 'clean' ) )
-{
-    task flush( type: Delete, dependsOn: clean ) {
-        description = 'Clean the project from built sources and dependencies'
-        delete '.xp'
+afterEvaluate {
+    if ( hasTask( 'clean' ) )
+    {
+        task flush( type: Delete, dependsOn: clean ) {
+            description = 'Clean the project from built sources and dependencies'
+            delete '.xp'
+        }
     }
 }

--- a/gradle/lib-admin.gradle
+++ b/gradle/lib-admin.gradle
@@ -29,12 +29,9 @@ def applyBuildTaskDependencies()
     }
     if ( hasTask( 'typescript' ) ) {
         typescript.dependsOn libAdminBuildTask
-        typescript.mustRunAfter(libAdminBuildTask)
-
     }
     if ( hasTask( 'webpack' ) ) {
         webpack.dependsOn libAdminBuildTask
-        webpack.mustRunAfter(libAdminBuildTask)
     }
 }
 

--- a/modules/app/build.gradle
+++ b/modules/app/build.gradle
@@ -49,6 +49,8 @@ task copyDevResources {
             into '.xp'
         }
     }
+
+    dependsOn ':lib-contentstudio:devJar'
 }
 
 npmInstall.dependsOn copyDevResources


### PR DESCRIPTION
Made `copyDevResources` and JS sources build tasks (`typescript` and `webpack`) depend on lib-admin-ui `build` task to prevent them from starting before the `lib-admin-ui-*-dev-resources.jar` is ready.