### PR TITLE
Error in log when archiving items #3609

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -710,7 +710,8 @@ export class ContentTreeGrid
 
         items.forEach((item: DeletedContentItem) => {
             const nodeToDelete: TreeNode<ContentSummaryAndCompareStatus> = allNodes.find(
-                (node: TreeNode<ContentSummaryAndCompareStatus>) => node.getData()?.getPath()?.equals(item.path));
+                (node: TreeNode<ContentSummaryAndCompareStatus>) => node.getData()?.getPath()?.equals(item.path) ||
+                                                                    node.getData()?.getContentId().equals(item.id));
 
             if (nodeToDelete) {
                 this.deleteNode(nodeToDelete);

--- a/modules/lib/src/main/resources/assets/js/app/event/AggregatedServerEventsListener.ts
+++ b/modules/lib/src/main/resources/assets/js/app/event/AggregatedServerEventsListener.ts
@@ -12,6 +12,7 @@ import {RepositoryId} from '../repository/RepositoryId';
 import {IssueServerEvent} from './IssueServerEvent';
 import {NodeServerEvent} from 'lib-admin-ui/event/NodeServerEvent';
 import {ArchiveServerEvent} from './ArchiveServerEvent';
+import {NodeServerChangeType} from 'lib-admin-ui/event/NodeServerChange';
 
 export class AggregatedServerEventsListener
     extends ServerEventsListener {
@@ -23,12 +24,9 @@ export class AggregatedServerEventsListener
 
         this.aggregator = new ServerEventAggregator();
 
-        this.aggregator.onBatchIsReady(() => {
-            const event: BatchContentServerEvent =
-                new BatchContentServerEvent(<ContentServerChangeItem[]>this.aggregator.getItems(), this.aggregator.getType());
+        this.aggregator.onBatchIsReady((items: ContentServerChangeItem[], type: NodeServerChangeType) => {
+            const event: BatchContentServerEvent = new BatchContentServerEvent(items, type);
             this.fireEvent(event);
-
-            this.aggregator.resetItems();
         });
 
         this.setServerEventsTranslator(new ContentServerEventsTranslator());

--- a/modules/lib/src/main/resources/assets/js/app/event/ContentServerChange.ts
+++ b/modules/lib/src/main/resources/assets/js/app/event/ContentServerChange.ts
@@ -14,6 +14,10 @@ export class ContentServerChange
         return <ContentServerChange>new ContentServerChangeBuilder().fromJson(nodeEventJson).build();
     }
 
+    getChangeItems(): ContentServerChangeItem[] {
+        return <ContentServerChangeItem[]>super.getChangeItems();
+    }
+
 }
 
 export class ContentServerChangeBuilder

--- a/modules/lib/src/main/resources/assets/js/app/event/ContentServerEventsHandler.ts
+++ b/modules/lib/src/main/resources/assets/js/app/event/ContentServerEventsHandler.ts
@@ -81,7 +81,7 @@ export class ContentServerEventsHandler {
 
         ArchiveServerEvent.on((event: ArchiveServerEvent) => {
             if (event.getNodeChange().getChangeType() === NodeServerChangeType.MOVE) {
-                this.handleContentRestored(<ContentServerChangeItem[]>event.getNodeChange().getChangeItems());
+                this.handleContentRestored(event.getNodeChange().getChangeItems());
             }
         });
     }

--- a/modules/lib/src/main/resources/assets/js/app/event/ServerEventAggregator.ts
+++ b/modules/lib/src/main/resources/assets/js/app/event/ServerEventAggregator.ts
@@ -1,116 +1,104 @@
-import {NodeServerEvent} from 'lib-admin-ui/event/NodeServerEvent';
-import {NodeServerChange, NodeServerChangeType} from 'lib-admin-ui/event/NodeServerChange';
+import {NodeServerChangeType} from 'lib-admin-ui/event/NodeServerChange';
 import {AppHelper} from 'lib-admin-ui/util/AppHelper';
-import {NodeServerChangeItem} from 'lib-admin-ui/event/NodeServerChangeItem';
+import {ContentServerEvent} from './ContentServerEvent';
+import {ContentServerChangeItem} from './ContentServerChangeItem';
 
 export class ServerEventAggregator {
 
     private static AGGREGATION_TIMEOUT: number = 500;
 
-    private items: NodeServerChangeItem[];
+    private batchReadyListeners: { (items: ContentServerChangeItem[], type: NodeServerChangeType): void }[] = [];
 
-    private type: NodeServerChangeType;
+    private typesAndDelayedFunctions: Map<NodeServerChangeType, Function> = new Map<NodeServerChangeType, Function>();
 
-    private batchReadyListeners: { (event: any): void }[] = [];
-
-    private debouncedNotification: Function;
+    private typesAndChangeItems: Map<NodeServerChangeType, ContentServerChangeItem[]> =
+        new Map<NodeServerChangeType, ContentServerChangeItem[]>();
 
     constructor() {
-        this.debouncedNotification = AppHelper.debounce(() => {
-            this.notifyBatchIsReady();
-        }, ServerEventAggregator.AGGREGATION_TIMEOUT, false);
+    //
     }
 
-    getItems(): NodeServerChangeItem[] {
-        return this.items;
-    }
+    appendEvent(event: ContentServerEvent) {
+        const type: NodeServerChangeType = event.getNodeChange().getChangeType();
+        this.processNewEvent(event);
 
-    resetItems() {
-        this.items = [];
-    }
-
-    appendEvent(event: NodeServerEvent) {
-        if (this.isEmpty()) {
-            this.init(event);
+        if (this.typesAndDelayedFunctions.get(type)) {
+            this.typesAndDelayedFunctions.get(type)();
+            this.typesAndChangeItems.get(type).push(...event.getNodeChange().getChangeItems());
         } else {
-            this.processAppendedEvent(event);
+            const debouncedFunc: Function = AppHelper.debounce(() => {
+                const items: ContentServerChangeItem[] = this.typesAndChangeItems.get(type);
+
+                this.typesAndDelayedFunctions.delete(type);
+                this.typesAndChangeItems.delete(type);
+
+                if (items?.length > 0) {
+                    this.notifyBatchIsReady(items, type);
+                }
+
+            }, ServerEventAggregator.AGGREGATION_TIMEOUT);
+
+            this.typesAndDelayedFunctions.set(type, debouncedFunc);
+            this.typesAndChangeItems.set(type, event.getNodeChange().getChangeItems());
+
+            debouncedFunc();
         }
 
-        this.debouncedNotification();
     }
 
-    private isEmpty(): boolean {
-        return this.items == null || this.items.length === 0;
-    }
-
-    private processAppendedEvent(event: NodeServerEvent) {
-        if (this.isTheSameTypeEvent(event)) {
-            this.items.push(...event.getNodeChange().getChangeItems());
+    private processNewEvent(event: ContentServerEvent) {
+        if (!this.isMoveEvent(event)) {
             return;
         }
 
-        if (this.isEventItemMovedToOtherRoot(event)) {
-            if (this.type === NodeServerChangeType.UPDATE) {
-                this.processBatchedUpdateEvents(event);
-            }
+        const itemsMovedToOtherRoot: ContentServerChangeItem[] = this.getItemsMovedToOtherRoot(event);
 
-            this.init(event);
-            return;
+        if (itemsMovedToOtherRoot.length > 0) {
+            this.filterEventsOfDeletedOrMovedItems(itemsMovedToOtherRoot);
         }
-
-        this.notifyBatchIsReady();
-        this.init(event);
     }
 
-    getType(): NodeServerChangeType {
-        return this.type;
-    }
-
-    private isTheSameTypeEvent(event: NodeServerEvent) {
-        const change: NodeServerChange = event.getNodeChange();
-
-        if (this.type !== change.getChangeType()) {
-            return false;
-        }
-
-        return true;
-    }
-
-    private init(event: NodeServerEvent) {
-        this.items = event.getNodeChange().getChangeItems();
-        this.type = !!event.getNodeChange() ? event.getNodeChange().getChangeType() : null;
-    }
-
-    private isEventItemMovedToOtherRoot(event: NodeServerEvent): boolean {
-        return event.getNodeChange()?.getChangeItems().some((item: NodeServerChangeItem) => {
-            return item.getNewPath()?.toString().indexOf('/archive') === 0;
+    private getItemsMovedToOtherRoot(event: ContentServerEvent): ContentServerChangeItem[] {
+        return event.getNodeChange().getChangeItems().filter((item: ContentServerChangeItem) => {
+            return item.getNewPath()?.isInArchiveRoot();
         });
     }
 
-    private processBatchedUpdateEvents(event: NodeServerEvent) {
-        const archivedItems: NodeServerChangeItem[] = event.getNodeChange().getChangeItems();
-        const nonArchivedItems: NodeServerChangeItem[] =
-            this.items.filter((item: NodeServerChangeItem) => !archivedItems.some(
-                (archivedItem: NodeServerChangeItem) => archivedItem.getId() === item.getId()));
-
-        if (nonArchivedItems.length > 0) {
-            this.notifyBatchIsReady();
-        }
+    private isMoveEvent(event: ContentServerEvent): boolean {
+        return event.getNodeChange().getChangeType() === NodeServerChangeType.MOVE;
     }
 
-    onBatchIsReady(listener: (event: any) => void) {
+    private filterEventsOfDeletedOrMovedItems(itemsMovedToOtherRoot: ContentServerChangeItem[]) {
+        const updatedItems: ContentServerChangeItem[] = this.typesAndChangeItems.get(NodeServerChangeType.UPDATE) || [];
+        const renamedItems: ContentServerChangeItem[] = this.typesAndChangeItems.get(NodeServerChangeType.RENAME) || [];
+
+        const filteredUpdatedItems: ContentServerChangeItem[] =
+            updatedItems.filter((item: ContentServerChangeItem) => !this.contains(itemsMovedToOtherRoot, item));
+        const filteredRenamedItems: ContentServerChangeItem[] =
+            renamedItems.filter((item: ContentServerChangeItem) => !this.contains(itemsMovedToOtherRoot, item));
+
+        this.typesAndChangeItems.set(NodeServerChangeType.UPDATE, filteredUpdatedItems);
+        this.typesAndChangeItems.set(NodeServerChangeType.RENAME, filteredRenamedItems);
+    }
+
+    private contains(items: ContentServerChangeItem[], item: ContentServerChangeItem): boolean {
+        return items.some((i: ContentServerChangeItem) => i.getId() === item.getId());
+    }
+
+    onBatchIsReady(listener: (items: ContentServerChangeItem[], type: NodeServerChangeType) => void) {
         this.batchReadyListeners.push(listener);
     }
 
-    unBatchIsReady(listener: (event: any) => void) {
-        this.batchReadyListeners = this.batchReadyListeners.filter((currentListener: (event: any) => void) => {
-            return listener !== currentListener;
-        });
+    unBatchIsReady(listener: (items: ContentServerChangeItem[], type: NodeServerChangeType) => void) {
+        this.batchReadyListeners =
+            this.batchReadyListeners.filter((currentListener: (items: ContentServerChangeItem[], type: NodeServerChangeType) => void) => {
+                return listener !== currentListener;
+            });
     }
 
-    private notifyBatchIsReady() {
-        this.batchReadyListeners.forEach((listener: (event: any) => void) => {
-            listener.call(this);
+    private notifyBatchIsReady(items: ContentServerChangeItem[], type: NodeServerChangeType) {
+        this.batchReadyListeners.forEach((listener: (items: ContentServerChangeItem[], type: NodeServerChangeType) => void) => {
+            listener(items, type);
         });
     }
 


### PR DESCRIPTION
-Problem with archiving items is that after triggering archiving we receive update->rename(not always)->move events, and attempt to fetch "updated" or "renamed" item is doomed to fail since item is already in other root (/archive). Handling this situation with smarter event handling - grouping them by type and filtering moved to archive items from update and rename events