### PR TITLE
B/I/U formatting disappears when pasting from Word/Google docs #3617

### DIFF
--- a/modules/app/src/main/resources/assets/styles/inputtype/text/htmlarea/fullscreen-dialog.less
+++ b/modules/app/src/main/resources/assets/styles/inputtype/text/htmlarea/fullscreen-dialog.less
@@ -51,6 +51,24 @@
     }
   }
 
+  &.hide-bold {
+    .cke_button__bold {
+      display: none;
+    }
+  }
+
+  &.hide-italic {
+    .cke_button__italic {
+      display: none;
+    }
+  }
+
+  &.hide-underline {
+    .cke_button__underline {
+      display: none;
+    }
+  }
+
   &.masked {
 
     border: 1px solid;

--- a/modules/app/src/main/resources/assets/styles/inputtype/text/htmlarea/html-area.less
+++ b/modules/app/src/main/resources/assets/styles/inputtype/text/htmlarea/html-area.less
@@ -5,13 +5,30 @@
     display: none;
   }
 
+  &.hide-bold {
+    .cke_button__bold {
+      display: none;
+    }
+  }
+
+  &.hide-italic {
+    .cke_button__italic {
+      display: none;
+    }
+  }
+
+  &.hide-underline {
+    .cke_button__underline {
+      display: none;
+    }
+  }
+
   .cke_top {
     position: sticky;
     top: 0;
     padding: 6px 8px 0;
 
     .cke_toolbox {
-
       display: flex;
       flex-wrap: wrap;
 

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
@@ -76,8 +76,8 @@ export class HtmlArea
 
     private processInputConfig() {
         this.allowHeadingsConfig = this.getAllowedHeadingsConfig();
-        this.enabledTools = this.getTools('include');
-        this.disabledTools = this.getTools('exclude');
+        this.enabledTools = this.getTools(true);
+        this.disabledTools = this.getTools(false);
 
         if (!this.enabledTools.some((tool: string) => tool === 'Bold')) {
             this.addClass('hide-bold');
@@ -287,8 +287,8 @@ export class HtmlArea
         return HtmlEditor.create(htmlEditorParams);
     }
 
-    private getTools(toolsType: string): string[] {
-        const toolsObj: any = this.getContext().inputConfig[toolsType];
+    private getTools(enabled: boolean): string[] {
+        const toolsObj: any = this.getContext().inputConfig[enabled ? 'include' : 'exclude'];
         const result: string[] = [];
 
         if (toolsObj && toolsObj instanceof Array) {

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditorParams.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditorParams.ts
@@ -25,7 +25,8 @@ export class HtmlEditorParams {
     private fixedToolbarContainer: string;
     private editableSourceCode: boolean;
     private customStylesToBeUsed: boolean = false;
-    private tools: any;
+    private enabledTools: string[];
+    private disabledTools: string[];
     private allowScripts: boolean = false;
     private allowedHeadings: string;
 
@@ -52,7 +53,8 @@ export class HtmlEditorParams {
         this.fixedToolbarContainer = builder.fixedToolbarContainer;
         this.editableSourceCode = builder.editableSourceCode;
         this.customStylesToBeUsed = builder.customStylesToBeUsed;
-        this.tools = builder.tools;
+        this.enabledTools = builder.enabledTools;
+        this.disabledTools = builder.disabledTools;
         this.allowScripts = builder.allowScripts;
         this.allowedHeadings = builder.allowedHeadings;
     }
@@ -167,8 +169,12 @@ export class HtmlEditorParams {
         return this.customStylesToBeUsed;
     }
 
-    getTools(): any {
-        return this.tools;
+    getEnabledTools(): string[] {
+        return this.enabledTools;
+    }
+
+    getDisabledTools(): string[] {
+        return this.disabledTools;
     }
 
     isScriptAllowed(): boolean {
@@ -222,7 +228,9 @@ export class HtmlEditorParamsBuilder {
 
     customStylesToBeUsed: boolean = false;
 
-    tools: any;
+    enabledTools: string[];
+
+    disabledTools: string[];
 
     allowScripts: boolean = false;
 
@@ -321,8 +329,13 @@ export class HtmlEditorParamsBuilder {
         return this;
     }
 
-    setTools(tools: any): HtmlEditorParamsBuilder {
-        this.tools = tools;
+    setEnabledTools(tools: string[]): HtmlEditorParamsBuilder {
+        this.enabledTools = tools;
+        return this;
+    }
+
+    setDisabledTools(tools: string[]): HtmlEditorParamsBuilder {
+        this.disabledTools = tools;
         return this;
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/FullscreenDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/FullscreenDialog.ts
@@ -104,19 +104,25 @@ export class FullscreenDialog
         const disabledTools: string[] = this.editorParams.getDisabledTools();
         const enabledTools: string[] = this.editorParams.getEnabledTools();
 
-        if (disabledTools && disabledTools.length === 1 && disabledTools[0] === '*') {
-            if (!enabledTools.some((tool: string) => tool === 'Bold')) {
-                this.addClass('hide-bold');
-            }
-
-            if (!enabledTools.some((tool: string) => tool === 'Italic')) {
-                this.addClass('hide-italic');
-            }
-
-            if (!enabledTools.some((tool: string) => tool === 'Underline')) {
-                this.addClass('hide-underline');
-            }
+        if (!this.isAllTools(disabledTools)) {
+            return;
         }
+
+        if (!enabledTools.some((tool: string) => tool === 'Bold')) {
+            this.addClass('hide-bold');
+        }
+
+        if (!enabledTools.some((tool: string) => tool === 'Italic')) {
+            this.addClass('hide-italic');
+        }
+
+        if (!enabledTools.some((tool: string) => tool === 'Underline')) {
+            this.addClass('hide-underline');
+        }
+    }
+
+    private isAllTools(tools: string[]): boolean {
+        return tools && tools.length === 1 && tools[0] === '*';
     }
 
     private editorReadyHandler() {

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/FullscreenDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/FullscreenDialog.ts
@@ -108,6 +108,10 @@ export class FullscreenDialog
             return;
         }
 
+        this.doUpdateBoldItalicUnderline(enabledTools);
+    }
+
+    private doUpdateBoldItalicUnderline(enabledTools: string[]) {
         if (!enabledTools.some((tool: string) => tool === 'Bold')) {
             this.addClass('hide-bold');
         }

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/FullscreenDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/FullscreenDialog.ts
@@ -66,6 +66,8 @@ export class FullscreenDialog
     }
 
     private initEditor() {
+        this.updateBoldItalicUnderline();
+
         const editorParams: HtmlEditorParams = HtmlEditorParams.create()
             .setEditorContainerId(this.textArea.getId())
             .setAssetsUri(CONFIG.assetsUri)
@@ -76,7 +78,8 @@ export class FullscreenDialog
             .setContentPath(this.editorParams.getContentPath())
             .setContent(this.editorParams.getContent())
             .setApplicationKeys(this.editorParams.getApplicationKeys())
-            .setTools(this.editorParams.getTools())
+            .setEnabledTools(this.editorParams.getEnabledTools())
+            .setDisabledTools(this.editorParams.getDisabledTools())
             .setEditableSourceCode(this.editorParams.getEditableSourceCode())
             .setAllowedHeadings(this.editorParams.getAllowedHeadings())
             .setCustomStylesToBeUsed(true)
@@ -95,6 +98,25 @@ export class FullscreenDialog
                 });
             });
         });
+    }
+
+    private updateBoldItalicUnderline() {
+        const disabledTools: string[] = this.editorParams.getDisabledTools();
+        const enabledTools: string[] = this.editorParams.getEnabledTools();
+
+        if (disabledTools && disabledTools.length === 1 && disabledTools[0] === '*') {
+            if (!enabledTools.some((tool: string) => tool === 'Bold')) {
+                this.addClass('hide-bold');
+            }
+
+            if (!enabledTools.some((tool: string) => tool === 'Italic')) {
+                this.addClass('hide-italic');
+            }
+
+            if (!enabledTools.some((tool: string) => tool === 'Underline')) {
+                this.addClass('hide-underline');
+            }
+        }
     }
 
     private editorReadyHandler() {


### PR DESCRIPTION
-Reworked HtmlEditor and HtmlArea:
1) Processing input config for editor just once for entire input
2) Using array to pass include/exclude toolbar items values
3) Always keeping Bold, Italics, Underline items in the toolbar so shortcuts and paste functionality for applying their styles is always working and hiding those buttons with styles on demand, otherwise paste and shortcuts won't work without tons of code