### PR TITLE
Docked Details Panel remains empty after a content is selected #3811

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/view/context/NonMobileContextPanelsManager.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/NonMobileContextPanelsManager.ts
@@ -69,7 +69,9 @@ export class NonMobileContextPanelsManager {
         });
 
         this.splitPanelWithContext.whenShown(() => {
-            if (this.getActivePanel().getActiveWidget() && !this.requiresFloatingPanelDueToShortWidth()) {
+            if (!this.requiresCollapsedContextPanel() && this.getActivePanel().getActiveWidget() &&
+                !this.requiresFloatingPanelDueToShortWidth()) {
+                this.setActivePanel();
                 this.getActivePanel().getActiveWidget().slideIn();
                 this.setState(ContextPanelState.DOCKED);
             }


### PR DESCRIPTION
-Need to set docked panel as active when initially showing it for large resolutions