### PR TITLE
Remove unnamed subname for folders in Settings statistics panel #3885

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/settings/browse/statistics/view/folder/FolderStatisticsView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/browse/statistics/view/folder/FolderStatisticsView.ts
@@ -1,7 +1,5 @@
 import {SettingsStatisticsView} from '../SettingsStatisticsView';
 import {FolderViewItem} from '../../../../view/FolderViewItem';
-import {FolderItemViewer} from '../../../viewer/FolderItemViewer';
-import {NamesAndIconViewer} from 'lib-admin-ui/ui/NamesAndIconViewer';
 import {FolderStatisticsViewer} from './FolderStatisticsViewer';
 
 export class FolderStatisticsView extends SettingsStatisticsView<FolderViewItem> {

--- a/modules/lib/src/main/resources/assets/js/app/settings/browse/statistics/view/folder/FolderStatisticsViewer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/browse/statistics/view/folder/FolderStatisticsViewer.ts
@@ -4,6 +4,10 @@ import {FolderViewItem} from '../../../../view/FolderViewItem';
 export class FolderStatisticsViewer
     extends NamesAndIconViewer<FolderViewItem> {
 
+    constructor() {
+        super('folder-statistics-viewer');
+    }
+
     resolveDisplayName(item: FolderViewItem): string {
         return item.getDisplayName();
     }

--- a/modules/lib/src/main/resources/assets/styles/main.less
+++ b/modules/lib/src/main/resources/assets/styles/main.less
@@ -108,6 +108,7 @@
 @import "project/project-list";
 @import "project/projects-chain";
 @import "project/lang-based-content-summary-viewer";
+@import "settings/browse/folder-statistics-viewer";
 @import "settings/browse/settings-browse-item-panel";
 @import "settings/browse/settings-item-statistics-panel";
 @import "settings/browse/settings-tree-grid";

--- a/modules/lib/src/main/resources/assets/styles/settings/browse/folder-statistics-viewer.less
+++ b/modules/lib/src/main/resources/assets/styles/settings/browse/folder-statistics-viewer.less
@@ -1,0 +1,5 @@
+.folder-statistics-viewer {
+  .@{_COMMON_PREFIX}sub-name {
+    display: none;
+  }
+}

--- a/modules/lib/src/main/resources/assets/styles/settings/browse/settings-tree-grid.less
+++ b/modules/lib/src/main/resources/assets/styles/settings/browse/settings-tree-grid.less
@@ -5,5 +5,11 @@
         flex-grow: 1;
       }
     }
+
+    .highlight {
+      .display-name-postfix {
+        color: #cccccc;
+      }
+    }
   }
 }

--- a/modules/lib/src/main/resources/assets/styles/settings/browse/settings-tree-grid.less
+++ b/modules/lib/src/main/resources/assets/styles/settings/browse/settings-tree-grid.less
@@ -8,7 +8,7 @@
 
     .highlight {
       .display-name-postfix {
-        color: #cccccc;
+        color: @admin-font-gray;
       }
     }
   }


### PR DESCRIPTION
Removed unnamed subtitle on settings folder.
Made localization text on highlighted node more visible.