### PR TITLE
Added keyboard accessibility to 'mark as ready' (#3086)

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
@@ -23,7 +23,8 @@ import {DefaultErrorHandler} from 'lib-admin-ui/DefaultErrorHandler';
 import {Action} from 'lib-admin-ui/ui/Action';
 import {showFeedback} from 'lib-admin-ui/notify/MessageBus';
 import {ContentId} from '../content/ContentId';
-import {Menu} from 'lib-admin-ui/ui/menu/Menu';
+import {MenuItem} from 'lib-admin-ui/ui/menu/MenuItem';
+import {MenuButton} from 'lib-admin-ui/ui/button/MenuButton';
 import {AccessibilityHelper} from '../util/AccessibilityHelper';
 
 export abstract class BasePublishDialog
@@ -330,16 +331,19 @@ export abstract class BasePublishDialog
 export class PublishDialogButtonRow
     extends DropdownButtonRow {
 
+    makeActionMenu(mainAction: Action, menuActions: Action[], useDefault?: boolean): MenuButton {
+        const menuButton: MenuButton = super.makeActionMenu(mainAction, menuActions, useDefault);
+        this.addAccessibilityToMarkAsReadyTotalElement();
+        return menuButton;
+    }
+
     setTotalInProgress(totalInProgress: number) {
         this.toggleClass('has-items-in-progress', totalInProgress > 0);
         this.getMenuActions()[0].setLabel(i18n('action.markAsReadyTotal', totalInProgress));
-        this.addAccessibilityToMarkAsReadyTotalElement();
     }
 
     private addAccessibilityToMarkAsReadyTotalElement(): void{
-        const menu = this.actionMenu.getChildren()
-            .find((el) => el instanceof Menu) || {} as Menu;
-        const markAsReadyTotalElement = menu.getFirstChild();
-        markAsReadyTotalElement && AccessibilityHelper.tabIndex(markAsReadyTotalElement);
+        const markAsReadyMenuItem: MenuItem = this.actionMenu.getMenuItem(this.getMenuActions()[0]);
+        AccessibilityHelper.tabIndex(markAsReadyMenuItem);
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
@@ -23,6 +23,8 @@ import {DefaultErrorHandler} from 'lib-admin-ui/DefaultErrorHandler';
 import {Action} from 'lib-admin-ui/ui/Action';
 import {showFeedback} from 'lib-admin-ui/notify/MessageBus';
 import {ContentId} from '../content/ContentId';
+import {Menu} from 'lib-admin-ui/ui/menu/Menu';
+import {AccessibilityHelper} from '../util/AccessibilityHelper';
 
 export abstract class BasePublishDialog
     extends DependantItemsWithProgressDialog {
@@ -331,5 +333,13 @@ export class PublishDialogButtonRow
     setTotalInProgress(totalInProgress: number) {
         this.toggleClass('has-items-in-progress', totalInProgress > 0);
         this.getMenuActions()[0].setLabel(i18n('action.markAsReadyTotal', totalInProgress));
+        this.addAccessibilityToMarkAsReadyTotalElement();
+    }
+
+    private addAccessibilityToMarkAsReadyTotalElement(): void{
+        const menu = this.actionMenu.getChildren()
+            .find((el) => el instanceof Menu) || {} as Menu;
+        const markAsReadyTotalElement = menu.getFirstChild();
+        markAsReadyTotalElement && AccessibilityHelper.tabIndex(markAsReadyTotalElement);
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/util/AccessibilityHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/util/AccessibilityHelper.ts
@@ -8,7 +8,7 @@ export class AccessibilityHelper {
 
        // Enter event will execute a click
        element.onKeyPressed((event: KeyboardEvent) => {
-           event.keyCode === 13 && element.getHTMLElement().click();
+           event.key === 'Enter' && element.getHTMLElement().click();
        });
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/util/AccessibilityHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/util/AccessibilityHelper.ts
@@ -1,0 +1,14 @@
+import {Element} from 'lib-admin-ui/dom/Element';
+
+export class AccessibilityHelper {
+
+    static tabIndex(element: Element, index: number = 0) {
+       // Tab navigation
+       element.getEl().setTabIndex(index);
+
+       // Enter event will execute a click
+       element.onKeyPressed((event: KeyboardEvent) => {
+           event.keyCode === 13 && element.getHTMLElement().click();
+       });
+    }
+}


### PR DESCRIPTION
Now the user can use the keyboard (tab + enter) to navigate and activate the "Mark as ready" option:

https://user-images.githubusercontent.com/67838246/145598830-d2c38234-81c6-4596-8a29-cfa2eb6b3e04.mp4
