### PR TITLE
Added keyboard accessibility to 'new project/layer' dialog  (#2985)

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
@@ -23,6 +23,8 @@ import {DefaultErrorHandler} from 'lib-admin-ui/DefaultErrorHandler';
 import {Action} from 'lib-admin-ui/ui/Action';
 import {showFeedback} from 'lib-admin-ui/notify/MessageBus';
 import {ContentId} from '../content/ContentId';
+import {Menu} from 'lib-admin-ui/ui/menu/Menu';
+import {AccessibilityHelper} from '../util/AccessibilityHelper';
 
 export abstract class BasePublishDialog
     extends DependantItemsWithProgressDialog {
@@ -331,5 +333,13 @@ export class PublishDialogButtonRow
     setTotalInProgress(totalInProgress: number) {
         this.toggleClass('has-items-in-progress', totalInProgress > 0);
         this.getMenuActions()[0].setLabel(i18n('action.markAsReadyTotal', totalInProgress));
+        this.addAccessibilityToMarkAsReadyTotalElement();
+    }
+
+    private addAccessibilityToMarkAsReadyTotalElement(): void{
+        const menu = this.actionMenu.getChildren()
+            .find((el) => el instanceof Menu) || {} as Menu;
+        const markAsReadyTotalElement = menu.getFirstChild();
+        markAsReadyTotalElement && AccessibilityHelper.tabIndex(markAsReadyTotalElement);
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/settings/dialog/SettingsTypeListBox.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/dialog/SettingsTypeListBox.ts
@@ -2,6 +2,7 @@ import {ListBox} from 'lib-admin-ui/ui/selector/list/ListBox';
 import {SettingsType} from './SettingsType';
 import {NamesAndIconViewer} from 'lib-admin-ui/ui/NamesAndIconViewer';
 import {SettingsTypeViewer} from './SettingsTypeViewer';
+import {AccessibilityHelper} from '../../util/AccessibilityHelper';
 
 export class SettingsTypeListBox
     extends ListBox<SettingsType> {
@@ -11,9 +12,12 @@ export class SettingsTypeListBox
     createItemView(item: SettingsType): NamesAndIconViewer<SettingsType> {
         const itemView: SettingsTypeViewer = new SettingsTypeViewer(item.getName().toLowerCase());
 
+        AccessibilityHelper.tabIndex(itemView);
+
         itemView.onClicked(() => {
             this.notifyItemClicked(item);
         });
+
         itemView.setObject(item);
 
         return itemView;
@@ -38,5 +42,4 @@ export class SettingsTypeListBox
             listener(item);
         });
     }
-
 }

--- a/modules/lib/src/main/resources/assets/js/app/util/AccessibilityHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/util/AccessibilityHelper.ts
@@ -1,0 +1,14 @@
+import {Element} from 'lib-admin-ui/dom/Element';
+
+export class AccessibilityHelper {
+
+    static tabIndex(element: Element, index: number = 0) {
+       // Tab navigation
+       element.getEl().setTabIndex(index);
+
+       // Enter event will execute a click
+       element.onKeyPressed((event: KeyboardEvent) => {
+           event.keyCode === 13 && element.getHTMLElement().click();
+       });
+    }
+}


### PR DESCRIPTION
Now the user can use the keyboard (tab + enter) to navigate in the new project / layer dialog:

https://user-images.githubusercontent.com/67838246/145605961-3367b906-eae2-4725-ab48-1da18ad2cfd7.mp4