### PR TITLE
Added keyboard accessibility to open 'select project' dialog (#2986)

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/bar/ContentAppBar.ts
+++ b/modules/lib/src/main/resources/assets/js/app/bar/ContentAppBar.ts
@@ -11,6 +11,7 @@ import {i18n} from 'lib-admin-ui/util/Messages';
 import {ProjectUpdatedEvent} from '../settings/event/ProjectUpdatedEvent';
 import {ProjectListRequest} from '../settings/resource/ProjectListRequest';
 import {ProjectListWithMissingRequest} from '../settings/resource/ProjectListWithMissingRequest';
+import {AccessibilityHelper} from '../util/AccessibilityHelper';
 
 export class ContentAppBar
     extends AppBar {
@@ -68,6 +69,7 @@ export class ContentAppBar
     doRender(): Q.Promise<boolean> {
         return super.doRender().then((rendered: boolean) => {
             const iconEl: DivEl = new DivEl('project-selection-icon icon-compare');
+            AccessibilityHelper.tabIndex(iconEl);
             this.selectedProjectViewer.appendChild(iconEl);
             this.selectedProjectViewer.setTitle(i18n('text.selectContext'));
             this.addClass('appbar-content');

--- a/modules/lib/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
@@ -23,6 +23,8 @@ import {DefaultErrorHandler} from 'lib-admin-ui/DefaultErrorHandler';
 import {Action} from 'lib-admin-ui/ui/Action';
 import {showFeedback} from 'lib-admin-ui/notify/MessageBus';
 import {ContentId} from '../content/ContentId';
+import {Menu} from 'lib-admin-ui/ui/menu/Menu';
+import {AccessibilityHelper} from '../util/AccessibilityHelper';
 
 export abstract class BasePublishDialog
     extends DependantItemsWithProgressDialog {
@@ -331,5 +333,13 @@ export class PublishDialogButtonRow
     setTotalInProgress(totalInProgress: number) {
         this.toggleClass('has-items-in-progress', totalInProgress > 0);
         this.getMenuActions()[0].setLabel(i18n('action.markAsReadyTotal', totalInProgress));
+        this.addAccessibilityToMarkAsReadyTotalElement();
+    }
+
+    private addAccessibilityToMarkAsReadyTotalElement(): void{
+        const menu = this.actionMenu.getChildren()
+            .find((el) => el instanceof Menu) || {} as Menu;
+        const markAsReadyTotalElement = menu.getFirstChild();
+        markAsReadyTotalElement && AccessibilityHelper.tabIndex(markAsReadyTotalElement);
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/util/AccessibilityHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/util/AccessibilityHelper.ts
@@ -1,0 +1,14 @@
+import {Element} from 'lib-admin-ui/dom/Element';
+
+export class AccessibilityHelper {
+
+    static tabIndex(element: Element, index: number = 0) {
+       // Tab navigation
+       element.getEl().setTabIndex(index);
+
+       // Enter event will execute a click
+       element.onKeyPressed((event: KeyboardEvent) => {
+           event.keyCode === 13 && element.getHTMLElement().click();
+       });
+    }
+}


### PR DESCRIPTION
Now the user can use the keyboard (tab + enter) to open the 'select project' dialog:

https://user-images.githubusercontent.com/67838246/145607342-ebaf911b-dae4-4d7d-b631-73cc0cda0b1b.mp4