### PR TITLE
Added shortcut for toggling browse panel (#2945)

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/ContentAppPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentAppPanel.ts
@@ -20,7 +20,7 @@ export class ContentAppPanel
 
     protected resolveActions(panel: Panel): Action[] {
         const actions = super.resolveActions(panel);
-        return [...actions, ...this.getBrowsePanel().getNonToolbarActions()];
+        return [...actions, ...this.getBrowsePanel().getNonToolbarActions(), this.getBrowsePanel().getToggleSearchAction()];
     }
 
     calculateOffset() {

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -37,6 +37,7 @@ import {i18n} from 'lib-admin-ui/util/Messages';
 import {NonMobileContextPanelToggleButton} from '../view/context/button/NonMobileContextPanelToggleButton';
 import {ContextView} from '../view/context/ContextView';
 import {ResponsiveBrowsePanel} from './ResponsiveBrowsePanel';
+import { Body } from 'lib-admin-ui/dom/Body';
 
 export class ContentBrowsePanel
     extends ResponsiveBrowsePanel {
@@ -92,8 +93,20 @@ export class ContentBrowsePanel
     protected initListeners() {
         super.initListeners();
 
+        const toggleBrowsePanelHandler = (event: KeyboardEvent) => {
+            if (event.shiftKey && event.key === 'F') {
+                this.toggleFilterPanelButton.getHTMLElement().click();
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            }
+        }
+
         this.onShown(() => {
+
+            Body.get().onKeyDown(toggleBrowsePanelHandler);
+
             Router.get().setHash(UrlAction.BROWSE);
+
             this.treeGrid.resizeCanvas();
         });
 

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -93,18 +93,7 @@ export class ContentBrowsePanel
     protected initListeners() {
         super.initListeners();
 
-        const toggleBrowsePanelHandler = (event: KeyboardEvent) => {
-            if (event.shiftKey && event.key === 'F') {
-                this.toggleFilterPanelButton.getHTMLElement().click();
-                event.preventDefault();
-                event.stopImmediatePropagation();
-            }
-        };
-
         this.onShown(() => {
-
-            Body.get().onKeyDown(toggleBrowsePanelHandler);
-
             Router.get().setHash(UrlAction.BROWSE);
 
             this.treeGrid.resizeCanvas();
@@ -119,6 +108,10 @@ export class ContentBrowsePanel
 
     getNonToolbarActions(): Action[] {
         return this.getBrowseActions().getPublishActions();
+    }
+
+    getToggleSearchAction(): Action {
+        return this.getBrowseActions().getToggleSearchPanelAction();
     }
 
     protected createToolbar(): ContentBrowseToolbar {
@@ -183,7 +176,7 @@ export class ContentBrowsePanel
 
     private handleGlobalEvents() {
         ResponsiveManager.onAvailableSizeChanged(this, (item: ResponsiveItem) => {
-            this.getBrowseActions().getAction(ActionName.TOGGLE_SEARCH_PANEL).setVisible(
+            this.getBrowseActions().getToggleSearchPanelAction().setVisible(
                 item.isInRangeOrSmaller(ResponsiveRanges._540_720));
         });
 

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -37,7 +37,7 @@ import {i18n} from 'lib-admin-ui/util/Messages';
 import {NonMobileContextPanelToggleButton} from '../view/context/button/NonMobileContextPanelToggleButton';
 import {ContextView} from '../view/context/ContextView';
 import {ResponsiveBrowsePanel} from './ResponsiveBrowsePanel';
-import { Body } from 'lib-admin-ui/dom/Body';
+import {Body} from 'lib-admin-ui/dom/Body';
 
 export class ContentBrowsePanel
     extends ResponsiveBrowsePanel {
@@ -99,7 +99,7 @@ export class ContentBrowsePanel
                 event.preventDefault();
                 event.stopImmediatePropagation();
             }
-        }
+        };
 
         this.onShown(() => {
 

--- a/modules/lib/src/main/resources/assets/js/app/browse/action/ContentTreeGridActions.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/action/ContentTreeGridActions.ts
@@ -157,6 +157,10 @@ export class ContentTreeGridActions implements TreeGridActions<ContentSummaryAnd
         return this.getAction(ActionName.PUBLISH);
     }
 
+    getToggleSearchPanelAction(): Action {
+        return this.getAction(ActionName.TOGGLE_SEARCH_PANEL);
+    }
+
     getAllActionsNoPublish(): Action[] {
         return [
             ...this.getAllCommonActions()

--- a/modules/lib/src/main/resources/assets/js/app/browse/action/ToggleSearchPanelAction.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/action/ToggleSearchPanelAction.ts
@@ -1,6 +1,4 @@
 import {ToggleSearchPanelEvent} from '../ToggleSearchPanelEvent';
-
-import {Action} from 'lib-admin-ui/ui/Action';
 import {ContentTreeGridAction} from './ContentTreeGridAction';
 import {ContentTreeGrid} from '../ContentTreeGrid';
 import {ContentTreeGridItemsState} from './ContentTreeGridItemsState';
@@ -8,7 +6,7 @@ import {ContentTreeGridItemsState} from './ContentTreeGridItemsState';
 export class ToggleSearchPanelAction extends ContentTreeGridAction {
 
     constructor(grid: ContentTreeGrid) {
-        super(grid);
+        super(grid, '', 'shift+f', true);
 
         this.setIconClass('icon-search3');
     }


### PR DESCRIPTION
The author suggested the use of `/` to open the browse panel. From [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#numeric_keypad_keys), it seems that the suggested key ("Divide") is only available in numerical keypads. For example, in my notebook, to get `/` I need to type `AltGr + q`, and that would be handled.

@alansemenov suggested to find a shortcut combination that is not reserved in browsers (list of shortcuts for [Chrome](https://support.google.com/chrome/answer/157179?hl=en&co=GENIE.Platform%3DDesktop#zippy=%2Ctab-and-window-shortcuts) and [Firefox](https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly)).

Therefore I set the shortcut to be `Shift + F`. I don't know if this is a good combination, but from what I've seen it's not used in the browsers above and the `F` stands for find, which makes sense.

If accepted, might be necessary to update [this list of shortcuts for the app-contentstudio](https://developer.enonic.com/docs/content-studio/stable/keyboard-shortcuts).