### PR TITLE
Remove animation of the grid toolbar #4026

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/ContentAppPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentAppPanel.ts
@@ -8,6 +8,8 @@ export class ContentAppPanel
 
     constructor() {
         super('content-app-panel');
+
+        this.setDoOffset(false); // will set in css since a toolbar has a static height
     }
 
     protected createBrowsePanel() {
@@ -21,9 +23,5 @@ export class ContentAppPanel
     protected resolveActions(panel: Panel): Action[] {
         const actions = super.resolveActions(panel);
         return [...actions, ...this.getBrowsePanel().getNonToolbarActions()];
-    }
-
-    calculateOffset() {
-        this.getEl().setTopPx(44); // static header height
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/browse/ResponsiveBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ResponsiveBrowsePanel.ts
@@ -30,6 +30,7 @@ export abstract class ResponsiveBrowsePanel extends BrowsePanel {
                 this.toggleMobilePreviewMode(false);
             }
 
+            Body.get().toggleClass(ResponsiveBrowsePanel.MOBILE_MODE_CLASS, isMobile);
             this.toggleClass(ResponsiveBrowsePanel.MOBILE_MODE_CLASS, isMobile);
             this.treeGrid.toggleClass(ResponsiveBrowsePanel.MOBILE_MODE_CLASS, isMobile);
         });

--- a/modules/lib/src/main/resources/assets/styles/body.less
+++ b/modules/lib/src/main/resources/assets/styles/body.less
@@ -10,15 +10,21 @@ body {
     }
   }
 
-  &.mobile-preview-on {
+  &.mobile-mode {
     .content-app-panel {
-      top: 0 !important;
-      z-index: 1;
+      transition: top 0.5s ease-in-out;
     }
 
-    .sidebar-toggler,
-    .launcher-button {
-      display: none;
+    &.mobile-preview-on {
+      .content-app-panel {
+        top: 0 !important;
+        z-index: 1;
+      }
+
+      .sidebar-toggler,
+      .launcher-button {
+        display: none;
+      }
     }
   }
 }

--- a/modules/lib/src/main/resources/assets/styles/browse/content-app-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/browse/content-app-panel.less
@@ -1,3 +1,3 @@
 .content-app-panel {
-  transition: top 0.5s ease-in-out;
+  top: 44px;
 }


### PR DESCRIPTION
-setting app panels top offset via css because app bar also has static height and no need in dynamic calc of offset
-updated styling of Body to reflect mobile mode