### PR TITLE
Missing spacing between content name and status columns #4037

### DIFF
--- a/modules/lib/src/main/resources/assets/styles/browse/content-tree-grid.less
+++ b/modules/lib/src/main/resources/assets/styles/browse/content-tree-grid.less
@@ -5,8 +5,6 @@
         flex-grow: 1;
 
         .viewer {
-          max-width: calc(100% - 36px);
-
           .@{_COMMON_PREFIX}wrapper {
             flex-shrink: 0;
           }

--- a/modules/lib/src/main/resources/assets/styles/content/content-summary-and-compare-status-viewer.less
+++ b/modules/lib/src/main/resources/assets/styles/content/content-summary-and-compare-status-viewer.less
@@ -1,6 +1,4 @@
 .names-and-icon-viewer.content-summary-and-compare-status-viewer {
-  overflow: visible;
-
   &.invalid,
   &.ready,
   &.in-progress {
@@ -35,7 +33,7 @@
   }
 
   .names-and-icon-view {
-    overflow: visible;
+    padding: 4px;
 
     .@{_COMMON_PREFIX}wrapper {
       position: relative;

--- a/modules/lib/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
+++ b/modules/lib/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
@@ -33,8 +33,7 @@
   }
 
   .browse-selection-item {
-    padding: 4px;
-    padding-right: 0;
+    padding: 0px;
     margin: 0;
     display: flex;
     line-height: 26px;
@@ -63,6 +62,14 @@
       order: 1;
       margin: 0;
       margin-left: 20px;
+    }
+  }
+
+  .item-list {
+    .browse-selection-item {
+      &:not(:last-child) {
+        margin-bottom: 4px;
+      }
     }
   }
 
@@ -103,7 +110,7 @@
     }
 
     .browse-selection-item {
-      padding: 6px 0 6px 5px;
+      padding: 2px 0 6px 5px;
 
       .remove {
         height: 16px;
@@ -135,9 +142,7 @@
   .dialog-togglable-item-list + .dependants .dependants-body {
     .browse-selection-item:hover {
       background-color: @admin-bg-light-gray;
-      margin: 0 -5px;
-      padding-left: 10px;
-      padding-right: 5px;
+      outline: 2px solid @admin-bg-light-gray;
     }
   }
 
@@ -172,7 +177,6 @@
 
         .browse-selection-item {
           padding: 0;
-          padding-left: 5px;
 
           .@{_COMMON_PREFIX}names-view .@{_COMMON_PREFIX}main-name, .status {
             font-size: 12px;


### PR DESCRIPTION
-It was a wrong decision by me to solve issue  with not fully visible inheritance status icon in viewer  by allowing elements overflow to be visible, that lead to a situation when name and subname were overflowing siblings elements
-Fixing it by adding more padding around NamesAndIconView to let icon fit