### PR TITLE
Line breaks in HtmlArea's macro TextArea fields are being removed #4083

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/MacroModalDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/MacroModalDialog.ts
@@ -202,8 +202,8 @@ export class MacroModalDialog
     }
 
     private insertUpdatedMacroIntoTextArea(macroString: string) {
-        this.selectedMacro.element.setText(
-            this.selectedMacro.element.getText().replace(this.selectedMacro.macroText, macroString));
+        this.selectedMacro.element.$.innerText =
+            this.selectedMacro.element.$.innerText.replace(this.selectedMacro.macroText, macroString);
         this.getEditor().fire('saveSnapshot'); // to trigger change event
     }
 

--- a/modules/lib/src/main/resources/assets/lib/ckeditor/plugins/macro/plugin.js
+++ b/modules/lib/src/main/resources/assets/lib/ckeditor/plugins/macro/plugin.js
@@ -101,9 +101,10 @@ CKEDITOR.plugins.add('macro', {
 
         function checkMacroWithBodySelected() {
             var regexMacroWithBody = /\[(\w+[\w-]*)[^\]]*\]([^\[]*)\[\/(\w+[\w-]*)\]/g;
-
             var result;
-            while (result = regexMacroWithBody.exec(selectedElement.getText())) {
+
+            // using innerText instead of getText() to preserve line breaks and spaces
+            while (result = regexMacroWithBody.exec(selectedElement.$.innerText)) {
                 if (result[1] === result[3] && isSelectionWithinMacro(result)) {
                     selectedMacro = makeMakroObject(result);
                     selectedMacro.body = result[2];
@@ -114,9 +115,10 @@ CKEDITOR.plugins.add('macro', {
 
         function checkMacroNoBodySelected() {
             var regexMacroNoBody = /\[(\w+[\w-]*)[^\]]*\/\]/g;
-
             var result;
-            while (result = regexMacroNoBody.exec(selectedElement.getText())) {
+
+            // using innerText instead of getText() to preserve line breaks and spaces
+            while (result = regexMacroNoBody.exec(selectedElement.$.innerText)) {
                 if (isSelectionWithinMacro(result)) {
                     selectedMacro = makeMakroObject(result);
                     break;


### PR DESCRIPTION
-using cke element's innerText property to get/set macro text to preserve line breaks