### PR TITLE
Manual sorting is broken in layers #4080

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/sort/dialog/SortContentDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/sort/dialog/SortContentDialog.ts
@@ -147,13 +147,15 @@ export class SortContentDialog
     private saveSortOrder(): Q.Promise<any> {
         this.showLoadingSpinner();
 
+        if (this.sortContentMenu.isInheritedItemSelected()) {
+            return this.saveInheritedOrder();
+        }
+
         if (this.getSelectedOrder().isManual()) {
             return this.saveManualOrder();
-        } else if (this.sortContentMenu.isInheritedItemSelected()) {
-            return this.saveInheritedOrder();
-        } else {
-            return this.saveContentChildOrder();
         }
+
+        return this.saveContentChildOrder();
     }
 
     private handleOpenSortDialogEvent(event: OpenSortDialogEvent) {

--- a/modules/lib/src/main/resources/assets/styles/browse/sort-content-dialog.less
+++ b/modules/lib/src/main/resources/assets/styles/browse/sort-content-dialog.less
@@ -160,6 +160,7 @@
         overflow: hidden;
         white-space: pre;
         line-height: 20px;
+        color: @admin-dark-gray;
         .ellipsis();
 
         &::before {
@@ -252,8 +253,8 @@
           }
 
           &.manual {
-            .label {
-              color: @admin-button-blue2;
+            &.active {
+              outline: 1px solid @admin-button-blue2;
             }
           }
         }


### PR DESCRIPTION
-using regular gray color for a manual order to not distract from selected option
-fixed switching to the inherited: manual option so content gets Sort inherit property