### PR TITLE
Refresh tree grid after sort reverted to inherited #4143

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -387,7 +387,7 @@ export class ContentBrowsePanel
     private doHandleContentUpdate(data: ContentSummaryAndCompareStatus[]) {
         this.handleCUD();
         this.updateContextPanel(data);
-        this.treeGrid.updateNodesByData(data);
+        this.treeGrid.updateNodesWithSortChangedCheck(data);
     }
 
     private handleContentSorted(data: ContentSummaryAndCompareStatus[]) {

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -536,17 +536,17 @@ export class ContentTreeGrid
 
     updateNodesWithSortChangedCheck(data: ContentSummaryAndCompareStatus[]): void {
         // when items sorting was changed from manual to inherited manual we have to trigger sort ourselves since no sort event coming
-        const itemWithSortChangedFromManualToInheritedManual: ContentSummaryAndCompareStatus = data.find(
-            (item: ContentSummaryAndCompareStatus) => this.isInheritanceChangedFromManualToInheritedManual(item));
+        const isSortingChangedToManualInheritance: ContentSummaryAndCompareStatus = data.find(
+            (item: ContentSummaryAndCompareStatus) => this.isSortingChangedToManualInheritance(item));
 
-        if (itemWithSortChangedFromManualToInheritedManual) {
-            this.sortNodesChildren([itemWithSortChangedFromManualToInheritedManual]);
+        if (isSortingChangedToManualInheritance) {
+            this.sortNodesChildren([isSortingChangedToManualInheritance]);
         } else {
             this.updateNodesByData(data);
         }
     }
 
-    private isInheritanceChangedFromManualToInheritedManual(item: ContentSummaryAndCompareStatus): boolean {
+    private isSortingChangedToManualInheritance(item: ContentSummaryAndCompareStatus): boolean {
         if (!item.getContentSummary()?.getChildOrder().isManual()) {
             return false;
         }

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -534,6 +534,32 @@ export class ContentTreeGrid
         }
     }
 
+    updateNodesWithSortChangedCheck(data: ContentSummaryAndCompareStatus[]): void {
+        // when items sorting was changed from manual to inherited manual we have to trigger sort ourselves since no sort event coming
+        const itemWithSortChangedFromManualToInheritedManual: ContentSummaryAndCompareStatus = data.find(
+            (item: ContentSummaryAndCompareStatus) => this.isInheritanceChangedFromManualToInheritedManual(item));
+
+        if (itemWithSortChangedFromManualToInheritedManual) {
+            this.sortNodesChildren([itemWithSortChangedFromManualToInheritedManual]);
+        } else {
+            this.updateNodesByData(data);
+        }
+    }
+
+    private isInheritanceChangedFromManualToInheritedManual(item: ContentSummaryAndCompareStatus): boolean {
+        if (!item.getContentSummary()?.getChildOrder().isManual()) {
+            return false;
+        }
+
+        if (!item.isSortInherited()) {
+            return false;
+        }
+
+        const node: TreeNode<ContentSummaryAndCompareStatus> = this.getRoot().getNodeByDataIdFromCurrent(item.getId());
+
+        return node && !node.getData().isSortInherited();
+    }
+
     sortNodesChildren(data: ContentSummaryAndCompareStatus[]) {
         this.updateNodesByData(data);
 


### PR DESCRIPTION
-When switching from manual sorting to inherited manual we don't receive sort event but only update event; Solved by checking updated items sort order and inheritance and if it differs from the one in the grid then triggering sort of the items rather than update. No total grid reload needed