### PR TITLE
Unpublish item dialog remains visible after clicking on Cancel button…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/publish/ContentUnpublishDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/publish/ContentUnpublishDialog.ts
@@ -88,6 +88,7 @@ export class ContentUnpublishDialog
         this.unPublishConfirmationDialog.setHeaderText(i18n('dialog.unpublish.confirm.title'));
         this.unPublishConfirmationDialog.setSubheaderText(i18n('dialog.unpublish.confirm.subtitle'));
         this.unPublishConfirmationDialog.setYesCallback(this.doUnPublish.bind(this));
+        this.unPublishConfirmationDialog.setNoCallback(this.close.bind(this));
     }
 
     private useDefaultSubTitle() {


### PR DESCRIPTION
… in Confirm dialog #4168

-Hiding Unpublish dialog after cancel or close button of a confirmation dialog clicked