### PR TITLE
Content grid is not properly refreshed after move/archive #4219

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/MovedContentItem.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/MovedContentItem.ts
@@ -1,0 +1,14 @@
+import {ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
+import {ContentPath} from '../content/ContentPath';
+
+export class MovedContentItem {
+
+    readonly item: ContentSummaryAndCompareStatus;
+
+    readonly oldPath: ContentPath;
+
+    constructor(item: ContentSummaryAndCompareStatus, oldPath: ContentPath) {
+        this.item = item;
+        this.oldPath = oldPath;
+    }
+}

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -137,6 +137,7 @@ import {ContentWizardContextSplitPanel} from './ContentWizardContextSplitPanel';
 import {ContextPanelMode} from '../view/context/ContextSplitPanel';
 import {ContextPanelState} from '../view/context/ContextPanelState';
 import {CONFIG} from 'lib-admin-ui/util/Config';
+import {MovedContentItem} from '../browse/MovedContentItem';
 
 export class ContentWizardPanel
     extends WizardPanel<Content> {
@@ -1346,15 +1347,15 @@ export class ContentWizardPanel
             }
         };
 
-        const movedHandler = (data: ContentSummaryAndCompareStatus[], oldPaths: ContentPath[]) => {
+        const movedHandler = (movedItems: MovedContentItem[]) => {
             this.handleCUD();
 
-            const wasMoved: boolean = oldPaths.some((oldPath: ContentPath) => {
-                return this.persistedItemPathIsDescendantOrEqual(oldPath);
+            const wasMoved: boolean = movedItems.some((movedItem: MovedContentItem) => {
+                return this.persistedItemPathIsDescendantOrEqual(movedItem.oldPath);
             });
 
             if (wasMoved) {
-                updateHandler(data[0]);
+                updateHandler(movedItems[0].item);
             }
         };
 


### PR DESCRIPTION
-when moving/deleting items we are receiving updates not only from current repo but also from all child layers where those changes are being replicated, thus our debounced server event handlers (that group events by type) couldn't fire. Fixed by separating events by not only a type but also a repo, so event triggers immediately when stops receiving calls from current repo