### PR TITLE
Custom selector won't filter by description #4270

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/customselector/CustomSelectorLoader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/customselector/CustomSelectorLoader.ts
@@ -79,6 +79,6 @@ export class CustomSelectorLoader
     }
 
     filterFn(item: CustomSelectorItem): boolean {
-        return item.displayName.toLowerCase().indexOf(this.getSearchString().toLowerCase()) !== -1;
+        return true;
     }
 }


### PR DESCRIPTION
-removing frontend filtering to let service decide what result to filter and return and to avoid filtering by display name only