### PR TITLE
Server-side error when archiving content #4291

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/DependantItemsDialog.ts
@@ -109,6 +109,10 @@ export abstract class DependantItemsDialog
     }
 
     protected lazyLoadDependants(): void {
+        if (this.isClosed()) { // debounced call after dialog is closed
+            return;
+        }
+
         const size: number = this.getDependantList().getItemCount();
         this.showLoadMask();
 
@@ -188,7 +192,7 @@ export abstract class DependantItemsDialog
         return this.itemList;
     }
 
-    protected getDependantList(): ListBox<ContentSummaryAndCompareStatus> {
+    protected getDependantList(): DialogDependantList {
         return this.dependantList;
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/event/ServerEventAggregator.ts
+++ b/modules/lib/src/main/resources/assets/js/app/event/ServerEventAggregator.ts
@@ -58,7 +58,7 @@ export class ServerEventAggregator {
     }
 
     private isNotMoveOrDeleteEvent(typeAndRepo: string): boolean {
-        const eventType: string = typeAndRepo.substring(0, typeAndRepo.indexOf(':'));
+        const eventType: string = typeAndRepo.split(':')[0];
         return eventType !== NodeServerChangeType[NodeServerChangeType.MOVE]
                && eventType !== NodeServerChangeType[NodeServerChangeType.DELETE];
     }

--- a/modules/lib/src/main/resources/assets/js/app/remove/ContentDeleteDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/remove/ContentDeleteDialog.ts
@@ -159,10 +159,6 @@ export class ContentDeleteDialog
         return new DeleteDialogDependantList();
     }
 
-    protected getDependantList(): DialogDependantList {
-        return <DialogDependantList>super.getDependantList();
-    }
-
     private handleItemClick(contentSummary: ContentSummary) {
         new ShowDependenciesEvent(contentSummary.getContentId(), true).fire();
     }
@@ -389,18 +385,6 @@ export class ContentDeleteDialog
     private doAnyHaveChildren(items: ContentSummaryAndCompareStatus[]): boolean {
         return items.some((item: ContentSummaryAndCompareStatus) => {
             return item.getContentSummary().hasChildren();
-        });
-    }
-
-    private isEveryOffline(items: ContentSummaryAndCompareStatus[]): boolean {
-        return items.every((item: ContentSummaryAndCompareStatus) => {
-            return item.getCompareStatus() === CompareStatus.NEW;
-        });
-    }
-
-    private isEveryPendingDelete(items: ContentSummaryAndCompareStatus[]): boolean {
-        return items.every((item: ContentSummaryAndCompareStatus) => {
-            return item.getCompareStatus() === CompareStatus.PENDING_DELETE;
         });
     }
 


### PR DESCRIPTION
Issue is in that when archiving items we also receive update events prior to delete/move events, that triggers fetching of content that is already can't be found in the root

-improved event filtering: we use debounce for all types of events, so when it is time to execute update event handler we check if items in update queue are also can be found in the move/delete queue, and if they do then we remove those items from update queue
-Not executing lazy load handler in dependants list if dialog is closed