### PR TITLE
Custom Selector returns unique Id error

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/customselector/CustomSelectorComboBox.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/customselector/CustomSelectorComboBox.ts
@@ -26,9 +26,7 @@ export class CustomSelectorComboBox
 
         loader.setSearchString(inputValue);
 
-        return loader.load().then(() => {
-            return loader.search(inputValue);
-        });
+        return loader.load().then(() => loader.search(inputValue));
     }
 
     static create(): CustomSelectorComboBoxBuilder {

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/customselector/CustomSelectorLoader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/customselector/CustomSelectorLoader.ts
@@ -22,7 +22,7 @@ export class CustomSelectorLoader
         this.debouncedRequest = AppHelper.debounce((promise: Q.Deferred<CustomSelectorItem[]>) => {
             const superPromise = super.sendRequest();
             superPromise.then((results: CustomSelectorItem[]) => {
-                if (superPromise.isFulfilled()) {
+                if (superPromise.isFulfilled() && this.getRequest().isFulfilled()) {
                     promise.resolve(results);
                 }
                 if (superPromise.isRejected()) {
@@ -30,6 +30,12 @@ export class CustomSelectorLoader
                 }
             });
         }, 200);
+    }
+
+    load(postLoad: boolean = false): Q.Promise<CustomSelectorItem[]> {
+        this.getRequest().setPostLoading(postLoad);
+
+        return super.load(postLoad);
     }
 
     setRequestPath(requestPath: string) {


### PR DESCRIPTION
When several requests from CustomSelector go in parallel (on slow bandwidths), their responses will be concatenated resulting in non-unique Id error in SlickGrid. Solved by keeping track of the number of parallel requests and returning response only for the last request.