### PR TITLE
Correctly handle missing <widget> tag in a widget's template #4412

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/view/context/WidgetItemView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/WidgetItemView.ts
@@ -5,6 +5,7 @@ import {RepositoryId} from '../../repository/RepositoryId';
 import {ProjectContext} from '../../project/ProjectContext';
 import {CONFIG} from 'lib-admin-ui/util/Config';
 import {WidgetHelper} from '../../util/WidgetHelper';
+import {i18n} from 'lib-admin-ui/util/Messages';
 
 export class WidgetItemView
     extends DivEl {
@@ -43,8 +44,9 @@ export class WidgetItemView
     }
 
     public fetchWidgetContents(url: string, contentId: string): Q.Promise<void> {
-        const deferred = Q.defer<void>();
-        const fullUrl = WidgetItemView.getFullWidgetUrl(url, contentId);
+        const deferred: Q.Deferred<void> = Q.defer<void>();
+        const fullUrl: string = WidgetItemView.getFullWidgetUrl(url, contentId);
+
         fetch(fullUrl)
             .then(response => response.text())
             .then((html: string) => {
@@ -52,12 +54,18 @@ export class WidgetItemView
                 this.injectWidget(html);
                 deferred.resolve();
             })
-            .catch(err => {
+            .catch(() => {
                 deferred.reject();
-                throw new Error('Failed to fetch page: ' + err);
+                this.handleWidgetRenderError();
             });
 
         return deferred.promise;
+    }
+
+    private handleWidgetRenderError(): void {
+        const errorElement: DivEl = new DivEl('widget-error');
+        errorElement.setHtml(i18n('widget.render.error'));
+        this.appendChild(errorElement);
     }
 
     public reset() {

--- a/modules/lib/src/main/resources/assets/styles/view/context/context-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/view/context/context-panel.less
@@ -30,12 +30,13 @@
       .context-container {
         display: none;
       }
+
       .no-selection-message {
         display: block;
       }
     }
 
-    .no-selection-message {
+    .no-selection-message, .widget-error {
       .watermark-text();
       display: none;
       height: 60px;
@@ -47,6 +48,10 @@
       h6 {
         font-size: 13px;
       }
+    }
+
+    .widget-error {
+      display: block;
     }
   }
 
@@ -93,6 +98,7 @@
         .selected-option .option-value {
           margin: 0;
         }
+
         .@{_COMMON_PREFIX}dropdown-handle {
           display: none;
         }

--- a/modules/lib/src/main/resources/i18n/phrases.properties
+++ b/modules/lib/src/main/resources/i18n/phrases.properties
@@ -331,6 +331,7 @@ widget.components.insert.text=Text
 widget.components.insert.fragment=Fragment
 widget.components.insert.region=Region
 widget.components.insert.page=Page
+widget.render.error=Failed to render the widget
 #
 # Tooltip
 #


### PR DESCRIPTION
-showing error block if widget wasn't rendered