### PR TITLE
Component's name is duplicated after dragging text components in Page…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/page-editor/text/TextComponentView.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/text/TextComponentView.ts
@@ -549,6 +549,6 @@ export class TextComponentView
             return this.htmlAreaEditor.extractText();
         }
 
-        return $(this.getHTMLElement()).text().trim();
+        return this.rootElement.getHTMLElement().textContent.trim();
     }
 }


### PR DESCRIPTION
… Component View #3349

-Can't use TextComponentView's inner text as a replacement for a non initialized html editor because it has section and div elements for editor use that contain same value, that leads to the issue with duplicated text component name