### PR TITLE
Don't show image selector in the Insert Image dialog until selected image is loaded

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/image/ImageModalDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/image/ImageModalDialog.ts
@@ -109,7 +109,6 @@ export class ImageModalDialog
             this.imageUploaderEl.setParams({
                 parent: this.content.getContentId().toString()
             });
-            this.imageUploaderEl.show();
         });
 
         this.submitAction.onExecuted(() => {
@@ -172,15 +171,15 @@ export class ImageModalDialog
         new GetContentByIdRequest(new ContentId(imageId)).sendAndParse().then((imageContent: Content) => {
             this.imageSelector.setValue(imageContent.getId());
             this.imageSelector.getComboBox().onValueLoaded((options: Option<MediaTreeSelectorItem>[]) => {
-               if (options.length === 1 && options[0].getId() === imageContent.getId()) {
-                   this.imageSelectorFormItem.show();
-               }
+                if (options.length === 1 && options[0].getId() === imageContent.getId()) {
+                    this.imageSelector.show();
+                }
             });
             this.previewImage(imageContent, presetStyles);
             this.imageSelectorFormItem.addClass('selected-item-preview');
         }).catch((reason: any) => {
             this.presetImageEl = null;
-            this.imageSelectorFormItem.show();
+            this.imageSelector.show();
             DefaultErrorHandler.handle(reason);
         }).done();
     }
@@ -204,7 +203,8 @@ export class ImageModalDialog
     protected getMainFormItems(): FormItem[] {
         this.imageSelectorFormItem = this.createImageSelector('imageId');
         if (this.presetImageEl) {
-            this.imageSelectorFormItem.hide();
+            this.imageSelector.hide();
+            this.imageUploaderEl.hide();
         }
 
         this.imageCaptionField = this.createFormItem(new ModalDialogFormItemBuilder('caption', i18n('dialog.image.formitem.caption')));
@@ -332,10 +332,6 @@ export class ImageModalDialog
             this.createPreviewFrame();
         }
 
-        if (this.imagePreviewContainer.isVisible()) {
-            this.imageLoadMask.show();
-        }
-
         this.figure.setClass(presetStyles || ImageModalDialog.defaultStyles.join(' ').trim());
 
         if (!StyleHelper.getAlignmentStyles().some(style => this.figure.hasClass(style))) {
@@ -370,6 +366,10 @@ export class ImageModalDialog
         this.imageCaptionField.show();
         this.imageAltTextField.show();
         this.imageUploaderEl.hide();
+
+        if (!image.isLoaded()) {
+            this.imageLoadMask.show();
+        }
     }
 
 

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/image/ImageModalDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/image/ImageModalDialog.ts
@@ -46,6 +46,7 @@ import {UriHelper} from 'lib-admin-ui/util/UriHelper';
 import {LinkEl} from 'lib-admin-ui/dom/LinkEl';
 import {ContentSummary} from '../../../../../content/ContentSummary';
 import {ContentId} from '../../../../../content/ContentId';
+import {Option} from 'lib-admin-ui/ui/selector/Option';
 import eventInfo = CKEDITOR.eventInfo;
 
 export class ImageModalDialog
@@ -170,10 +171,16 @@ export class ImageModalDialog
 
         new GetContentByIdRequest(new ContentId(imageId)).sendAndParse().then((imageContent: Content) => {
             this.imageSelector.setValue(imageContent.getId());
+            this.imageSelector.getComboBox().onValueLoaded((options: Option<MediaTreeSelectorItem>[]) => {
+               if (options.length === 1 && options[0].getId() === imageContent.getId()) {
+                   this.imageSelectorFormItem.show();
+               }
+            });
             this.previewImage(imageContent, presetStyles);
             this.imageSelectorFormItem.addClass('selected-item-preview');
         }).catch((reason: any) => {
             this.presetImageEl = null;
+            this.imageSelectorFormItem.show();
             DefaultErrorHandler.handle(reason);
         }).done();
     }
@@ -196,6 +203,9 @@ export class ImageModalDialog
 
     protected getMainFormItems(): FormItem[] {
         this.imageSelectorFormItem = this.createImageSelector('imageId');
+        if (this.presetImageEl) {
+            this.imageSelectorFormItem.hide();
+        }
 
         this.imageCaptionField = this.createFormItem(new ModalDialogFormItemBuilder('caption', i18n('dialog.image.formitem.caption')));
         this.imageAltTextField = this.createFormItem(new ModalDialogFormItemBuilder('altText', i18n('dialog.image.formitem.alttext')));
@@ -322,7 +332,9 @@ export class ImageModalDialog
             this.createPreviewFrame();
         }
 
-        this.imageLoadMask.show();
+        if (this.imagePreviewContainer.isVisible()) {
+            this.imageLoadMask.show();
+        }
 
         this.figure.setClass(presetStyles || ImageModalDialog.defaultStyles.join(' ').trim());
 


### PR DESCRIPTION
Hide Image Selector in the Insert Image dialog until image is preloaded (#4585)