### PR TITLE
Browser tabs freezes after trying to reopen a site with an open inser…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/ContentEventsProcessor.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentEventsProcessor.ts
@@ -20,6 +20,8 @@ import {UrlHelper} from './util/UrlHelper';
 
 export class ContentEventsProcessor {
 
+    static openTabs: Map<string, Window> = new Map<string, Window>();
+
     static openWizardTab(params: ContentWizardPanelParams): Window {
         const wizardUrl: string = UrlHelper.getPrefixedUrl(ContentEventsProcessor.generateURL(params), '');
         return ContentEventsProcessor.openTab(wizardUrl, ContentEventsProcessor.makeWizardId(params));
@@ -36,7 +38,19 @@ export class ContentEventsProcessor {
     }
 
     static openTab(url: string, target?: string): Window {
-        return window.open(url, target);
+        if (ContentEventsProcessor.openTabs.has(target)) {
+            const existingWindow: Window = ContentEventsProcessor.openTabs.get(target);
+
+            if (!existingWindow.closed) {
+                existingWindow.focus();
+                return existingWindow;
+            }
+        }
+
+        const newWindow: Window = window.open(url, target);
+        ContentEventsProcessor.openTabs.set(target, newWindow);
+
+        return newWindow;
     }
 
     static popupBlocked(win: Window) {


### PR DESCRIPTION
…t link dialog #4695

-Current browser behavior with window.open(url, name) - it loads resource under url provided in the tab with name provided, so now it just finds existing tab and reloads it. Can't prevent this behavior
-Partially fixed by saving references to the open tabs and using window.focus() on them