### PR TITLE
<use> tags are stripped out from Custom Selector's SVG #4699

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/customselector/CustomSelectorItemViewer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/customselector/CustomSelectorItemViewer.ts
@@ -19,7 +19,7 @@ export class CustomSelectorItemViewer
 
     resolveIconEl(object: CustomSelectorItem): Element {
         if (object.icon && object.icon.data) {
-            return Element.fromString(object.icon.data);
+            return Element.fromString(object.icon.data, true, {addTags: ['use']});
         }
         return null;
     }


### PR DESCRIPTION
-<use> tag is being stripped out by a sanitizing function. Fixed by providing a custom config to a sanitizing function, allowing this tag