### PR TITLE
Edit page saving can reload the page and loose scrolling position

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -624,7 +624,7 @@ export class HtmlEditor {
                 const config: any = {
                     editor: editor,
                     editorParams: this.editorParams,
-                    cursorPosition: this.getCursorPosition(editor)
+                    cursorPosition: this.getCursorPosition()
                 };
 
                 this.notifyFullscreenDialog(config);
@@ -674,13 +674,13 @@ export class HtmlEditor {
         });
     }
 
-    private getCursorPosition(editor: CKEDITOR.editor): HtmlEditorCursorPosition {
-        const selection: CKEDITOR.dom.selection = editor.getSelection();
+    getCursorPosition(): HtmlEditorCursorPosition {
+        const selection: CKEDITOR.dom.selection = this.editor.getSelection();
         const range: CKEDITOR.dom.range = selection.getRanges()[0];
         const isCursorSetOnText: boolean = (!!range && !!range.startContainer && range.startContainer.$.nodeName === '#text');
 
         return {
-            selectionIndexes: editor.elementPath().elements.map(e => e.getIndex()).reverse().slice(1),
+            selectionIndexes: this.editor.elementPath().elements.map(e => e.getIndex()).reverse().slice(1),
             indexOfSelectedElement: isCursorSetOnText ? range.startContainer.getIndex() : -1,
             startOffset: isCursorSetOnText ? range.startOffset : null
         };
@@ -923,19 +923,23 @@ export class HtmlEditor {
         this.editor.on(eventName, handler);
     }
 
-    public setSelectionByCursorPosition(cursorPositon: HtmlEditorCursorPosition) {
-        let elementContainer: CKEDITOR.dom.element = this.editor.document.getBody();
-        cursorPositon.selectionIndexes.forEach((index: number) => {
+    public setSelectionByCursorPosition(cursorPosition: HtmlEditorCursorPosition) {
+        let elementContainer: CKEDITOR.dom.element = this.editorParams.isInline() ?
+            this.editor.container :
+            this.editor.document.getBody();
+
+        cursorPosition.selectionIndexes.forEach((index: number) => {
             elementContainer = <CKEDITOR.dom.element>elementContainer.getChild(index);
         });
 
         elementContainer.scrollIntoView();
 
-        const selectedElement: CKEDITOR.dom.node =
-            cursorPositon.indexOfSelectedElement > -1 ? elementContainer.getChild(cursorPositon.indexOfSelectedElement) : elementContainer;
+        const selectedElement: CKEDITOR.dom.node = cursorPosition.indexOfSelectedElement > -1 ?
+            elementContainer.getChild(cursorPosition.indexOfSelectedElement) :
+            elementContainer;
 
         const range: CKEDITOR.dom.range = this.editor.createRange();
-        range.setStart(selectedElement, cursorPositon.startOffset || 0);
+        range.setStart(selectedElement, cursorPosition.startOffset || 0);
         range.select();
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/PageComponentsTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/PageComponentsTreeGrid.ts
@@ -244,7 +244,6 @@ export class PageComponentsTreeGrid
         const node: TreeNode<ItemViewTreeGridWrapper> = this.getRoot().getNodeByDataIdFromCurrent(dataId);
 
         if (node) {
-            node.getData().getItemView().scrollComponentIntoView();
             this.scrollToRow(this.getGrid().getDataView().getRowById(node.getId()));
         }
     }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
@@ -2,7 +2,6 @@ import * as $ from 'jquery';
 import * as Q from 'q';
 import {Element} from '@enonic/lib-admin-ui/dom/Element';
 import {Event} from '@enonic/lib-admin-ui/event/Event';
-import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {ModalDialog} from '@enonic/lib-admin-ui/ui/dialog/ModalDialog';
 import {LiveEditModel} from '../../../page-editor/LiveEditModel';
 import {PageView} from '../../../page-editor/PageView';
@@ -421,13 +420,6 @@ export class LiveEditPageProxy {
 
         // Notify loaded no matter the result
         this.notifyLoaded();
-    }
-
-    private handlePlaceholderIFrameLoadedEvent(iframe: IFrameEl) {
-        let window = iframe.getHTMLElement()['contentWindow'];
-
-        $(window.document.body).find('.page-placeholder-info-line1').text(i18n('text.nocontrollers'));
-        $(window.document.body).find('.page-placeholder-info-line2').text(i18n('text.addapplications'));
     }
 
     public loadComponent(componentView: ComponentView<Component>, componentUrl: string,

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -88,6 +88,9 @@ import {assertNotNull} from '@enonic/lib-admin-ui/util/Assert';
 import {SpanEl} from '@enonic/lib-admin-ui/dom/SpanEl';
 import {BrEl} from '@enonic/lib-admin-ui/dom/BrEl';
 import {ContentId} from '../../content/ContentId';
+import {ItemView} from '../../../page-editor/ItemView';
+import {HtmlEditorCursorPosition} from '../../inputtype/ui/text/HtmlEditor';
+import * as $ from 'jquery';
 
 export interface LiveFormPanelConfig {
 
@@ -352,6 +355,12 @@ export class LiveFormPanel
 
     private createContextWindow(proxy: LiveEditPageProxy, model: LiveEditModel): ContextWindow { //
         this.inspectionsPanel = this.createInspectionsPanel();
+
+        this.pageView?.getPageViewController().onTextEditModeChanged((value: boolean) => {
+            if (this.inspectionsPanel.getPanelShown() === this.textInspectionPanel) {
+                this.inspectionsPanel.setButtonContainerVisible(value);
+            }
+        });
 
         this.insertablesPanel = new InsertablesPanel({
             liveEditPage: proxy,
@@ -659,22 +668,26 @@ export class LiveFormPanel
             this.inspectPage(false);
         });
 
-        this.liveEditPageProxy.onPageUnlocked(() => {
-            //this.contextWindow.clearSelection();
-        });
-
         let path;
         let isComponentView: boolean = false;
+        let textEditorCursorPos: HtmlEditorCursorPosition;
 
         BeforeContentSavedEvent.on(() => {
             path = null;
+            textEditorCursorPos = null;
+
             if (!this.pageView) {
                 return;
             }
-            const selected = this.pageView.getSelectedView();
+            const selected: ItemView = this.pageView.getSelectedView();
+
             if (ObjectHelper.iFrameSafeInstanceOf(selected, ComponentView)) {
                 path = (<ComponentView<any>>selected).getComponentPath();
                 isComponentView = true;
+
+                if (this.pageView.isTextEditMode() && ObjectHelper.iFrameSafeInstanceOf(selected, TextComponentView)) {
+                    textEditorCursorPos = (<TextComponentView>selected).getCursorPosition();
+                }
             } else if (ObjectHelper.iFrameSafeInstanceOf(selected, RegionView)) {
                 path = (<RegionView>selected).getRegionPath();
             }
@@ -694,6 +707,12 @@ export class LiveFormPanel
                                                                         : this.pageView.getRegionViewByPath(path);
                 if (selected) {
                     selected.selectWithoutMenu(true);
+                    selected.scrollComponentIntoView();
+
+                    if (textEditorCursorPos && ObjectHelper.iFrameSafeInstanceOf(selected, TextComponentView)) {
+                        this.setCursorPositionInTextComponent(<TextComponentView>selected, textEditorCursorPos);
+                        textEditorCursorPos = null;
+                    }
                 }
             }
         };
@@ -734,8 +753,17 @@ export class LiveFormPanel
                 return;
             }
 
+            itemView.scrollComponentIntoView();
             if (ObjectHelper.iFrameSafeInstanceOf(itemView, ComponentView)) {
                 this.inspectComponent(<ComponentView<Component>>itemView, newSelection, newSelection && defaultClicked);
+
+                if (textEditorCursorPos && this.pageView.isTextEditMode() &&
+                    ObjectHelper.iFrameSafeInstanceOf(itemView, TextComponentView)) {
+                    this.setCursorPositionInTextComponent(<TextComponentView>itemView, textEditorCursorPos);
+                    textEditorCursorPos = null;
+                }
+            } else {
+                this.inspectionsPanel.updateButtonsVisibility();
             }
         });
 
@@ -829,6 +857,16 @@ export class LiveFormPanel
             let modalDialog = HTMLAreaDialogHandler.createAndOpenDialog(event);
             this.liveEditPageProxy.notifyLiveEditPageDialogCreated(modalDialog, event.getConfig());
         });
+    }
+
+    private setCursorPositionInTextComponent(textComponentView: TextComponentView, cursorPosition: HtmlEditorCursorPosition): void {
+        this.pageView.appendContainerForTextToolbar();
+        textComponentView.startPageTextEditMode();
+        $(textComponentView.getHTMLElement()).simulate('click');
+
+        textComponentView.onEditorReady(() =>
+            setTimeout(() => textComponentView.setCursorPosition(cursorPosition), 100)
+        );
     }
 
     private saveMarkedContentAndReloadOnlyComponent(componentView: ComponentView<Component>) {
@@ -938,6 +976,7 @@ export class LiveFormPanel
             showInspectionPanel(this.layoutInspectionPanel);
         } else if (ObjectHelper.iFrameSafeInstanceOf(componentView, TextComponentView)) {
             this.textInspectionPanel.setTextComponent(<TextComponentView>componentView);
+            this.inspectionsPanel.setButtonContainerVisible(this.pageView?.getPageViewController().isTextEditMode());
             showInspectionPanel(this.textInspectionPanel);
         } else if (ObjectHelper.iFrameSafeInstanceOf(componentView, FragmentComponentView)) {
             this.fragmentInspectionPanel.setFragmentComponentView(<FragmentComponentView>componentView);

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/InspectionsPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/InspectionsPanel.ts
@@ -31,18 +31,11 @@ export interface InspectionsPanelConfig {
 export class InspectionsPanel
     extends Panel {
 
-    private deck: DeckPanel;
-    private buttonContainer: DivEl;
+    private readonly deck: DeckPanel;
+    private readonly buttonContainer: DivEl;
 
-    private noSelectionPanel: NoSelectionInspectionPanel;
-    private imageInspectionPanel: ImageInspectionPanel;
-    private partInspectionPanel: PartInspectionPanel;
-    private layoutInspectionPanel: LayoutInspectionPanel;
-    private contentInspectionPanel: ContentInspectionPanel;
-    private pageInspectionPanel: PageInspectionPanel;
-    private regionInspectionPanel: RegionInspectionPanel;
-    private fragmentInspectionPanel: FragmentInspectionPanel;
-    private textInspectionPanel: TextInspectionPanel;
+    private readonly noSelectionPanel: NoSelectionInspectionPanel;
+    private readonly pageInspectionPanel: PageInspectionPanel;
 
     constructor(config: InspectionsPanelConfig) {
         super('inspections-panel');
@@ -50,23 +43,24 @@ export class InspectionsPanel
         this.deck = new DeckPanel();
 
         this.noSelectionPanel = new NoSelectionInspectionPanel();
-        this.imageInspectionPanel = config.imageInspectionPanel;
-        this.partInspectionPanel = config.partInspectionPanel;
-        this.layoutInspectionPanel = config.layoutInspectionPanel;
-        this.contentInspectionPanel = config.contentInspectionPanel;
         this.pageInspectionPanel = config.pageInspectionPanel;
-        this.regionInspectionPanel = config.regionInspectionPanel;
-        this.fragmentInspectionPanel = config.fragmentInspectionPanel;
-        this.textInspectionPanel = config.textInspectionPanel;
 
-        this.deck.addPanel(this.imageInspectionPanel);
-        this.deck.addPanel(this.partInspectionPanel);
-        this.deck.addPanel(this.layoutInspectionPanel);
-        this.deck.addPanel(this.contentInspectionPanel);
-        this.deck.addPanel(this.regionInspectionPanel);
+        const imageInspectionPanel = config.imageInspectionPanel;
+        const partInspectionPanel = config.partInspectionPanel;
+        const layoutInspectionPanel = config.layoutInspectionPanel;
+        const contentInspectionPanel = config.contentInspectionPanel;
+        const regionInspectionPanel = config.regionInspectionPanel;
+        const fragmentInspectionPanel = config.fragmentInspectionPanel;
+        const textInspectionPanel = config.textInspectionPanel;
+
+        this.deck.addPanel(imageInspectionPanel);
+        this.deck.addPanel(partInspectionPanel);
+        this.deck.addPanel(layoutInspectionPanel);
+        this.deck.addPanel(contentInspectionPanel);
+        this.deck.addPanel(regionInspectionPanel);
         this.deck.addPanel(this.pageInspectionPanel);
-        this.deck.addPanel(this.fragmentInspectionPanel);
-        this.deck.addPanel(this.textInspectionPanel);
+        this.deck.addPanel(fragmentInspectionPanel);
+        this.deck.addPanel(textInspectionPanel);
         this.deck.addPanel(this.noSelectionPanel);
 
         this.deck.showPanel(this.pageInspectionPanel);
@@ -76,38 +70,32 @@ export class InspectionsPanel
 
         this.appendChildren(<Element>this.deck, this.buttonContainer);
 
-        this.partInspectionPanel.onDescriptorLoaded(this.updateButtonsVisibility.bind(this));
-        this.layoutInspectionPanel.onDescriptorLoaded(this.updateButtonsVisibility.bind(this));
+        partInspectionPanel.onDescriptorLoaded(this.updateButtonsVisibility.bind(this));
+        layoutInspectionPanel.onDescriptorLoaded(this.updateButtonsVisibility.bind(this));
     }
 
-    private getPanelDescriptor(panel: Panel): Descriptor {
-        if (panel instanceof DescriptorBasedComponentInspectionPanel || panel instanceof PageInspectionPanel) {
-            return panel.getDescriptor();
-        }
-
-        return null;
-    }
-
-    public showInspectionPanel(panel: Panel) {
+    public showInspectionPanel(panel: Panel): void {
         this.deck.showPanel(panel);
+    }
 
-        const descriptor = this.getPanelDescriptor(panel);
-        if (!descriptor) {
-            this.buttonContainer.setVisible(false);
+    public setButtonContainerVisible(isVisible: boolean = true): void {
+        this.buttonContainer.setVisible(isVisible);
+    }
+
+    public updateButtonsVisibility(descriptor?: Descriptor): void {
+        let thisDescriptor: Descriptor = descriptor;
+        if (!thisDescriptor) {
+            const panel: Panel = this.deck.getPanelShown();
+            if (panel instanceof DescriptorBasedComponentInspectionPanel || panel instanceof PageInspectionPanel) {
+                thisDescriptor = panel.getDescriptor();
+            }
         }
+        const showButtons = thisDescriptor ? thisDescriptor.getConfig()?.getFormItems().length > 0 : false;
+        this.setButtonContainerVisible(showButtons);
     }
 
-    private updateButtonsVisibility(descriptor: Descriptor): void {
-        const showButtons = descriptor ? descriptor.getConfig()?.getFormItems().length > 0 : false;
-        this.buttonContainer.setVisible(showButtons);
-    }
-
-    public clearInspection() {
+    public clearInspection(): void {
         this.showInspectionPanel(this.pageInspectionPanel);
-    }
-
-    public isInspecting(): boolean {
-        return this.deck.getPanelShown() !== this.noSelectionPanel;
     }
 
     public getPanelShown(): Panel {

--- a/modules/lib/src/main/resources/assets/js/page-editor/PageView.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/PageView.ts
@@ -597,6 +597,10 @@ export class PageView
         return this;
     }
 
+    getPageViewController(): PageViewController {
+        return PageViewController.get();
+    }
+
     getCurrentContextMenu(): ItemViewContextMenu {
         return this.lockedContextMenu || super.getCurrentContextMenu();
     }

--- a/modules/lib/src/main/resources/assets/js/page-editor/PageViewController.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/PageViewController.ts
@@ -10,7 +10,7 @@ export class PageViewController {
     private highlightingDisabled: boolean;
     private contextMenuDisabled: boolean;
     private pageLocked: boolean;
-    private textEditMode: boolean;
+    private textEditMode: boolean = false;
     private editorToolbar: DivEl;
 
     private textEditModeListeners: { (flag: boolean): void }[] = [];

--- a/modules/lib/src/main/resources/assets/styles/wizard/page/contextwindow/inspections-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/page/contextwindow/inspections-panel.less
@@ -32,6 +32,8 @@
     box-sizing: border-box;
 
     .action-button {
+      display: block;
+      margin: 0 auto;
       padding: 4px 19px;
     }
   }

--- a/testing/page_objects/wizardpanel/liveform/live.form.panel.js
+++ b/testing/page_objects/wizardpanel/liveform/live.form.panel.js
@@ -14,11 +14,13 @@ const xpath = {
     itemViewContextMenu: "//div[contains(@id,'ItemViewContextMenu')]",
     layoutComponentView: "//div[contains(@id,'LayoutComponentView')]",
     textComponentView: "//div[contains(@id,'TextComponentView')]",
+    editableTextComponentView: "//div[contains(@id,'TextComponentView') and @contenteditable='true']",
     previewNotAvailableSpan: "//p[@class='no-preview-message']/span[1]",
     imageInTextComponentByDisplayName:
         displayName => `//figure[contains(@data-widget,'image')]//img[contains(@src,'${displayName}')]`,
+    editableTextComponentByText: text => `//div[contains(@id,'TextComponentView') and @contenteditable='true']//p[contains(.,'${text}')]`,
     textComponentByText: text => `//div[contains(@id,'TextComponentView')]//p[contains(.,'${text}')]`,
-    captionByText: text => `//div[contains(@id,'TextComponentView')]//figcaption[contains(.,'${text}')]`
+    captionByText: text => `//div[contains(@id,'TextComponentView') and @contenteditable='true']//figcaption[contains(.,'${text}')]`
 };
 
 class LiveFormPanel extends Page {
@@ -91,6 +93,16 @@ class LiveFormPanel extends Page {
             throw new Error("Error when getting text in the layout component! " + err);
         }
     }
+    async getTextInEditableLayoutComponent() {
+        try {
+            let selector = xpath.layoutComponentView + xpath.editableTextComponentView + "/p";
+            await this.waitForElementDisplayed(selector, appConst.mediumTimeout);
+            return await this.getTextInDisplayedElements(selector);
+        } catch (err) {
+            await this.saveScreenshot(appConst.generateRandomName('err_layout_text'));
+            throw new Error("Error when getting text in the layout component! " + err);
+        }
+    }
 
     async waitForImageDisplayed(imageName) {
         try {
@@ -112,9 +124,9 @@ class LiveFormPanel extends Page {
         }
     }
 
-    async waitForTextComponentDisplayed(text) {
+    async waitForEditableTextComponentDisplayed(text) {
         try {
-            let selector = xpath.textComponentByText(text);
+            let selector = xpath.editableTextComponentByText(text);
             return await this.waitForElementDisplayed(selector, appConst.mediumTimeout);
         } catch (err) {
             this.saveScreenshot("err_live_frame_text_component1");

--- a/testing/specs/page-editor/revert.site.with.components.spec.js
+++ b/testing/specs/page-editor/revert.site.with.components.spec.js
@@ -46,8 +46,8 @@ describe("revert.site.with.components.spec: Insert Text component then revert th
             await textComponentCke.typeTextInCkeEditor(TEXT);
             await contentWizard.waitAndClickOnSave();
             await textComponentCke.switchToLiveEditFrame();
-            //Verify that text component is present:
-            await liveFormPanel.waitForTextComponentDisplayed(TEXT);
+            //Verify that text component in edit mode is present:
+            await liveFormPanel.waitForEditableTextComponentDisplayed(TEXT);
         });
 
     it(`GIVEN existing site with image component is opened WHEN do right click on the image-component THEN component's context menu should appear`,

--- a/testing/specs/page-editor/site.with.layout.component.spec.js
+++ b/testing/specs/page-editor/site.with.layout.component.spec.js
@@ -62,7 +62,7 @@ describe('site.with.layout.component.spec - specification', function () {
             await textComponentCke.typeTextInCkeEditor("text left");
             await contentWizard.waitAndClickOnSave();
             await contentWizard.switchToLiveEditFrame();
-            let result = await liveFormPanel.getTextInLayoutComponent();
+            let result = await liveFormPanel.getTextInEditableLayoutComponent()
             assert.equal(result[0], "text left", "Expected text should be present in the layout component");
         });
 
@@ -83,7 +83,7 @@ describe('site.with.layout.component.spec - specification', function () {
             await textComponentCke.typeTextInCkeEditor("text center");
             await contentWizard.waitAndClickOnSave();
             await contentWizard.switchToLiveEditFrame();
-            let result = await liveFormPanel.getTextInLayoutComponent();
+            let result = await liveFormPanel.getTextInEditableLayoutComponent();
             assert.equal(result[1], "text center", "Expected text should be present in the layout component");
         });
 
@@ -104,7 +104,7 @@ describe('site.with.layout.component.spec - specification', function () {
             await textComponentCke.typeTextInCkeEditor("text right");
             await contentWizard.waitAndClickOnSave();
             await contentWizard.switchToLiveEditFrame();
-            let result = await liveFormPanel.getTextInLayoutComponent();
+            let result = await liveFormPanel.getTextInEditableLayoutComponent();
             assert.equal(result[2], "text right", "Expected text should be present in the layout component");
         });
 

--- a/testing/specs/page-editor/text.component.image.caption.spec.js
+++ b/testing/specs/page-editor/text.component.image.caption.spec.js
@@ -1,9 +1,7 @@
 /**
  * Created on 09.07.2021
- *
  */
 const chai = require('chai');
-const assert = chai.assert;
 const webDriverHelper = require('../../libs/WebDriverHelper');
 const studioUtils = require('../../libs/studio.utils.js');
 const ContentWizard = require('../../page_objects/wizardpanel/content.wizard.panel');
@@ -55,7 +53,7 @@ describe("text.component.image.caption.spec: Inserts a text component with an im
             await insertImageDialog.clickOnInsertButton();
             await insertImageDialog.waitForDialogClosed();
             await contentWizard.waitAndClickOnSave();
-            studioUtils.saveScreenshot('text_component_image_caption');
+            await studioUtils.saveScreenshot('text_component_image_caption');
             await contentWizard.waitForNotificationMessage();
             await contentWizard.switchToLiveEditFrame();
             //5. Verify that the caption is present in Page Editor:


### PR DESCRIPTION
-Fixed PageComponentsTreeGrid not to affect scrolling to the item views
-Updated TextComponentView to let set/get editor's cursor position
-Small update in HtmlEditor to remove redundant param
-Forcing scrolling to the loaded(saved) ItemView and scrolling to the last selected item after save
-Saving latest cursor position within TextComponent's editor before saving content and then restoring selection after save is complete