### PR TITLE
Can't open New wizard for the same content type #4735

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/ContentAppBarTabId.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentAppBarTabId.ts
@@ -87,6 +87,6 @@ export class ContentAppBarTabId
     toString(): string {
         const project: string = ProjectContext.get().getProject().getName();
 
-        return `${this.getMode()}:${project}/${this.getId()}`;
+        return `${this.getMode()}:${project}:${this.getId()}`;
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -2816,9 +2816,7 @@ export class ContentWizardPanel
                                ? UrlAction.LOCALIZE
                                : UrlAction.EDIT;
         Router.get().setPath(UrlHelper.createContentEditUrl(this.getPersistedItem().getId(), action));
-        if (!window.name) {
-            window.name = `${action}:${this.getPersistedItem().getId()}`;
-        }
+        window.name = `${action}:${ProjectContext.get().getProject().getName()}:${this.getPersistedItem().getId()}`;
     }
 
     protected setPersistedItem(newPersistedItem: Content): void {


### PR DESCRIPTION
-always setting proper name in a window tab after opening
-adjusted and synced window name used in wizard panel and ContentAppBarTabId.ts
-adjusted handling of open windows
-removing closed windows from the list