### PR TITLE
Custom validation is not working for Selector inputs #4936

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/customselector/CustomSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/customselector/CustomSelector.ts
@@ -38,13 +38,12 @@ export class CustomSelector
     private comboBox: RichComboBox<CustomSelectorItem>;
 
     constructor(context: ContentInputTypeViewContext) {
-        super('custom-selector');
+        super(context, 'custom-selector');
 
         if (CustomSelector.debug) {
             console.debug('CustomSelector: config', context.inputConfig);
         }
 
-        this.readConfig(context);
         this.subscribeToContentUpdates();
     }
 
@@ -64,8 +63,8 @@ export class CustomSelector
         }
     }
 
-    private readConfig(context: ContentInputTypeViewContext): void {
-        const cfg = context.inputConfig;
+    protected readInputConfig(): void {
+        const cfg = this.context.inputConfig;
         const serviceCfg = cfg['service'];
         let serviceUrl;
         if (serviceCfg) {
@@ -78,7 +77,7 @@ export class CustomSelector
             return prev;
         }, {});
 
-        this.content = context.content;
+        this.content = (<ContentInputTypeViewContext>this.context).content;
 
         if (serviceUrl) {
             this.requestPath = CustomSelector.portalUrl + UriHelper.appendUrlParams(serviceUrl, params);
@@ -164,7 +163,7 @@ export class CustomSelector
 
             this.ignorePropertyChange(false);
 
-            this.validate(false);
+            this.handleValueChanged(false);
             this.fireFocusSwitchEvent(event);
         });
 
@@ -175,12 +174,12 @@ export class CustomSelector
 
             this.refreshSortable();
             this.ignorePropertyChange(false);
-            this.validate(false);
+            this.handleValueChanged(false);
         });
 
         comboBox.onOptionMoved((moved: SelectedOption<any>, fromIndex: number) => this.handleMove(moved, fromIndex));
 
-        comboBox.onValueLoaded(() => this.validate(false));
+        comboBox.onValueLoaded(() => this.handleValueChanged(false));
 
         return comboBox;
     }

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/schema/ContentTypeFilter.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/schema/ContentTypeFilter.ts
@@ -21,24 +21,23 @@ import {Class} from '@enonic/lib-admin-ui/Class';
 export class ContentTypeFilter
     extends BaseInputTypeManagingAdd {
 
+    protected context: ContentInputTypeViewContext;
+
     private combobox: ContentTypeComboBox;
 
-    private context: ContentInputTypeViewContext;
-
-    private onContentTypesLoadedHandler: (contentTypeArray: ContentTypeSummary[]) => void;
+    private readonly onContentTypesLoadedHandler: (contentTypeArray: ContentTypeSummary[]) => void;
 
     private isContextDependent: boolean;
 
     constructor(context: ContentInputTypeViewContext) {
-        super('content-type-filter');
-        this.context = context;
+        super(context, 'content-type-filter');
         this.onContentTypesLoadedHandler = this.onContentTypesLoaded.bind(this);
-        this.readConfig(context.inputConfig);
     }
 
-    protected readConfig(inputConfig: { [element: string]: { [name: string]: string }[]; }): void {
-        const isContextDependentConfig = inputConfig['context'] ? inputConfig['context'][0] : {};
-        const value = isContextDependentConfig['value'] || '';
+    protected readInputConfig(): void {
+        const contextDependentProp: { [name: string]: string } =
+            this.context.inputConfig['context'] ? this.context.inputConfig['context'][0] : {};
+        const value: string = contextDependentProp['value'] || '';
         this.isContextDependent = value.toLowerCase() === 'true';
     }
 
@@ -105,14 +104,14 @@ export class ContentTypeFilter
             this.getPropertyArray().add(value);
         }
 
-        this.validate(false);
+        this.handleValueChanged(false);
         this.ignorePropertyChange(false);
     }
 
     private onContentTypeDeselected(option: SelectedOption<ContentTypeSummary>): void {
         this.ignorePropertyChange(true);
         this.getPropertyArray().remove(option.getIndex());
-        this.validate(false);
+        this.handleValueChanged(false);
         this.ignorePropertyChange(false);
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentSelector.ts
@@ -47,13 +47,13 @@ export class ContentSelector
 
     protected static loadSummaries: () => void = AppHelper.debounce(ContentSelector.doFetchSummaries, 10, false);
 
-    constructor(config?: ContentInputTypeViewContext) {
-        super('content-selector', config);
+    constructor(config: ContentInputTypeViewContext) {
+        super(config, 'content-selector');
         this.initEventsListeners();
     }
 
     private initEventsListeners() {
-        const contentId: string = this.config.content.getId();
+        const contentId: string = this.context.content.getId();
 
         ContentServerEventsHandler.getInstance().onContentRenamed((data: ContentSummaryAndCompareStatus[]) => {
             const isCurrentContentRenamed: boolean = data.some((item: ContentSummaryAndCompareStatus) => item.getId() === contentId);
@@ -81,8 +81,8 @@ export class ContentSelector
         return new ContentTreeSelectorItem(content);
     }
 
-    protected readConfig(): void {
-        const inputConfig: { [element: string]: { [name: string]: string }[]; } = this.config.inputConfig;
+    protected readInputConfig(): void {
+        const inputConfig: { [element: string]: { [name: string]: string }[]; } = this.context.inputConfig;
         const isTreeModeConfig = inputConfig['treeMode'] ? inputConfig['treeMode'][0] : {};
         this.treeMode = !StringHelper.isBlank(isTreeModeConfig['value']) ? isTreeModeConfig['value'].toLowerCase() === 'true' : false;
 
@@ -90,7 +90,7 @@ export class ContentSelector
         this.hideToggleIcon =
             !StringHelper.isBlank(hideToggleIconConfig['value']) ? hideToggleIconConfig['value'].toLowerCase() === 'true' : false;
 
-        super.readConfig();
+        super.readInputConfig();
     }
 
     protected getDefaultAllowPath(): string {
@@ -173,7 +173,7 @@ export class ContentSelector
             .setAllowedContentPaths(this.allowedContentPaths)
             .setContentTypeNames(this.allowedContentTypes)
             .setRelationshipType(this.relationshipType)
-            .setContent(this.config.content);
+            .setContent(this.context.content);
     }
 
     protected doCreateContentComboBoxBuilder(): ContentComboBoxBuilder<ContentTreeSelectorItem> {
@@ -205,7 +205,7 @@ export class ContentSelector
     protected initEvents(contentComboBox: ContentComboBox<ContentTreeSelectorItem>) {
         contentComboBox.getComboBox().onContentMissing((ids: string[]) => {
             ids.forEach(id => this.removePropertyWithId(id));
-            this.validate(false);
+            this.handleValueChanged(false);
         });
 
         contentComboBox.onOptionSelected((event: SelectedOptionEvent<ContentTreeSelectorItem>) => {
@@ -219,7 +219,7 @@ export class ContentSelector
                 this.updateSelectedOptionIsEditable(event.getSelectedOption());
                 this.getSelectedOptionsView().refreshSortable();
                 this.updateSelectedOptionStyle();
-                this.validate(false);
+                this.handleValueChanged(false);
                 this.contentComboBox.getComboBox().setIgnoreNextFocus(true);
             }
 
@@ -228,7 +228,7 @@ export class ContentSelector
         contentComboBox.onOptionDeselected((event: SelectedOptionEvent<ContentTreeSelectorItem>) => {
             this.handleDeselected(event.getSelectedOption().getIndex());
             this.updateSelectedOptionStyle();
-            this.validate(false);
+            this.handleValueChanged(false);
         });
 
         contentComboBox.onOptionMoved(this.handleMoved.bind(this));
@@ -384,7 +384,7 @@ export class ContentSelector
 
     protected updateSelectedOptionIsEditable(selectedOption: SelectedOption<ContentTreeSelectorItem>) {
         const selectedContentId: ContentId = selectedOption.getOption().getDisplayValue().getContentId();
-        const refersToItself: boolean = selectedContentId.toString() === this.config.content.getId();
+        const refersToItself: boolean = selectedContentId.toString() === this.context.content.getId();
         selectedOption.getOptionView().toggleClass('non-editable', refersToItself);
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ImageSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ImageSelector.ts
@@ -32,8 +32,8 @@ export class ImageSelector
 
     private isPendingPreload: boolean = true;
 
-    constructor(config: ContentInputTypeViewContext) {
-        super(config);
+    constructor(context: ContentInputTypeViewContext) {
+        super(context);
 
         this.addClass('image-selector');
 
@@ -78,7 +78,7 @@ export class ImageSelector
                 }
 
             });
-            this.validate(false);
+            this.handleValueChanged(false);
         });
 
         return selectedOptionsView;
@@ -110,7 +110,7 @@ export class ImageSelector
             });
             this.isPendingPreload = false;
             if (data.length > 0) {
-                this.validate(false);
+                this.handleValueChanged(false);
             }
             loader.unPreloadedData(onPreloadedData);
         };
@@ -123,7 +123,7 @@ export class ImageSelector
             if (option.getOption().getDisplayValue().getContentSummary()) {
                 this.handleDeselected(option.getIndex());
             }
-            this.validate(false);
+            this.handleValueChanged(false);
         });
 
         comboBox.onOptionSelected((event: SelectedOptionEvent<MediaTreeSelectorItem>) => {
@@ -137,12 +137,12 @@ export class ImageSelector
 
                 this.setContentIdProperty(contentId);
             }
-            this.validate(false);
+            this.handleValueChanged(false);
         });
 
         comboBox.onOptionMoved((moved: SelectedOption<MediaTreeSelectorItem>, fromIndex: number) => {
             this.handleMoved(moved, fromIndex);
-            this.validate(false);
+            this.handleValueChanged(false);
         });
     }
 
@@ -221,23 +221,6 @@ export class ImageSelector
             super.validate(silent);
         }
     }
-/*
-    onEditContentRequest(listener: (content: ContentSummary) => void) {
-        this.editContentRequestListeners.push(listener);
-    }
-
-    unEditContentRequest(listener: (content: ContentSummary) => void) {
-        this.editContentRequestListeners = this.editContentRequestListeners
-            .filter(function (curr: (content: ContentSummary) => void) {
-                return curr !== listener;
-            });
-    }
-
-    private notifyEditContentRequested(content: ContentSummary) {
-        this.editContentRequestListeners.forEach((listener) => {
-            listener(content);
-        });
-    }*/
 }
 
 InputTypeManager.register(new Class('ImageSelector', ImageSelector));

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/selector/MediaSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/selector/MediaSelector.ts
@@ -24,16 +24,15 @@ export class MediaSelector
 
     protected uploader: MediaUploaderEl;
 
-    constructor(config?: ContentInputTypeViewContext) {
-        super(config);
+    constructor(context: ContentInputTypeViewContext) {
+        super(context);
         this.addClass('media-selector');
     }
 
     layout(input: Input, propertyArray: PropertyArray): Q.Promise<void> {
-
         return super.layout(input, propertyArray).then(() => {
-            if (this.config.content) {
-                return this.createUploader().then((mediaUploader) => {
+            if (this.context.content) {
+                return this.createUploader().then((mediaUploader: MediaUploaderEl) => {
                     this.comboBoxWrapper.appendChild(this.uploader = mediaUploader);
 
                     if (!this.contentComboBox.getComboBox().isVisible()) {
@@ -48,8 +47,8 @@ export class MediaSelector
         return ContentTypeName.getMediaTypes();
     }
 
-    protected readConfig(): void {
-        super.readConfig();
+    protected readInputConfig(): void {
+        super.readInputConfig();
 
         const allowedContentTypes: string[] = this.getDefaultContentTypes().map(type => type.toString());
         let allowedMediaTypes: string[] = this.allowedContentTypes.filter(value => allowedContentTypes.indexOf(value) >= 0);
@@ -86,7 +85,7 @@ export class MediaSelector
 
         return {
             params: {
-                parent: this.config.content.getContentId().toString()
+                parent: this.context.content.getContentId().toString()
             },
             operation: MediaUploaderElOperation.create,
             name: 'media-selector-upload-el',

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -32,13 +32,10 @@ export class SiteConfigurator
 
     private siteConfigProvider: ApplicationConfigProvider;
 
-    private formContext: ContentFormContext;
-
     private readOnlyPromise: Q.Promise<boolean>;
 
-    constructor(config: ContentInputTypeViewContext) {
-        super('application-configurator');
-        this.formContext = config.formContext;
+    constructor(context: ContentInputTypeViewContext) {
+        super(context, 'application-configurator');
 
         this.readOnlyPromise = this.isReadOnly();
     }
@@ -180,7 +177,7 @@ export class SiteConfigurator
         const value = this.getValueFromPropertyArray(this.getPropertyArray());
         const siteConfigFormsToDisplay = value.split(';');
         const maximum = input.getOccurrences().getMaximum() || 0;
-        const comboBox = new SiteConfiguratorComboBox(maximum, siteConfigProvider, this.formContext, value);
+        const comboBox = new SiteConfiguratorComboBox(maximum, siteConfigProvider, <ContentFormContext>this.context.formContext, value);
 
         const forcedValidate = () => {
             this.ignorePropertyChange(false);

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/tag/Tag.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/tag/Tag.ts
@@ -18,8 +18,6 @@ import {BaseInputTypeManagingAdd} from '@enonic/lib-admin-ui/form/inputtype/supp
 export class Tag
     extends BaseInputTypeManagingAdd {
 
-    private context: ContentInputTypeViewContext;
-
     private tags: Tags;
 
     private allowedContentPaths: string[];
@@ -27,22 +25,17 @@ export class Tag
     private tagSuggester: ContentTagSuggester;
 
     constructor(context: ContentInputTypeViewContext) {
-        super('tag');
-        this.addClass('input-type-view');
-
-        this.context = context;
-        this.readConfig(this.context.inputConfig);
+        super(context, 'tag');
 
         this.tagSuggester = new ContentTagSuggesterBuilder()
-            .setDataPath(Tag.resolveDataPath(this.context))
-            .setContent(this.context.content)
+            .setDataPath(Tag.resolveDataPath(context))
+            .setContent(context.content)
             .setAllowedContentPaths(this.allowedContentPaths)
             .build();
     }
 
-    protected readConfig(inputConfig: { [element: string]: { [name: string]: string }[]; }): void {
-
-        const allowContentPathConfig = inputConfig['allowPath'] || [];
+    protected readInputConfig(): void {
+        const allowContentPathConfig: { [name: string]: string }[] = this.context.inputConfig['allowPath'] || [];
 
         this.allowedContentPaths =
             allowContentPathConfig.length > 0
@@ -85,14 +78,14 @@ export class Tag
                 } else {
                     this.getPropertyArray().add(value);
                 }
-                this.validate(false);
+                this.handleValueChanged(false);
                 this.ignorePropertyChange(false);
             });
 
             this.tags.onTagRemoved((event: TagRemovedEvent) => {
                 this.ignorePropertyChange(true);
                 this.getPropertyArray().remove(event.getIndex());
-                this.validate(false);
+                this.handleValueChanged(false);
                 this.ignorePropertyChange(false);
             });
 

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/selector/ContentInputTypeManagingAdd.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/selector/ContentInputTypeManagingAdd.ts
@@ -17,7 +17,7 @@ import {MovedContentItem} from '../../../browse/MovedContentItem';
 export class ContentInputTypeManagingAdd<RAW_VALUE_TYPE>
     extends BaseInputTypeManagingAdd {
 
-    protected config: ContentInputTypeViewContext;
+    protected context: ContentInputTypeViewContext;
 
     protected relationshipType: string;
 
@@ -27,12 +27,8 @@ export class ContentInputTypeManagingAdd<RAW_VALUE_TYPE>
 
     protected contentDeletedListener: (paths: ContentServerChangeItem[], pending?: boolean) => void;
 
-    constructor(className?: string, config?: ContentInputTypeViewContext) {
-        super(className);
-        this.addClass('input-type-view');
-        this.config = config;
-
-        this.readConfig();
+    constructor(context: ContentInputTypeViewContext, className?: string) {
+        super(context, className);
 
         this.handleContentDeletedEvent();
         this.handleContentUpdatedEvent();
@@ -71,7 +67,7 @@ export class ContentInputTypeManagingAdd<RAW_VALUE_TYPE>
     }
 
     private getAllowedContentTypes(inputConfig: { [element: string]: { [name: string]: string }[]; }): string[] {
-        const applicationKey: ApplicationKey = (<FormItem>this.config.input).getApplicationKey();
+        const applicationKey: ApplicationKey = (<FormItem>this.context.input).getApplicationKey();
         const allowContentTypeConfig = inputConfig['allowContentType'] || [];
         return allowContentTypeConfig
             .map((cfg) => this.prependApplicationName(applicationKey, cfg['value']))
@@ -92,8 +88,8 @@ export class ContentInputTypeManagingAdd<RAW_VALUE_TYPE>
         return [];
     }
 
-    protected readConfig(): void {
-        const inputConfig: { [element: string]: { [name: string]: string }[]; } = this.config.inputConfig;
+    protected readInputConfig(): void {
+        const inputConfig: { [element: string]: { [name: string]: string }[]; } = this.context.inputConfig;
 
         this.relationshipType = this.getRelationShipType(inputConfig);
         this.allowedContentTypes = this.getAllowedContentTypes(inputConfig);

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/upload/AttachmentUploader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/upload/AttachmentUploader.ts
@@ -30,20 +30,19 @@ import {ValueChangedEvent} from '@enonic/lib-admin-ui/form/inputtype/ValueChange
 export class AttachmentUploader
     extends BaseInputTypeManagingAdd {
 
+    protected context: ContentInputTypeViewContext;
+
     private uploadButton: Button;
 
     private uploaderWrapper: DivEl;
 
     private uploaderEl: AttachmentUploaderEl;
 
-    private config: ContentInputTypeViewContext;
-
     private hasAttachmentErrors: boolean;
 
-    constructor(config: ContentInputTypeViewContext) {
-        super('file-uploader');
+    constructor(context: ContentInputTypeViewContext) {
+        super(context, 'file-uploader');
         this.addClass('attachment-uploader');
-        this.config = config;
     }
 
     getValueType(): ValueType {
@@ -123,13 +122,13 @@ export class AttachmentUploader
     private createUploaderConfig(): AttachmentUploaderElConfig {
         return {
             params: {
-                id: this.config.content.getContentId().toString()
+                id: this.context.content.getContentId().toString()
             },
-            contentId: this.config.content.getContentId().toString(),
-            name: this.config.input.getName(),
+            contentId: this.context.content.getContentId().toString(),
+            name: this.context.input.getName(),
             showCancel: false,
             allowMultiSelection: this.getInput().getOccurrences().getMaximum() !== 1,
-            hideDefaultDropZone: !!(<any>(this.config.inputConfig)).hideDropZone,
+            hideDefaultDropZone: !!(<any>(this.context.inputConfig)).hideDropZone,
             deferred: true,
             attachmentRemoveCallback: this.removeItemCallback.bind(this),
             getTotalAllowedToUpload: this.getTotalAllowedToUpload.bind(this),
@@ -145,7 +144,7 @@ export class AttachmentUploader
             const index: number = values.indexOf(attachmentName);
             this.getPropertyArray().remove(index);
 
-            new ContentRequiresSaveEvent(this.config.content.getContentId()).fire();
+            new ContentRequiresSaveEvent(this.context.content.getContentId()).fire();
         }).catch(DefaultErrorHandler.handle);
     }
 
@@ -170,11 +169,11 @@ export class AttachmentUploader
     }
 
     private isAttachmentReferencedFromPage(attachmentName: string): boolean {
-        if (!this.config.content.isPage()) {
+        if (!this.context.content.isPage()) {
             return false;
         }
 
-        const content: Content = <Content>this.config.content;
+        const content: Content = <Content>this.context.content;
         const page: Page = content.getPage();
 
         if (!page.hasRegions()) {
@@ -188,7 +187,7 @@ export class AttachmentUploader
 
     private deleteAttachment(itemName: string): Q.Promise<Content> {
         return new DeleteAttachmentRequest()
-            .setContentId(this.config.content.getContentId())
+            .setContentId(this.context.content.getContentId())
             .addAttachmentName(itemName)
             .sendAndParse();
     }
@@ -235,7 +234,7 @@ export class AttachmentUploader
                 this.addFileNameToProperty(itemName);
             });
 
-            new ContentRequiresSaveEvent(this.config.content.getContentId()).fire();
+            new ContentRequiresSaveEvent(this.context.content.getContentId()).fire();
         });
 
         this.uploaderEl.onUploadFailed((event: UploadFailedEvent<Attachment>) => {
@@ -281,7 +280,7 @@ export class AttachmentUploader
     }
 
     private getCustomValidationErrors(): ValidationError[] {
-        return this.config.formContext.getPersistedContent().getValidationErrors();
+        return this.context.formContext.getPersistedContent().getValidationErrors();
     }
 
     private getAttachmentNamesFromCustomErrors(): string[] {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
@@ -152,6 +152,14 @@ export class ContentWizardHeader
         super.toggleNameInput(enable);
     }
 
+    isDisplayNameInputDirty(): boolean {
+        return this.displayNameEl.isDirty();
+    }
+
+    isNameInputDirty(): boolean {
+        return this.nameEl.isDirty();
+    }
+
     private lock(): void {
         this.loadSpinner.show();
         this.notifyNameCheckIsOn();

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -1368,13 +1368,7 @@ export class ContentWizardPanel
                 return;
             }
 
-            this.setUpdatedContent(updatedContent);
-
-            this.fetchPersistedContent().then((content) => {
-                this.setPersistedItem(content.clone());
-                this.updateEditPermissionsButtonIcon(content);
-                this.setAllowedActionsBasedOnPermissions();
-            });
+            this.handlePersistedContentUpdate(updatedContent);
         };
 
         const sortedHandler = (data: ContentSummaryAndCompareStatus[]) => {
@@ -2627,8 +2621,13 @@ export class ContentWizardPanel
     private updateWizardHeader(content: Content) {
         this.updateThumbnailWithContent(content);
 
-        this.getWizardHeader().setDisplayName(content.getDisplayName());
-        this.getWizardHeader().setName(content.getName().toString());
+        if (!this.getWizardHeader().isDisplayNameInputDirty()) {
+            this.getWizardHeader().setDisplayName(content.getDisplayName());
+        }
+
+        if (!this.getWizardHeader().isNameInputDirty()) {
+            this.getWizardHeader().setName(content.getName().toString());
+        }
 
         // case when content was moved
         this.getWizardHeader()


### PR DESCRIPTION
-Most of the BaseInputType.ts inheritors use context object and read config out of it; moved context and readConfig() to their common parent
-Updated BaseInputTypeManagingAdd inheritors to use newly added function in their parent - handleValueChanged - to correctly set custom validation errors that supposed to be set and displayed only once when rendering or updating content