### PR TITLE
OptionSet wizard - Save button gets enabled after updating permission…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
@@ -152,6 +152,14 @@ export class ContentWizardHeader
         super.toggleNameInput(enable);
     }
 
+    isDisplayNameInputDirty(): boolean {
+        return this.displayNameEl.isDirty();
+    }
+
+    isNameInputDirty(): boolean {
+        return this.nameEl.isDirty();
+    }
+
     private lock(): void {
         this.loadSpinner.show();
         this.notifyNameCheckIsOn();

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -2281,10 +2281,6 @@ export class ContentWizardPanel
         return this.getPersistedItem().getDisplayName() !== this.getWizardHeader().getDisplayName();
     }
 
-    private isNameUpdated(): boolean {
-        return this.getPersistedItem().getName().getValue() !== this.getWizardHeader().getName();
-    }
-
     hasUnsavedChanges(): boolean {
         if (!this.isRendered()) {
             return false;

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -1368,13 +1368,7 @@ export class ContentWizardPanel
                 return;
             }
 
-            this.setUpdatedContent(updatedContent);
-
-            this.fetchPersistedContent().then((content) => {
-                this.setPersistedItem(content.clone());
-                this.updateEditPermissionsButtonIcon(content);
-                this.setAllowedActionsBasedOnPermissions();
-            });
+            this.handlePersistedContentUpdate(updatedContent);
         };
 
         const sortedHandler = (data: ContentSummaryAndCompareStatus[]) => {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -2622,11 +2622,14 @@ export class ContentWizardPanel
         this.scheduleWizardStepForm.update(content, unchangedOnly);
     }
 
-    private updateWizardHeader(content: Content, unchangedOnly: boolean = true) {
+    private updateWizardHeader(content: Content) {
         this.updateThumbnailWithContent(content);
 
-        if (!unchangedOnly) {
+        if (!this.getWizardHeader().isDisplayNameInputDirty()) {
             this.getWizardHeader().setDisplayName(content.getDisplayName());
+        }
+
+        if (!this.getWizardHeader().isNameInputDirty()) {
             this.getWizardHeader().setName(content.getName().toString());
         }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -2281,6 +2281,10 @@ export class ContentWizardPanel
         return this.getPersistedItem().getDisplayName() !== this.getWizardHeader().getDisplayName();
     }
 
+    private isNameUpdated(): boolean {
+        return this.getPersistedItem().getName().getValue() !== this.getWizardHeader().getName();
+    }
+
     hasUnsavedChanges(): boolean {
         if (!this.isRendered()) {
             return false;
@@ -2618,11 +2622,13 @@ export class ContentWizardPanel
         this.scheduleWizardStepForm.update(content, unchangedOnly);
     }
 
-    private updateWizardHeader(content: Content) {
+    private updateWizardHeader(content: Content, unchangedOnly: boolean = true) {
         this.updateThumbnailWithContent(content);
 
-        this.getWizardHeader().setDisplayName(content.getDisplayName());
-        this.getWizardHeader().setName(content.getName().toString());
+        if (!unchangedOnly) {
+            this.getWizardHeader().setDisplayName(content.getDisplayName());
+            this.getWizardHeader().setName(content.getName().toString());
+        }
 
         // case when content was moved
         this.getWizardHeader()


### PR DESCRIPTION
…s #4915

-issue was that permissions update handler was not enriching persisted item data with empty properties that are set during forms layout; Thus comparing viewed and persisted data was saying that those unequal; Fixed by using update handler that will put fresh content data (received after permissions updated) through wizard forms and enrich it with missing empty props that makes viewed and persisted data equal