### PR TITLE
A new content item is incorrectly placed in the tree structure #4992

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -634,7 +634,7 @@ export class ContentTreeGrid
                         return false;
                     });
 
-                    if (insertPosition > -1) {
+                    if (insertPosition > -1 && insertPosition <= parentNode.getChildren().length) {
                         this.insertDataToParentNode(item, parentNode, insertPosition);
                     }
                 });


### PR DESCRIPTION
-Inserting newly created item only when it's preceding sibling are loaded