### PR TITLE
ui-tests issue#5027

### DIFF
--- a/testing/specs/page-editor/generate.name.for.fragments.spec.js
+++ b/testing/specs/page-editor/generate.name.for.fragments.spec.js
@@ -176,6 +176,35 @@ describe('Generate name for fragments specification', function () {
             assert.equal(number, 3, "Three fragments should be in Live Edit");
         });
 
+    //Verifies : Workflow state is incorrect after pressing Mark as Ready #4964
+    it(`GIVEN an image has been inserted in new text-component WHEN 'Mark as ready' button has been pressed THEN Ready for publishing state should be displayed in the wizard`,
+        async () => {
+            let contentWizard = new ContentWizard();
+            let textComponentCke = new TextComponentCke();
+            let pageComponentView = new PageComponentView();
+            let insertImageDialog = new InsertImageDialog();
+            //1. Open existing site:
+            await studioUtils.selectContentAndOpenWizard(SITE.displayName);
+            await contentWizard.clickOnShowComponentViewToggler();
+            //2. Insert new text-component
+            await pageComponentView.openMenu("main");
+            await pageComponentView.selectMenuItemAndCloseDialog(["Insert", "Text"]);
+            await textComponentCke.switchToLiveEditFrame();
+            //3. Open 'Insert Image' dialog and insert an image in htmlArea:
+            await textComponentCke.clickOnInsertImageButton();
+            await insertImageDialog.filterAndSelectImage(TEST_IMAGE_NAME);
+            await insertImageDialog.clickOnInsertButton();
+            //4. Click on Mark as ready button and save all:
+            await contentWizard.clickOnMarkAsReadyButton();
+            await contentWizard.waitForNotificationMessage();
+            //5. Verify the workflow state:
+            let state = await contentWizard.getToolbarWorkflowState();
+            assert.equal(state, appConst.WORKFLOW_STATE.READY_FOR_PUBLISHING, "Ready for publishing state should be in the wizard ");
+            //6. Verify that Save button is disabled:
+            await contentWizard.waitForSaveButtonDisabled();
+        });
+
+
     beforeEach(() => studioUtils.navigateToContentStudioApp());
     afterEach(() => studioUtils.doCloseAllWindowTabsAndSwitchToHome());
     before(async () => {

--- a/testing/specs/page-editor/text.component.image.caption.spec.js
+++ b/testing/specs/page-editor/text.component.image.caption.spec.js
@@ -60,6 +60,27 @@ describe("text.component.image.caption.spec: Inserts a text component with an im
             await liveFormPanel.waitForCaptionDisplayed(CAPTION);
         });
 
+    //Verifies: Browser hangs after a page with an open modal dialogs is refreshed #5003
+    //          Insert Image dialog - upload button is not displayed in the dialog #5002
+    it(`GIVEN text component is inserted WHEN insert image dialog has been opened THEN Upload button should be present in the modal dialog`,
+        async () => {
+            let pageComponentView = new PageComponentView();
+            let contentWizard = new ContentWizard();
+            let textComponent = new TextComponentCke();
+            let insertImageDialog = new InsertImageDialog();
+            //1. Open existing site:
+            await studioUtils.selectContentAndOpenWizard(SITE.displayName);
+            await contentWizard.clickOnShowComponentViewToggler();
+            //2. Insert new text component:
+            await pageComponentView.openMenu("main");
+            await pageComponentView.selectMenuItemAndCloseDialog(["Insert", "Text"]);
+            await contentWizard.switchToLiveEditFrame();
+            //3. Open Insert Image modal dialog:
+            await textComponent.clickOnInsertImageButton();
+            //4. Verify that 'Upload' button is present in the dialog:
+            await insertImageDialog.waitForUploadButtonDisplayed();
+        });
+
     beforeEach(() => studioUtils.navigateToContentStudioApp());
     afterEach(() => studioUtils.doCloseAllWindowTabsAndSwitchToHome());
     before(async () => {


### PR DESCRIPTION
Tests to verify issues :
https://github.com/enonic/app-contentstudio/issues/5003 Browser hangs after refresing a page with opend Insert Image, Inseret Link,

https://github.com/enonic/app-contentstudio/issues/5002 Insert Image dialog - upload button is not displayed in the dialog

Workflow state is incorrect after pressing Mark as Ready https://github.com/enonic/app-contentstudio/issues/4964