### PR TITLE
Correctly display "move" in the Version History widget #4916

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/ContentVersion.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentVersion.ts
@@ -4,6 +4,7 @@ import {Cloneable} from '@enonic/lib-admin-ui/Cloneable';
 import {Workflow} from './content/Workflow';
 import {WorkflowState} from './content/WorkflowState';
 import {ChildOrder} from './resource/order/ChildOrder';
+import {AccessControlList} from './access/AccessControlList';
 
 export class ContentVersion
     implements Cloneable {
@@ -30,6 +31,8 @@ export class ContentVersion
 
     private readonly workflowInfo: Workflow;
 
+    private readonly permissions: AccessControlList;
+
     constructor(builder: ContentVersionBuilder) {
         this.modifier = builder.modifier;
         this.displayName = builder.displayName;
@@ -42,6 +45,7 @@ export class ContentVersion
         this.workspaces = builder.workspaces || [];
         this.publishInfo = builder.publishInfo;
         this.workflowInfo = builder.workflowInfo;
+        this.permissions = builder.permissions;
 
         if (this.publishInfo && this.publishInfo.getPublishedFrom()) {
             if (ContentVersion.equalDates(this.publishInfo.getPublishedFrom(), this.publishInfo.getTimestamp(), 500)) {
@@ -146,6 +150,10 @@ export class ContentVersion
         return this.workflowInfo && this.workflowInfo.getState() === WorkflowState.READY;
     }
 
+    getPermissions(): AccessControlList {
+        return this.permissions;
+    }
+
     newBuilder(): ContentVersionBuilder {
         return new ContentVersionBuilder(this);
     }
@@ -178,6 +186,8 @@ export class ContentVersionBuilder {
 
     workflowInfo: Workflow;
 
+    permissions: AccessControlList;
+
     constructor(source?: ContentVersion) {
         if (source) {
             this.modifier = source.getModifier();
@@ -191,6 +201,7 @@ export class ContentVersionBuilder {
             this.workspaces = source.getWorkspaces().slice();
             this.publishInfo = source.getPublishInfo();
             this.workflowInfo = source.getWorkflowInfo();
+            this.permissions = source.getPermissions();
         }
     }
 
@@ -206,6 +217,7 @@ export class ContentVersionBuilder {
         this.workspaces = workspaces || [];
         this.publishInfo = ContentVersionPublishInfo.fromJson(contentVersionJson.publishInfo);
         this.workflowInfo = Workflow.fromJson(contentVersionJson.workflow);
+        this.permissions = !!contentVersionJson.permissions ? AccessControlList.fromJson(contentVersionJson.permissions) : null;
 
         return this;
     }

--- a/modules/lib/src/main/resources/assets/js/app/ContentVersions.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentVersions.ts
@@ -21,6 +21,10 @@ export class ContentVersions {
         return this.activeVersionId;
     }
 
+    getVersionById(value: string): ContentVersion {
+        return this.contentVersions.find((version: ContentVersion) => version.getId() === value);
+    }
+
     static fromJson(contentVersionForViewJson: GetContentVersionsForViewResultsJson): ContentVersions {
         const contentVersions: ContentVersion[] = contentVersionForViewJson.contentVersions.map(
             (contentVersionViewJson: ContentVersionViewJson) => {

--- a/modules/lib/src/main/resources/assets/js/app/resource/json/ContentVersionJson.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/json/ContentVersionJson.ts
@@ -1,6 +1,7 @@
 import {ContentVersionPublishInfoJson} from './ContentVersionPublishInfoJson';
 import {WorkflowJson} from '@enonic/lib-admin-ui/content/json/WorkflowJson';
 import {ChildOrderJson} from './ChildOrderJson';
+import {PermissionsJson} from '../../access/PermissionsJson';
 
 export interface ContentVersionJson {
 
@@ -23,4 +24,6 @@ export interface ContentVersionJson {
     publishInfo: ContentVersionPublishInfoJson;
 
     workflow: WorkflowJson;
+
+    permissions: PermissionsJson;
 }

--- a/modules/lib/src/main/resources/assets/js/app/view/context/widget/version/VersionHistoryHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/widget/version/VersionHistoryHelper.ts
@@ -3,8 +3,13 @@ import {VersionHistoryItem} from './VersionHistoryItem';
 export class VersionHistoryHelper {
 
     static isInteractableItem(version: VersionHistoryItem): boolean {
+        return VersionHistoryHelper.isRevertableItem(version) &&
+               !version.isMoved() &&
+               !version.isPermissions();
+    }
+
+    static isRevertableItem(version: VersionHistoryItem): boolean {
         return !version.isPublishAction() &&
-               !version.isChanged() &&
                !version.isRestored() &&
                !version.isArchived();
     }

--- a/modules/lib/src/main/resources/assets/js/app/view/context/widget/version/VersionHistoryItem.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/widget/version/VersionHistoryItem.ts
@@ -15,13 +15,15 @@ export enum VersionItemStatus {
     MARKED_AS_READY = 'markedAsReady',
     EDITED = 'edited',
     SORTED = 'sorted',
-    CHANGED = 'changed'
+    PERMISSIONS = 'permissions',
+    MOVED = 'moved'
 }
 
 export interface CreateParams {
     createdDate?: Date;
     isSort?: boolean;
-    isNonTrackableChange?: boolean;
+    isPermissionsChange?: boolean;
+    isMove?: boolean;
 }
 
 export class VersionHistoryItem implements Cloneable {
@@ -108,8 +110,10 @@ export class VersionHistoryItem implements Cloneable {
             builder.setIconCls('icon-wand').setStatus(VersionItemStatus.CREATED);
         } else if (createParams.isSort) {
             builder.setIconCls('icon-sort-amount-asc').setStatus(VersionItemStatus.SORTED);
-        } else if (createParams.isNonTrackableChange) {
-            builder.setIconCls('icon-checkmark').setStatus(VersionItemStatus.CHANGED);
+        } else if (createParams.isPermissionsChange) {
+            builder.setIconCls('icon-masks').setStatus(VersionItemStatus.PERMISSIONS);
+        } else if (createParams.isMove) {
+            builder.setIconCls('icon-fragment').setStatus(VersionItemStatus.MOVED);
         } else if (contentVersion.isInReadyState()) {
             builder.setIconCls('icon-state-ready').setStatus(VersionItemStatus.MARKED_AS_READY);
         } else {
@@ -196,8 +200,12 @@ export class VersionHistoryItem implements Cloneable {
         return this.status === VersionItemStatus.SORTED;
     }
 
-    isChanged(): boolean {
-        return this.status === VersionItemStatus.CHANGED;
+    isMoved(): boolean {
+        return this.status === VersionItemStatus.MOVED;
+    }
+
+    isPermissions(): boolean {
+        return this.status === VersionItemStatus.PERMISSIONS;
     }
 
     getContentVersion(): ContentVersion {

--- a/modules/lib/src/main/resources/assets/js/app/view/context/widget/version/VersionHistoryListItem.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/widget/version/VersionHistoryListItem.ts
@@ -35,7 +35,7 @@ export class VersionHistoryListItem
     private createVersionViewer(): VersionHistoryItemViewer {
         const versionViewer: VersionHistoryItemViewer = new VersionHistoryItemViewer();
 
-        if (this.isInteractableItem() || this.isActiveChangedVersion()) {
+        if (this.isInteractableItem()) {
             this.addOnClickHandler(versionViewer);
         }
 
@@ -52,22 +52,22 @@ export class VersionHistoryListItem
             versionViewer.appendChild(messageBlock);
         }
 
-        versionViewer.toggleClass('interactable', this.isInteractableItem() || this.isActiveChangedVersion());
+        versionViewer.toggleClass('interactable', this.isInteractableItem());
         versionViewer.toggleClass('active', this.isActive());
 
         return versionViewer;
     }
 
     private isCompareButtonRequired(): boolean {
-        return !this.isActive() && this.isInteractableItem();
+        return !this.isActive() && this.isRevertableItem();
     }
 
     private isInteractableItem(): boolean {
         return VersionHistoryHelper.isInteractableItem(this.version);
     }
 
-    private isActiveChangedVersion(): boolean {
-        return this.isActive() && this.version.isChanged();
+    private isRevertableItem(): boolean {
+        return VersionHistoryHelper.isRevertableItem(this.version);
     }
 
     private createTooltip() {

--- a/modules/lib/src/main/resources/i18n/phrases.properties
+++ b/modules/lib/src/main/resources/i18n/phrases.properties
@@ -287,6 +287,7 @@ status.workflow.in_progress=Work in progress
 status.workflow.ready=Ready for publishing
 status.sorted=Sorted
 status.changed=Changed
+status.permissions=Permissions
 
 #
 # Texts

--- a/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/json/content/ContentVersionJson.java
+++ b/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/json/content/ContentVersionJson.java
@@ -6,6 +6,7 @@ import com.enonic.xp.app.contentstudio.rest.resource.content.ContentPrincipalsRe
 import com.enonic.xp.app.contentstudio.rest.resource.content.json.ChildOrderJson;
 import com.enonic.xp.content.ContentVersion;
 import com.enonic.xp.security.Principal;
+import com.enonic.xp.security.acl.AccessControlList;
 
 public class ContentVersionJson
 {
@@ -28,6 +29,7 @@ public class ContentVersionJson
     private final ContentVersionPublishInfoJson publishInfo;
 
     private final ContentWorkflowInfoJson workflow;
+    private final RootPermissionsJson permissions;
 
     public ContentVersionJson( final ContentVersion contentVersion, final ContentPrincipalsResolver principalsResolver )
     {
@@ -41,12 +43,13 @@ public class ContentVersionJson
         this.modifierDisplayName = modifier != null ? modifier.getDisplayName() : "";
         this.modifier = contentVersion.getModifier().toString();
         this.id = contentVersion.getId().toString();
-        this.childOrder = contentVersion.getChildOrder() != null ? new ChildOrderJson(contentVersion.getChildOrder()) : null;
+        this.childOrder = contentVersion.getChildOrder() != null ? new ChildOrderJson( contentVersion.getChildOrder() ) : null;
         this.publishInfo = contentVersion.getPublishInfo() != null ? new ContentVersionPublishInfoJson( contentVersion.getPublishInfo(),
                                                                                                         principalsResolver ) : null;
 
         this.workflow = contentVersion.getWorkflowInfo() != null ? new ContentWorkflowInfoJson( contentVersion.getWorkflowInfo() ) : null;
-
+        this.permissions =
+            contentVersion.getPermissions() != null ? new RootPermissionsJson( contentVersion.getPermissions(), principalsResolver ) : null;
     }
 
     @SuppressWarnings("UnusedDeclaration")
@@ -107,4 +110,11 @@ public class ContentVersionJson
     {
         return workflow;
     }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public RootPermissionsJson getPermissions()
+    {
+        return permissions;
+    }
+
 }


### PR DESCRIPTION
-Fetching newly added content version's field 'permissions' -Adding 'Permissions' entry to the version history -Considering all non-data changes that are not sort or permissions changes as a content move