### PR TITLE
Dropdown selector is not reset after Move operation

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/move/ContentMoveComboBox.ts
+++ b/modules/lib/src/main/resources/assets/js/app/move/ContentMoveComboBox.ts
@@ -4,7 +4,7 @@ import {ContentTreeSelectorItem} from '../item/ContentTreeSelectorItem';
 import {ContentAndStatusTreeSelectorItem} from '../item/ContentAndStatusTreeSelectorItem';
 import {SelectedOptionsView} from '@enonic/lib-admin-ui/ui/selector/combobox/SelectedOptionsView';
 import {ContentTypeName} from '@enonic/lib-admin-ui/schema/content/ContentTypeName';
-import {ContentSummaryViewer} from '../content/ContentSummaryViewer';
+import {ContentTreeSelectorItemViewer} from '../item/ContentTreeSelectorItemViewer';
 import {ContentSummary} from '../content/ContentSummary';
 import {ContentPath} from '../content/ContentPath';
 
@@ -22,7 +22,7 @@ export class ContentMoveComboBox
             .setComboBoxName('contentSelector')
             .setLoader(ContentSummaryOptionDataLoader.create().setSmartTreeMode(false).build())
             .setSelectedOptionsView(<SelectedOptionsView<ContentTreeSelectorItem>>new ContentSelectedOptionsView())
-            .setOptionDisplayValueViewer(new ContentSummaryViewer())
+            .setOptionDisplayValueViewer(new ContentTreeSelectorItemViewer())
             .setDelayedInputValueChangedHandling(500)
             .setSkipAutoDropShowOnValueChange(true)
             .setTreegridDropdownEnabled(true)

--- a/modules/lib/src/main/resources/assets/js/app/move/MoveContentDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/move/MoveContentDialog.ts
@@ -244,6 +244,7 @@ export class MoveContentDialog
     open(reset: boolean = true) {
         if (reset && !this.progressManager.isEnabled()) {
             this.destinationSearchInput.clearCombobox();
+            this.destinationSearchInput.getLoader().resetParams();
         }
         super.open();
     }

--- a/modules/lib/src/main/resources/assets/js/app/resource/ListByIdSelectorRequest.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/ListByIdSelectorRequest.ts
@@ -59,4 +59,10 @@ export class ListByIdSelectorRequest<DATA extends ContentTreeSelectorItem>
         this.metadata = new ResultMetadata(0, 0);
         return [];
     }
+
+    resetParams() {
+        super.resetParams();
+        this.content = null;
+        this.childOrder = null;
+    }
 }


### PR DESCRIPTION
* Switched ContentMoveCombobox to a different viewer to avoid showing display of workflow icons
* Added full reset of request params when Content Move dialog opens
