### PR TITLE
Version History: certain operations not shown after publishing #5244

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/dialog/CompareContentVersionsDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/CompareContentVersionsDialog.ts
@@ -280,8 +280,8 @@ export class CompareContentVersionsDialog
         return this;
     }
 
-    setLeftVersion(versionId: string): CompareContentVersionsDialog {
-        this.leftVersionId = versionId;
+    setLeftVersion(version: VersionHistoryItem): CompareContentVersionsDialog {
+        this.leftVersionId = `${version.getId()}:${version.getStatus()}`;
         return this;
     }
 
@@ -342,10 +342,10 @@ export class CompareContentVersionsDialog
                 // init latest versions by default if nothing is set
                 const newestVersionOption: Option<VersionHistoryItem> = this.getNewestVersionOption(options);
                 if (!this.leftVersionId) {
-                    this.leftVersionId = newestVersionOption.getDisplayValue().getId();
+                    this.leftVersionId = newestVersionOption.getValue();
                 }
                 if (!this.rightVersionId) {
-                    this.rightVersionId = newestVersionOption.getDisplayValue().getId();
+                    this.rightVersionId = newestVersionOption.getValue();
                 }
 
                 const leftAliases: Option<VersionHistoryItem>[] =
@@ -406,9 +406,9 @@ export class CompareContentVersionsDialog
                 dropdown.selectOption(alias, true);
                 // update version with new alias id
                 if (isLeft) {
-                    this.leftVersionId = alias.getDisplayValue().getId();
+                    this.leftVersionId = alias.getValue();
                 } else {
-                    this.rightVersionId = alias.getDisplayValue().getId();
+                    this.rightVersionId = alias.getValue();
                 }
             }
         });
@@ -515,7 +515,7 @@ export class CompareContentVersionsDialog
     private createAliasOption(version: VersionHistoryItem, alias: string, type: AliasType): Option<VersionHistoryItem> {
         const versionId: string = version.getId();
         let counter: number = this.versionIdCounters[versionId] || 0;
-        const aliasId: string = `alias|${versionId}|${++counter}`;
+        const aliasId: string = `${versionId}:alias|${++counter}`;
         this.versionIdCounters[versionId] = counter;
 
         const aliasVersionItem: VersionHistoryItem = version.createAlias(alias, type);
@@ -524,7 +524,7 @@ export class CompareContentVersionsDialog
     }
 
     private createOption(version: VersionHistoryItem): Option<VersionHistoryItem> {
-        return this.doCreateOption(version.getId(), version);
+        return this.doCreateOption(`${version.getId()}:${version.getStatus()}`, version);
     }
 
     private doCreateOption(value: string, version: VersionHistoryItem): Option<VersionHistoryItem> {
@@ -569,15 +569,16 @@ export class CompareContentVersionsDialog
     }
 
     private leftVersionRequiresForcedSelection() {
-        const leftTime = this.leftDropdown.getSelectedOption().getDisplayValue().getContentVersion().getTimestamp();
-        const rightTime = this.rightDropdown.getSelectedOption().getDisplayValue().getContentVersion().getTimestamp();
+        const leftTime: Date = this.leftDropdown.getSelectedOption().getDisplayValue().getContentVersion().getTimestamp();
+        const rightTime: Date = this.rightDropdown.getSelectedOption().getDisplayValue().getContentVersion().getTimestamp();
 
         return leftTime.getTime() > rightTime.getTime();
     }
 
     private forceSelectVersion(dropdown: Dropdown<VersionHistoryItem>, versionId: string, silent?: boolean) {
-        const newOption = dropdown.getOptionByValue(versionId);
-        const selectedValue = dropdown.getValue();
+        const newOption: Option<VersionHistoryItem> = dropdown.getOptionByValue(versionId);
+        const selectedValue: string = dropdown.getValue();
+
         if (!!newOption && versionId !== selectedValue) {
             dropdown.selectOption(newOption, silent);
         }
@@ -665,8 +666,8 @@ export class CompareContentVersionsDialog
     }
 
     private displayDiff(): Q.Promise<void> {
-        const leftVersionId = this.leftVersionId;
-        const rightVersionId = this.rightVersionId;
+        const leftVersionId: string = this.leftVersionId.split(':')[0];
+        const rightVersionId: string = this.rightVersionId.split(':')[0];
 
         const promises = [
             this.fetchVersionPromise(leftVersionId)

--- a/modules/lib/src/main/resources/assets/js/app/view/context/widget/version/VersionHistoryListItem.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/widget/version/VersionHistoryListItem.ts
@@ -138,7 +138,7 @@ export class VersionHistoryListItem
         CompareContentVersionsDialog.get()
             .setContent(this.content)
             .setReadOnly(this.content.isReadOnly())
-            .setLeftVersion(this.version.getId())
+            .setLeftVersion(this.version)
             .resetRightVersion()
             .setRevertVersionCallback(this.revert.bind(this))
             .open();

--- a/testing/page_objects/details_panel/base.versions.widget.js
+++ b/testing/page_objects/details_panel/base.versions.widget.js
@@ -30,10 +30,26 @@ class BaseVersionsWidget extends Page {
         return items.length;
     }
 
+    async waitForPermissionsUpdatedItemDisplayed() {
+        try {
+            await this.waitForElementDisplayed(this.permissionsUpdatedItems, appConst.mediumTimeout);
+        } catch (err) {
+            let screenshot = appConst.generateRandomName("err_perm_updated");
+            await this.saveScreenshot(screenshot);
+            throw new Error("'Permissions updated' items are not displayed in the widget, screenshot: " + screenshot + " " + err);
+        }
+    }
+
     async countPermissionsUpdatedItems() {
-        await this.waitForElementDisplayed(this.permissionsUpdatedItems, appConst.mediumTimeout)
-        let items = await this.findElements(this.permissionsUpdatedItems);
-        return items.length;
+        try {
+            await this.waitForPermissionsUpdatedItemDisplayed();
+            let items = await this.findElements(this.permissionsUpdatedItems);
+            return items.length;
+        } catch (err) {
+            let screenshot = appConst.generateRandomName("err_perm_updated");
+            await this.saveScreenshot(screenshot);
+            throw new Error("Error when counting 'Permissions updated' items, screenshot: " + screenshot + " " + err);
+        }
     }
 
     async countSortedItems() {
@@ -45,6 +61,12 @@ class BaseVersionsWidget extends Page {
     async countPublishedItems() {
         await this.waitForElementDisplayed(this.publishedItems, appConst.mediumTimeout)
         let items = await this.findElements(this.publishedItems);
+        return items.length;
+    }
+
+    async countMarkedAsReadyItems() {
+        await this.waitForElementDisplayed(this.markedAsReadyItems, appConst.mediumTimeout)
+        let items = await this.findElements(this.markedAsReadyItems);
         return items.length;
     }
 
@@ -154,7 +176,8 @@ class BaseVersionsWidget extends Page {
             await this.clickOnElement(this.revertButton);
             return await this.pause(2000);
         } catch (err) {
-            throw new Error("Version Widget - error when clicking on 'Revert' button " + err);
+            let screenshot = appConst.generateRandomName("err_revert_btn");
+            throw new Error("Version Widget - error when clicking on 'Revert' button, screenshot: " + screenshot + " " + err);
         }
     }
 

--- a/testing/specs/content-types/occurrences.textline.spec.js
+++ b/testing/specs/content-types/occurrences.textline.spec.js
@@ -74,7 +74,7 @@ describe('occurrences.textline.spec: tests for textline(0-1,1-0, 1-1)', function
             let textLine = new TextLine();
             let wizardVersionsWidget = new WizardVersionsWidget();
             let wizardDetailsPanel = new WizardDetailsPanel();
-            //1. Open existing textline:
+            //1. Open existing text-line content:
             await studioUtils.selectAndOpenContentInWizard(TEXTLINE_0_1);
             //2. Verify the text in the input:
             let result1 = await textLine.getTexLineValues();

--- a/testing/specs/publish/version.items.after.publishing.spec.js
+++ b/testing/specs/publish/version.items.after.publishing.spec.js
@@ -1,0 +1,109 @@
+/**
+ * Created on 11.10.2022
+ */
+const chai = require('chai');
+const assert = chai.assert;
+const webDriverHelper = require('../../libs/WebDriverHelper');
+const studioUtils = require('../../libs/studio.utils.js');
+const appConst = require('../../libs/app_const');
+const ContentWizard = require('../../page_objects/wizardpanel/content.wizard.panel');
+const EditPermissionsDialog = require('../../page_objects/edit.permissions.dialog');
+const WizardDetailsPanel = require('../../page_objects/wizardpanel/details/wizard.details.panel');
+const WizardVersionsWidget = require('../../page_objects/wizardpanel/details/wizard.versions.widget');
+const PublishContentDialog = require('../../page_objects/content.publish.dialog');
+
+describe('version.items.after.publishing.spec tests for version items', function () {
+    this.timeout(appConst.SUITE_TIMEOUT);
+    if (typeof browser === "undefined") {
+        webDriverHelper.setupBrowser();
+    }
+
+    let FOLDER_NAME= appConst.generateRandomName("folder");
+
+    it("Preconditions- published folder should be added",
+        async () => {
+            let contentWizard = new ContentWizard();
+            let publishContentDialog = new PublishContentDialog();
+            //1. Open new wizard for folder
+            await studioUtils.openContentWizard(appConst.contentTypes.FOLDER);
+            //2. Fill in the name input
+            await contentWizard.typeDisplayName(FOLDER_NAME);
+            //3. Publish this folder:
+            await contentWizard.clickOnMarkAsReadyButton();
+            await contentWizard.clickOnPublishButton();
+            await publishContentDialog.waitForDialogOpened();
+            await publishContentDialog.clickOnPublishNowButton();
+            await publishContentDialog.waitForDialogClosed();
+        });
+
+    it(`GIVEN existing published folder is opened WHEN permissions have been updated THEN 'Permissions updated' item should appear in Versions Widget`,
+        async () => {
+            let contentWizard = new ContentWizard();
+            let wizardDetailsPanel = new WizardDetailsPanel();
+            let wizardVersionsWidget = new WizardVersionsWidget();
+            let editPermissionsDialog = new EditPermissionsDialog();
+            //1. Select the folder:
+            await studioUtils.selectAndOpenContentInWizard(FOLDER_NAME);
+            await wizardDetailsPanel.openVersionHistory();
+            let allVersions = await wizardVersionsWidget.countVersionItems();
+            //2. Update permissions:
+            await contentWizard.clickOnEditPermissionsButton();
+            await editPermissionsDialog.waitForDialogLoaded();
+            await editPermissionsDialog.clickOnInheritPermissionsCheckBox();
+            await editPermissionsDialog.clickOnApplyButton();
+            //3. Verify that 'Permissions updated' item appears in the widget
+            await wizardVersionsWidget.waitForPermissionsUpdatedItemDisplayed();
+            //4. Verify that the total number of items is 4
+            allVersions = await wizardVersionsWidget.countVersionItems();
+            assert.equal(allVersions,4,"4 version items should be present in the widget");
+            //5. Verify that one 'Published' item is present in the widget
+            let publishedItems = await wizardVersionsWidget.countPublishedItems();
+            assert.equal(publishedItems,1,"One 'Published' item should be present in the widget");
+            //6. Verify that one 'Marked as ready' item is present in the widget
+            let markedAsReadyItems = await wizardVersionsWidget.countMarkedAsReadyItems();
+            assert.equal(markedAsReadyItems,1,"One 'Marked as Ready' item should be present in the widget");
+            //7. Verify that one 'Permissions updated' item is present in the widget
+            let permissionsUpdatedItems = await wizardVersionsWidget.countPermissionsUpdatedItems();
+            assert.equal(permissionsUpdatedItems,1,"One 'Permissions updated' item should be present in the widget");
+        });
+
+    it(`GIVEN existing folder with 'Permissions updated' is opened WHEN the folder has been published THEN 'Permissions updated' item should be present in Versions Widget`,
+        async () => {
+            let contentWizard = new ContentWizard();
+            let wizardDetailsPanel = new WizardDetailsPanel();
+            let wizardVersionsWidget = new WizardVersionsWidget();
+            let publishContentDialog = new PublishContentDialog();
+            //1. Select the folder:
+            await studioUtils.selectAndOpenContentInWizard(FOLDER_NAME);
+            await wizardDetailsPanel.openVersionHistory();
+            //2. Publish the folder:
+            let allVersions = await wizardVersionsWidget.countVersionItems();
+            await contentWizard.clickOnPublishButton();
+            await publishContentDialog.waitForDialogOpened();
+            await publishContentDialog.clickOnPublishNowButton();
+            await publishContentDialog.waitForDialogClosed();
+            //3. Verify that 'Permissions updated' item remains visible after the publishing
+            await wizardVersionsWidget.waitForPermissionsUpdatedItemDisplayed();
+            //4. Verify that the total number of version items is 5 now
+            allVersions = await wizardVersionsWidget.countVersionItems();
+            assert.equal(allVersions,5,"Total number of versions should be increased by 1");
+            //5. Verify that two 'Published' item is present in the widget
+            let publishedItems = await wizardVersionsWidget.countPublishedItems();
+            assert.equal(publishedItems,2,"Two Published items should be displayed");
+            //6. Verify that one 'Marked as ready' item is present in the widget
+            let markedAsReadyItems = await wizardVersionsWidget.countMarkedAsReadyItems();
+            assert.equal(markedAsReadyItems,1,"One 'Marked as Ready' item should be present in the widget");
+            //7. Verify that one 'Permissions updated' item is present in the widget
+            let permissionsUpdatedItems = await wizardVersionsWidget.countPermissionsUpdatedItems();
+            assert.equal(permissionsUpdatedItems,1,"One 'Permissions updated' item should be present in the widget");
+
+        });
+    beforeEach(() => studioUtils.navigateToContentStudioApp());
+    afterEach(() => studioUtils.doCloseAllWindowTabsAndSwitchToHome());
+    before(async () => {
+        if (typeof browser !== "undefined") {
+            await studioUtils.getBrowser().setWindowSize(appConst.BROWSER_WIDTH, appConst.BROWSER_HEIGHT);
+        }
+        return console.log('specification starting: ' + this.title);
+    });
+});


### PR DESCRIPTION
-When publishing item second or more times then backend doesn't create a new version for publish, just uses existing one and adds publishInfo for it. So we need to create virtual extra version so it is to be displayed in a version history and make CompareContentVersionsDialog.ts to correctly display it