### PR TITLE
Preselection of options inside option-set doesn't work in site.xml #4629

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -101,7 +101,7 @@ export class SiteConfigurator
                 <SiteConfiguratorSelectedOptionView>this.selectOptionFromProperty(property)?.getOptionView());
 
             const updatePromises = selectedOptionViews.filter(view => !!view).map((view, index) => {
-                const configSet = propertyArray.get(index).getPropertySet().getProperty('config').getPropertySet();
+                const configSet = propertyArray.get(index).getPropertySet().getProperty(ApplicationConfig.PROPERTY_CONFIG).getPropertySet();
                 return view.getFormView().update(configSet, unchangedOnly);
             });
 
@@ -128,9 +128,8 @@ export class SiteConfigurator
 
         this.comboBox.getSelectedOptionViews().forEach(oldView => {
             const haveToDeselect = !newPropertyArray.some(property => {
-                const key = property.getPropertySet().getProperty('applicationKey').getValue().getString();
+                const key = property.getPropertySet().getProperty(ApplicationConfig.PROPERTY_KEY).getValue().getString();
                 return SiteConfigurator.optionViewToKey(oldView) === key;
-
             });
 
             if (haveToDeselect) {
@@ -140,7 +139,7 @@ export class SiteConfigurator
     }
 
     private selectOptionFromProperty(property: Property): SelectedOption<Application> {
-        const key = property.getPropertySet().getProperty('applicationKey').getValue().getString();
+        const key = property.getPropertySet().getProperty(ApplicationConfig.PROPERTY_KEY).getValue().getString();
         const selectedOptions: SiteConfiguratorSelectedOptionView[] = this.comboBox.getSelectedOptionViews();
         const alreadySelected = selectedOptions.some(option => SiteConfigurator.optionViewToKey(option) === key);
         if (!alreadySelected) {
@@ -159,8 +158,8 @@ export class SiteConfigurator
         let config = siteConfig.getConfig();
         let appKey = siteConfig.getApplicationKey();
 
-        propertySet.setStringByPath('applicationKey', appKey.toString());
-        propertySet.setPropertySetByPath('config', config);
+        propertySet.setStringByPath(ApplicationConfig.PROPERTY_KEY, appKey.toString());
+        propertySet.setPropertySetByPath(ApplicationConfig.PROPERTY_CONFIG, config);
     }
 
     protected getValueFromPropertyArray(propertyArray: PropertyArray): string {
@@ -205,8 +204,8 @@ export class SiteConfigurator
             const view: SiteConfiguratorSelectedOptionView = <SiteConfiguratorSelectedOptionView>selectedOption.getOptionView();
 
             const propertyArray: PropertyArray = this.getPropertyArray();
-            const configSet: PropertySet =
-                propertyArray.get(selectedOption.getIndex()).getPropertySet().getProperty('config').getPropertySet();
+            const configSet: PropertySet = propertyArray.get(selectedOption.getIndex()).getPropertySet().getProperty(
+                ApplicationConfig.PROPERTY_CONFIG).getPropertySet();
 
             view.whenRendered(() => {
                 view.getFormView().update(configSet, false);

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionsView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionsView.ts
@@ -12,11 +12,11 @@ import {ApplicationConfig} from '@enonic/lib-admin-ui/application/ApplicationCon
 export class SiteConfiguratorSelectedOptionsView
     extends BaseSelectedOptionsView<Application> {
 
-    private siteConfigProvider: ApplicationConfigProvider;
+    private readonly siteConfigProvider: ApplicationConfigProvider;
 
     private siteConfigFormDisplayedListeners: { (applicationKey: ApplicationKey, formView: FormView): void }[] = [];
 
-    private formContext: ContentFormContext;
+    private readonly formContext: ContentFormContext;
 
     private items: SiteConfiguratorSelectedOptionView[] = [];
 
@@ -25,19 +25,20 @@ export class SiteConfiguratorSelectedOptionsView
         this.siteConfigProvider = siteConfigProvider;
         this.formContext = formContext;
 
-        this.siteConfigProvider.onPropertyChanged(() => {
+        this.initListeners();
+        this.setOccurrencesSortable(true);
+    }
 
+    protected initListeners(): void {
+        this.siteConfigProvider.onPropertyChanged(() => {
             this.items.forEach((optionView: SiteConfiguratorSelectedOptionView) => {
-                const newConfig: ApplicationConfig =
-                    this.siteConfigProvider.getConfig(optionView.getSiteConfig().getApplicationKey(), false);
+                const newConfig: ApplicationConfig = this.siteConfigProvider.getConfig(optionView.getSiteConfig().getApplicationKey());
+
                 if (newConfig) {
                     optionView.setSiteConfig(newConfig);
                 }
             });
-
         });
-
-        this.setOccurrencesSortable(true);
     }
 
     makeEmptyOption(id: string): Option<Application> {
@@ -54,8 +55,15 @@ export class SiteConfiguratorSelectedOptionsView
     }
 
     createSelectedOption(option: Option<Application>): SelectedOption<Application> {
-        const siteConfig: ApplicationConfig = this.siteConfigProvider.getConfig(option.getDisplayValue().getApplicationKey());
-        const optionView: SiteConfiguratorSelectedOptionView = new SiteConfiguratorSelectedOptionView(option, siteConfig, this.formContext);
+        const key: ApplicationKey = option.getDisplayValue().getApplicationKey();
+        const existingConfig: ApplicationConfig = this.siteConfigProvider.getConfig(key);
+        const siteConfig: ApplicationConfig = existingConfig || this.siteConfigProvider.addConfig(key);
+        const optionView: SiteConfiguratorSelectedOptionView = new SiteConfiguratorSelectedOptionView({
+            option: option,
+            siteConfig: siteConfig,
+            formContext: this.formContext,
+            isNew: !existingConfig
+        });
 
         optionView.setReadonly(this.readonly);
 

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/siteconfigurator/SiteConfiguratorDialog.ts
@@ -1,7 +1,23 @@
 import * as Q from 'q';
-import {ApplicationConfiguratorDialog} from '@enonic/lib-admin-ui/form/inputtype/appconfig/ApplicationConfiguratorDialog';
+import {
+    ApplicationConfiguratorDialog,
+    ApplicationConfiguratorDialogParams
+} from '@enonic/lib-admin-ui/form/inputtype/appconfig/ApplicationConfiguratorDialog';
+
+export interface SiteConfiguratorDialogParams extends ApplicationConfiguratorDialogParams {
+    isDirtyCallback?: () => boolean;
+}
+
 export class SiteConfiguratorDialog
     extends ApplicationConfiguratorDialog {
+
+    private readonly isDirtyCallback?: () => boolean;
+
+    constructor(params: SiteConfiguratorDialogParams) {
+        super(params);
+
+        this.isDirtyCallback = params.isDirtyCallback;
+    }
 
     close() {
         this.destroyCkeInstancesInDialog();
@@ -31,5 +47,9 @@ export class SiteConfiguratorDialog
                 }
             }
         }
+    }
+
+    isDirty(): boolean {
+        return this.isDirtyCallback ? this.isDirtyCallback() : super.isDirty();
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/site/ApplicationAddedEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/app/site/ApplicationAddedEvent.ts
@@ -1,11 +1,15 @@
 import {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
 import {ApplicationConfig} from '@enonic/lib-admin-ui/application/ApplicationConfig';
+import {Event} from '@enonic/lib-admin-ui/event/Event';
+import {ClassHelper} from '@enonic/lib-admin-ui/ClassHelper';
 
-export class ApplicationAddedEvent {
+export class ApplicationAddedEvent
+    extends Event {
 
-    private applicationConfig: ApplicationConfig;
+    private readonly applicationConfig: ApplicationConfig;
 
     constructor(applicationConfig: ApplicationConfig) {
+        super();
         this.applicationConfig = applicationConfig;
     }
 
@@ -15,5 +19,13 @@ export class ApplicationAddedEvent {
 
     getApplicationConfig(): ApplicationConfig {
         return this.applicationConfig;
+    }
+
+    static on(handler: (event: ApplicationAddedEvent) => void) {
+        Event.bind(ClassHelper.getFullName(this), handler);
+    }
+
+    static un(handler?: (event: ApplicationAddedEvent) => void) {
+        Event.unbind(ClassHelper.getFullName(this), handler);
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -143,6 +143,7 @@ import {Workflow} from '../content/Workflow';
 import {KeyHelper} from '@enonic/lib-admin-ui/ui/KeyHelper';
 import {ContentTabBarItem} from './ContentTabBarItem';
 import {VersionContext} from '../view/context/widget/version/VersionContext';
+import {ApplicationConfig} from '@enonic/lib-admin-ui/application/ApplicationConfig';
 
 export class ContentWizardPanel
     extends WizardPanel<Content> {
@@ -223,7 +224,7 @@ export class ContentWizardPanel
 
     private dataChangedListeners: { (): void } [];
 
-    private applicationAddedListener: (event: ApplicationAddedEvent) => void;
+    private applicationAddedListener: (applicationConfig: ApplicationConfig) => void;
 
     private applicationRemovedListener: (event: ApplicationRemovedEvent) => void;
 
@@ -322,18 +323,23 @@ export class ContentWizardPanel
                 this.handleAppChange();
                 return;
             }
+
             (force ? Q.resolve(true) : this.checkIfAppsHaveDescriptors(applicationKeys))
                 .then((appsHaveDescriptors: boolean) => appsHaveDescriptors ? this.saveChanges() : Q.resolve())
                 .then(this.handleAppChange)
                 .finally(() => applicationKeys = []);
         };
+
         const debouncedSaveOnAppChange = AppHelper.debounce(saveOnAppChange, 300);
 
-        this.applicationAddedListener = (event: ApplicationAddedEvent) => {
-            this.addXDataStepForms(event.getApplicationKey());
-            applicationKeys.push(event.getApplicationKey());
-            debouncedSaveOnAppChange();
+        this.applicationAddedListener = (applicationConfig: ApplicationConfig) => {
+            this.addXDataStepForms(applicationConfig.getApplicationKey());
+            applicationKeys.push(applicationConfig.getApplicationKey());
         };
+
+        ApplicationAddedEvent.on(() => {
+            debouncedSaveOnAppChange();
+        });
 
         this.applicationRemovedListener = (event: ApplicationRemovedEvent) => {
             this.removeXDataStepForms(event.getApplicationKey())


### PR DESCRIPTION
-Stopped saving content using side effects after adding a new application to a site config: save was triggered in a middle of a process of adding new props to a content's property set and it's listeners were firing save in a middle of it; Now saving newly added app in a config only after it's form config is rendered and populated content's site config with all required config form's props
-SiteConfiguratorDialog: checking if dialog is dirty via comparing configs