### PR TITLE
Preselection of options inside option-set doesn't work in site.xml #4629

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -101,7 +101,7 @@ export class SiteConfigurator
                 <SiteConfiguratorSelectedOptionView>this.selectOptionFromProperty(property)?.getOptionView());
 
             const updatePromises = selectedOptionViews.filter(view => !!view).map((view, index) => {
-                const configSet = propertyArray.get(index).getPropertySet().getProperty('config').getPropertySet();
+                const configSet = propertyArray.get(index).getPropertySet().getProperty(ApplicationConfig.PROPERTY_CONFIG).getPropertySet();
                 return view.getFormView().update(configSet, unchangedOnly);
             });
 
@@ -128,9 +128,8 @@ export class SiteConfigurator
 
         this.comboBox.getSelectedOptionViews().forEach(oldView => {
             const haveToDeselect = !newPropertyArray.some(property => {
-                const key = property.getPropertySet().getProperty('applicationKey').getValue().getString();
+                const key = property.getPropertySet().getProperty(ApplicationConfig.PROPERTY_KEY).getValue().getString();
                 return SiteConfigurator.optionViewToKey(oldView) === key;
-
             });
 
             if (haveToDeselect) {
@@ -140,7 +139,7 @@ export class SiteConfigurator
     }
 
     private selectOptionFromProperty(property: Property): SelectedOption<Application> {
-        const key = property.getPropertySet().getProperty('applicationKey').getValue().getString();
+        const key = property.getPropertySet().getProperty(ApplicationConfig.PROPERTY_KEY).getValue().getString();
         const selectedOptions: SiteConfiguratorSelectedOptionView[] = this.comboBox.getSelectedOptionViews();
         const alreadySelected = selectedOptions.some(option => SiteConfigurator.optionViewToKey(option) === key);
         if (!alreadySelected) {
@@ -159,8 +158,8 @@ export class SiteConfigurator
         let config = siteConfig.getConfig();
         let appKey = siteConfig.getApplicationKey();
 
-        propertySet.setStringByPath('applicationKey', appKey.toString());
-        propertySet.setPropertySetByPath('config', config);
+        propertySet.setStringByPath(ApplicationConfig.PROPERTY_KEY, appKey.toString());
+        propertySet.setPropertySetByPath(ApplicationConfig.PROPERTY_CONFIG, config);
     }
 
     protected getValueFromPropertyArray(propertyArray: PropertyArray): string {
@@ -205,8 +204,8 @@ export class SiteConfigurator
             const view: SiteConfiguratorSelectedOptionView = <SiteConfiguratorSelectedOptionView>selectedOption.getOptionView();
 
             const propertyArray: PropertyArray = this.getPropertyArray();
-            const configSet: PropertySet =
-                propertyArray.get(selectedOption.getIndex()).getPropertySet().getProperty('config').getPropertySet();
+            const configSet: PropertySet = propertyArray.get(selectedOption.getIndex()).getPropertySet().getProperty(
+                ApplicationConfig.PROPERTY_CONFIG).getPropertySet();
 
             view.whenRendered(() => {
                 view.getFormView().update(configSet, false);

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
@@ -10,25 +10,39 @@ import {ApplicationConfig} from '@enonic/lib-admin-ui/application/ApplicationCon
 import {HtmlAreaResizeEvent} from '../text/HtmlAreaResizeEvent';
 import {SiteConfiguratorDialog} from '../ui/siteconfigurator/SiteConfiguratorDialog';
 import {ContentFormContext} from '../../ContentFormContext';
-import {ContentRequiresSaveEvent} from '../../event/ContentRequiresSaveEvent';
 import {BaseSelectedOptionView, BaseSelectedOptionViewBuilder} from '@enonic/lib-admin-ui/ui/selector/combobox/BaseSelectedOptionView';
 import {FormValidityChangedEvent} from '@enonic/lib-admin-ui/form/FormValidityChangedEvent';
 import {NamesAndIconViewSize} from '@enonic/lib-admin-ui/app/NamesAndIconViewSize';
 import {FormState} from '@enonic/lib-admin-ui/app/wizard/WizardPanel';
 import {GetApplicationRequest} from '../../resource/GetApplicationRequest';
+import {ApplicationAddedEvent} from '../../site/ApplicationAddedEvent';
+import {Property} from '@enonic/lib-admin-ui/data/Property';
+import {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
+import {ContentRequiresSaveEvent} from '../../event/ContentRequiresSaveEvent';
+
+export interface SiteConfiguratorSelectedOptionViewParams {
+    option: Option<Application>,
+    siteConfig: ApplicationConfig,
+    formContext: ContentFormContext,
+    isNew?: boolean
+}
 
 export class SiteConfiguratorSelectedOptionView
     extends BaseSelectedOptionView<Application> {
 
-    private application: Application;
+    private readonly application: Application;
 
     private formView: FormView;
 
     private siteConfig: ApplicationConfig;
 
+    private tempSiteConfig: ApplicationConfig;
+
     private siteConfigFormDisplayedListeners: { (applicationKey: ApplicationKey): void }[];
 
     private formContext: ContentFormContext;
+
+    private isNew: boolean;
 
     private formValidityChangedHandler: { (event: FormValidityChangedEvent): void };
 
@@ -38,15 +52,22 @@ export class SiteConfiguratorSelectedOptionView
 
     private namesAndIconView: NamesAndIconView;
 
-    constructor(option: Option<Application>, siteConfig: ApplicationConfig, formContext: ContentFormContext) {
-        super(new BaseSelectedOptionViewBuilder<Application>().setOption(option));
+    constructor(params: SiteConfiguratorSelectedOptionViewParams) {
+        super(new BaseSelectedOptionViewBuilder<Application>().setOption(params.option));
 
         this.siteConfigFormDisplayedListeners = [];
-        this.application = option.getDisplayValue();
-        this.siteConfig = siteConfig;
-        this.formContext = formContext;
+        this.application = params.option.getDisplayValue();
+        this.siteConfig = params.siteConfig;
+        this.formContext = params.formContext;
+        this.isNew = params.isNew;
 
         this.setEditable(this.application.getForm()?.getFormItems().length > 0);
+
+        if (params.isNew) {
+            this.onRendered(() => {
+                this.saveOnFirstTimeRendered();
+            });
+        }
     }
 
     doRender(): Q.Promise<boolean> {
@@ -113,7 +134,6 @@ export class SiteConfiguratorSelectedOptionView
     }
 
     showConfigureDialog() {
-
         if (this.formView) {
             this.formViewStateOnDialogOpen = this.formView;
             this.unbindValidationEvent(this.formViewStateOnDialogOpen);
@@ -136,26 +156,30 @@ export class SiteConfiguratorSelectedOptionView
         if (this.formView) {
             this.formView.remove();
         }
-        const tempSiteConfig: ApplicationConfig = this.makeTemporarySiteConfig();
 
-        this.formView = this.createFormView(tempSiteConfig);
+        this.tempSiteConfig = this.makeTemporarySiteConfig();
+
+        this.formView = this.createFormView(this.tempSiteConfig);
         this.bindValidationEvent(this.formView);
-
-        const okCallback = () => {
-            if (!tempSiteConfig.equals(this.siteConfig)) {
-                this.applyTemporaryConfig(tempSiteConfig);
-                new ContentRequiresSaveEvent(this.formContext.getPersistedContent().getContentId()).fire();
-            }
-        };
 
         const cancelCallback = () => {
             this.revertFormViewToGivenState(this.formViewStateOnDialogOpen);
         };
 
-        const siteConfiguratorDialog = new SiteConfiguratorDialog(this.application,
-            this.formView,
-            okCallback,
-            cancelCallback
+        const okCallback = (): void => {
+            if (this.isConfigChanged()) {
+                this.applyTemporaryConfig(this.tempSiteConfig);
+                new ContentRequiresSaveEvent(this.formContext.getPersistedContent().getContentId()).fire();
+            }
+        };
+
+        const siteConfiguratorDialog = new SiteConfiguratorDialog({
+                application: this.application,
+                formView: this.formView,
+                okCallback: okCallback,
+                cancelCallback: cancelCallback,
+                isDirtyCallback: this.isConfigChanged.bind(this)
+            }
         );
 
         const handleAvailableSizeChanged = () => siteConfiguratorDialog.handleAvailableSizeChanged();
@@ -166,6 +190,19 @@ export class SiteConfiguratorSelectedOptionView
         });
 
         return siteConfiguratorDialog;
+    }
+
+    private saveOnFirstTimeRendered(): void {
+        if (this.isConfigChanged()) {
+            this.applyTemporaryConfig(this.tempSiteConfig);
+            new ApplicationAddedEvent(this.siteConfig).fire();
+        } else if (!this.configureDialog) {
+            new ApplicationAddedEvent(this.siteConfig).fire();
+        }
+    }
+
+    private isConfigChanged(): boolean {
+        return this.tempSiteConfig && !this.tempSiteConfig.equals(this.siteConfig);
     }
 
     private revertFormViewToGivenState(formViewStateToRevertTo: FormView) {
@@ -181,11 +218,13 @@ export class SiteConfiguratorSelectedOptionView
     }
 
     private applyTemporaryConfig(tempSiteConfig: ApplicationConfig) {
-        tempSiteConfig.getConfig().forEach((property) => {
+        tempSiteConfig.getConfig().forEach((property: Property) => {
             this.siteConfig.getConfig().setProperty(property.getName(), property.getIndex(), property.getValue());
         });
-        this.siteConfig.getConfig().forEach((property) => {
-            let prop = tempSiteConfig.getConfig().getProperty(property.getName(), property.getIndex());
+
+        this.siteConfig.getConfig().forEach((property: Property) => {
+            const prop: Property = tempSiteConfig.getConfig().getProperty(property.getName(), property.getIndex());
+
             if (!prop) {
                 this.siteConfig.getConfig().removeProperty(property.getName(), property.getIndex());
             }
@@ -193,20 +232,22 @@ export class SiteConfiguratorSelectedOptionView
     }
 
     private makeTemporarySiteConfig(): ApplicationConfig {
-        let propSet = (new PropertyTree(this.siteConfig.getConfig())).getRoot();
+        const propSet: PropertySet = (new PropertyTree(this.siteConfig.getConfig())).getRoot();
         return ApplicationConfig.create().setConfig(propSet).setApplicationKey(this.siteConfig.getApplicationKey()).build();
     }
 
     private createFormView(siteConfig: ApplicationConfig): FormView {
-        const context: ContentFormContext = <ContentFormContext>this.formContext.cloneBuilder().setFormState(new FormState(false)).build();
-        const formView: FormView = new FormView(context, this.application.getForm(), siteConfig.getConfig());
-        formView.addClass('site-form');
+        const context: ContentFormContext =
+            <ContentFormContext>this.formContext.cloneBuilder().setFormState(new FormState(this.isNew)).build();
+        const formView: FormView =
+            <FormView>new FormView(context, this.application.getForm(), siteConfig.getConfig()).addClass('site-form');
 
         formView.onLayoutFinished(() => {
             formView.displayValidationErrors(true);
             formView.validate(false, true);
             this.toggleClass('invalid', !formView.isValid());
             this.notifySiteConfigFormDisplayed(this.application.getApplicationKey());
+            this.isNew = false;
         });
 
         return formView;

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionsView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionsView.ts
@@ -12,11 +12,11 @@ import {ApplicationConfig} from '@enonic/lib-admin-ui/application/ApplicationCon
 export class SiteConfiguratorSelectedOptionsView
     extends BaseSelectedOptionsView<Application> {
 
-    private siteConfigProvider: ApplicationConfigProvider;
+    private readonly siteConfigProvider: ApplicationConfigProvider;
 
     private siteConfigFormDisplayedListeners: { (applicationKey: ApplicationKey, formView: FormView): void }[] = [];
 
-    private formContext: ContentFormContext;
+    private readonly formContext: ContentFormContext;
 
     private items: SiteConfiguratorSelectedOptionView[] = [];
 
@@ -25,19 +25,20 @@ export class SiteConfiguratorSelectedOptionsView
         this.siteConfigProvider = siteConfigProvider;
         this.formContext = formContext;
 
-        this.siteConfigProvider.onPropertyChanged(() => {
+        this.initListeners();
+        this.setOccurrencesSortable(true);
+    }
 
+    protected initListeners(): void {
+        this.siteConfigProvider.onPropertyChanged(() => {
             this.items.forEach((optionView: SiteConfiguratorSelectedOptionView) => {
-                const newConfig: ApplicationConfig =
-                    this.siteConfigProvider.getConfig(optionView.getSiteConfig().getApplicationKey(), false);
+                const newConfig: ApplicationConfig = this.siteConfigProvider.getConfig(optionView.getSiteConfig().getApplicationKey());
+
                 if (newConfig) {
                     optionView.setSiteConfig(newConfig);
                 }
             });
-
         });
-
-        this.setOccurrencesSortable(true);
     }
 
     makeEmptyOption(id: string): Option<Application> {
@@ -54,8 +55,15 @@ export class SiteConfiguratorSelectedOptionsView
     }
 
     createSelectedOption(option: Option<Application>): SelectedOption<Application> {
-        const siteConfig: ApplicationConfig = this.siteConfigProvider.getConfig(option.getDisplayValue().getApplicationKey());
-        const optionView: SiteConfiguratorSelectedOptionView = new SiteConfiguratorSelectedOptionView(option, siteConfig, this.formContext);
+        const key: ApplicationKey = option.getDisplayValue().getApplicationKey();
+        const existingConfig: ApplicationConfig = this.siteConfigProvider.getConfig(key);
+        const siteConfig: ApplicationConfig = existingConfig || this.siteConfigProvider.addConfig(key);
+        const optionView: SiteConfiguratorSelectedOptionView = new SiteConfiguratorSelectedOptionView({
+            option: option,
+            siteConfig: siteConfig,
+            formContext: this.formContext,
+            isNew: !existingConfig
+        });
 
         optionView.setReadonly(this.readonly);
 

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/siteconfigurator/SiteConfiguratorDialog.ts
@@ -1,7 +1,23 @@
 import * as Q from 'q';
-import {ApplicationConfiguratorDialog} from '@enonic/lib-admin-ui/form/inputtype/appconfig/ApplicationConfiguratorDialog';
+import {
+    ApplicationConfiguratorDialog,
+    ApplicationConfiguratorDialogParams
+} from '@enonic/lib-admin-ui/form/inputtype/appconfig/ApplicationConfiguratorDialog';
+
+export interface SiteConfiguratorDialogParams extends ApplicationConfiguratorDialogParams {
+    isDirtyCallback?: () => boolean;
+}
+
 export class SiteConfiguratorDialog
     extends ApplicationConfiguratorDialog {
+
+    private readonly isDirtyCallback?: () => boolean;
+
+    constructor(params: SiteConfiguratorDialogParams) {
+        super(params);
+
+        this.isDirtyCallback = params.isDirtyCallback;
+    }
 
     close() {
         this.destroyCkeInstancesInDialog();
@@ -31,5 +47,9 @@ export class SiteConfiguratorDialog
                 }
             }
         }
+    }
+
+    isDirty(): boolean {
+        return this.isDirtyCallback ? this.isDirtyCallback() : super.isDirty();
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/site/ApplicationAddedEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/app/site/ApplicationAddedEvent.ts
@@ -1,11 +1,15 @@
 import {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
 import {ApplicationConfig} from '@enonic/lib-admin-ui/application/ApplicationConfig';
+import {Event} from '@enonic/lib-admin-ui/event/Event';
+import {ClassHelper} from '@enonic/lib-admin-ui/ClassHelper';
 
-export class ApplicationAddedEvent {
+export class ApplicationAddedEvent
+    extends Event {
 
-    private applicationConfig: ApplicationConfig;
+    private readonly applicationConfig: ApplicationConfig;
 
     constructor(applicationConfig: ApplicationConfig) {
+        super();
         this.applicationConfig = applicationConfig;
     }
 
@@ -15,5 +19,13 @@ export class ApplicationAddedEvent {
 
     getApplicationConfig(): ApplicationConfig {
         return this.applicationConfig;
+    }
+
+    static on(handler: (event: ApplicationAddedEvent) => void) {
+        Event.bind(ClassHelper.getFullName(this), handler);
+    }
+
+    static un(handler?: (event: ApplicationAddedEvent) => void) {
+        Event.unbind(ClassHelper.getFullName(this), handler);
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/site/SiteModel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/site/SiteModel.ts
@@ -1,5 +1,4 @@
 import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
-import {ApplicationAddedEvent} from './ApplicationAddedEvent';
 import {ApplicationRemovedEvent} from './ApplicationRemovedEvent';
 import {Site} from '../content/Site';
 import {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
@@ -17,7 +16,7 @@ export class SiteModel {
 
     private siteConfigs: ApplicationConfig[];
 
-    private applicationAddedListeners: { (event: ApplicationAddedEvent): void }[] = [];
+    private applicationAddedListeners: { (applicationConfig: ApplicationConfig): void }[] = [];
 
     private applicationRemovedListeners: { (event: ApplicationRemovedEvent): void }[] = [];
 
@@ -44,40 +43,44 @@ export class SiteModel {
 
     private initApplicationPropertyListeners() {
         this.applicationPropertyAddedListener = (event: PropertyAddedEvent) => {
-            let property: Property = event.getProperty();
+            const property: Property = event.getProperty();
 
-            if (property.getPath().toString().indexOf('.siteConfig') === 0 && property.getName() === 'config') {
-                let siteConfig: ApplicationConfig = ApplicationConfig.create().fromData(property.getParent()).build();
+            if (property.getPath().toString().indexOf('.siteConfig') === 0 &&
+                property.getName() === ApplicationConfig.PROPERTY_CONFIG) {
+                const siteConfig: ApplicationConfig = ApplicationConfig.create().fromData(property.getParent()).build();
+
                 if (!this.siteConfigs) {
                     this.siteConfigs = [];
                 }
+
                 this.siteConfigs.push(siteConfig);
                 this.notifyApplicationAdded(siteConfig);
             }
         };
 
         this.applicationPropertyRemovedListener = (event: PropertyRemovedEvent) => {
-            let property: Property = event.getProperty();
+            const property: Property = event.getProperty();
+
             if (property.getName() === 'siteConfig') {
-                let applicationKey = ApplicationKey.fromString(property.getPropertySet().getString('applicationKey'));
-                this.siteConfigs = this.siteConfigs.filter((siteConfig: ApplicationConfig) =>
-                    !siteConfig.getApplicationKey().equals(applicationKey)
-                );
+                const applicationKey: ApplicationKey =
+                    ApplicationKey.fromString(property.getPropertySet().getString(ApplicationConfig.PROPERTY_KEY));
+                this.siteConfigs =
+                    this.siteConfigs.filter((siteConfig: ApplicationConfig) => !siteConfig.getApplicationKey().equals(applicationKey));
                 this.notifyApplicationRemoved(applicationKey);
             }
         };
 
         this.applicationGlobalEventsListener = (event: ApplicationEvent) => {
             switch (event.getEventType()) {
-                case ApplicationEventType.STOPPED:
-                    this.notifyApplicationStopped(event);
-                    break;
-                case ApplicationEventType.STARTED:
-                    this.notifyApplicationStarted(event);
-                    break;
-                case ApplicationEventType.UNINSTALLED:
-                    this.notifyApplicationUninstalled(event);
-                    break;
+            case ApplicationEventType.STOPPED:
+                this.notifyApplicationStopped(event);
+                break;
+            case ApplicationEventType.STARTED:
+                this.notifyApplicationStarted(event);
+                break;
+            case ApplicationEventType.UNINSTALLED:
+                this.notifyApplicationUninstalled(event);
+                break;
             }
         };
     }
@@ -131,19 +134,18 @@ export class SiteModel {
             this.propertyChangedListeners.filter((curr: (event: PropertyChangedEvent) => void) => listener !== curr);
     }
 
-    onApplicationAdded(listener: (event: ApplicationAddedEvent) => void) {
+    onApplicationAdded(listener: (applicationConfig: ApplicationConfig) => void) {
         this.applicationAddedListeners.push(listener);
     }
 
-    unApplicationAdded(listener: (event: ApplicationAddedEvent) => void) {
+    unApplicationAdded(listener: (applicationConfig: ApplicationConfig) => void) {
         this.applicationAddedListeners =
-            this.applicationAddedListeners.filter((curr: (event: ApplicationAddedEvent) => void) => listener !== curr);
+            this.applicationAddedListeners.filter((curr: (config: ApplicationConfig) => void) => listener !== curr);
     }
 
-    private notifyApplicationAdded(siteConfig: ApplicationConfig) {
-        let event = new ApplicationAddedEvent(siteConfig);
-        this.applicationAddedListeners.forEach((listener: (event: ApplicationAddedEvent) => void) => {
-            listener(event);
+    private notifyApplicationAdded(applicationConfig: ApplicationConfig) {
+        this.applicationAddedListeners.forEach((listener: (applicationConfig) => void) => {
+            listener(applicationConfig);
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -143,6 +143,7 @@ import {Workflow} from '../content/Workflow';
 import {KeyHelper} from '@enonic/lib-admin-ui/ui/KeyHelper';
 import {ContentTabBarItem} from './ContentTabBarItem';
 import {VersionContext} from '../view/context/widget/version/VersionContext';
+import {ApplicationConfig} from '@enonic/lib-admin-ui/application/ApplicationConfig';
 
 export class ContentWizardPanel
     extends WizardPanel<Content> {
@@ -223,7 +224,7 @@ export class ContentWizardPanel
 
     private dataChangedListeners: { (): void } [];
 
-    private applicationAddedListener: (event: ApplicationAddedEvent) => void;
+    private applicationAddedListener: (applicationConfig: ApplicationConfig) => void;
 
     private applicationRemovedListener: (event: ApplicationRemovedEvent) => void;
 
@@ -322,18 +323,27 @@ export class ContentWizardPanel
                 this.handleAppChange();
                 return;
             }
+
             (force ? Q.resolve(true) : this.checkIfAppsHaveDescriptors(applicationKeys))
                 .then((appsHaveDescriptors: boolean) => appsHaveDescriptors ? this.saveChanges() : Q.resolve())
                 .then(this.handleAppChange)
                 .finally(() => applicationKeys = []);
         };
+
         const debouncedSaveOnAppChange = AppHelper.debounce(saveOnAppChange, 300);
 
-        this.applicationAddedListener = (event: ApplicationAddedEvent) => {
-            this.addXDataStepForms(event.getApplicationKey());
-            applicationKeys.push(event.getApplicationKey());
-            debouncedSaveOnAppChange();
+        this.applicationAddedListener = (applicationConfig: ApplicationConfig) => {
+            this.addXDataStepForms(applicationConfig.getApplicationKey());
+            applicationKeys.push(applicationConfig.getApplicationKey());
         };
+
+        ApplicationAddedEvent.on((event: ApplicationAddedEvent) => {
+            if (!applicationKeys.some((key: ApplicationKey) => key.equals(event.getApplicationKey()))) {
+                applicationKeys.push(event.getApplicationKey());
+            }
+
+            debouncedSaveOnAppChange();
+        });
 
         this.applicationRemovedListener = (event: ApplicationRemovedEvent) => {
             this.removeXDataStepForms(event.getApplicationKey())


### PR DESCRIPTION
-Stopped saving content using side effects after adding a new application to a site config: save was triggered in a middle of a process of adding new props to a content's property set and it's listeners were firing save in a middle of it; Now saving newly added app in a config only after it's form config is rendered and populated content's site config with all required config form's props
-SiteConfiguratorDialog: checking if dialog is dirty via comparing configs