### PR TITLE
Move and Archive dialog: status column overflows #5239

### DIFF
--- a/modules/lib/src/main/resources/assets/styles/browse/content-tree-grid.less
+++ b/modules/lib/src/main/resources/assets/styles/browse/content-tree-grid.less
@@ -30,6 +30,7 @@
         span {
           .ellipsis();
           white-space: pre-wrap;
+          padding-right: 2px;
         }
       }
 

--- a/modules/lib/src/main/resources/assets/styles/inputtype/selector/content-combo-box.less
+++ b/modules/lib/src/main/resources/assets/styles/inputtype/selector/content-combo-box.less
@@ -6,10 +6,12 @@
         text-align: center;
         font-style: normal;
         font-size: 11px;
-        flex-basis: 70px;
+        flex-basis: 80px;
 
         span {
           .ellipsis();
+          white-space: normal;
+          padding-right: 2px;
         }
       }
 


### PR DESCRIPTION
-italic text for 'modifed' status is not seen when overflow is set to 'hidden', adding small padding for it -giving more space for statuses to let long texts to fit (content-combo-box) -allowing statuses to wrap into multiple lines (content-combo-box)