### PR TITLE
ui-tests issue#5477

### DIFF
--- a/testing/libs/elements.js
+++ b/testing/libs/elements.js
@@ -42,9 +42,9 @@ module.exports = Object.freeze({
                `//div[contains(@class,'slick-viewport')]//div[contains(@class,'slick-row') and descendant::h6[contains(@class,'main-name') and contains(.,'${displayName}')]]`;
     },
     actionButton: (label) => `//button[contains(@id,'ActionButton') and child::span[contains(.,'${label}')]]`,
-    slickRowByName: (container, displayName) => {
+    slickRowByName: (container, name) => {
         return container +
-               `//div[contains(@class,'slick-viewport')]//div[contains(@class,'slick-row') and descendant::p[contains(@class,'sub-name') and contains(.,'${displayName}')]]`;
+               `//div[contains(@class,'slick-viewport')]//div[contains(@class,'slick-row') and descendant::p[contains(@class,'sub-name') and contains(.,'${name}')]]`;
     },
     itemByDisplayName: displayName => {
         return `//div[contains(@id,'NamesView') and child::h6[contains(@class,'main-name') and contains(.,'${displayName}')]]`

--- a/testing/libs/studio.utils.js
+++ b/testing/libs/studio.utils.js
@@ -604,7 +604,7 @@ module.exports = {
     },
     async clickOnContentStudioLink(userName, password) {
         let launcherPanel = new LauncherPanel();
-        let result = await launcherPanel.waitForPanelDisplayed(2000);
+        let result = await launcherPanel.isDisplayed(2000);
         console.log("Launcher Panel is opened, click on the `Content Studio` link...");
         if (result) {
             await launcherPanel.clickOnContentStudioLink(userName, password);
@@ -754,15 +754,13 @@ module.exports = {
             return console.log('screenshot was not saved ' + screenshotsDir + 'utils  ' + err);
         })
     },
-    openDependencyWidgetInBrowsePanel() {
+    async openDependencyWidgetInBrowsePanel() {
         let browsePanel = new BrowsePanel();
         let browseDependenciesWidget = new BrowseDependenciesWidget();
         let browseDetailsPanel = new BrowseDetailsPanel();
-        return browsePanel.openDetailsPanel().then(() => {
-            return browseDetailsPanel.openDependencies();
-        }).then(() => {
-            return browseDependenciesWidget.waitForWidgetLoaded();
-        })
+        await browsePanel.openDetailsPanel();
+        await browseDetailsPanel.openDependencies();
+        return await browseDependenciesWidget.waitForWidgetLoaded();
     },
     async openLayersWidgetInBrowsePanel() {
         let browsePanel = new BrowsePanel();
@@ -834,7 +832,7 @@ module.exports = {
     async navigateToUsersApp(userName, password) {
         try {
             let launcherPanel = new LauncherPanel();
-            let isDisplayed = await launcherPanel.waitForPanelDisplayed(appConst.mediumTimeout);
+            let isDisplayed = await launcherPanel.isDisplayed(appConst.mediumTimeout);
             if (isDisplayed) {
                 console.log("Launcher Panel is opened, click on the `Users` link...");
                 await launcherPanel.pause(300);
@@ -945,7 +943,7 @@ module.exports = {
             await this.clickOnElement(selector);
             //let el = await this.getDisplayedElements(selector);
             //await el[0].click();
-            return await launcherPanel.waitForPanelDisplayed(1000);
+            return await launcherPanel.waitForPanelDisplayed();
         } catch (err) {
             await this.saveScreenshot(appConst.generateRandomName("err_launcher_button"));
             await this.getBrowser().refresh();
@@ -955,7 +953,7 @@ module.exports = {
 
             let el = await this.getDisplayedElements(selector);
             await el[0].click();
-            return await launcherPanel.waitForPanelDisplayed(1000);
+            return await launcherPanel.waitForPanelDisplayed();
         }
 
     },

--- a/testing/page_objects/browsepanel/content.browse.panel.js
+++ b/testing/page_objects/browsepanel/content.browse.panel.js
@@ -395,10 +395,15 @@ class ContentBrowsePanel extends BaseBrowsePanel {
         }
     }
 
-    waitForContentNotDisplayed(contentName) {
-        return this.waitForElementNotDisplayed(XPATH.treeGrid + lib.itemByName(contentName), appConst.mediumTimeout).catch(err => {
-            throw new Error("Content is still displayed :" + err);
-        });
+    async waitForContentNotDisplayed(contentName) {
+        let locator = XPATH.treeGrid + lib.itemByName(contentName)
+        try {
+            await this.waitForElementNotDisplayed(locator, appConst.mediumTimeout);
+        } catch (err) {
+            let screenshot = appConst.generateRandomName("err_preview_btn_disabled");
+            await this.saveScreenshot(screenshot);
+            throw new Error("Content is still displayed, screenshot :" + screenshot + "  " + err);
+        }
     }
 
     async clickOnPreviewButton() {
@@ -416,18 +421,24 @@ class ContentBrowsePanel extends BaseBrowsePanel {
         return this.isElementDisplayed(this.searchButton);
     }
 
-    waitForPreviewButtonDisabled() {
-        return this.waitForElementDisabled(this.previewButton, appConst.mediumTimeout).catch(err => {
-            this.saveScreenshot('err_preview_disabled_button');
-            throw Error('Preview button should be disabled : ' + err);
-        })
+    async waitForPreviewButtonDisabled() {
+        try {
+            await this.waitForElementDisabled(this.previewButton, appConst.mediumTimeout)
+        } catch (err) {
+            let screenshot = appConst.generateRandomName("err_preview_btn_disabled");
+            await this.saveScreenshot(screenshot);
+            throw Error('Preview button should be disabled, screenshot  : ' + screenshot + "  " + err);
+        }
     }
 
-    waitForPreviewButtonEnabled() {
-        return this.waitForElementEnabled(this.previewButton, appConst.mediumTimeout).catch(err => {
-            this.saveScreenshot('err_preview_enabled_button');
-            throw Error('Preview button should be enabled, timeout: ' + err);
-        })
+    async waitForPreviewButtonEnabled() {
+        try {
+            await this.waitForElementEnabled(this.previewButton, appConst.mediumTimeout)
+        } catch (err) {
+            let screenshot = appConst.generateRandomName("err_preview_btn_enabled");
+            await this.saveScreenshot(screenshot);
+            throw Error('Preview button should be enabled, screenshot  : ' + screenshot + "  " + err);
+        }
     }
 
     waitForDetailsPanelToggleButtonDisplayed() {

--- a/testing/page_objects/launcher.panel.js
+++ b/testing/page_objects/launcher.panel.js
@@ -64,10 +64,15 @@ class LauncherPanel extends Page {
         return this.waitForElementDisplayed(this.logoutLink);
     }
 
-    waitForPanelDisplayed(ms) {
+    isDisplayed(ms) {
         return this.waitForElementDisplayed(XPATH.container, ms).catch(err => {
             return false;
         })
+    }
+
+    async waitForPanelDisplayed() {
+        await this.waitForElementDisplayed(XPATH.container, appConst.mediumTimeout);
+        await this.pause(500);
     }
 
     async waitForPanelClosed() {

--- a/testing/page_objects/wizardpanel/content.wizard.panel.js
+++ b/testing/page_objects/wizardpanel/content.wizard.panel.js
@@ -588,8 +588,8 @@ class ContentWizardPanel extends Page {
             await this.waitForSavingButtonNotVisible();
             return await this.pause(1200);
         } catch (err) {
-            this.saveScreenshot(appConst.generateRandomName("err_save"));
-            throw new Error(err);
+            await this.saveScreenshot(appConst.generateRandomName("err_save"));
+            throw new Error("Error in waitAndClickOnSave: " + err);
         }
     }
 
@@ -843,9 +843,9 @@ class ContentWizardPanel extends Page {
         })
     }
 
-    waitForMarkAsReadyButtonVisible() {
+    async waitForMarkAsReadyButtonVisible() {
         let selector = XPATH.container + XPATH.markAsReadyButton;
-        return this.waitForElementDisplayed(selector, appConst.mediumTimeout);
+        return await this.waitForElementDisplayed(selector, appConst.mediumTimeout);
     }
 
     waitForOpenRequestButtonVisible() {
@@ -928,18 +928,17 @@ class ContentWizardPanel extends Page {
         return await createRequestPublishDialog.clickOnCreateRequestButton();
     }
 
-    // async showPublishMenuClickOnMarkAsReadyMenuItem() {
-    //     await this.openPublishMenuSelectItem(appConst.PUBLISH_MENU.MARK_AS_READY);
-    //     let dialog = new ConfirmationDialog();
-    //     await dialog.waitForDialogOpened();
-    //     return await dialog.clickOnYesButton();
-    // }
-
     async clickOnMarkAsReadyButton() {
-        let selector = XPATH.container + XPATH.markAsReadyButton;
-        await this.waitForMarkAsReadyButtonVisible();
-        await this.clickOnElement(selector);
-        return await this.pause(1000);
+        try {
+            let selector = XPATH.container + XPATH.markAsReadyButton;
+            await this.waitForMarkAsReadyButtonVisible();
+            await this.clickOnElement(selector);
+            return await this.pause(1000);
+        } catch (err) {
+            let screenshot = appConst.generateRandomName('err_mark_as_ready_btn');
+            await this.saveScreenshot(screenshot);
+            throw new Error("Error in clickOnMarkAsReadyButton, screenshot:" + screenshot + " " + err);
+        }
     }
 
     async clickOnUnpublishButton() {
@@ -1170,9 +1169,14 @@ class ContentWizardPanel extends Page {
         }
     }
 
-    getMessageInPagePlaceholderInfoBlock() {
+    getMessageInLiveFormPanel() {
         let locator = XPATH.pagePlaceholderInfoBlock1;
         return this.getText(locator);
+    }
+
+    async waitForErrorMessageInLiveFormPanel(message) {
+        let locator = `//div[contains(@id,'PagePlaceholderInfoBlock')]//div[contains(@class,'page-placeholder-info-line1') and contains(.,'${message}')]`;
+        return await this.waitForElementDisplayed(locator, appConst.mediumTimeout);
     }
 }
 

--- a/testing/specs/launcher.panel.spec.js
+++ b/testing/specs/launcher.panel.spec.js
@@ -18,7 +18,7 @@ describe('launcher.panel.spec: test for Launcher Panel', function () {
     it("WHEN su is logged in THEN 'Home' link should be active, Super User is current user",
         async () => {
             let launcherPanel = new LauncherPanel();
-            await launcherPanel.waitForPanelDisplayed(appConst.mediumTimeout);
+            await launcherPanel.waitForPanelDisplayed();
             let currentUser = await launcherPanel.getCurrentUser();
             assert.equal(currentUser, "Super User");
             let result = await launcherPanel.getActiveLink();
@@ -28,7 +28,7 @@ describe('launcher.panel.spec: test for Launcher Panel', function () {
     it("GIVEN su is logged in WHEN 'Close XP menu' button has been clicked THEN launcher panel gets not visible",
         async () => {
             let launcherPanel = new LauncherPanel();
-            await launcherPanel.waitForPanelDisplayed(appConst.mediumTimeout);
+            await launcherPanel.waitForPanelDisplayed();
             await launcherPanel.clickOnLauncherToggler();
             await studioUtils.saveScreenshot("launcher_closed");
             await launcherPanel.waitForPanelClosed();
@@ -42,7 +42,7 @@ describe('launcher.panel.spec: test for Launcher Panel', function () {
             if (!result) {
                 await launcherPanel.clickOnLauncherToggler();
             }
-            await launcherPanel.waitForPanelDisplayed(appConst.mediumTimeout);
+            await launcherPanel.waitForPanelDisplayed();
             await launcherPanel.clickOnLogoutLink();
             await studioUtils.saveScreenshot("logout_link_pressed");
             await loginPage.waitForPageLoaded();

--- a/testing/specs/page-editor/app.generic.custom.error.handling.spec.js
+++ b/testing/specs/page-editor/app.generic.custom.error.handling.spec.js
@@ -17,7 +17,8 @@ describe('Custom error handling - specification. Verify that application error p
     }
 
     let SITE;
-    let CONTROLLER_WITH_ERROR = 'Page with error';
+    const CONTROLLER_WITH_ERROR = 'Page with error';
+    const ERROR_MESSAGE_LIVE_EDIT = "Failed to render content preview.";
 
     it(`WHEN a controller with error has been selected THEN 'Preview' button should be disabled in the browse toolbar`,
         async () => {
@@ -37,12 +38,11 @@ describe('Custom error handling - specification. Verify that application error p
             await contentWizard.waitForPreviewButtonNotDisplayed();
             //4. 'Show Component View' should not be visible
             await contentWizard.waitForShowComponentVewTogglerNotVisible();
-            //4. Verify that 'Failed to render content preview' message appears in the wizard page:
-            let message = await contentWizard.getMessageInPagePlaceholderInfoBlock();
-            assert.equal(message, "Failed to render content preview.");
+            //5. Verify that 'Failed to render content preview' message appears in the wizard page:
+            await contentWizard.waitForErrorMessageInLiveFormPanel(ERROR_MESSAGE_LIVE_EDIT);
             await studioUtils.doCloseCurrentBrowserTab();
             await studioUtils.doSwitchToContentBrowsePanel();
-            //5. Verify that Preview button is disabled on the browse toolbar:
+            //6. Verify that 'Preview' button is disabled in the browse panel toolbar:
             await studioUtils.findAndSelectItem(SITE.displayName);
             await contentBrowsePanel.pause(1000);
             await contentBrowsePanel.waitForPreviewButtonDisabled();

--- a/testing/specs/publish/refresh.publish.content.dialog.spec.js
+++ b/testing/specs/publish/refresh.publish.content.dialog.spec.js
@@ -22,7 +22,7 @@ describe('refresh.publish.dialog.spec - opens publish content modal dialog and c
 
     //verifies https://github.com/enonic/app-contentstudio/issues/697
     //         https://github.com/enonic/lib-admin-ui/issues/1061
-    it(`GIVEN new folder ('Work in progress') is selected AND Publish dialog has been opened WHEN this folder has been clicked in the dialog and 'Marked as ready' has been done in the wizard THEN Publish Wizard should be updated`,
+    it(`GIVEN 'Ready for publishing' folder is selected AND Publish dialog has been opened WHEN folder-link has been clicked in the dialog and a language has been selected THEN the workflow-status should be updated in Publish Wizard`,
         async () => {
             let contentWizard = new ContentWizard();
             let contentBrowsePanel = new ContentBrowsePanel();
@@ -32,11 +32,11 @@ describe('refresh.publish.dialog.spec - opens publish content modal dialog and c
             //1. New folder has been added:(status of this folder is Ready for publishing)
             await studioUtils.doAddReadyFolder(FOLDER);
             await studioUtils.findAndSelectItem(FOLDER.displayName);
-            //2. expand 'Publish Menu' and select 'Publish...' menu item, Publish Wizard gets visible:
+            //2. expand 'Publish Menu' and select 'Publish...' menu item, Publish Wizard should be loaded:
             await contentBrowsePanel.openPublishMenuSelectItem(appConst.PUBLISH_MENU.PUBLISH);
             await contentPublishDialog.waitForPublishNowButtonEnabled();
 
-            //3. click on the folder-name in the modal dialog and switches to new wizard-tab:
+            //3. click on the folder-name in the modal dialog then switch to the wizard-tab:
             await contentPublishDialog.clickOnItemToPublishAndSwitchToWizard(FOLDER.displayName);
             //4. Select a language in the wizard. The folder gets Work in Progress
             let settingsForm = new SettingsStepForm();


### PR DESCRIPTION
1. Update failed ui-tests for Custom error handling - need to waitForMessage in LiveEdit panel after selecting a controller with error
2. Update periodically failed test for Launcher Panel 