### PR TITLE
Show layer only under main parent #5484

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/project/list/ProjectList.ts
+++ b/modules/lib/src/main/resources/assets/js/app/project/list/ProjectList.ts
@@ -59,7 +59,7 @@ export class ProjectList
     }
 
     private getDirectProjectChildren(project: Project, projects: Project[]): Project[] {
-        return projects.filter((item: Project) => item.hasParentByName(project.getName()));
+        return projects.filter((item: Project) => item.hasMainParentByName(project.getName()));
     }
 
     private sortProjects(items: Project[]): Project[] {

--- a/modules/lib/src/main/resources/assets/js/app/settings/data/project/Project.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/data/project/Project.ts
@@ -87,6 +87,10 @@ export class Project
         return this.parents?.length > 0;
     }
 
+    hasMainParentByName(projectName: string): boolean {
+        return this.parents?.indexOf(projectName) === 0;
+    }
+
     hasParentByName(projectName: string): boolean {
         return this.parents?.indexOf(projectName) >= 0;
     }

--- a/modules/lib/src/main/resources/assets/js/app/settings/dialog/project/create/ProjectWizardDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/dialog/project/create/ProjectWizardDialog.ts
@@ -72,14 +72,16 @@ export class ProjectWizardDialog
 
     private setNameFromParentProjects(): void {
         const parents = this.getParentProjects();
-        const locale: Locale = this.getSelectedLocale();
+        const hasParents = parents?.length > 0;
 
-        if (parents?.length > 0 && locale) {
+        if (hasParents) {
+            const locale = this.getSelectedLocale();
+
             const names = parents.map(p => p.getName()).join('-');
-            const newName: string = `${names}-${locale.getId().toLowerCase()}`;
+            const newName = locale ? `${names}-${locale.getId().toLowerCase()}` : names;
 
             const parentDescription = parents.length === 1 ? parents[0].getDescription() : null;
-            const description = parentDescription ? `${parentDescription} (${locale.getDisplayName()})` : '';
+            const description = parentDescription ? `${parentDescription}${locale ? ` (${locale.getDisplayName()})` : ''}` : '';
 
             (<ProjectIdDialogStep>this.currentStep).setDescription(description, true);
             (<ProjectIdDialogStep>this.currentStep).setDisplayName(newName, true);

--- a/modules/lib/src/main/resources/assets/js/app/settings/dialog/project/create/step/summary/ProjectsValueContainer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/dialog/project/create/step/summary/ProjectsValueContainer.ts
@@ -10,6 +10,7 @@ export class ProjectsValueContainer
     }
 
     updateValue(value: Project[]): ProjectsValueContainer {
+        this.itemContainer.removeChildren();
         value.forEach(project => {
             const row = new SpanEl('project-item');
             row.setHtml(`${project.getDisplayName()} (${project.getName()})`);

--- a/modules/lib/src/main/resources/assets/js/app/settings/grid/SettingsItemsTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/grid/SettingsItemsTreeGrid.ts
@@ -73,13 +73,13 @@ export class SettingsItemsTreeGrid
         if (parentName == null) {
             return this.projects.filter((project: Project) => (project.getParents() ?? []).length === 0);
         } else {
-            return this.projects.filter((project: Project) => project.hasParentByName(parentName));
+            return this.projects.filter((project: Project) => project.hasMainParentByName(parentName));
         }
     }
 
     hasChildren(item: SettingsViewItem): boolean {
         return ObjectHelper.iFrameSafeInstanceOf(item, FolderViewItem) ||
-               this.projects.some((project: Project) => project.hasParentByName(item.getId()));
+               this.projects.some((project: Project) => project.hasMainParentByName(item.getId()));
     }
 
     getItemById(id: string): SettingsViewItem {

--- a/modules/lib/src/main/resources/assets/js/app/settings/resource/ProjectsTreeBuilder.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/resource/ProjectsTreeBuilder.ts
@@ -52,8 +52,7 @@ export class ProjectsTreeBuilder {
             return;
         }
 
-        const parentProjectsTreeItem: ProjectsTreeItem =
-            projectsTreeItems.find((item: ProjectsTreeItem) => project.hasParentByName(item.getName()));
+        const parentProjectsTreeItem = projectsTreeItems.find((item: ProjectsTreeItem) => project.hasMainParentByName(item.getName()));
 
         if (!parentProjectsTreeItem) {
             return;
@@ -70,7 +69,7 @@ export class ProjectsTreeBuilder {
     }
 
     private isDefaultOrHasParent(project: Project): boolean {
-        return ProjectHelper.isDefault(project) || this.projectsTree.some((p: Project) => project.hasParentByName(p.getName()));
+        return ProjectHelper.isDefault(project) || this.projectsTree.some((p: Project) => project.hasMainParentByName(p.getName()));
     }
 
     private getProjectsWithoutParents(): Project[] {
@@ -108,6 +107,6 @@ export class ProjectsTreeBuilder {
     }
 
     private getParent(project: Project): Project {
-        return this.projectsTree.find((p: Project) => project.hasParentByName(p.getName()));
+        return this.projectsTree.find((p: Project) => project.hasMainParentByName(p.getName()));
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectOptionDataHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectOptionDataHelper.ts
@@ -23,7 +23,7 @@ export class ProjectOptionDataHelper
     }
 
     isExpandable(data: Project): boolean {
-        return this.projects.some((project: Project) => project.hasParentByName(data.getName()));
+        return this.projects.some((project: Project) => project.hasMainParentByName(data.getName()));
     }
 
     isSelectable(data: Project): boolean {

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectOptionDataLoader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectOptionDataLoader.ts
@@ -57,7 +57,7 @@ export class ProjectOptionDataLoader
     }
 
     private getDirectProjectChildren(project: Project): Project[] {
-        return this.getResults().filter((item: Project) => item.hasParentByName(project.getName()));
+        return this.getResults().filter((item: Project) => item.hasMainParentByName(project.getName()));
     }
 
     onLoadModeChanged(listener: (isTreeMode: boolean) => void) {

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectsComboBox.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectsComboBox.ts
@@ -67,7 +67,7 @@ export class ProjectsComboBox extends RichComboBox<Project> {
 
     protected createOptions(items: Project[]): Q.Promise<Option<Project>[]> {
         this.helper.setProjects(items);
-        const result: Project[] = this.isSearchStringSet() ? items : items.filter((item: Project) => !item.getParents());
+        const result: Project[] = this.isSearchStringSet() ? items : items.filter((item: Project) => !item.hasParents());
         return super.createOptions(result);
     }
 


### PR DESCRIPTION
Prevented children projects from to be shown under non-main parent in grid, select dialog and combobox. 
Fixed problem with projects summary gets duplicated after returning to summary step from the previous one. 
Fixed problem with projects not shown in the combobox.
Made name autocomplete works even if the language step was skipped.