### PR TITLE
Injections tests fail #5626

### DIFF
--- a/modules/app/src/test/java/com/enonic/xp/app/contentstudio/LiveEditInjectionTest.java
+++ b/modules/app/src/test/java/com/enonic/xp/app/contentstudio/LiveEditInjectionTest.java
@@ -77,7 +77,7 @@ class LiveEditInjectionTest
 
         final String result = list.get( 0 );
         assertNotNull( result );
-        assertEquals( readResource( templateName ).trim() + System.lineSeparator(), result );
+        assertEquals( readResource( templateName ).trim(), result.trim() );
     }
 
     @Test
@@ -109,7 +109,7 @@ class LiveEditInjectionTest
 
         final String result = list.get( 0 );
         assertNotNull( result );
-        assertEquals( readResource( "liveEditInjectionBodyEnd.html" ).trim() + System.lineSeparator(), result );
+        assertEquals( readResource( "liveEditInjectionBodyEnd.html" ).trim(), result.trim() );
     }
 
     private void mockCurrentContextHttpRequest()


### PR DESCRIPTION
System.lineSeparator() and actual line ending are not equals on some OS.