### PR TITLE
Fix Grid formatters errors in dev mode #5682

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,10 +71,3 @@ htmlSanityCheck {
 }
 
 build.enabled = false
-
-if ( hasProperty( 'env' ) )
-{
-    gradle.startParameter.getExcludedTaskNames().forEach( taskName -> {
-        gradle.includedBuild( 'lib-admin-ui' )?.task( ":$taskName" )?.resolveTask()?.enabled = false
-    } )
-}

--- a/gradle/lib-admin.gradle
+++ b/gradle/lib-admin.gradle
@@ -17,18 +17,33 @@ def applyResourcesTaskDependencies()
 {
     def libAdminDevJarTask = gradle.includedBuild( 'lib-admin-ui' ).task( ':devJar' )
     def libAdminBuildTask = gradle.includedBuild( 'lib-admin-ui' ).task( ':build' )
+    def libAdminCleanTask = gradle.includedBuild( 'lib-admin-ui' ).task( ':clean' )
 
-    if ( hasTask( 'copyDevResources' ) ) {
+    if ( hasTask( 'copyDevResources' ) )
+    {
         copyDevResources.dependsOn libAdminDevJarTask
     }
 
     build.dependsOn += libAdminBuildTask
+
+    if ( hasTask( 'clean' ) )
+    {
+        clean.dependsOn += libAdminCleanTask
+    }
+}
+
+def excludeTasks()
+{
+    gradle.startParameter.getExcludedTaskNames().forEach( taskName -> {
+        gradle.includedBuild( 'lib-admin-ui' ).task( ":$taskName" )?.resolveTask()?.enabled = false
+    } )
 }
 
 if ( hasLibAdminUi() )
 {
     afterEvaluate {
         applyResourcesTaskDependencies()
+        excludeTasks()
     }
 }
 

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentRowFormatter.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentRowFormatter.ts
@@ -1,23 +1,23 @@
-import {StringHelper} from '@enonic/lib-admin-ui/util/StringHelper';
-import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
 import {DivEl} from '@enonic/lib-admin-ui/dom/DivEl';
+import {SpanEl} from '@enonic/lib-admin-ui/dom/SpanEl';
+import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
+import {ProgressBar} from '@enonic/lib-admin-ui/ui/ProgressBar';
 import {TreeNode} from '@enonic/lib-admin-ui/ui/treegrid/TreeNode';
-import {ContentTreeSelectorItem} from '../item/ContentTreeSelectorItem';
-import {ContentAndStatusTreeSelectorItem} from '../item/ContentAndStatusTreeSelectorItem';
+import {StringHelper} from '@enonic/lib-admin-ui/util/StringHelper';
 import {ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
 import {ContentSummaryAndCompareStatusViewer} from '../content/ContentSummaryAndCompareStatusViewer';
-import {SpanEl} from '@enonic/lib-admin-ui/dom/SpanEl';
-import {ProgressBar} from '@enonic/lib-admin-ui/ui/ProgressBar';
-import {MediaTreeSelectorItem} from '../inputtype/ui/selector/media/MediaTreeSelectorItem';
 import {ContentSummaryListViewer} from '../content/ContentSummaryListViewer';
+import {MediaTreeSelectorItem} from '../inputtype/ui/selector/media/MediaTreeSelectorItem';
+import {ContentAndStatusTreeSelectorItem} from '../item/ContentAndStatusTreeSelectorItem';
+import {ContentTreeSelectorItem} from '../item/ContentTreeSelectorItem';
 
 export class ContentRowFormatter {
 
-    public static nameFormatter(_row: number, _cell: number, _value: any, _columnDef: any,
-                                node: TreeNode<ContentSummaryAndCompareStatus>) {
+    public static nameFormatter(_row: number, _cell: number, _value: unknown, _columnDef: unknown,
+                                node: TreeNode<ContentSummaryAndCompareStatus>): string {
         const data = node.getData();
         if (data.getContentSummary() || data.getUploadItem()) {
-            let viewer = <ContentSummaryAndCompareStatusViewer> node.getViewer('name');
+            let viewer = <ContentSummaryAndCompareStatusViewer>node.getViewer('name');
             if (!viewer) {
                 viewer = new ContentSummaryListViewer();
                 node.setViewer('name', viewer);
@@ -30,8 +30,8 @@ export class ContentRowFormatter {
         return '';
     }
 
-    public static orderFormatter(_row: number, _cell: number, value: any, _columnDef: any,
-                                 node: TreeNode<ContentSummaryAndCompareStatus>) {
+    public static orderFormatter(_row: number, _cell: number, value: string, _columnDef: object,
+                                 node: TreeNode<ContentSummaryAndCompareStatus>): string {
         let wrapper = new SpanEl();
 
         if (!StringHelper.isBlank(value)) {
@@ -60,11 +60,12 @@ export class ContentRowFormatter {
         return wrapper.toString();
     }
 
-    public static statusFormatter({}: any, {}: any, {}: any, {}: any, dataContext: TreeNode<ContentSummaryAndCompareStatus>) {
+    public static statusFormatter(_row: number, _cell: number, value: number, _columnDef: object,
+                                  dataContext: TreeNode<ContentSummaryAndCompareStatus>): string {
         return ContentRowFormatter.doStatusFormat(dataContext.getData());
     }
 
-    public static statusSelectorFormatter({}: any, {}: any, value: ContentTreeSelectorItem, {}: any, {}: any) {
+    public static statusSelectorFormatter(_row: number, _cell: number, value: ContentTreeSelectorItem): string {
 
         if (ObjectHelper.iFrameSafeInstanceOf(value, ContentAndStatusTreeSelectorItem) ||
             ObjectHelper.iFrameSafeInstanceOf(value, MediaTreeSelectorItem)) {

--- a/modules/lib/src/main/resources/assets/js/app/settings/grid/SettingsItemRowFormatter.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/grid/SettingsItemRowFormatter.ts
@@ -1,20 +1,22 @@
-import {TreeNode} from '@enonic/lib-admin-ui/ui/treegrid/TreeNode';
 import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
-import {FolderItemViewer} from '../browse/viewer/FolderItemViewer';
-import {SettingsViewItem} from '../view/SettingsViewItem';
-import {ProjectViewItem} from '../view/ProjectViewItem';
-import {FolderViewItem} from '../view/FolderViewItem';
-import {ProjectViewer} from '../wizard/viewer/ProjectViewer';
+import {TreeNode} from '@enonic/lib-admin-ui/ui/treegrid/TreeNode';
 import {Viewer} from '@enonic/lib-admin-ui/ui/Viewer';
+import {FolderItemViewer} from '../browse/viewer/FolderItemViewer';
 import {Project} from '../data/project/Project';
+import {FolderViewItem} from '../view/FolderViewItem';
+import {ProjectViewItem} from '../view/ProjectViewItem';
+import {SettingsViewItem} from '../view/SettingsViewItem';
+import {ProjectViewer} from '../wizard/viewer/ProjectViewer';
 
 export class SettingsItemRowFormatter {
 
-    public static nameFormatter({}: any, {}: any, {}: any, {}: any, dataContext: TreeNode<SettingsViewItem>) {
-        return SettingsItemRowFormatter.getViewerForSettingsItem(dataContext).toString();
+    public static nameFormatter(_row: number, _cell: number, value: number, _columnDef: object,
+                                dataContext: TreeNode<SettingsViewItem>): string {
+        const viewer = SettingsItemRowFormatter.getViewerForSettingsItem(dataContext).toString();
+        return viewer ? viewer.toString() : '';
     }
 
-    private static getViewerForSettingsItem(dataContext: TreeNode<SettingsViewItem>): Viewer<any> {
+    private static getViewerForSettingsItem(dataContext: TreeNode<SettingsViewItem>): Viewer<any> | null {
         if (ObjectHelper.iFrameSafeInstanceOf(dataContext.getData(), ProjectViewItem)) {
             const viewer: Viewer<Project> = dataContext.getViewer('displayName') || new ProjectViewer();
             viewer.setObject((<ProjectViewItem>dataContext.getData()).getData());


### PR DESCRIPTION
Removed parameter destructing from the formatter functions, because it will lead to errors, when one of the arguments is undefined. Moved lib-admin-ui tasks exclusion to the separate file. Added `clean` Gradle task call in lib-admin-ui, when clean is called in the project.