### PR TITLE
Error message appears in wizard after renaming a published content #5844

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
@@ -66,7 +66,8 @@ export class ContentWizardHeader
                 this.renameDialog = new RenameContentDialog();
 
                 this.renameDialog.onRenamed((newName: string) => {
-                    this.setName(newName);
+                    this.setName(newName, true); // setting silently to avoid duplication check
+                    this.nameEl.show(); // using workaround to trigger AutosizeTextInput's resize
                     this.notifyRenamed();
                 });
             }
@@ -255,5 +256,11 @@ export class ContentWizardHeader
 
         const path: string = content.getPath().getParentPath().isRoot() ? '/' : `${content.getPath().getParentPath().toString()}/`;
         this.setPath(path);
+    }
+
+    toggleEnabled(enable: boolean) {
+        super.toggleEnabled(enable);
+
+        this.lockElem?.setEnabled(enable);
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -923,6 +923,7 @@ export class ContentWizardPanel
         this.isFirstUpdateAndRenameEventSkiped = false;
         this.contentWizardStepForm?.getFormView()?.clean();
         new BeforeContentSavedEvent().fire();
+        this.wizardHeader.toggleEnabled(false);
 
         return super.saveChanges().then((content: Content) => {
             if (this.reloadPageEditorOnSave) {
@@ -937,6 +938,7 @@ export class ContentWizardPanel
             this.contentUpdateDisabled = false;
             this.isRename = false;
             this.updateButtonsState();
+            this.wizardHeader.toggleEnabled(true);
         });
     }
 


### PR DESCRIPTION
-Setting new name to the input silently to not trigger uninqueness check -Triggering resize for name's Autosize input by invoking .show() -Disabling wizard header while saving content to prevent editing name in-between