### PR TITLE
Checks section on the second step of Publishing Request dialog #5973

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/publish/RequestContentPublishDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/publish/RequestContentPublishDialog.ts
@@ -29,7 +29,8 @@ import {CreateIssueRequest} from '../issue/resource/CreateIssueRequest';
 import {PrincipalLoader} from '../security/PrincipalLoader';
 
 enum Step {
-    ITEMS, DETAILS
+    ITEMS = 'items-step',
+    DETAILS = 'details-step',
 }
 /**
  * ContentPublishDialog manages list of initially checked (initially requested) items resolved via ResolvePublishDependencies command.
@@ -174,12 +175,19 @@ export class RequestContentPublishDialog
     }
 
     private goToStep(step: Step): void {
-        const isDetailsStep: boolean = step === Step.DETAILS;
+        const isDetailsStep = step === Step.DETAILS;
+
+        for (const key in Step) {
+            this.removeClass(Step[key]);
+        }
+        this.addClass(step);
+
         this.requestPublishAction.setVisible(isDetailsStep);
         this.publishItemsStep.setVisible(!isDetailsStep);
         this.requestDetailsStep.setVisible(isDetailsStep);
         this.prevAction.setVisible(isDetailsStep);
         this.getButtonRow().getActionMenu().setVisible(!isDetailsStep);
+
         this.setSubTitle(i18n(`dialog.requestPublish.subname${this.getCurrentStep() + 1}`));
         this.updateControls();
 

--- a/modules/lib/src/main/resources/assets/styles/publish/request-content-publish-dialog.less
+++ b/modules/lib/src/main/resources/assets/styles/publish/request-content-publish-dialog.less
@@ -2,6 +2,12 @@
 
   .base-publish-dialog();
 
+  &.details-step {
+    .dialog-state-bar {
+      display: none;
+    }
+  }
+
   .modal-dialog-header {
 
     .icon-publish-request {


### PR DESCRIPTION
* Added styles to hide state bar on details step of request publish dialog. 
* Changed compilation target from ES2015 to ES2018, as ES5 is outdated and does not support commonly used built-in functions in basic types.