### PR TITLE
Excluded dependencies toggler must not be visible if all items are required #5990

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/publish/PublishDialogDependantList.ts
+++ b/modules/lib/src/main/resources/assets/js/app/publish/PublishDialogDependantList.ts
@@ -86,6 +86,10 @@ export class PublishDialogDependantList
         return !this.requiredIds.contains(item.getContentId());
     }
 
+    hasExcluded(): boolean {
+        return this.excludedIds.filter(id => !this.requiredIds.contains(id)).length > 0;
+    }
+
     setRequiredIds(value: ContentId[]) {
         this.requiredIds = ContentIds.from(value);
     }


### PR DESCRIPTION
Updated `hasExcluded` method in the `PublishDialogDependantList` to filter out required content, that must not be counted as excluded, even though it might be added somewhere, e.g. while performing All exclusion.