### PR TITLE
Inclusion of excluded items in the Publishing dialog stopped working #6019

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/BasePublishDialog.ts
@@ -101,6 +101,7 @@ export abstract class BasePublishDialog
             resolvedText: i18n('dialog.publish.error.resolved'),
             edit: {
                 applyHandler: () => {
+                    this.publishProcessor.setLoadExcluded(false);
                     this.excludedToggler.setActive(false);
                     this.getDependantList().saveExclusions();
                     this.markEditing(false);

--- a/modules/lib/src/main/resources/assets/js/app/issue/view/CreateIssueDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/issue/view/CreateIssueDialog.ts
@@ -64,6 +64,7 @@ export class CreateIssueDialog
             hideIfResolved: true,
             edit: {
                 applyHandler: () => {
+                    this.publishProcessor.setLoadExcluded(false);
                     this.excludedToggler.setActive(false);
                     this.getDependantList().saveExclusions();
                     this.markEditing(false);

--- a/modules/lib/src/main/resources/assets/js/app/issue/view/IssueDetailsDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/issue/view/IssueDetailsDialog.ts
@@ -243,6 +243,7 @@ export class IssueDetailsDialog
             edit: {
                 applyHandler: () => {
                     this.saveOnLoaded = true;
+                    this.publishProcessor.setLoadExcluded(false);
                     this.excludedToggler.setActive(false);
                     this.getDependantList().saveExclusions();
                     this.markEditing(false);

--- a/modules/lib/src/main/resources/assets/js/app/publish/PublishProcessor.ts
+++ b/modules/lib/src/main/resources/assets/js/app/publish/PublishProcessor.ts
@@ -488,8 +488,8 @@ export class PublishProcessor {
         this.ignoreDependantItemsChanged = value;
     }
 
-    isLoadExcluded(): boolean {
-        return this.loadExcluded;
+    setLoadExcluded(loadExcluded: boolean): void {
+        this.loadExcluded = loadExcluded;
     }
 
     private countToPublish(summaries: ContentSummaryAndCompareStatus[]): number {


### PR DESCRIPTION
Added manual change of the loadExcluded flag on apply action to prevent `updateLoadExcluded` from sending requests and updating dependencies, because it will be done properly in `reloadPublishDependencies`.