### PR TITLE
Disable Next button in Request publish dialog manually #6066

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/publish/RequestContentPublishDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/publish/RequestContentPublishDialog.ts
@@ -126,6 +126,10 @@ export class RequestContentPublishDialog
             this.setSubTitle(i18n('dialog.requestPublish.error.loadFailed'));
         });
 
+        this.getDependantList().onSelectionChanged((original) => {
+            this.nextAction.setEnabled(original);
+        });
+
         (<PrincipalComboBox>this.assigneesFormItem.getInput()).onValueChanged(() => this.handleDataChanged());
         (<TextInput>this.detailsFormItem.getInput()).onValueChanged(() => this.handleDataChanged());
     }

--- a/modules/lib/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
+++ b/modules/lib/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
@@ -9,7 +9,6 @@
     .include-children-toggler,
     .removable .remove,
     .schedule-control,
-    .action-button.next,
     .dialog-buttons .action-button:not(.force-enabled) {
       opacity: 0.5;
       cursor: default;


### PR DESCRIPTION
Disabled next button manually when dependencies selection changes for ease of testing.