### PR TITLE
Content grid loses selection when refreshed after content update #6354

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -166,12 +166,11 @@ export class ContentBrowseFilterPanel
 
     doRefresh(): Q.Promise<void> {
         if (!this.isFilteredOrConstrained()) {
-            return this.resetFacets();
+            return this.resetFacets(true);
         }
 
         return this.getAndUpdateAggregations().then((aggregationsQueryResult: AggregationsQueryResult) => {
             if (aggregationsQueryResult.getMetadata().getTotalHits() > 0) {
-                this.notifySearchEvent(this.aggregationsFetcher.createContentQuery(this.getSearchInputValues()));
                 return Q.resolve();
             }
 
@@ -179,7 +178,7 @@ export class ContentBrowseFilterPanel
                 this.removeDependencyItem();
             }
 
-            return this.reset();
+            return this.reset(true);
         });
     }
 
@@ -249,7 +248,10 @@ export class ContentBrowseFilterPanel
 
     protected resetFacets(suppressEvent?: boolean, doResetAll?: boolean): Q.Promise<void> {
         return this.getAndUpdateAggregations().then(() => {
-            this.notifySearchEvent();
+            if (!suppressEvent) {
+                this.notifySearchEvent();
+            }
+
             return Q.resolve();
         });
     }

--- a/modules/lib/src/main/resources/assets/js/app/resource/ContentQueryRequest.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/ContentQueryRequest.ts
@@ -15,6 +15,8 @@ import {HttpMethod} from '@enonic/lib-admin-ui/rest/HttpMethod';
 import {ContentSummary} from '../content/ContentSummary';
 import {ContentSummaryJson} from '../content/ContentSummaryJson';
 import {CmsContentResourceRequest} from './CmsContentResourceRequest';
+import {ContentIdBaseItemJson} from './json/ContentIdBaseItemJson';
+import {ContentId} from '../content/ContentId';
 
 export class ContentQueryRequest<CONTENT_JSON extends ContentSummaryJson, CONTENT extends ContentSummary>
     extends CmsContentResourceRequest<ContentQueryResult<CONTENT, CONTENT_JSON>> {
@@ -166,8 +168,7 @@ export class ContentQueryRequest<CONTENT_JSON extends ContentSummaryJson, CONTEN
         return ContentSummary.fromJson(json);
     }
 
-    fromJsonToContentIdBaseItemArray(jsonArray: ContentSummaryJson[]): ContentSummary[] {
-
-        return ContentSummary.fromJsonArray(jsonArray);
+    fromJsonToContentIdBaseItemArray(jsonArray: ContentIdBaseItemJson[]): ContentId[] {
+        return jsonArray?.map((json: ContentIdBaseItemJson) => new ContentId(json.id)) || [];
     }
 }


### PR DESCRIPTION
-Filter refresh must not trigger reload of a content tree grid
-Adding/deleting content items in both filtered and default grid roots