### PR TITLE
Publish Wizard - wrong state of 'show excluded' button #6540

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/upload/MediaUploaderEl.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/upload/MediaUploaderEl.ts
@@ -110,7 +110,7 @@ export class MediaUploaderEl
         const name: string = this.generateUniqueName(imgSrc);
         const parent: string = this.config.params.parent;
 
-        const uploadItem = new UploadItem<Content>({name: name});
+        const uploadItem = new UploadItem<Content>({name});
         this.notifyFileUploadStarted([uploadItem]);
 
         new CreateMediaFromUrlRequest()


### PR DESCRIPTION
Turned off missing dependencies restoration, when `resetExclusions` is `true`.
Refactored load result handling methods.