### PR TITLE
Ditch extra preview requests + special handling for shortcut preview

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -37,6 +37,7 @@ import {ContextView} from '../view/context/ContextView';
 import {ResponsiveBrowsePanel} from './ResponsiveBrowsePanel';
 import {MovedContentItem} from './MovedContentItem';
 import {ContentQuery} from '../content/ContentQuery';
+import {StatusCode} from '@enonic/lib-admin-ui/rest/StatusCode';
 
 export class ContentBrowsePanel
     extends ResponsiveBrowsePanel {
@@ -492,8 +493,8 @@ export class ContentBrowsePanel
         const selectedItem: ContentSummaryAndCompareStatus = this.treeGrid.getLastSelectedOrHighlightedItem();
 
         if (selectedItem) {
-            new IsRenderableRequest(selectedItem.getContentSummary()).sendAndParse().then((isRenderable: boolean) => {
-                this.treeGrid.updateItemIsRenderable(selectedItem.getId(), isRenderable);
+            new IsRenderableRequest(selectedItem.getContentSummary()).sendAndParse().then((statusCode: number) => {
+                this.treeGrid.updateItemIsRenderable(selectedItem.getId(), statusCode === StatusCode.OK);
                 super.updateActionsAndPreview();
             }).catch(DefaultErrorHandler.handle);
         } else {

--- a/modules/lib/src/main/resources/assets/js/app/resource/ContentSummaryAndCompareStatusFetcher.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/ContentSummaryAndCompareStatusFetcher.ts
@@ -17,6 +17,7 @@ import {ChildOrder} from './order/ChildOrder';
 import {ContentId} from '../content/ContentId';
 import {FieldOrderExpr, FieldOrderExprBuilder} from './order/FieldOrderExpr';
 import {ContentResourceRequest} from './ContentResourceRequest';
+import {StatusCode} from '@enonic/lib-admin-ui/rest/StatusCode';
 
 export class ContentSummaryAndCompareStatusFetcher {
 
@@ -181,8 +182,8 @@ export class ContentSummaryAndCompareStatusFetcher {
     updateRenderableContent(content: ContentSummaryAndCompareStatus, projectName?: string): Q.Promise<void> {
         return new IsRenderableRequest(content.getContentSummary())
             .sendAndParse()
-            .then((isRenderable: boolean) => {
-                content.setRenderable(isRenderable);
+            .then((statusCode: number) => {
+                content.setRenderable(statusCode === StatusCode.OK);
                 return Q(null);
             });
     }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -139,6 +139,7 @@ import {LiveEditPageProxy} from './page/LiveEditPageProxy';
 import {PageComponentsView} from './PageComponentsView';
 import {PageView} from '../../page-editor/PageView';
 import {WizardStep} from '@enonic/lib-admin-ui/app/wizard/WizardStep';
+import {StatusCode} from '@enonic/lib-admin-ui/rest/StatusCode';
 
 export class ContentWizardPanel
     extends WizardPanel<Content> {
@@ -2497,7 +2498,8 @@ export class ContentWizardPanel
     }
 
     private checkIfRenderable(item?: ContentSummary): Q.Promise<boolean> {
-        return new IsRenderableRequest(item || this.getPersistedItem(), RenderingMode.EDIT).sendAndParse().then((renderable: boolean) => {
+        return new IsRenderableRequest(item || this.getPersistedItem(), RenderingMode.EDIT).sendAndParse().then((statusCode: number) => {
+            const renderable = statusCode === StatusCode.OK;
             this.renderable = renderable;
             this.contextView?.setIsPageRenderable(renderable);
 


### PR DESCRIPTION
* Don't allow two concurrent IsRenderableRequests
* IsRenderableRequest now returns status code instead of just true/false
* Use IsRenderableRequest instead of plain fetch request to verify if a content has preview