### PR TITLE
Incorrect position of minimize Live Edit icon #6471

### DIFF
--- a/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -161,6 +161,12 @@
         }
       }
     }
+
+    .wizard-steps-panel {
+      .wizard-step-form:last-of-type {
+        height: auto !important;
+      }
+    }
   }
 
   &:not(.rendered) {
@@ -363,6 +369,16 @@
           position: absolute;
           left: 5px;
           top: 5px;
+        }
+      }
+
+      &:not(.minimized) {
+        .wizard-step-navigator-and-toolbar {
+          &:not(.folded) {
+            &:not(.scroll-stick) {
+              width: auto !important;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
- Removing extra vertical scrollbar in the wizard panel produced by PanelStrip.updateLastPanelHeight() by forcing auto height of the last step form 
- Forcing auto width of the toolbar that contains minimize icon when it is in normal position (not sticky, not folded) so it occupies available width no matther if there's a scrollbar or not