### PR TITLE
Inspect panel expands when text component is in edit mode #6828

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/event/InspectEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/app/event/InspectEvent.ts
@@ -8,8 +8,8 @@ export class InspectEvent
 
     private readonly showPanel: boolean;
 
-    constructor(showWidget: boolean, showPanel: boolean, name?: string) {
-        super(name);
+    constructor(showWidget: boolean, showPanel: boolean) {
+        super();
         this.showWidget = showWidget;
         this.showPanel = showPanel;
     }

--- a/modules/lib/src/main/resources/assets/js/app/view/context/ContextSplitPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/ContextSplitPanel.ts
@@ -25,7 +25,7 @@ export class ContextSplitPanel
     public static CONTEXT_MIN_WIDTH: number = 280;
 
     private contextPanelMode: ContextPanelMode;
-    private static contextPanelState: ContextPanelState = ContextPanelState.COLLAPSED;
+    private contextPanelState: ContextPanelState = ContextPanelState.COLLAPSED;
     private debouncedResizeHandler: () => void = AppHelper.debounce(this.doHandleResizeEvent, 650, false);
     private mobileMode: boolean;
     private contextView: ContextView;
@@ -39,7 +39,7 @@ export class ContextSplitPanel
     constructor(splitPanelBuilder: ContextSplitPanelBuilder) {
         super(splitPanelBuilder);
 
-        this.addClass(`context-split-panel ${ContextSplitPanel.contextPanelState}`);
+        this.addClass(`context-split-panel ${this.contextPanelState}`);
 
         this.contextView = splitPanelBuilder.contextView;
         this.dockedContextPanel = splitPanelBuilder.getSecondPanel();
@@ -53,13 +53,13 @@ export class ContextSplitPanel
         this.dockedContextPanel.onAdded(this.renderAfterDockedPanelReady.bind(this));
 
         InspectEvent.on((event: InspectEvent) => {
-            if (event.isShowPanel() && this.isRendered() && !ContextSplitPanel.isExpanded()) {
+            if (event.isShowPanel() && this.isRendered() && !this.isExpanded()) {
                 this.showContextPanel();
             }
         });
 
         ToggleContextPanelEvent.on(() => {
-            if (ContextSplitPanel.isExpanded()) {
+            if (this.isExpanded()) {
                 this.hideContextPanel();
             } else {
                 this.showContextPanel();
@@ -127,7 +127,7 @@ export class ContextSplitPanel
     }
 
     private doHandleResizeEvent(): void {
-        if (ContextSplitPanel.isCollapsed()) {
+        if (this.isCollapsed()) {
             return;
         }
 
@@ -202,21 +202,25 @@ export class ContextSplitPanel
     }
 
     setState(state: ContextPanelState): void {
-        if (state !== ContextSplitPanel.contextPanelState) {
-            this.removeClass(ContextSplitPanel.contextPanelState);
-            ContextSplitPanel.contextPanelState = state;
+        if (state !== this.contextPanelState) {
+            this.removeClass(this.contextPanelState);
+            this.contextPanelState = state;
             this.addClass(state);
             new ContextPanelStateEvent(state).fire();
             this.notifyStateChanged();
         }
     }
 
-    static isExpanded(): boolean {
-        return !ContextSplitPanel.isCollapsed();
+    getState(): ContextPanelState {
+        return this.contextPanelState;
     }
 
-    static isCollapsed(): boolean {
-        return ContextSplitPanel.contextPanelState === ContextPanelState.COLLAPSED;
+    isExpanded(): boolean {
+        return !this.isCollapsed();
+    }
+
+    isCollapsed(): boolean {
+        return this.contextPanelState === ContextPanelState.COLLAPSED;
     }
 
     onMobileModeChanged(listener: (isMobile: boolean) => void): void {
@@ -256,7 +260,7 @@ export class ContextSplitPanel
     }
 
     private notifyStateChanged(): void {
-        this.stateChangedListeners.forEach((curr: (state: ContextPanelState) => void) => curr(ContextSplitPanel.contextPanelState));
+        this.stateChangedListeners.forEach((curr: (state: ContextPanelState) => void) => curr(this.contextPanelState));
     }
 
     static create(firstPanel: Panel, secondPanel: DockedContextPanel): ContextSplitPanelBuilder {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -629,6 +629,7 @@ export class ContentWizardPanel
         if (this.livePanel) {
             this.splitPanel.onPanelResized(() => this.updateStickyToolbar());
             this.contextView.appendContextWindow(this.getLivePanel().getContextWindow());
+            this.livePanel.setContextPanelState(this.contextSplitPanel.getState());
 
             this.contextSplitPanel.onModeChanged((mode: ContextPanelMode) => {
                 if (!this.isMinimized()) {
@@ -636,9 +637,13 @@ export class ContentWizardPanel
                     this.splitPanel.setFirstPanelSize(SplitPanelSize.PERCENTS(formPanelSizePercents));
                     this.splitPanel.distribute(true);
                 }
+
+                this.livePanel.setContextPanelMode(mode);
             });
 
             this.contextSplitPanel.onStateChanged((state: ContextPanelState) => {
+                this.livePanel.setContextPanelState(state);
+
                 if (this.isMinimized()) {
                     return;
                 }

--- a/testing/specs/page-editor/fragment.layout.inspect.panel.spec.js
+++ b/testing/specs/page-editor/fragment.layout.inspect.panel.spec.js
@@ -55,7 +55,7 @@ describe('fragment.layout.inspect.panel.spec - Select a site with invalid child 
             await pageComponentView.selectMenuItem(['Insert', 'Layout']);
             // 3. Verifies #6393: we keep 'Inspect panel' collapsed (or collapse it if it was expanded).
             // So need to open 'Inspect panel':
-            await contentWizardPanel.clickOnDetailsPanelToggleButton();
+            //await contentWizardPanel.clickOnDetailsPanelToggleButton();
             await layoutInspectionPanel.typeNameAndSelectLayout(LAYOUT_2_COL);
             await pageComponentView.pause(500);
             let actualDescriptionLayout = await pageComponentView.getComponentDescription(LAYOUT_2_COL);
@@ -95,7 +95,7 @@ describe('fragment.layout.inspect.panel.spec - Select a site with invalid child 
             await contentWizardPanel.clickOnMinimizeLiveEditToggler();
             await pageComponentView.openMenu(MAIN_COMPONENT_NAME);
             await pageComponentView.selectMenuItem(['Insert', 'Layout']);
-            await contentWizardPanel.clickOnDetailsPanelToggleButton();
+            // Inspect panel should be expanded in this case :
             await layoutInspectionPanel.typeNameAndSelectLayout(LAYOUT_3_COL);
             // 3. Verify that the site is automatically saved after selecting a layout in the dropdown:
             await contentWizardPanel.waitForNotificationMessage();

--- a/testing/specs/page-editor/layout.config.inspect.panel.spec.js
+++ b/testing/specs/page-editor/layout.config.inspect.panel.spec.js
@@ -46,7 +46,7 @@ describe('layout.config.inspect.panel.spec: tests for layout with config', funct
             await pageComponentView.selectMenuItem(['Insert', 'Layout']);
             // 4. Verifies #6393: we keep 'Inspect panel' collapsed (or collapse it if it was expanded).
             // So need to open 'Inspect panel':
-            await contentWizard.clickOnDetailsPanelToggleButton();
+            //await contentWizard.clickOnDetailsPanelToggleButton();
             await layoutInspectionPanel.typeNameAndSelectLayout('Centered');
             // 5. Site should be saved automatically:
             await contentWizard.waitForNotificationMessage();


### PR DESCRIPTION
- removed static fields from ContextSplitPanel.ts since it doesn't belong there (class is not singleton for example and using other instance will break the logic) 
- hiding context panel if text mode is on and if context panel is in floating mode