### PR TITLE
Fix for "Remove pencil icon from the Content Wizard header"

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
@@ -59,7 +59,7 @@ export class ContentWizardHeader
             }
         });
 
-        this.nameEl.onFocus(() => {
+        this.bottomRow.onClicked(() => {
             if (this.hasClass(ContentWizardHeader.LOCKED_CLASS)) {
                 if (!this.renameDialog) {
                     this.renameDialog = new RenameContentDialog();
@@ -131,23 +131,28 @@ export class ContentWizardHeader
         this.updateIsNameUnique(true);
     }
 
+    setPath(value: string) {
+        if (!this.persistedContent) {
+            return;
+        }
+        const isLockedPath = this.hasClass(ContentWizardHeader.LOCKED_CLASS);
+
+        const pathValue = isLockedPath ? this.persistedContent.getPath().toString() : value;
+        super.setPath(pathValue);
+
+        if (isLockedPath) {
+            this.pathEl.setTitle(i18n('path.lock'));
+        }
+    }
+
     setOnline(isOnline: boolean) {
         this.toggleClass(ContentWizardHeader.LOCKED_CLASS, isOnline);
         this.toggleNameGeneration(!isOnline);
-
-        if (isOnline) {
-            this.nameEl.getEl().setTabIndex(-1);
-        } else {
-            this.nameEl.getEl().removeAttribute('tabindex');
-        }
+        this.nameEl.setVisible(!isOnline);
     }
 
     isValid(): boolean {
         return super.isValid() && this.isNameUnique;
-    }
-
-    isValidForSaving(): boolean {
-        return !!this.getName() && this.isNameUnique;
     }
 
     toggleNameInput(enable: boolean): void {
@@ -156,6 +161,10 @@ export class ContentWizardHeader
         }
 
         super.toggleNameInput(enable);
+    }
+
+    isValidForSaving(): boolean {
+        return !!this.getName() && this.isNameUnique;
     }
 
     isDisplayNameInputDirty(): boolean {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
@@ -59,7 +59,7 @@ export class ContentWizardHeader
             }
         });
 
-        this.bottomRow.onClicked(() => {
+        this.pathEl.onClicked(() => {
             if (this.hasClass(ContentWizardHeader.LOCKED_CLASS)) {
                 if (!this.renameDialog) {
                     this.renameDialog = new RenameContentDialog();

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -542,7 +542,6 @@ export class ContentWizardPanel
 
                 this.wizardHeader.setPlaceholder(this.contentType?.getDisplayNameLabel());
                 this.wizardHeader.setPersistedPath(this.isItemPersisted() ? this.getPersistedItem() : null);
-                this.wizardHeader.setPath(this.getWizardHeaderPath());
 
                 const existing: Content = this.getPersistedItem();
                 if (existing) {
@@ -2566,7 +2565,8 @@ export class ContentWizardPanel
         ContentContext.get().setContent(content);
 
         this.wizardHeader?.setOnline(!this.persistedContent.isNew());
-        this.wizardHeader.setDir(Locale.supportsRtl(this.persistedContent.getLanguage()) ? LangDirection.RTL : LangDirection.AUTO);
+        this.wizardHeader?.setPath(this.getWizardHeaderPath());
+        this.wizardHeader?.setDir(Locale.supportsRtl(this.persistedContent.getLanguage()) ? LangDirection.RTL : LangDirection.AUTO);
         this.contextView?.setItem(content).then(() => this.contextView.updateWidgetsVisibility());
     }
 

--- a/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -70,10 +70,6 @@
     }
 
     .wizard-header-bottom-row {
-      input {
-        display: inline-block;
-      }
-
       .icon-spinner {
         .animation(rotate360, 0.5s, 0s, linear);
       }
@@ -88,6 +84,20 @@
         input {
           border: 1px solid @admin-input-red;
           box-shadow: 0 0 3px 1px darken(@admin-input-red, 10%);
+        }
+      }
+    }
+
+    &.locked {
+      .wizard-header-bottom-row {
+        .path{
+          ~ * {
+            display: none !important;
+          }
+
+          &:hover {
+            cursor: pointer;
+          }
         }
       }
     }

--- a/modules/lib/src/main/resources/i18n/phrases.properties
+++ b/modules/lib/src/main/resources/i18n/phrases.properties
@@ -467,7 +467,7 @@ settings.items.wizard.application.stopped=Stopped
 #
 path.available=Available
 path.not.available=Not available
-path.lock=Click to modify the path
+path.lock=Click to rename the content
 
 #
 # Validation

--- a/testing/specs/publish/change.display.name.rename.published.content.spec.js
+++ b/testing/specs/publish/change.display.name.rename.published.content.spec.js
@@ -32,16 +32,17 @@ describe('change.display.name.rename.published.content.dialog.spec - tests for R
     it("GIVEN display name is modified WHEN the content has been renamed THEN the display name should not be updated after the renaming",
         async () => {
             let contentWizard = new ContentWizard();
+            // 1. Open the published content in the wizard:
             await studioUtils.selectAndOpenContentInWizard(TEST_FOLDER.displayName);
-            // 1. Update the display name:
+            // 2. Update the display name:
             await contentWizard.typeDisplayName(NEW_NAME);
-            // 2.  Click on the locked 'path input' and open the modal dialog:
-            let renamePublishedContentDialog = await contentWizard.clickOnLockedInputModifyPath();
+            // 3.  Click on the 'path input' and open the modal dialog:
+            let renamePublishedContentDialog = await contentWizard.clickOnNameInputOpenModifyPathDialog();
             await renamePublishedContentDialog.typeInNewNameInput(NEW_NAME);
-            // 3. Click on 'Rename' button and wait for the dialog is closed:
+            // 4. Click on 'Rename' button and wait for the dialog is closed:
             await renamePublishedContentDialog.clickOnRenameButton();
             await contentWizard.pause(1200);
-            // 4. Verify the display name:
+            // 5. Verify the display name:
             let actualDisplayName = await contentWizard.getDisplayName();
             assert.equal(actualDisplayName, NEW_NAME, 'Display name should not be rolled back after renaming the content');
         });

--- a/testing/specs/publish/rename.published.content.dialog.spec.js
+++ b/testing/specs/publish/rename.published.content.dialog.spec.js
@@ -38,7 +38,7 @@ describe('rename.published.content.dialog.spec - tests for Rename published cont
             let contentWizard = new ContentWizard();
             await studioUtils.selectAndOpenContentInWizard(TEST_FOLDER.displayName);
             //  Click on the locked 'path input' and open the modal dialog
-            let renamePublishedContentDialog = await contentWizard.clickOnLockedInputModifyPath();
+            let renamePublishedContentDialog = await contentWizard.clickOnNameInputOpenModifyPathDialog();
             let title = await renamePublishedContentDialog.getDialogTitle();
             assert.equal(title, DIALOG_HEADER, 'Expected title should be in the dialog');
             let path = await renamePublishedContentDialog.getPath();
@@ -50,7 +50,7 @@ describe('rename.published.content.dialog.spec - tests for Rename published cont
             let contentWizard = new ContentWizard();
             await studioUtils.selectAndOpenContentInWizard(TEST_FOLDER.displayName);
             // 1. Click on the locked 'path input' and open the modal dialog:
-            let renamePublishedContentDialog = await contentWizard.clickOnLockedInputModifyPath();
+            let renamePublishedContentDialog = await contentWizard.clickOnNameInputOpenModifyPathDialog();
             await renamePublishedContentDialog.typeInNewNameInput(NEW_NAME);
             // 2. Verify that Rename button gets enabled:
             await renamePublishedContentDialog.waitForRenameButtonEnabled();
@@ -61,7 +61,7 @@ describe('rename.published.content.dialog.spec - tests for Rename published cont
             let contentWizard = new ContentWizard();
             await studioUtils.selectAndOpenContentInWizard(TEST_FOLDER.displayName);
             // 1. Click on 'Modify path icon' and open the modal dialog:
-            let renamePublishedContentDialog = await contentWizard.clickOnLockedInputModifyPath();
+            let renamePublishedContentDialog = await contentWizard.clickOnNameInputOpenModifyPathDialog();
             await renamePublishedContentDialog.typeInNewNameInput(NEW_NAME);
             // 2. Verify that 'Rename' button gets enabled:
             await renamePublishedContentDialog.waitForRenameButtonEnabled();
@@ -69,8 +69,19 @@ describe('rename.published.content.dialog.spec - tests for Rename published cont
             await renamePublishedContentDialog.waitForDialogClosed();
             let actualPath = await contentWizard.getPath();
             assert.equal(actualPath, TEST_FOLDER.displayName, "Path in wizard page should not be updated");
-            // 3. Verify that 'path input' remains locked after canceling the modal dialog:
-            await contentWizard.waitForPathInputLocked();
+            // 3. Verify that 'Click to rename the content' tooltip is present in wizard header after canceling the modal dialog:
+            await contentWizard.waitForModifyPathSpanDisplayed();
+        });
+
+    it("GIVEN published content has been opened WHEN cursor moved to the path input THEN 'Click to the rename the content' tooltip should be displayed",
+        async () => {
+            let contentWizard = new ContentWizard();
+            await studioUtils.selectAndOpenContentInWizard(TEST_FOLDER.displayName);
+            // 1. Move mouse to the 'path' input:
+            await contentWizard.moveMouseToModifyPathSpan();
+            await studioUtils.saveScreenshot('click_to_rename_the_content_tooltip1');
+            // 2. Verify that tooltip appears
+            await contentWizard.waitForModifyPathTooltipDisplayed();
         });
 
     // Verifies: Path field gets unlocked after a published content is modified #5073
@@ -79,7 +90,7 @@ describe('rename.published.content.dialog.spec - tests for Rename published cont
             let contentWizard = new ContentWizard();
             await studioUtils.selectAndOpenContentInWizard(TEST_FOLDER.displayName);
             // 1. Click on 'Modify path icon' and open the modal dialog:
-            let renamePublishedContentDialog = await contentWizard.clickOnLockedInputModifyPath();
+            let renamePublishedContentDialog = await contentWizard.clickOnNameInputOpenModifyPathDialog();
             await renamePublishedContentDialog.typeInNewNameInput(NEW_NAME);
             // 2. Verify that 'Rename' button gets enabled:
             await renamePublishedContentDialog.waitForRenameButtonEnabled();
@@ -87,8 +98,9 @@ describe('rename.published.content.dialog.spec - tests for Rename published cont
             let message = await contentWizard.waitForNotificationMessage();
             let actualPath = await contentWizard.getPath();
             assert.equal(actualPath, NEW_NAME, 'Path in wizard page should be updated');
-            // 3. Verify that 'path input' remains locked in wizard page after updating the path:
-            await contentWizard.waitForPathInputLocked();
+            // 3. Verify that 'Click to rename the content' tooltip is present in wizard header after updating the path:
+            await contentWizard.waitForModifyPathSpanDisplayed();
+            await studioUtils.saveScreenshot('click_to_rename_the_content_tooltip');
             // 4. Verify that content's status gets 'Moved'
             await contentWizard.waitForContentStatus(appConst.CONTENT_STATUS.MOVED);
             // 5. Verify that expected notification message:
@@ -103,8 +115,8 @@ describe('rename.published.content.dialog.spec - tests for Rename published cont
             //2. Do unpublish the folder:
             await studioUtils.doUnPublishInWizard();
             await studioUtils.saveScreenshot('unpublished_content_modify_path_icon');
-            //3. Verify that 'path-input' is not locked in the unpublished content:
-            await contentWizard.waitForPathInputNotLocked();
+            //3. Verify that span with 'Click to rename the content' is not displayed for the unpublished content:
+            await contentWizard.waitForModifyPathSpanNotDisplayed();
         });
 
     it("GIVEN 'Rename published content' dialog is opened WHEN the path of existing content has been typed THEN 'Not available' message should appear in the dialog",
@@ -115,7 +127,7 @@ describe('rename.published.content.dialog.spec - tests for Rename published cont
             await contentWizard.openPublishMenuAndPublish();
             await contentWizard.pause(1000);
             // 1. Click on the locked 'path input' and open the modal dialog:
-            let renamePublishedContentDialog = await contentWizard.clickOnLockedInputModifyPath();
+            let renamePublishedContentDialog = await contentWizard.clickOnNameInputOpenModifyPathDialog();
             // 2. Type the path of existing content:
             await renamePublishedContentDialog.typeInNewNameInput(NOT_AVAILABLE_PATH);
             // 3. Verify that 'Rename' button gets disabled:
@@ -131,7 +143,7 @@ describe('rename.published.content.dialog.spec - tests for Rename published cont
             let contentWizard = new ContentWizard();
             await studioUtils.openContentAndSwitchToTabByDisplayName(NEW_NAME, TEST_FOLDER.displayName);
             // 1. Click on the locked 'path input' and open the modal dialog:
-            let renamePublishedContentDialog = await contentWizard.clickOnLockedInputModifyPath();
+            let renamePublishedContentDialog = await contentWizard.clickOnNameInputOpenModifyPathDialog();
             // 2. Type an available name:
             await renamePublishedContentDialog.typeInNewNameInput(NEW_AVAILABLE_NAME);
             // 3. Type a name of the existing content :


### PR DESCRIPTION
@ashklianko Changed behaviour, so that the entire path element of a published item is clickable and opens the Rename dialog. Please verify everything is ok.