### PR TITLE
Modified dependencies are not displayed in the Publishing Wizard #7005

### DIFF
--- a/testing/specs/hide-default-project/publish.wizard.non.required.dependencies.spec.js
+++ b/testing/specs/hide-default-project/publish.wizard.non.required.dependencies.spec.js
@@ -245,13 +245,13 @@ describe('publish.wizard.non.required.dependencies.spec - tests for config with 
 
     it("GIVEN a site with non-required dependant is selected AND new issue has been created WHEN 'Items tab' in 'Issue Details' has been opened THEN 'Hide Excluded' button should be visible in Items tab",
         async () => {
-            let contentBrowsePanel = new ContentBrowsePanel();
-            let createIssueDialog = new CreateIssueDialog();
-            let issueDetailsDialog = new IssueDetailsDialog();
-            let issueDetailsDialogItemsTab = new IssueDetailsDialogItemsTab();
-            // 1. Select the existing site with a dependency click on 'Mark as Ready' button::
-            await studioUtils.findAndSelectItem(SITE.displayName);
-            await contentBrowsePanel.openPublishMenuAndClickOnCreateIssue();
+                let contentBrowsePanel = new ContentBrowsePanel();
+                let createIssueDialog = new CreateIssueDialog();
+                let issueDetailsDialog = new IssueDetailsDialog();
+                let issueDetailsDialogItemsTab = new IssueDetailsDialogItemsTab();
+                // 1. Select the existing site with a dependency click on 'Mark as Ready' button::
+                await studioUtils.findAndSelectItem(SITE.displayName);
+                await contentBrowsePanel.openPublishMenuAndClickOnCreateIssue();
                 // 2. Create issue dialog should be loaded:
                 await createIssueDialog.waitForDialogLoaded();
                 // 3. Fill in the title and click on 'Create Issue' button:
@@ -330,16 +330,16 @@ describe('publish.wizard.non.required.dependencies.spec - tests for config with 
                     let depItems = await createRequestPublishDialog.getDisplayNameInDependentItems();
                     assert.equal(depItems.length, 1, 'The only one dependent item should be in the dependencies list');
                     // 7. Verify that the checkbox for the dependency item is not selected:
-            let isCheckboxSelected = await createRequestPublishDialog.isDependantCheckboxSelected(TEST_FOLDER.displayName);
-            assert.isFalse(isCheckboxSelected, 'Checkbox for the dependent item should not be selected');
-        });
+                    let isCheckboxSelected = await createRequestPublishDialog.isDependantCheckboxSelected(TEST_FOLDER.displayName);
+                    assert.isFalse(isCheckboxSelected, 'Checkbox for the dependent item should not be selected');
+            });
 
-    it("GIVEN 'Request Publishing' dialog has been opened WHEN checkbox for non-required item has been clicked THEN 'Show/Hide' excluded buttons are not displayed",
-        async () => {
-            let contentBrowsePanel = new ContentBrowsePanel();
-            let createRequestPublishDialog = new CreateRequestPublishDialog();
-            // 1. Select the existing site with a dependency click on 'Request Publishing...' menu item:
-            await studioUtils.findAndSelectItem(SITE.displayName);
+        it("GIVEN 'Request Publishing' dialog has been opened WHEN checkbox for non-required item has been clicked THEN 'Show/Hide' excluded buttons are not displayed",
+            async () => {
+                    let contentBrowsePanel = new ContentBrowsePanel();
+                    let createRequestPublishDialog = new CreateRequestPublishDialog();
+                    // 1. Select the existing site with a dependency click on 'Request Publishing...' menu item:
+                    await studioUtils.findAndSelectItem(SITE.displayName);
             await contentBrowsePanel.openPublishMenuAndClickOnRequestPublish();
             // 2. 'Request Publish' dialog should be loaded:
             await createRequestPublishDialog.waitForDialogLoaded();


### PR DESCRIPTION
Fixed detection of the published (online/equal) content.
Removed deprecated methods.