### PR TITLE
Publishing Wizard allows publishing before dependencies are loaded #7051

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/DependantItemsDialog.ts
@@ -65,7 +65,7 @@ export abstract class DependantItemsDialog
     protected config: DependantItemsDialogConfig;
 
     protected constructor(config: DependantItemsDialogConfig) {
-        super(config);
+        super({...config, class: `dependant-items-dialog ${config.class ?? ''}`.trim()});
         this.postInitListeners();
         this.dependantIds = [];
         this.resolvedIds = [];
@@ -152,7 +152,6 @@ export abstract class DependantItemsDialog
 
     doRender(): Q.Promise<boolean> {
         return super.doRender().then((rendered: boolean) => {
-            this.addClass('dependant-items-dialog');
             this.getBody().addClass('mask-wrapper');
             this.itemList.addClass('item-list');
             this.appendChildToHeader(this.subTitle);

--- a/modules/lib/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
+++ b/modules/lib/src/main/resources/assets/styles/dialog/dependant-items-dialog.less
@@ -23,6 +23,13 @@
     }
   }
 
+  &.locked {
+    .excluded-items-toggler {
+      pointer-events: none;
+      opacity: 0.5;
+    }
+  }
+
   .dialog-state-bar.editing {
     position: sticky;
     top: 0;


### PR DESCRIPTION
Prevented the dialog from being unlocked by the "update" event (usually comes from the "mark as ready" in the wizard, while still fetching data. 
Disabled "show/hide excluded" while controls are locked.