### PR TITLE
Fragment component - inserted image gets not visible after refreshing…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/page-editor/fragment/FragmentComponentView.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/fragment/FragmentComponentView.ts
@@ -37,22 +37,11 @@ export class FragmentComponentView
         this.fragmentContainsLayout = false;
         this.setPlaceholder(new FragmentPlaceholder(this));
         this.disableLinks();
+
+        this.parseFragmentComponents(this);
+        this.handleErrors();
     }
 
-    protected initListeners() {
-        super.initListeners();
-
-        // parsing fragment after it was registered in a parent region, so it has a path
-        const thisItemAddedListener = (event: ItemViewAddedEvent) => {
-            if (event.getView() === this) {
-                this.getParentItemView().unItemViewAdded(thisItemAddedListener);
-                this.parseFragmentComponents(this);
-                this.handleErrors();
-            }
-        };
-
-        this.getParentItemView().onItemViewAdded(thisItemAddedListener);
-    }
 
     containsLayout(): boolean {
         return this.fragmentContainsLayout;


### PR DESCRIPTION
… LiveEdit in browser #7075

-parsing fragment immediately since it doesn't receive added event when parsing live edit html