### PR TITLE
Region placeholder is not replaced with a dropped component on DnD #7110

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/PageComponentsTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/PageComponentsTreeGrid.ts
@@ -60,7 +60,7 @@ export class PageComponentsTreeGrid
 
     private initListeners(): void {
         PageState.getEvents().onComponentAdded((event: ComponentAddedEvent) => {
-            this.addComponent(event.getComponent()).catch(DefaultErrorHandler.handle);
+            this.addComponent(event.getComponent())?.catch(DefaultErrorHandler.handle);
         });
 
         PageState.getEvents().onComponentRemoved((event: ComponentRemovedEvent) => {

--- a/modules/lib/src/main/resources/assets/js/page-editor/LiveEditPage.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/LiveEditPage.ts
@@ -356,7 +356,7 @@ export class LiveEditPage {
             const itemToMove: ItemView = this.getItemViewByPath(from);
             const regionViewTo: ItemView = this.getItemViewByPath(to.getParentPath());
 
-            if (itemToMove && itemToMove instanceof ComponentView && regionViewTo && regionViewTo instanceof RegionView) {
+            if (itemToMove instanceof ComponentView && regionViewTo instanceof RegionView) {
                 itemToMove.moveToRegion(regionViewTo, to.getPath() as number);
             }
         };
@@ -493,6 +493,7 @@ export class LiveEditPage {
                     createViewConfig) as ComponentView;
 
                 componentView.replaceWith(newComponentView);
+                newComponentView.getParentItemView().registerComponentViewListeners(newComponentView);
 
                 const event: ComponentLoadedEvent = new ComponentLoadedEvent(newComponentView);
                 event.fire();

--- a/modules/lib/src/main/resources/assets/js/page-editor/RegionView.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/RegionView.ts
@@ -263,8 +263,10 @@ export class RegionView
     }
 
     registerComponentView(componentView: ComponentView, index?: number) {
-        this.registerComponentViewInParent(componentView, index);
-        this.registerComponentViewListeners(componentView);
+        if (this.componentViews.indexOf(componentView) === -1) { // do not register twice
+            this.registerComponentViewInParent(componentView, index);
+            this.registerComponentViewListeners(componentView);
+        }
     }
 
     registerComponentViewInParent(componentView: ComponentView, index?: number): void {
@@ -279,7 +281,7 @@ export class RegionView
         }
     }
 
-    private registerComponentViewListeners(componentView: ComponentView): void {
+    registerComponentViewListeners(componentView: ComponentView): void {
         componentView.setParentItemView(this);
         componentView.onItemViewAdded(this.itemViewAddedListener);
         componentView.onItemViewRemoved(this.itemViewRemovedListener);

--- a/modules/lib/src/main/resources/assets/js/page-editor/RegionViewContextMenuTitle.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/RegionViewContextMenuTitle.ts
@@ -1,6 +1,5 @@
 import {ItemViewContextMenuTitle} from './ItemViewContextMenuTitle';
 import {RegionItemType} from './RegionItemType';
-import {Region} from '../app/page/region/Region';
 
 export class RegionViewContextMenuTitle
     extends ItemViewContextMenuTitle {

--- a/modules/lib/src/main/resources/assets/js/page-editor/text/TextComponentView.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/text/TextComponentView.ts
@@ -31,7 +31,6 @@ import {ContentContext} from '../../app/wizard/ContentContext';
 import {CreateTextComponentViewConfig} from '../CreateTextComponentViewConfig';
 import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
 import {Content} from '../../app/content/Content';
-import {TextComponent} from '../../app/page/region/TextComponent';
 import {PageUnlockedEvent} from '../event/outgoing/manipulation/PageUnlockedEvent';
 
 export class TextComponentViewBuilder


### PR DESCRIPTION
-Reloading a component leads to registering it twice, fixing it with a check for the component presence. Issue occurred because now component is being registered immediately on creation if position index is provided