### PR TITLE
Multi layers project graph improvements #7108

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/settings/browse/statistics/view/project/ProjectDAGVisualization.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/browse/statistics/view/project/ProjectDAGVisualization.ts
@@ -12,13 +12,13 @@ interface DATA {
     displayName: string
     iconHTML: string,
     language: string
-    parentIds: Array<string>
+    parentIds: string[]
     group?: string
 }
 
-type D3SVG = d3.Selection<SVGSVGElement, unknown, HTMLElement, any>;
+type D3SVG = d3.Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
 
-type D3SVGG = d3.Selection<SVGGElement, unknown | string, HTMLElement | SVGGElement, any>;
+type D3SVGG = d3.Selection<SVGGElement, string, HTMLElement | SVGGElement, unknown>;
 
 export class ProjectDAGVisualization extends DivEl{
     private static TEXTS_LEFT = 45;
@@ -27,10 +27,10 @@ export class ProjectDAGVisualization extends DivEl{
     private static RECT_HEIGHT = 50;
     private static RECT_LEFT = 60;
     private static RECT_BG_COLOR = '#ffffff';
-    private static PATH_COLOR = '#343434'
+    private static PATH_COLOR = '#343434';
 
     private allProjects: Project[];
-    private data: Array<DATA>;
+    private data: DATA[];
     private svgContainerId: string = 'svg-container';
 
     constructor(projectId?: string) {

--- a/modules/lib/src/main/resources/assets/styles/project/project-dag-visualization.less
+++ b/modules/lib/src/main/resources/assets/styles/project/project-dag-visualization.less
@@ -45,6 +45,10 @@
         box-sizing: border-box;
         background-position: center;
       }
+      
+      .flag.fi::before {
+        height: 25px;
+      }
 
       .custom-icon {
         width: 100%;


### PR DESCRIPTION
- [x] If there are no layers in the current project hierarchy (only projects on the first level), there will be console error and only one of the projects will be rendered in the graph;
- [x] Node box width is incorrect - it's too narrow and project/layer names leaks out of the box;
- [x] Improve path position on boxes;
- [x] Improve path color and stroke;
- [x] Fix flag ::before content that was showing on some country flags inside the boxes
- [ ] Node boxes are squeezed to the top of the panel. I believe they used to be better spread out.

The last one was not done on purpose since this is actually a feature that was requested (I believe by Thomas) when I initially coded the graph visualization: All root projects are on the 1st row of the visualization. Their direct child layers will be on the 2nd row, the child of those child layers on the 3rd row, and so on...