### PR TITLE
Content changes are not saved along with meta data updates #7128

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,6 @@ projectName=rootcontentstudio
 appProjectName=contentstudio
 libProjectName=lib-contentstudio
 restProjectName=rest
-xpVersion=7.13.0
+xpVersion=7.13.5-SNAPSHOT
 libAdminUiVersion=4.9.0-SNAPSHOT
 version=5.2.0-SNAPSHOT


### PR DESCRIPTION
-Problem with considering equal empty value and no value. After form layout is done, some new empty property arrays may be added, and thus persisted item becomes not equal to the viewed one

Fixing it with ignoring empty values until new item is modified