### PR TITLE
[Firefox] Entire top region is selected after DnD#7154

### DIFF
--- a/modules/lib/src/main/resources/assets/js/page-editor/DragAndDrop.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/DragAndDrop.ts
@@ -21,7 +21,6 @@ import {RegionItemType} from './RegionItemType';
 import {ItemView} from './ItemView';
 import {PageView} from './PageView';
 import {LayoutItemType} from './layout/LayoutItemType';
-import {Component} from '../app/page/region/Component';
 import {DragHelper} from '@enonic/lib-admin-ui/ui/DragHelper';
 import {assertState} from '@enonic/lib-admin-ui/util/Assert';
 import {AddComponentEvent} from './event/outgoing/manipulation/AddComponentEvent';
@@ -54,6 +53,8 @@ export class DragAndDrop {
     private dragging: boolean = false;
 
     private wasDropped: boolean = false;
+
+    private newlyDropped: boolean = false;
 
     private wasDestroyed: boolean = false;
 
@@ -326,6 +327,16 @@ export class DragAndDrop {
         }
         this.newItemItemType = null;
         this.draggedComponentView = null;
+        this.newlyDropped = true;
+
+        // in FF after item was dragged a redundant click event is fired
+        setTimeout(() => {
+            this.newlyDropped = false;
+        }, 100);
+    }
+
+    isNewlyDropped(): boolean {
+        return this.newlyDropped;
     }
 
     /*

--- a/modules/lib/src/main/resources/assets/js/page-editor/ItemView.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/ItemView.ts
@@ -38,6 +38,7 @@ import {IDentifiable} from '@enonic/lib-admin-ui/IDentifiable';
 import {ComponentPath} from '../app/page/region/ComponentPath';
 import {LiveEditParams} from './LiveEditParams';
 import {AddComponentEvent} from './event/outgoing/manipulation/AddComponentEvent';
+import {DragAndDrop} from './DragAndDrop';
 
 export interface ElementDimensions {
     top: number;
@@ -606,7 +607,7 @@ export abstract class ItemView
     handleClick(event: MouseEvent) {
         event.stopPropagation();
 
-        if (event instanceof PointerEvent && event.pointerType === 'touch') {
+        if (event instanceof PointerEvent && event.pointerType === 'touch' || DragAndDrop.get().isNewlyDropped()) {
             return;
         }
 


### PR DESCRIPTION
-FF generates an extra click event on Layout or Region after drag and drop was made, handling by skipping this event