### PR TITLE
Content form is auto-collapsed when a component is selected in PCV #7159

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/event/InspectEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/app/event/InspectEvent.ts
@@ -1,5 +1,6 @@
 import {Event} from '@enonic/lib-admin-ui/event/Event';
 import {ClassHelper} from '@enonic/lib-admin-ui/ClassHelper';
+import {PageNavigationEventSource} from '../wizard/PageNavigationEventData';
 
 export class InspectEvent
     extends Event {
@@ -8,10 +9,14 @@ export class InspectEvent
 
     private readonly showPanel: boolean;
 
-    constructor(showWidget: boolean, showPanel: boolean) {
+    private readonly source: PageNavigationEventSource;
+
+    constructor(builder: InspectEventBuilder) {
         super();
-        this.showWidget = showWidget;
-        this.showPanel = showPanel;
+
+        this.showWidget = builder.showWidget;
+        this.showPanel = builder.showPanel;
+        this.source = builder.source;
     }
 
     isShowWidget(): boolean {
@@ -22,6 +27,10 @@ export class InspectEvent
         return this.showPanel;
     }
 
+    getSource(): PageNavigationEventSource {
+        return this.source;
+    }
+
     static on(handler: (event: InspectEvent) => void) {
         Event.bind(ClassHelper.getFullName(this), handler);
     }
@@ -30,4 +39,36 @@ export class InspectEvent
         Event.unbind(ClassHelper.getFullName(this), handler);
     }
 
+    static create(): InspectEventBuilder {
+        return new InspectEventBuilder();
+    }
+
+}
+
+export class InspectEventBuilder {
+
+    showWidget: boolean;
+
+    showPanel: boolean;
+
+    source: PageNavigationEventSource;
+
+    setShowWidget(value: boolean): InspectEventBuilder {
+        this.showWidget = value;
+        return this;
+    }
+
+    setShowPanel(value: boolean): InspectEventBuilder {
+        this.showPanel = value;
+        return this;
+    }
+
+    setSource(value: PageNavigationEventSource): InspectEventBuilder {
+        this.source = value;
+        return this;
+    }
+
+    build(): InspectEvent {
+        return new InspectEvent(this);
+    }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -141,6 +141,7 @@ import {XDataWizardStepForms} from './XDataWizardStepForms';
 import {PageTemplate} from '../content/PageTemplate';
 import {GetPageTemplateByKeyRequest} from '../resource/GetPageTemplateByKeyRequest';
 import {InspectEvent} from '../event/InspectEvent';
+import {PageNavigationEventSource} from './PageNavigationEventData';
 
 export class ContentWizardPanel
     extends WizardPanel<Content> {
@@ -1214,6 +1215,7 @@ export class ContentWizardPanel
 
         InspectEvent.on((event: InspectEvent) => {
             const minimizeWizard = event.isShowPanel() &&
+                                   event.getSource() === PageNavigationEventSource.EDITOR &&
                                    !this.isMinimized() &&
                                    this.isRenderable() &&
                                    this.getLivePanel().isShown() &&

--- a/modules/lib/src/main/resources/assets/js/app/wizard/PageNavigationEventData.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/PageNavigationEventData.ts
@@ -1,14 +1,25 @@
 import {ComponentPath} from '../page/region/ComponentPath';
 
+export enum PageNavigationEventSource {
+    EDITOR, FORM
+}
+
 export class PageNavigationEventData {
 
-    path?: ComponentPath;
+    private readonly path?: ComponentPath;
 
-    constructor(path?: ComponentPath) {
+    private readonly source?: PageNavigationEventSource;
+
+    constructor(path?: ComponentPath, source?: PageNavigationEventSource) {
         this.path = path;
+        this.source = source;
     }
 
     getPath(): ComponentPath {
         return this.path;
+    }
+
+    getSource(): PageNavigationEventSource {
+        return this.source;
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
@@ -38,7 +38,7 @@ import {PageNavigationHandler} from '../PageNavigationHandler';
 import {PageNavigationEvent} from '../PageNavigationEvent';
 import {PageNavigationMediator} from '../PageNavigationMediator';
 import {PageNavigationEventType} from '../PageNavigationEventType';
-import {PageNavigationEventData} from '../PageNavigationEventData';
+import {PageNavigationEventData, PageNavigationEventSource} from '../PageNavigationEventData';
 import {BeforeContentSavedEvent} from '../../event/BeforeContentSavedEvent';
 import {LiveEditParams} from '../../../page-editor/LiveEditParams';
 import {CreateFragmentEvent} from '../../../page-editor/event/outgoing/manipulation/CreateFragmentEvent';
@@ -556,9 +556,10 @@ export class LiveEditPageProxy
         SelectComponentEvent.on((event: SelectComponentEvent) => {
             const pathAsString: string = event.getComponentPathAsString();
             const path: ComponentPath = ComponentPath.fromString(pathAsString);
+            const eventData = new PageNavigationEventData(path, PageNavigationEventSource.EDITOR);
 
             PageNavigationMediator.get().notify(
-                new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)), this);
+                new PageNavigationEvent(PageNavigationEventType.SELECT, eventData), this);
         }, contextWindow);
 
         DeselectComponentEvent.on(() => {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/contextwindow/ContextWindow.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/contextwindow/ContextWindow.ts
@@ -13,6 +13,7 @@ import {Panel} from '@enonic/lib-admin-ui/ui/panel/Panel';
 import {DockedPanel} from '@enonic/lib-admin-ui/ui/panel/DockedPanel';
 import {NavigatedDeckPanel} from '@enonic/lib-admin-ui/ui/panel/NavigatedDeckPanel';
 import {PageState} from '../PageState';
+import {PageNavigationEventSource} from '../../PageNavigationEventData';
 
 export interface ContextWindowConfig {
 
@@ -29,6 +30,7 @@ export interface InspectParameters {
     showPanel: boolean;
     keepPanelSelection?: boolean;
     silent?: boolean;
+    source?: PageNavigationEventSource;
 }
 
 const DefaultInspectParameters = {
@@ -98,7 +100,11 @@ export class ContextWindow
         this.toggleClass('no-inspection', !canSelectPanel);
         if (canSelectPanel) {
             if (!params.silent) {
-                new InspectEvent(params.showWidget, params.showPanel).fire();
+                InspectEvent.create()
+                    .setShowWidget(params.showWidget)
+                    .setShowPanel(params.showPanel)
+                    .setSource(params.source)
+                    .build().fire();
             }
 
             this.inspectionsPanel.showInspectionPanel(params.panel);


### PR DESCRIPTION
- Tracking source of the select/inspect event, so if it is triggered from Live Edit then don't collapse