### PR TITLE
X-data is not shown for fragments #7284

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -1284,7 +1284,13 @@ export class ContentWizardPanel
     }
 
     private createFragmentSteps(): ContentWizardStep[] {
-        return [this.initPageComponentsWizardStep()];
+        const steps = [this.initPageComponentsWizardStep()];
+
+        this.xDataWizardStepForms.forEach((form: XDataWizardStepForm) => {
+            steps.push(new XDataWizardStep(form));
+        });
+
+        return steps;
     }
 
     private createPageTemplateSteps(): ContentWizardStep[] {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -655,6 +655,7 @@ export class LiveFormPanel
 
             if (changedComponent instanceof DescriptorBasedComponent && persistedComponent instanceof DescriptorBasedComponent) {
                 changedComponent.setConfig(persistedComponent.getConfig().copy());
+                this.inspectComponentOnDemand(changedComponent);
             }
         });
     }


### PR DESCRIPTION
- Enabling Save button in Inspections panel only if page obj changed
- After saving component (via Page update) have to trigger component inspection (if inspection panel is open) to make component form to be re-rendered with a new config value (config may have been updated on backend with default values etc.)