### PR TITLE
Changing a part inside a fragment causes console errors #7278

### DIFF
--- a/modules/lib/src/main/resources/assets/js/page-editor/LiveEditPage.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/LiveEditPage.ts
@@ -493,7 +493,11 @@ export class LiveEditPage {
                     createViewConfig) as ComponentView;
 
                 componentView.replaceWith(newComponentView);
-                newComponentView.getParentItemView().registerComponentViewListeners(newComponentView);
+                const parentItemView = newComponentView.getParentItemView();
+
+                if (parentItemView instanceof RegionView) { // PageView for a fragment|
+                    newComponentView.getParentItemView().registerComponentViewListeners(newComponentView);
+                }
 
                 const event: ComponentLoadedEvent = new ComponentLoadedEvent(newComponentView);
                 event.fire();


### PR DESCRIPTION
- For fragment content reloading it's top component doesn't require registering component events listeners on the parent since there is no parent region for it