### PR TITLE
Content update triggers unnecessary requests

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -289,8 +289,6 @@ export class ContentBrowsePanel
                 data.map((item: ContentServerChangeItem) => new DeletedContentItem(item.getContentId(), item.getPath())));
         });
 
-        handler.onContentPending((data: ContentSummaryAndCompareStatus[]) => this.handleContentPending(data));
-
         handler.onContentPublished((data: ContentSummaryAndCompareStatus[]) => this.handleContentPublished(data));
 
         handler.onContentUnpublished((data: ContentSummaryAndCompareStatus[]) => this.handleContentUnpublished(data));
@@ -388,13 +386,6 @@ export class ContentBrowsePanel
         if (items.some((item: DeletedContentItem) => item.path.equals(itemPath))) {
             this.doUpdateContextPanel(null);
         }
-    }
-
-    private handleContentPending(data: ContentSummaryAndCompareStatus[]) {
-        if (ContentBrowsePanel.debug) {
-            console.debug('ContentBrowsePanel: pending', data);
-        }
-        this.doHandleContentUpdate(data);
     }
 
     private handleContentPublished(data: ContentSummaryAndCompareStatus[]) {

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -8,14 +8,11 @@ import {ContentTreeGridToolbar} from './ContentTreeGridToolbar';
 import {ContentTreeGridLoadedEvent} from './ContentTreeGridLoadedEvent';
 import {ContentQueryRequest} from '../resource/ContentQueryRequest';
 import {ContentQueryResult} from '../resource/ContentQueryResult';
-import {CompareContentResults} from '../resource/CompareContentResults';
-import {CompareContentRequest} from '../resource/CompareContentRequest';
 import {ContentSummaryAndCompareStatusFetcher} from '../resource/ContentSummaryAndCompareStatusFetcher';
 import {ContentResponse} from '../resource/ContentResponse';
 import {ContentRowFormatter} from './ContentRowFormatter';
 import {EditContentEvent} from '../event/EditContentEvent';
 import {ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
-import {CompareStatus} from '../content/CompareStatus';
 import {ContentQuery} from '../content/ContentQuery';
 import {ResultMetadata} from '../resource/ResultMetadata';
 import {TreeGrid} from '@enonic/lib-admin-ui/ui/treegrid/TreeGrid';
@@ -501,7 +498,7 @@ export class ContentTreeGrid
         }
     }
 
-    updateNodesWithSortChangedCheck(data: ContentSummaryAndCompareStatus[]): void {
+    updateNodes(data: ContentSummaryAndCompareStatus[]): void {
         // when items sorting was changed from manual to inherited manual we have to trigger sort ourselves since no sort event coming
         const isSortingChangedToManualInheritance: ContentSummaryAndCompareStatus = data.find(
             (item: ContentSummaryAndCompareStatus) => this.isSortingChangedToManualInheritance(item));
@@ -810,4 +807,21 @@ export class ContentTreeGrid
         this.doubleClickListeners.forEach((listener: () => void) => listener());
     }
 
+    copyStatusFromExistingNodes(data: ContentSummaryAndCompareStatus[]) {
+        data.forEach((newItem: ContentSummaryAndCompareStatus) => {
+            const existingItem: ContentSummaryAndCompareStatus = this.getRoot().getNodeByDataIdFromCurrent(newItem.getId())?.getData();
+            if (existingItem) {
+                newItem.setCompareStatus(existingItem.getCompareStatus());
+            }
+        });
+    }
+
+    copyPermissionsFromExistingNodes(data: ContentSummaryAndCompareStatus[]) {
+        data.forEach((newItem: ContentSummaryAndCompareStatus) => {
+            const existingItem: ContentSummaryAndCompareStatus = this.getRoot().getNodeByDataIdFromCurrent(newItem.getId())?.getData();
+            if (existingItem) {
+                newItem.setReadOnly(existingItem.isReadOnly());
+            }
+        });
+    }
 }

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -292,16 +292,10 @@ export class ContentTreeGrid
     private processContentQueryResponse(node: TreeNode<ContentSummaryAndCompareStatus>,
                                         data: ContentQueryResult<ContentSummary, ContentSummaryJson>,
                                         from: number): Q.Promise<ContentSummaryAndCompareStatus[]> {
-        const contentSummaries: ContentSummary[] = data.getContents();
-        const compareRequest: CompareContentRequest = CompareContentRequest.fromContentSummaries(contentSummaries);
 
-        return compareRequest.sendAndParse().then((compareResults: CompareContentResults) => {
-            const contents: ContentSummaryAndCompareStatus[] = node.getChildren().map((el) => {
-                return el.getData();
-            }).slice(0, from).concat(this.contentFetcher.updateCompareStatus(contentSummaries,
-                compareResults));
-
-            return this.contentFetcher.updateReadOnly(contents).then(() => {
+        return this.contentFetcher
+            .updateReadonlyAndCompareStatus(data.getContents())
+            .then((contents: ContentSummaryAndCompareStatus[]) => {
                 const meta: ResultMetadata = data.getMetadata();
                 if (this.isEmptyNodeNeeded(meta, from)) {
                     contents.push(new ContentSummaryAndCompareStatus());
@@ -309,8 +303,6 @@ export class ContentTreeGrid
                 node.setMaxChildren(meta.getTotalHits());
                 return contents;
             });
-
-        });
     }
 
     private doFetchChildren(parentNode: TreeNode<ContentSummaryAndCompareStatus>): Q.Promise<ContentSummaryAndCompareStatus[]> {
@@ -561,19 +553,19 @@ export class ContentTreeGrid
 
         let cssClasses: string = '';
 
-        if (!!node.getData().getContentSummary() && node.getData().getContentSummary().isDataInherited()) {
+        if (node.getData().getContentSummary()?.isDataInherited()) {
             cssClasses += 'data-inherited';
         }
 
-        if (!!node.getData().getContentSummary() && node.getData().getContentSummary().isSortInherited()) {
+        if (node.getData().getContentSummary()?.isSortInherited()) {
             cssClasses += ' sort-inherited';
         }
 
         if (node.getData().isReadOnly()) {
-            cssClasses += `readonly' title='${i18n('field.readOnly')}'`;
+            cssClasses += ' readonly';
         }
 
-        return {cssClasses: cssClasses};
+        return {cssClasses: cssClasses.trim()};
     }
 
     getSelectedOrHighlightedItems(): ContentSummaryAndCompareStatus[] {

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeGrid.ts
@@ -289,10 +289,16 @@ export class ContentTreeGrid
     private processContentQueryResponse(node: TreeNode<ContentSummaryAndCompareStatus>,
                                         data: ContentQueryResult<ContentSummary, ContentSummaryJson>,
                                         from: number): Q.Promise<ContentSummaryAndCompareStatus[]> {
-
         return this.contentFetcher
             .updateReadonlyAndCompareStatus(data.getContents())
-            .then((contents: ContentSummaryAndCompareStatus[]) => {
+            .then((processedContents: ContentSummaryAndCompareStatus[]) => {
+
+                const contents: ContentSummaryAndCompareStatus[] =
+                    node.getChildren()
+                        .map((el: TreeNode<ContentSummaryAndCompareStatus>) => el.getData())
+                        .slice(0, from)
+                        .concat(processedContents);
+
                 const meta: ResultMetadata = data.getMetadata();
                 if (this.isEmptyNodeNeeded(meta, from)) {
                     contents.push(new ContentSummaryAndCompareStatus());

--- a/modules/lib/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -94,22 +94,17 @@ export class ContentBrowseFilterPanel
             }
         });
 
-        const permissionsUpdatedHandler = (contentIds: ContentIds) => {
+        const permissionsUpdatedHandler = (data: ContentSummaryAndCompareStatus[]) => {
             if (!this.dependenciesSection.isActive()) {
                 return;
             }
 
-            const dependencyItemId: ContentId = this.dependenciesSection.getDependencyId();
-            const isDependencyItemUpdated: boolean = contentIds.contains(dependencyItemId);
-
-            if (isDependencyItemUpdated) {
+            if (ContentSummaryAndCompareStatus.isInArray(this.dependenciesSection.getDependencyId(), data)) {
                 this.search();
             }
         };
 
-        const updatedHandler = (data: ContentSummaryAndCompareStatus[]) => {
-            permissionsUpdatedHandler(ContentIds.from(data.map((item: ContentSummaryAndCompareStatus) => item.getContentId())));
-        };
+        const updatedHandler = (data: ContentSummaryAndCompareStatus[]) => permissionsUpdatedHandler(data);
 
         handler.onContentUpdated(updatedHandler);
         handler.onContentPermissionsUpdated(permissionsUpdatedHandler);

--- a/modules/lib/src/main/resources/assets/js/app/content/ContentSummary.ts
+++ b/modules/lib/src/main/resources/assets/js/app/content/ContentSummary.ts
@@ -83,6 +83,8 @@ export class ContentSummary {
 
     private readonly variantOf: string;
 
+    private readOnly: boolean;
+
     constructor(builder: ContentSummaryBuilder) {
         this.name = builder.name;
         this.displayName = builder.displayName;
@@ -118,6 +120,7 @@ export class ContentSummary {
         this.originalParentPath = builder.originalParentPath;
         this.originalName = builder.originalName;
         this.variantOf = builder.variantOf;
+        this.readOnly = builder.readOnly;
     }
 
     static fromJson(json: ContentSummaryJson): ContentSummary {
@@ -312,6 +315,14 @@ export class ContentSummary {
         return !!this.variantOf;
     }
 
+    setReadOnly(value: boolean) {
+        this.readOnly = value;
+    }
+
+    isReadOnly(): boolean {
+        return !!this.readOnly;
+    }
+
     private isInheritedByType(type: ContentInheritType): boolean {
         return this.isInherited() && this.inherit.some((inheritType: ContentInheritType) => inheritType === type);
     }
@@ -490,6 +501,8 @@ export class ContentSummaryBuilder {
 
     variantOf: string;
 
+    readOnly: boolean;
+
     constructor(source?: ContentSummary) {
         if (source) {
             this.id = source.getId();
@@ -525,6 +538,7 @@ export class ContentSummaryBuilder {
             this.originalParentPath = source.getOriginalParentPath();
             this.originalName = source.getOriginalName();
             this.variantOf = source.getVariantOf();
+            this.readOnly = source.isReadOnly();
         }
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatus.ts
+++ b/modules/lib/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatus.ts
@@ -49,6 +49,10 @@ export class ContentSummaryAndCompareStatus implements ViewItem, Cloneable {
         return new ContentSummaryAndCompareStatus().setUploadItem(item);
     }
 
+    public static isInArray(contentId: ContentId, array: ContentSummaryAndCompareStatus[]): boolean {
+        return array.some((c) => c.getContentId().equals(contentId));
+    }
+
     hasContentSummary(): boolean {
         return !!this.contentSummary;
     }

--- a/modules/lib/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatus.ts
+++ b/modules/lib/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatus.ts
@@ -23,8 +23,6 @@ export class ContentSummaryAndCompareStatus implements ViewItem, Cloneable {
 
     private publishStatus: PublishStatus;
 
-    private readOnly: boolean;
-
     private renderable: boolean = false;
 
     public static fromContentSummary(contentSummary: ContentSummary) {
@@ -276,11 +274,11 @@ export class ContentSummaryAndCompareStatus implements ViewItem, Cloneable {
     }
 
     setReadOnly(value: boolean) {
-        this.readOnly = value;
+        this.contentSummary?.setReadOnly(value);
     }
 
     isReadOnly(): boolean {
-        return !!this.readOnly;
+        return !!this.contentSummary ? this.contentSummary.isReadOnly() : false;
     }
 
     isPendingDelete(): boolean {
@@ -326,7 +324,7 @@ export class ContentSummaryAndCompareStatus implements ViewItem, Cloneable {
     canBeMarkedAsReady(): boolean {
         const contentSummary = this.getContentSummary();
 
-        return !this.isOnline() && !this.isPendingDelete() && contentSummary.isValid() && !contentSummary.isReady();
+        return !this.isOnline() && contentSummary.isValid() && !contentSummary.isReady();
     }
 
     clone(): ContentSummaryAndCompareStatus {
@@ -336,7 +334,6 @@ export class ContentSummaryAndCompareStatus implements ViewItem, Cloneable {
             this.compareStatus,
             this.publishStatus
         );
-        clone.setReadOnly(this.readOnly);
         clone.setRenderable(this.renderable);
         return clone;
     }

--- a/modules/lib/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatusViewer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatusViewer.ts
@@ -73,7 +73,6 @@ export class ContentSummaryAndCompareStatusViewer
         const invalid: boolean = !contentSummary.isValid() || !contentSummary.getDisplayName() || contentSummary.getName().isUnnamed();
         const isPendingDelete: boolean = contentSummary.getContentState().isPendingDelete();
         this.toggleClass('invalid', invalid);
-        this.toggleClass('readonly', object.isReadOnly());
         this.toggleClass('has-origin-project', object.hasOriginProject());
         this.toggleClass('data-inherited', object.isDataInherited());
         this.toggleClass('icon-variant', object.isVariant());

--- a/modules/lib/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatusViewer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatusViewer.ts
@@ -73,11 +73,14 @@ export class ContentSummaryAndCompareStatusViewer
         const invalid: boolean = !contentSummary.isValid() || !contentSummary.getDisplayName() || contentSummary.getName().isUnnamed();
         const isPendingDelete: boolean = contentSummary.getContentState().isPendingDelete();
         this.toggleClass('invalid', invalid);
-        this.toggleClass('pending-delete', isPendingDelete);
         this.toggleClass('readonly', object.isReadOnly());
         this.toggleClass('has-origin-project', object.hasOriginProject());
         this.toggleClass('data-inherited', object.isDataInherited());
         this.toggleClass('icon-variant', object.isVariant());
+
+        if (object.isReadOnly()) {
+            this.setTitle(i18n('field.readOnly'));
+        }
 
         if (!invalid && !object.isOnline() && !object.isPendingDelete()) {
             const workflowState = this.resolveWorkflowState(object);

--- a/modules/lib/src/main/resources/assets/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/DependantItemsDialog.ts
@@ -345,7 +345,7 @@ export abstract class DependantItemsDialog
 
     private loadDescendants(from: number, size = GetDescendantsOfContentsRequest.LOAD_SIZE): Q.Promise<ContentSummaryAndCompareStatus[]> {
         const ids = this.getDependantIdsToLoad(from, from + size);
-        return new ContentSummaryAndCompareStatusFetcher().fetchByIds(ids);
+        return new ContentSummaryAndCompareStatusFetcher().fetchAndCompareStatus(ids);
     }
 
     protected getDependantIdsToLoad(from: number, to: number): ContentId[] {

--- a/modules/lib/src/main/resources/assets/js/app/dialog/DialogTogglableItemList.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/DialogTogglableItemList.ts
@@ -50,15 +50,17 @@ export class DialogTogglableItemList
 
         const serverEvents = ContentServerEventsHandler.getInstance();
 
-        const itemsByIdsUpdatedHandler = (updatedIds: ContentIds): void => {
-            const isItemsUpdated = this.getItems().some(item => updatedIds.contains(item.getContentId()));
+        const itemsByIdsUpdatedHandler = (updatedItems: ContentSummaryAndCompareStatus[]): void => {
+            const updatedIds = updatedItems.map(item => item.getId());
+            const isItemsUpdated = this.getItems().some(item => updatedIds.findIndex(updatedId => updatedId === item.getId()) > -1);
+
             if (isItemsUpdated) {
                 this.notifyListChanged();
             }
         };
 
         const itemsUpdatedHandler = (updatedItems: ContentSummaryAndCompareStatus[]) => {
-            itemsByIdsUpdatedHandler(ContentIds.from(updatedItems.map(item => item.getContentId())));
+            itemsByIdsUpdatedHandler(updatedItems);
         };
 
         const deletedHandler = (deletedItems: ContentServerChangeItem[]) => {

--- a/modules/lib/src/main/resources/assets/js/app/event/ContentServerEventsHandler.ts
+++ b/modules/lib/src/main/resources/assets/js/app/event/ContentServerEventsHandler.ts
@@ -46,8 +46,6 @@ export class ContentServerEventsHandler {
 
     private contentUnpublishListeners: ((data: ContentSummaryAndCompareStatus[]) => void)[] = [];
 
-    private contentPendingListeners: ((data: ContentSummaryAndCompareStatus[]) => void)[] = [];
-
     private contentDuplicateListeners: ((data: ContentSummaryAndCompareStatus[]) => void)[] = [];
 
     private contentSortListeners: ((data: ContentSummaryAndCompareStatus[]) => void)[] = [];
@@ -154,27 +152,6 @@ export class ContentServerEventsHandler {
         contentDeletedEvent.fire();
 
         this.notifyContentDeleted(changeItems);
-    }
-
-    private handleContentPending(data: ContentSummaryAndCompareStatus[]) {
-        if (ContentServerEventsHandler.debug) {
-            console.debug('ContentServerEventsHandler: pending', data);
-        }
-        let contentDeletedEvent = new ContentDeletedEvent();
-
-        data.filter((el) => {
-            return !!el;        // not sure if this check is necessary
-        }).forEach((el) => {
-
-            if (CompareStatusChecker.isPendingDelete(el.getCompareStatus())) {
-                contentDeletedEvent.addPendingItem(el);
-            } else {
-                contentDeletedEvent.addUndeletedItem(el);
-            }
-        });
-        contentDeletedEvent.fire();
-
-        this.notifyContentPending(data);
     }
 
     private handleContentDuplicated(data: ContentSummaryAndCompareStatus[]) {
@@ -392,23 +369,6 @@ export class ContentServerEventsHandler {
         });
     }
 
-    onContentPending(listener: (data: ContentSummaryAndCompareStatus[]) => void) {
-        this.contentPendingListeners.push(listener);
-    }
-
-    unContentPending(listener: (data: ContentSummaryAndCompareStatus[]) => void) {
-        this.contentPendingListeners =
-            this.contentPendingListeners.filter((currentListener: (data: ContentSummaryAndCompareStatus[]) => void) => {
-                return currentListener !== listener;
-            });
-    }
-
-    private notifyContentPending(data: ContentSummaryAndCompareStatus[]) {
-        this.contentPendingListeners.forEach((listener: (data: ContentSummaryAndCompareStatus[]) => void) => {
-            listener(data);
-        });
-    }
-
     onContentSorted(listener: (data: ContentSummaryAndCompareStatus[]) => void) {
         this.contentSortListeners.push(listener);
     }
@@ -543,9 +503,6 @@ export class ContentServerEventsHandler {
                     // delete from draft has been handled without fetching summaries,
                     // deleting from master is unpublish
                     this.handleContentUnpublished(summaries);
-                    break;
-                case NodeServerChangeType.PENDING:
-                    this.handleContentPending(summaries);
                     break;
                 case NodeServerChangeType.DUPLICATE:
                     this.handleContentDuplicated(summaries);

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentSelector.ts
@@ -471,7 +471,7 @@ export class ContentSelector
     }
 
     private static doFetchSummaries() {
-        new ContentSummaryAndCompareStatusFetcher().fetchByIds(ContentSelector.contentIdBatch).then(
+        new ContentSummaryAndCompareStatusFetcher().fetchAndCompareStatus(ContentSelector.contentIdBatch).then(
             (result: ContentSummaryAndCompareStatus[]) => {
 
                 ContentSelector.contentIdBatch = []; // empty batch of ids after loading

--- a/modules/lib/src/main/resources/assets/js/app/issue/view/IssueDetailsDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/issue/view/IssueDetailsDialog.ts
@@ -342,7 +342,7 @@ export class IssueDetailsDialog
             this.saveOnLoaded = true;
             this.isUpdatePending = true;
             const ids = [option.getSelectedOption().getOption().getDisplayValue().getContentId()];
-            this.contentFetcher.fetchByIds(ids).then((result: ContentSummaryAndCompareStatus[]) => {
+            this.contentFetcher.fetchAndCompareStatus(ids).then((result: ContentSummaryAndCompareStatus[]) => {
                 this.addListItems(result);
             }).catch(DefaultErrorHandler.handle);
         });
@@ -561,7 +561,7 @@ export class IssueDetailsDialog
     }
 
     public reloadItemList() {
-        this.contentFetcher.fetchByIds(this.getItemList().getItemsIds()).then(items => {
+        this.contentFetcher.fetchAndCompareStatus(this.getItemList().getItemsIds()).then(items => {
             this.getItemList().replaceItems(items);
             this.getItemList().refreshList();
 
@@ -739,7 +739,7 @@ export class IssueDetailsDialog
         this.itemSelector.setValue(ids.map(id => id.toString()).join(';'));
         this.showLoadMask();
 
-        this.contentFetcher.fetchByIds(ids).then((items: ContentSummaryAndCompareStatus[]) => {
+        this.contentFetcher.fetchAndCompareStatus(ids).then((items: ContentSummaryAndCompareStatus[]) => {
             this.clearListItems(true);
             this.setListItems(items);
         }).catch(

--- a/modules/lib/src/main/resources/assets/js/app/issue/view/IssueDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/issue/view/IssueDialog.ts
@@ -111,7 +111,7 @@ export abstract class IssueDialog
         this.closeIcon.onClicked(() => this.opener ? this.opener.close() : true);
 
         this.debouncedAddItems = AppHelper.debounce(() => {
-            new ContentSummaryAndCompareStatusFetcher().fetchByIds(
+            new ContentSummaryAndCompareStatusFetcher().fetchAndCompareStatus(
                 this.newItems.map(summary => summary.getContentId())).then((result) => {
 
                 this.addListItems(result);

--- a/modules/lib/src/main/resources/assets/js/app/publish/PublishDialogDependantList.ts
+++ b/modules/lib/src/main/resources/assets/js/app/publish/PublishDialogDependantList.ts
@@ -74,8 +74,9 @@ export class PublishDialogDependantList
 
         const serverEvents = ContentServerEventsHandler.getInstance();
 
-        const permissionsUpdatedHandler = (updatedIds: ContentIds): void => {
-            const isItemsPermissionsUpdated = this.getItems().some(item => updatedIds.contains(item.getContentId()));
+        const permissionsUpdatedHandler = (updatedItems: ContentSummaryAndCompareStatus[]): void => {
+            const updatedIds = updatedItems.map(item => item.getId());
+            const isItemsPermissionsUpdated = this.getItems().some(item => updatedIds.findIndex(updatedId => updatedId === item.getId()) > -1);
             if (isItemsPermissionsUpdated) {
                 this.notifyListChanged();
             }
@@ -92,7 +93,7 @@ export class PublishDialogDependantList
         };
 
         const updatedHandler = (updatedItems: ContentSummaryAndCompareStatus[]) => {
-            permissionsUpdatedHandler(ContentIds.from(updatedItems.map(item => item.getContentId())));
+            permissionsUpdatedHandler(updatedItems);
         };
 
         this.onAdded(() => {

--- a/modules/lib/src/main/resources/assets/js/app/publish/PublishProcessor.ts
+++ b/modules/lib/src/main/resources/assets/js/app/publish/PublishProcessor.ts
@@ -453,7 +453,7 @@ export class PublishProcessor {
         }
 
         const slicedIds = dependantsIds.slice(0, GetDescendantsOfContentsRequest.LOAD_SIZE);
-        return new ContentSummaryAndCompareStatusFetcher().fetchByIds(slicedIds);
+        return new ContentSummaryAndCompareStatusFetcher().fetchAndCompareStatus(slicedIds);
     }
 
     private handleExclusionResult(): void {

--- a/modules/lib/src/main/resources/assets/js/app/resource/ContentSummaryFetcher.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/ContentSummaryFetcher.ts
@@ -35,7 +35,7 @@ export class ContentSummaryFetcher {
         return deferred.promise;
     }
 
-    static fetchByIds(ids: ContentId[]): Q.Promise<ContentSummary[]> {
+    static fetchAndCompareStatus(ids: ContentId[]): Q.Promise<ContentSummary[]> {
 
         let deferred = Q.defer<ContentSummary[]>();
 

--- a/modules/lib/src/main/resources/assets/js/app/view/context/ContextView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/ContextView.ts
@@ -114,16 +114,13 @@ export class ContextView
 
         const contentServerEventsHandler = ContentServerEventsHandler.getInstance();
 
-        contentServerEventsHandler.onContentPermissionsUpdated((contentIds: ContentIds) => {
+        contentServerEventsHandler.onContentPermissionsUpdated((contents: ContentSummaryAndCompareStatus[]) => {
             const itemSelected: boolean = this.item != null;
             const activeWidgetVisible: boolean = this.activeWidget != null && this.isVisible();
 
-            if (activeWidgetVisible && this.activeWidget.isInternal() && itemSelected) {
-                const selectedItemContentId: ContentId = this.item.getContentId();
-                const isSelectedItemPermissionsUpdated: boolean = contentIds.contains(selectedItemContentId);
-                if (isSelectedItemPermissionsUpdated) {
+            if (activeWidgetVisible && this.activeWidget.isInternal() && itemSelected &&
+                ContentSummaryAndCompareStatus.isInArray(this.item.getContentId(), contents)) {
                     this.updateActiveWidget();
-                }
             }
         });
 

--- a/modules/lib/src/main/resources/assets/js/app/view/context/widget/details/PageTemplateWidgetItemView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/widget/details/PageTemplateWidgetItemView.ts
@@ -76,15 +76,15 @@ export class PageTemplateWidgetItemView
 
     private initListeners() {
 
-        const onContentPermissionsUpdated = (contentIds: ContentIds) => {
+        const onContentPermissionsUpdated = (contents: ContentSummaryAndCompareStatus[]) => {
             const thisContentId: ContentId = this.content.getContentId();
-            const isThisContentUpdated: boolean = contentIds.contains(thisContentId);
 
-            if (!isThisContentUpdated) {
+            if (!ContentSummaryAndCompareStatus.isInArray(thisContentId, contents)) {
                 return;
             }
 
-            new ContentSummaryAndCompareStatusFetcher().fetch(this.content.getContentId())
+            new ContentSummaryAndCompareStatusFetcher()
+                .fetch(thisContentId)
                 .then(this.setContentAndUpdateView.bind(this))
                 .catch(DefaultErrorHandler.handle);
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -1414,15 +1414,14 @@ export class ContentWizardPanel
             }
         };
 
-        const contentPermissionsUpdatedHandler = (contentIds: ContentIds) => {
+        const contentPermissionsUpdatedHandler = (contents: ContentSummaryAndCompareStatus[]) => {
             if (this.contentUpdateDisabled || !this.getPersistedItem()) {
                 return;
             }
 
             const thisContentId: ContentId = this.getPersistedItem().getContentId();
-            const isThisContentUpdated: boolean = contentIds.contains(thisContentId);
 
-            if (!isThisContentUpdated) {
+            if (!ContentSummaryAndCompareStatus.isInArray(thisContentId, contents)) {
                 return;
             }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -182,7 +182,7 @@ export class LiveFormPanel
     private showLoadMaskHandler: () => void;
     private hideLoadMaskHandler: () => void;
     private contentUpdatedHandler: (data: ContentSummaryAndCompareStatus[]) => void;
-    private contentPermissionsUpdatedHandler: (contentIds: ContentIds) => void;
+    private contentPermissionsUpdatedHandler: (data: ContentSummaryAndCompareStatus[]) => void;
 
     constructor(config: LiveFormPanelConfig) {
         super('live-form-panel');
@@ -371,15 +371,14 @@ export class LiveFormPanel
         }
     }
 
-    private handleContentPermissionsUpdate(contentIds: ContentIds) {
+    private handleContentPermissionsUpdate(contents: ContentSummaryAndCompareStatus[]) {
         if (!this.content) {
             return;
         }
 
         const thisContentId: ContentId = this.content.getContentId();
-        const isThisContentUpdated: boolean = contentIds.contains(thisContentId);
 
-        if (!isThisContentUpdated) {
+        if (!ContentSummaryAndCompareStatus.isInArray(thisContentId, contents)) {
             return;
         }
 

--- a/modules/lib/src/main/resources/assets/styles/browse/content-tree-grid.less
+++ b/modules/lib/src/main/resources/assets/styles/browse/content-tree-grid.less
@@ -50,7 +50,16 @@
       z-index: 1;
     }
 
-    .names-and-icon-viewer.data-inherited {
+    &.readonly {
+      > * {
+        opacity: 0.25;
+      }
+      .display-name {
+        font-style: italic;
+      }
+    }
+
+    &:not(.readonly) .names-and-icon-viewer.data-inherited {
       opacity: 0.5;
     }
 


### PR DESCRIPTION
As of now Content Studio will fetch and update permissions and compare status on any content modification. Since content and permissions never get updated in one single operation, one of the two requests is always unnecessary.

This fix will make sure that Content Studio won't:
* fetch/update permissions (send `isReadOnlyContent` request) on every content update
* fetch/update compare status (send `compare` request) on permission update

