### PR TITLE
Handle unresolvable selected items in Content Selector #6026

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentSelector.ts
@@ -21,7 +21,7 @@ import {ContentTreeSelectorItem} from '../../item/ContentTreeSelectorItem';
 import {ValueTypeConverter} from '@enonic/lib-admin-ui/data/ValueTypeConverter';
 import {Reference} from '@enonic/lib-admin-ui/util/Reference';
 import {NotifyManager} from '@enonic/lib-admin-ui/notify/NotifyManager';
-import {ContentSummary} from '../../content/ContentSummary';
+import {ContentSummary, ContentSummaryBuilder} from '../../content/ContentSummary';
 import {ContentId} from '../../content/ContentId';
 import {ContentPath} from '../../content/ContentPath';
 import {ContentServerEventsHandler} from '../../event/ContentServerEventsHandler';
@@ -72,64 +72,67 @@ export class ContentSelector
             return;
         }
 
-        ContentServerEventsHandler.getInstance().onContentRenamed((data: ContentSummaryAndCompareStatus[]) => {
-            const isCurrentContentRenamed: boolean = data.some((item: ContentSummaryAndCompareStatus) => item.getId() === contentId);
-
-            if (isCurrentContentRenamed) {
-                this.handleContentRenamed();
-            }
+        ContentServerEventsHandler.getInstance().onContentRenamed((data: ContentSummaryAndCompareStatus[], oldPaths: ContentPath[]) => {
+            data.forEach((renamed: ContentSummaryAndCompareStatus, index: number) => {
+                this.updateSelectedItemsPathsIfParentRenamed(renamed, oldPaths[index]);
+            });
         });
 
         this.handleContentDeletedEvent();
         this.handleContentUpdatedEvent();
     }
 
-    protected handleContentRenamed() {
-        const selectedIds: ContentId[] = this.getSelectedOptions().map(
-            (option: SelectedOption<ContentTreeSelectorItem>) => option.getOption().getDisplayValue().getContentId());
+    private updateSelectedItemsPathsIfParentRenamed(renamedContent: ContentSummaryAndCompareStatus, renamedItemOldPath: ContentPath): void {
+        this.getSelectedOptions().forEach((selectedOption: SelectedOption<ContentTreeSelectorItem>) => {
+            const selectedOptionPath = selectedOption.getOption().getDisplayValue().getPath();
 
-        this.doLoadContent(selectedIds).then((contents: ContentSummaryAndCompareStatus[]) => {
-            this.contentComboBox.clearSelection(true, false);
-
-            contents.forEach((content: ContentSummaryAndCompareStatus) => {
-                this.contentComboBox.select(this.createSelectorItem(content));
-            });
+            if (selectedOptionPath?.isDescendantOf(renamedItemOldPath)) {
+                this.updatePathForRenamedItemDescendant(selectedOption, renamedItemOldPath, renamedContent);
+            }
         });
     }
 
-    private handleContentUpdatedEvent() {
-        const contentUpdatedListener = (statuses: ContentSummaryAndCompareStatus[], oldPaths?: ContentPath[]) => {
-            if (this.getSelectedOptions().length === 0) {
-                return;
-            }
+    private updatePathForRenamedItemDescendant(selectedOption: SelectedOption<ContentTreeSelectorItem>, renamedItemOldPath: ContentPath,
+                                               renamedAncestor: ContentSummaryAndCompareStatus) {
+        const selectedOptionPath = selectedOption.getOption().getDisplayValue().getPath();
+        const option = selectedOption.getOption();
+        const newPath = this.makeNewPathForRenamedItemDescendant(selectedOptionPath, renamedItemOldPath, renamedAncestor);
+        const newValue = this.makeNewItemWithUpdatedPath(option.getDisplayValue(), newPath);
+        option.setDisplayValue(newValue);
+        selectedOption.getOptionView().removeClass(ContentComboBox.NOT_FOUND_CLASS);
+        selectedOption.getOptionView().setOption(option);
+    }
 
-            statuses.forEach((status: ContentSummaryAndCompareStatus, index: number) => {
-                const selectedOption = oldPaths ? this.findSelectedOptionByContentPath(oldPaths[index]) :
-                                       this.getSelectedOptionsView().getById(status.getContentId().toString());
+    protected makeNewPathForRenamedItemDescendant(descendantItemPath: ContentPath, renamedItemOldPath: ContentPath,
+                                                  renamedItem: ContentSummaryAndCompareStatus): ContentPath {
+        const descendantItemPathAsString = descendantItemPath.toString();
+        const renamedItemOldPathAsString = renamedItemOldPath.toString();
+        const newSelectedOptionPathAsString = descendantItemPathAsString.replace(renamedItemOldPathAsString,
+            renamedItem.getPath().toString());
+        return ContentPath.create().fromString(newSelectedOptionPathAsString).build();
+    }
 
-                if (selectedOption) {
-                    const option = selectedOption.getOption();
-                    const oldValue = option.getDisplayValue();
-                    const newValue = this.createSelectorItem(status, oldValue.isSelectable(), oldValue.isExpandable());
-                    option.setDisplayValue(newValue);
-                    selectedOption.getOptionView().setOption(option);
-                }
-            });
-        };
+    private makeNewItemWithUpdatedPath(oldValue: ContentTreeSelectorItem, newPath: ContentPath): ContentTreeSelectorItem {
+        const content = oldValue.getContent();
+        const newContentSummary = new ContentSummaryBuilder(content).setPath(newPath).build();
+        const wrappedContent = this.wrapRenamedContentSummary(newContentSummary, oldValue);
 
-        const contentMovedListener = (movedItems: MovedContentItem[]) => {
-            if (this.getSelectedOptions().length === 0) {
-                return;
-            }
+        return this.createSelectorItem(wrappedContent, oldValue?.isSelectable(), oldValue?.isExpandable());
+    }
 
-            movedItems.forEach((movedItem: MovedContentItem) => {
-                const selectedOption: SelectedOption<ContentTreeSelectorItem> = this.findSelectedOptionByContentPath(movedItem.oldPath);
+    protected wrapRenamedContentSummary(newContentSummary: ContentSummary,
+                                        oldValue: ContentTreeSelectorItem): ContentSummary | ContentSummaryAndCompareStatus {
+        if (oldValue instanceof ContentAndStatusTreeSelectorItem) {
+            return ContentSummaryAndCompareStatus.fromContentAndCompareAndPublishStatus(newContentSummary, oldValue.getCompareStatus(),
+                oldValue.getPublishStatus());
+        }
 
-                if (selectedOption) {
-                    this.getContentComboBox().updateOption(selectedOption.getOption(), movedItem.item);
-                }
-            });
-        };
+        return newContentSummary;
+    }
+
+    private handleContentUpdatedEvent(): void {
+        const contentUpdatedListener = this.handleContentUpdated.bind(this);
+        const contentMovedListener = this.handleContentMoved.bind(this);
 
         const handler: ContentServerEventsHandler = ContentServerEventsHandler.getInstance();
         handler.onContentMoved(contentMovedListener);
@@ -159,7 +162,9 @@ export class ContentSelector
                 return;
             }
 
-            let selectedContentIdsMap: {} = {};
+            const optionsUpdated: SelectedOption<ContentTreeSelectorItem>[] = [];
+            const selectedContentIdsMap: {} = {};
+
             this.getSelectedOptions().forEach((selectedOption: SelectedOption<ContentTreeSelectorItem>) => {
                 if (selectedOption.getOption().getDisplayValue()?.getContentId()) {
                     selectedContentIdsMap[selectedOption.getOption().getDisplayValue().getContentId().toString()] = '';
@@ -168,11 +173,19 @@ export class ContentSelector
 
             paths.filter(deletedItem => !pending && selectedContentIdsMap.hasOwnProperty(deletedItem.getContentId().toString()))
                 .forEach((deletedItem) => {
-                    let option = this.getSelectedOptionsView().getById(deletedItem.getContentId().toString());
-                    if (option != null) {
-                        this.getSelectedOptionsView().removeOption(option.getOption(), false);
+                    const selectedOption = this.getSelectedOptionsView().getById(deletedItem.getContentId().toString());
+                    if (selectedOption) {
+                        const option = selectedOption.getOption();
+                        const newValue = this.createMissingContentItem(deletedItem.getContentId());
+                        option.setDisplayValue(newValue);
+                        selectedOption.getOptionView().setOption(option);
+                        optionsUpdated.push(selectedOption);
                     }
                 });
+
+            if (optionsUpdated.length > 0) {
+               this.handleOptionUpdated(optionsUpdated);
+            }
         };
 
         let handler = ContentServerEventsHandler.getInstance();
@@ -186,11 +199,73 @@ export class ContentSelector
     protected createSelectorItem(content: ContentSummary | ContentSummaryAndCompareStatus, selectable: boolean = true,
                                  expandable: boolean = true): ContentTreeSelectorItem {
         if (content instanceof ContentSummaryAndCompareStatus) {
-            return new ContentAndStatusTreeSelectorItem(content, selectable, expandable);
+                return new ContentAndStatusTreeSelectorItem(content, selectable, expandable);
         }
 
         return new ContentTreeSelectorItem(content, selectable, expandable);
     }
+
+    protected handleContentMoved(movedItems: MovedContentItem[]): void {
+        if (this.getSelectedOptions().length === 0) {
+            return;
+        }
+
+        movedItems.forEach((movedItem: MovedContentItem) => {
+            const selectedOption: SelectedOption<ContentTreeSelectorItem> = this.findSelectedOptionByContentPath(movedItem.oldPath);
+
+            if (selectedOption) {
+                this.getContentComboBox().updateOption(selectedOption.getOption(), movedItem.item);
+            }
+        });
+    }
+
+    protected handleContentUpdated(updatedContents: ContentSummaryAndCompareStatus[], oldPaths?: ContentPath[]): void {
+        if (this.getSelectedOptions().length === 0) {
+            return;
+        }
+
+        const optionsUpdated: SelectedOption<ContentTreeSelectorItem>[] = this.updateSelectedOptions(updatedContents, oldPaths);
+
+        if (optionsUpdated.length > 0) {
+            this.handleOptionUpdated(optionsUpdated);
+        }
+    }
+
+    private updateSelectedOptions(updatedContents: ContentSummaryAndCompareStatus[], oldPaths?: ContentPath[]): SelectedOption<ContentTreeSelectorItem>[] {
+        const updatedOptions: SelectedOption<ContentTreeSelectorItem>[] = [];
+
+        updatedContents.forEach((content, index) => {
+            const selectedOption = this.resolveSelectedOption(content, index, oldPaths);
+            if (selectedOption) {
+                this.updateSelectedOption(selectedOption, content);
+                updatedOptions.push(selectedOption);
+            }
+        });
+
+        return updatedOptions;
+    }
+
+    private resolveSelectedOption(content: ContentSummaryAndCompareStatus, index: number,
+                                  oldPaths?: ContentPath[]): SelectedOption<ContentTreeSelectorItem> {
+        return oldPaths ?
+               this.findSelectedOptionByContentPath(oldPaths[index]) :
+               this.getSelectedOptionsView().getById(content.getContentId().toString());
+    }
+
+    private updateSelectedOption(selectedOption: SelectedOption<ContentTreeSelectorItem>, content: ContentSummaryAndCompareStatus): void {
+        const option = selectedOption.getOption();
+        const oldValue = option.getDisplayValue();
+        const newValue = this.createSelectorItem(
+            content,
+            oldValue?.isSelectable(),
+            oldValue?.isExpandable()
+        );
+
+        option.setDisplayValue(newValue);
+        selectedOption.getOptionView().removeClass(ContentComboBox.NOT_FOUND_CLASS);
+        selectedOption.getOptionView().setOption(option);
+    }
+
 
     protected readInputConfig(): void {
         const inputConfig: Record<string, Record<string, string>[]> = this.context.inputConfig;
@@ -303,9 +378,16 @@ export class ContentSelector
             this.setupSortable();
 
             //TODO: original value doesn't work because of additional request, so have to select manually
-            contents.forEach((content: ContentSummaryAndCompareStatus) => {
-                this.contentComboBox.select(new ContentAndStatusTreeSelectorItem(content));
+            contentIds.forEach((contentId: ContentId) => {
+                const content = contents.find((item) => item.getContentId().equals(contentId));
+                const dataItem = content ? this.createSelectorItem(content) : this.createMissingContentItem(contentId);
+
+                this.contentComboBox.select(dataItem, undefined, true);
             });
+
+            this.contentComboBox.resetBaseValues();
+
+            this.updateNewContentButton();
 
             this.contentComboBox.getSelectedOptions().forEach((selectedOption: SelectedOption<ContentTreeSelectorItem>) => {
                 this.updateSelectedOptionIsEditable(selectedOption);
@@ -313,6 +395,11 @@ export class ContentSelector
 
             this.setLayoutInProgress(false);
         });
+    }
+
+    protected createMissingContentItem(id: ContentId): ContentTreeSelectorItem {
+        const content = new ContentSummary(new ContentSummaryBuilder().setId(id.toString()).setContentId(id));
+        return new ContentTreeSelectorItem(content);
     }
 
     protected createOptionDataLoaderBuilder(): ContentSummaryOptionDataLoaderBuilder {
@@ -326,7 +413,8 @@ export class ContentSelector
     }
 
     protected doCreateContentComboBoxBuilder(): ContentComboBoxBuilder<ContentTreeSelectorItem> {
-        return ContentComboBox.create().setProject(this.context.project);
+        return ContentComboBox.create().setRemoveMissingSelectedOptions(false).setDisplayMissingSelectedOptions(true).setProject(
+            this.context.project);
     }
 
     protected createOptionDataLoader(): ContentSummaryOptionDataLoader<ContentTreeSelectorItem> {
@@ -341,7 +429,6 @@ export class ContentSelector
             .setComboBoxName(input.getName())
             .setLoader(optionDataLoader)
             .setMaximumOccurrences(input.getOccurrences().getMaximum())
-            .setRemoveMissingSelectedOptions(true)
             .setTreegridDropdownEnabled(this.treeMode)
             .setTreeModeTogglerAllowed(!this.hideToggleIcon)
             .setValue(comboboxValue);
@@ -352,11 +439,6 @@ export class ContentSelector
     }
 
     protected initEvents(contentComboBox: ContentComboBox<ContentTreeSelectorItem>) {
-        contentComboBox.getComboBox().onContentMissing((ids: string[]) => {
-            ids.forEach(id => this.removePropertyWithId(id));
-            this.handleValueChanged(false);
-        });
-
         contentComboBox.onOptionSelected((event: SelectedOptionEvent<ContentTreeSelectorItem>) => {
             this.fireFocusSwitchEvent(event);
             this.updateNewContentButton();
@@ -550,6 +632,10 @@ export class ContentSelector
 
     private updateNewContentButton(): void {
         this.newContentButton?.setVisible(!this.contentComboBox.maximumOccurrencesReached());
+    }
+
+    protected handleOptionUpdated(optionsUpdated: SelectedOption<ContentTreeSelectorItem>[]): void {
+        //
     }
 
     giveFocus(): boolean {

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/selector/ContentSummaryOptionDataLoader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/selector/ContentSummaryOptionDataLoader.ts
@@ -94,7 +94,7 @@ export class ContentSummaryOptionDataLoader<DATA extends ContentTreeSelectorItem
     protected sendPreLoadRequest(ids: string): Q.Promise<DATA[]> {
         const contentIds = ids.split(';').map((id) => new ContentId(id));
         return new GetContentSummaryByIds(contentIds).setRequestProject(this.project).sendAndParse().then(((contents: ContentSummary[]) => {
-            return contents.map(content => new ContentTreeSelectorItem(content)) as DATA[];
+            return this.loadStatuses(contents.map(content => new ContentTreeSelectorItem(content)) as DATA[]);
         }));
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageSelectorSelectedOptionsView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/selector/image/ImageSelectorSelectedOptionsView.ts
@@ -207,7 +207,7 @@ export class ImageSelectorSelectedOptionsView
         this.setOutsideClickListener();
     }
 
-    private updateSelectionToolbarLayout() {
+    updateSelectionToolbarLayout() {
         let showToolbar = this.selection.length > 0;
         this.toolbar.setVisible(showToolbar);
         if (showToolbar) {
@@ -258,7 +258,7 @@ export class ImageSelectorSelectedOptionsView
 
         if (option.getOption().getDisplayValue().isEmptyContent()) {
             const missingItemId: string = option.getOption().getDisplayValue().getMissingItemId();
-            optionView.showError(!!missingItemId ? i18n('text.image.id.notavailable', missingItemId) : i18n('text.image.notavailable'));
+            optionView.showImageNotAvailable(missingItemId);
         }
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/item/ContentTreeSelectorItem.ts
+++ b/modules/lib/src/main/resources/assets/js/app/item/ContentTreeSelectorItem.ts
@@ -21,11 +21,11 @@ export class ContentTreeSelectorItemJson {
 export class ContentTreeSelectorItem
     implements Equitable {
 
-    private content: ContentSummary;
+    private readonly content: ContentSummary;
 
-    private selectable: boolean;
+    private readonly selectable: boolean;
 
-    private expandable: boolean;
+    private readonly expandable: boolean;
 
     constructor(content: ContentSummary, selectable: boolean = true, expandable: boolean = true) {
         this.content = content;

--- a/modules/lib/src/main/resources/assets/styles/inputtype/selector/content-combo-box.less
+++ b/modules/lib/src/main/resources/assets/styles/inputtype/selector/content-combo-box.less
@@ -47,13 +47,46 @@
     padding-left: 50px !important;
   }
 
-  .selected-option {
-    .status {
-      padding: 0 10px;
-      text-align: center;
-      flex-basis: 80px;
-      flex-shrink: 0;
-      .content-status-mixin();
+
+  .selected-options {
+    .selected-option {
+      .status {
+        padding: 0 10px;
+        text-align: center;
+        flex-basis: 80px;
+        flex-shrink: 0;
+        .content-status-mixin();
+      }
+
+      &.content-not-found {
+        .edit {
+          display: none;
+        }
+
+        .status {
+          display: none;
+        }
+
+        .names-and-icon-view {
+          .@{_COMMON_PREFIX}wrapper {
+            img.font-icon-default {
+              display: none;
+            }
+
+            div.font-icon-default {
+              display: flex !important;
+              align-items: center;
+              justify-content: center;
+              .icon-alert();
+            }
+          }
+
+          .@{_COMMON_PREFIX}sub-name {
+            color: @input-red-text;
+          }
+        }
+      }
     }
   }
+
 }

--- a/modules/lib/src/main/resources/assets/styles/inputtype/selector/image-selector.less
+++ b/modules/lib/src/main/resources/assets/styles/inputtype/selector/image-selector.less
@@ -129,27 +129,46 @@
           }
         }
 
-        > .progress-bar,
-        > .error {
+        > .progress-bar {
           position: absolute;
           width: 100%;
           top: 0;
           left: 0;
         }
-
-        > .error {
-          margin-left: 0;
-          text-align: center;
-          color: @admin-white;
-          font-weight: bold;
-          background-color: @admin-input-red;
-        }
       }
 
-      &.missing {
+      &.image-not-found {
         .squared-content {
+          > *:not(.error) {
+            display: none;
+          }
+
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+
           .error {
-            margin-top: 30%;
+            &.names-and-icon-view {
+              .@{_COMMON_PREFIX}wrapper {
+                margin-right: 4px;
+                margin-left: 4px;
+
+                img.font-icon-default {
+                  display: none;
+                }
+
+                div.font-icon-default {
+                  display: flex !important;
+                  align-items: center;
+                  justify-content: center;
+                  .icon-alert();
+                }
+              }
+
+              .@{_COMMON_PREFIX}sub-name {
+                color: @input-red-text;
+              }
+            }
           }
         }
       }
@@ -164,6 +183,10 @@
 
     button {
       margin-right: 10px;
+
+      &:disabled {
+        opacity: 0.5;
+      }
     }
 
     &.image-selector-toolbar-sticky {

--- a/modules/lib/src/main/resources/i18n/phrases.properties
+++ b/modules/lib/src/main/resources/i18n/phrases.properties
@@ -329,6 +329,7 @@ text.notemplates=No page templates supporting content type "{0}" found
 text.newIssue=New Issue
 text.application.not.available=Application "{0}" is not available
 text.application.is.stopped=Application "{0}" is stopped
+text.content.not.found=Content is not available
 
 #
 # Widget

--- a/testing/page_objects/page.js
+++ b/testing/page_objects/page.js
@@ -393,6 +393,9 @@ class Page {
 
     async doTouchAction(selector) {
         let el = await this.findElement(selector);
+        return await this.doTouchActionOnElement(el);
+    }
+    async doTouchActionOnElement(el) {
         await el.moveTo();
         let x = await el.getLocation('x');
         let y = await el.getLocation('y');

--- a/testing/page_objects/wizardpanel/imageselector.form.panel.js
+++ b/testing/page_objects/wizardpanel/imageselector.form.panel.js
@@ -5,6 +5,7 @@ const BaseSelectorForm = require('./base.selector.form');
 const lib = require('../../libs/elements');
 const appConst = require('../../libs/app_const');
 const LoaderComboBox = require('../components/loader.combobox');
+
 const XPATH = {
     container: "//div[contains(@id,'ImageSelector')]",
     wizardStep: "//li[contains(@id,'TabBarItem')]/a[text()='Image selector']",
@@ -14,10 +15,10 @@ const XPATH = {
     selectedOptions: "//div[contains(@id,'ImageSelectorSelectedOptionsView')]",
     editButton: "//div[contains(@id,'SelectionToolbar')]//button[child::span[contains(.,'Edit')]]",
     removeButton: "//div[contains(@id,'SelectionToolbar')]//button[child::span[contains(.,'Remove')]]",
-    selectedImageByDisplayName: function (imageDisplayName) {
+    selectedImageByDisplayName(imageDisplayName) {
         return `//div[contains(@id,'ImageSelectorSelectedOptionView') and descendant::div[contains(@class,'label') and text()='${imageDisplayName}']]`
     },
-    expanderIconByName: function (name) {
+    expanderIconByName(name) {
         return lib.itemByName(name) +
                `/ancestor::div[contains(@class,'slick-cell')]/span[contains(@class,'collapse') or contains(@class,'expand')]`;
     },
@@ -57,6 +58,23 @@ class ImageSelectorForm extends BaseSelectorForm {
         return this.selectImages(contentData.images);
     }
 
+    async waitForImageNotAvailableTextDisplayed() {
+        let locator = lib.FORM_VIEW + XPATH.selectedOption + lib.itemByName('Image is not available');
+        await this.waitForElementDisplayed(locator, appConst.mediumTimeout);
+        let elements = await this.findElements(locator);
+        return elements.length;
+    }
+
+    async clickOnSelectedOptionByIndex(index) {
+        let locator = lib.FORM_VIEW + XPATH.selectedOption + "//div[contains(@class,'squared-content')]";
+        await this.waitForElementDisplayed(locator, appConst.mediumTimeout);
+        let imagesEl = await this.findElements(locator);
+        if (index > imagesEl.length) {
+            throw new Error("Image selector form, the number of selected options less than the index");
+        }
+        return await this.doTouchActionOnElement(imagesEl[index]);
+    }
+
     async getSelectedImages() {
         let locator = XPATH.selectedOption + "//div[@class='label']";
         return await this.getTextInElements(locator);
@@ -68,7 +86,7 @@ class ImageSelectorForm extends BaseSelectorForm {
             return await this.pause(500);
         } catch (err) {
             await this.saveScreenshot('err_img_sel_dropdown_handle');
-            throw  new Error('image combobox dropdown handle not found ' + err);
+            throw new Error('image combobox dropdown handle not found ' + err);
         }
     }
 
@@ -248,9 +266,17 @@ class ImageSelectorForm extends BaseSelectorForm {
         return this.waitForElementDisplayed(this.editButton, appConst.mediumTimeout);
     }
 
+    waitForEditButtonDisabled() {
+        return this.waitForElementDisabled(this.editButton, appConst.mediumTimeout);
+    }
+
+    waitForRemoveButtonEnabled() {
+        return this.waitForElementEnabled(this.removeButton, appConst.mediumTimeout);
+    }
+
     async getNumberItemInRemoveButton() {
         await this.waitForRemoveButtonDisplayed();
-        let locator = this.removeButton + "/span";
+        let locator = this.removeButton + '/span';
         return await this.getText(locator);
     }
 }


### PR DESCRIPTION
- setting selected options correctly without triggering unnecessary updates
- Using same selected option value object class so that selected item could be easily updated to missing one and vice versa