### PR TITLE
Fragment: inspection panel doesn't trigger update events #7676

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -724,26 +724,25 @@ export class LiveFormPanel
             this.inspectPage({showPanel: false, showWidget: true});
         });
 
+        eventsManager.onLiveEditPageViewReady(() => {
+            if (this.insertablesPanel) {
+                // disable insert tab if there is no page for some reason (i.e. error occurred)
+                // or there is no controller or template set or no automatic template
+                const page = PageState.getState();
+                const isPageRenderable = !!page && (page.hasController() || !!page.getTemplate() || page.isFragment());
+                const hasDefaultTemplate = this.liveEditModel?.getDefaultModels().hasDefaultPageTemplate();
+                this.contextWindow.setItemVisible(this.insertablesPanel, isPageRenderable || hasDefaultTemplate);
+            }
 
-            eventsManager.onLiveEditPageViewReady(() => {
-                if (this.insertablesPanel) {
-                    // disable insert tab if there is no page for some reason (i.e. error occurred)
-                    // or there is no controller or template set or no automatic template
-                    const page = PageState.getState();
-                    const isPageRenderable = !!page && (page.hasController() || !!page.getTemplate() || page.isFragment());
-                    const hasDefaultTemplate = this.liveEditModel?.getDefaultModels().hasDefaultPageTemplate();
-                    this.contextWindow.setItemVisible(this.insertablesPanel, isPageRenderable || hasDefaultTemplate);
+            if (this.content.getPage()?.isFragment()) { // preselection selector's value to make it not empty
+                const component = PageState.getState().getFragment();
+                const inspectionPanel = this.availableInspectPanels.get(component.getType());
+
+                if (inspectionPanel instanceof ComponentInspectionPanel) {
+                    inspectionPanel.setComponent(component);
                 }
-
-                if (this.content.getPage()?.isFragment()) { // preselection selector's value to make it not empty
-                    const component = this.content.getPage().getFragment();
-                    const inspectionPanel = this.availableInspectPanels.get(component.getType());
-
-                    if (inspectionPanel instanceof ComponentInspectionPanel) {
-                        inspectionPanel.setComponent(component);
-                    }
-                }
-            });
+            }
+        });
 
 
         eventsManager.onPageSaveAsTemplate(() => {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/contextwindow/ContextWindow.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/contextwindow/ContextWindow.ts
@@ -113,7 +113,7 @@ export class ContextWindow
             }
 
             this.inspectionsPanel.showInspectionPanel(params.panel);
-            if (this.inspectTab) {
+            if (this.inspectTab && params.panel) {
                 this.inspectTab.setLabel(params.panel.getName());
             }
             if (!params.keepPanelSelection) {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/DescriptorBasedComponentInspectionPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/DescriptorBasedComponentInspectionPanel.ts
@@ -23,6 +23,7 @@ import {PageState} from '../../../PageState';
 import {ComponentUpdatedEvent} from '../../../../../page/region/ComponentUpdatedEvent';
 import {ComponentDescriptorUpdatedEvent} from '../../../../../page/region/ComponentDescriptorUpdatedEvent';
 import {PageEventsManager} from '../../../../PageEventsManager';
+import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
 
 export interface DescriptorBasedComponentInspectionPanelConfig
     extends ComponentInspectionPanelConfig {

--- a/testing/page_objects/wizardpanel/liveform/inspection/part.inspection.panel.js
+++ b/testing/page_objects/wizardpanel/liveform/inspection/part.inspection.panel.js
@@ -27,16 +27,26 @@ class PartInspectionPanel extends Page {
         return this.waitForElementDisplayed(xpath.container);
     }
 
-    async getTextFomTextInputConfig(){
-        let locatorTextLine = xpath.container + "//div[contains(@id,'TextLine')]"+ lib.TEXT_INPUT;
-        await this.waitForElementDisplayed(locatorTextLine,appConst.mediumTimeout);
-        return await this.getTextInInput(locatorTextLine + lib.TEXT_INPUT);
+    async getTextFomTextInputConfig() {
+        try {
+            let locatorTextLine = xpath.container + "//div[contains(@id,'TextLine')]" + lib.TEXT_INPUT;
+            await this.waitForElementDisplayed(locatorTextLine, appConst.mediumTimeout);
+            return await this.getTextInInput(locatorTextLine + lib.TEXT_INPUT);
+        } catch (err) {
+            let screenshot = await this.saveScreenshotUniqueName('err_part_inspect_text_input');
+            throw new Error(`Error occurred in Part Inspect Panel screenshot: ${screenshot} ` + err);
+        }
     }
 
-    async typeTexInTextInputConfig(text){
-        let locatorTextLine = xpath.container + "//div[contains(@id,'TextLine')]"+ lib.TEXT_INPUT;
-        await this.waitForElementDisplayed(locatorTextLine,appConst.mediumTimeout);
-        return await this.typeTextInInput(locatorTextLine, text);
+    async typeTexInTextInputConfig(text) {
+        try {
+            let locatorTextLine = xpath.container + "//div[contains(@id,'TextLine')]" + lib.TEXT_INPUT;
+            await this.waitForElementDisplayed(locatorTextLine, appConst.mediumTimeout);
+            return await this.typeTextInInput(locatorTextLine, text);
+        } catch (err) {
+            let screenshot = await this.saveScreenshotUniqueName('err_part_inspect_text_input');
+            throw new Error(`Error occurred in Part Inspect Panel screenshot: ${screenshot} ` + err);
+        }
     }
 }
 

--- a/testing/page_objects/wizardpanel/liveform/inspection/part.inspection.panel.js
+++ b/testing/page_objects/wizardpanel/liveform/inspection/part.inspection.panel.js
@@ -31,7 +31,7 @@ class PartInspectionPanel extends Page {
         try {
             let locatorTextLine = xpath.container + "//div[contains(@id,'TextLine')]" + lib.TEXT_INPUT;
             await this.waitForElementDisplayed(locatorTextLine, appConst.mediumTimeout);
-            return await this.getTextInInput(locatorTextLine + lib.TEXT_INPUT);
+            return await this.getTextInInput(locatorTextLine);
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_part_inspect_text_input');
             throw new Error(`Error occurred in Part Inspect Panel screenshot: ${screenshot} ` + err);

--- a/testing/page_objects/wizardpanel/liveform/inspection/part.inspection.panel.js
+++ b/testing/page_objects/wizardpanel/liveform/inspection/part.inspection.panel.js
@@ -26,6 +26,18 @@ class PartInspectionPanel extends Page {
     waitForOpened() {
         return this.waitForElementDisplayed(xpath.container);
     }
+
+    async getTextFomTextInputConfig(){
+        let locatorTextLine = xpath.container + "//div[contains(@id,'TextLine')]"+ lib.TEXT_INPUT;
+        await this.waitForElementDisplayed(locatorTextLine,appConst.mediumTimeout);
+        return await this.getTextInInput(locatorTextLine + lib.TEXT_INPUT);
+    }
+
+    async typeTexInTextInputConfig(text){
+        let locatorTextLine = xpath.container + "//div[contains(@id,'TextLine')]"+ lib.TEXT_INPUT;
+        await this.waitForElementDisplayed(locatorTextLine,appConst.mediumTimeout);
+        return await this.typeTextInInput(locatorTextLine, text);
+    }
 }
 
 module.exports = PartInspectionPanel;

--- a/testing/specs/page-editor/null.layout.spec.js
+++ b/testing/specs/page-editor/null.layout.spec.js
@@ -76,11 +76,15 @@ describe('null.layout.spec - test for layout-controller that returns null ', fun
             await contentWizard.pause(700);
             await studioUtils.doSwitchToNewWizard();
             let partInspectionPanel = new PartInspectionPanel();
+            await partInspectionPanel.waitForOpened();
+            await studioUtils.saveScreenshot('fragment_inspect_issue_7676_0');
             // 5. Type a text in the config in Inspect Panel
             await partInspectionPanel.typeTexInTextInputConfig(TEST_TEXT);
+            await studioUtils.saveScreenshot('fragment_inspect_issue_7676_1');
             // 6. Verify that Save button gets enabled:
             await contentWizard.waitForSaveButtonEnabled();
             await contentWizard.waitAndClickOnSave();
+            await studioUtils.saveScreenshot('fragment_inspect_issue_7676_3');
             // 7. Verify the saved text:
             let result = await partInspectionPanel.getTextFomTextInputConfig();
             assert.equal(result, TEST_TEXT, 'Expected text should be displayed in the input in Fragment(Part) Inspection Panel')


### PR DESCRIPTION
- Fix: Using page state component to set into the inspection panel, thus events start firing
- Fix: Context window should inspect non-null object