### PR TITLE
Update custom instructions handling #7884

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/ai/event/data/EnonicAiConfigData.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ai/event/data/EnonicAiConfigData.ts
@@ -1,6 +1,7 @@
 export interface EnonicAiConfigData {
-    user: {
+    user?: {
         fullName: string;
         shortName: string;
     };
+    instructions?: string;
 }

--- a/modules/lib/src/main/resources/assets/js/app/ai/event/data/EnonicAiContentData.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ai/event/data/EnonicAiContentData.ts
@@ -7,7 +7,6 @@ export interface EnonicAiContentData {
         form: FormJson;
         name: string;
     },
-    customPrompt?: string;
 }
 
 export interface ContentData {

--- a/modules/lib/src/main/resources/assets/js/app/ai/event/outgoing/EnonicAiContentOperatorConfigEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ai/event/outgoing/EnonicAiContentOperatorConfigEvent.ts
@@ -1,0 +1,28 @@
+import {ClassHelper} from '@enonic/lib-admin-ui/ClassHelper';
+import {Event} from '@enonic/lib-admin-ui/event/Event';
+import {EnonicAiConfigData} from '../data/EnonicAiConfigData';
+
+export class EnonicAiContentOperatorConfigEvent
+    extends Event {
+
+    private readonly payload: EnonicAiConfigData;
+
+    constructor(data: EnonicAiConfigData) {
+        super();
+
+        this.payload = data;
+    }
+
+    getData(): EnonicAiConfigData {
+        return this.payload;
+    }
+
+    static on(handler: (event: EnonicAiContentOperatorConfigEvent) => void) {
+        Event.bind(ClassHelper.getFullName(this), handler);
+    }
+
+    static un(handler?: (event: EnonicAiContentOperatorConfigEvent) => void) {
+        Event.unbind(ClassHelper.getFullName(this), handler);
+    }
+
+}

--- a/modules/lib/src/main/resources/assets/js/app/ai/event/outgoing/EnonicAiTranslatorConfigEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ai/event/outgoing/EnonicAiTranslatorConfigEvent.ts
@@ -2,7 +2,7 @@ import {ClassHelper} from '@enonic/lib-admin-ui/ClassHelper';
 import {Event} from '@enonic/lib-admin-ui/event/Event';
 import {EnonicAiConfigData} from '../data/EnonicAiConfigData';
 
-export class EnonicAiConfigEvent
+export class EnonicAiTranslatorConfigEvent
     extends Event {
 
     private readonly payload: EnonicAiConfigData;
@@ -17,11 +17,11 @@ export class EnonicAiConfigEvent
         return this.payload;
     }
 
-    static on(handler: (event: EnonicAiConfigEvent) => void) {
+    static on(handler: (event: EnonicAiTranslatorConfigEvent) => void) {
         Event.bind(ClassHelper.getFullName(this), handler);
     }
 
-    static un(handler?: (event: EnonicAiConfigEvent) => void) {
+    static un(handler?: (event: EnonicAiTranslatorConfigEvent) => void) {
         Event.unbind(ClassHelper.getFullName(this), handler);
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -588,7 +588,7 @@ export class ContentWizardPanel
                 }
 
                 AI.get().setContentTypeContext(this.contentType);
-                AI.get().updateCustomPrompts(this.getApplicationsConfigs());
+                AI.get().updateInstructions(this.getApplicationsConfigs());
 
                 return this.loadAndSetPageState(loader.content?.getPage()?.clone());
             }).then(() => super.doLoadData());
@@ -1012,7 +1012,9 @@ export class ContentWizardPanel
         let siteConfigApplyHandler = (event: ContentRequiresSaveEvent) => {
             if (this.isCurrentContentId(event.getContentId()) && this.hasUnsavedChanges()) {
                 this.setMarkedAsReady(false);
-                this.saveChanges();
+                this.saveChanges().then(() => {
+                    AI.get().updateInstructions(this.getApplicationsConfigs());
+                });
             }
         };
 


### PR DESCRIPTION
Renamed `customPrompt` into `instructions`.
Moved `instructions` to Config from Data event data. 
Added separate Config events for each plugin.
Made instructions update on site config update.