### PR TITLE
ui-tests issue #8050

### DIFF
--- a/testing/libs/studio.utils.js
+++ b/testing/libs/studio.utils.js
@@ -94,7 +94,7 @@ module.exports = {
             let selector = `//iframe[contains(@src,'${src}')]`;
             let el = await this.getBrowser().$(selector);
             await el.waitForDisplayed({timeout: 2000});
-            await this.getBrowser().switchToFrame(el);
+            await this.getBrowser().switchFrame(el);
         } catch (err) {
             throw new Error('Error when switch to frame  ' + err);
         }
@@ -583,7 +583,7 @@ module.exports = {
             await browsePanel.waitForSpinnerNotVisible(appConst.longTimeout);
             return await browsePanel.pause(800);
         } catch (err) {
-            await this.saveScreenshot(appConst.generateRandomName('err_spinner'));
+            await this.saveScreenshotUniqueName('err_spinner');
             throw new Error('Filter Panel-  error : ' + err);
         }
     },

--- a/testing/page_objects/issue/base.details.dialog.js
+++ b/testing/page_objects/issue/base.details.dialog.js
@@ -114,7 +114,7 @@ class BaseDetailsDialog extends Page {
         let statusSelectorButton = this.issueStatusSelector + "//div[contains(@id,'TabMenuButton')]";
         await this.waitForElementDisplayed(statusSelectorButton, appConst.mediumTimeout);
         await this.clickOnElement(statusSelectorButton);
-        return await this.pause(200);
+        return await this.pause(300);
     }
 
     async clickOnIssueStatusSelectorAndCloseIssue() {

--- a/testing/page_objects/issue/issue.details.dialog.js
+++ b/testing/page_objects/issue/issue.details.dialog.js
@@ -111,6 +111,7 @@ class IssueDetailsDialog extends BaseDetailsDialog {
 
     async clickOncloseTabMenuItem() {
         await this.waitForElementDisplayed(XPATH.closeTabMenuItem, appConst.mediumTimeout);
+        await this.pause(200);
         await this.clickOnElement(XPATH.closeTabMenuItem);
     }
 

--- a/testing/page_objects/issue/issue.list.dialog.js
+++ b/testing/page_objects/issue/issue.list.dialog.js
@@ -227,19 +227,19 @@ class IssuesListDialog extends Page {
         //})
     }
 
-    //Scrolls the modal dialog and clicks on the issue:
-    clickOnIssue(issueName) {
-        let issueXpath = xpath.issueByName(issueName);
-        return this.isElementDisplayed(issueXpath).then(result => {
+    // Scrolls the modal dialog and clicks on the issue:
+    async clickOnIssue(issueName) {
+        try {
+            let issueXpath = xpath.issueByName(issueName);
+            let result = await this.isElementDisplayed(issueXpath);
             if (!result) {
-                return this.scrollToIssue(issueXpath);
+                await this.scrollToIssue(issueXpath);
             }
-        }).then(() => {
-            return this.clickOnElement(issueXpath);
-        }).catch(err => {
-            this.saveScreenshot('err_click_on_issue');
-            throw new Error('error when clicked on issue' + err)
-        })
+            return await this.clickOnElement(issueXpath);
+        } catch (err) {
+            let screenshot = await this.saveScreenshotUniqueName('err_click_on_issue');
+            throw new Error(`error when clicked on issue, screenshot: ${screenshot} ` + err);
+        }
     }
 
     async waitForIssueNotPresent(issueName) {

--- a/testing/page_objects/page.js
+++ b/testing/page_objects/page.js
@@ -524,8 +524,7 @@ class Page {
         try {
             await this.waitUntilDisplayed(selector, appConst.mediumTimeout);
             let el = await this.findElement(selector);
-            //return await this.browser.switchToFrame(el.elementId); // Fail! Firefox and Chrome
-            return await this.getBrowser().switchToFrame(el);
+            return await this.getBrowser().switchFrame(el);
         } catch (err) {
             console.log('Error when switch to frame ' + selector);
             throw new Error('Error when switch to frame  ' + err);

--- a/testing/page_objects/wizardpanel/macro/insert.macro.dialog.cke.js
+++ b/testing/page_objects/wizardpanel/macro/insert.macro.dialog.cke.js
@@ -68,8 +68,15 @@ class InsertMacroModalDialog extends Page {
     }
 
     async clickOnPreviewTabItem() {
-        await this.clickOnElement(this.previewTabItem);
-        return await this.waitForElementDisplayed(XPATH.previewTab, appConst.mediumTimeout);
+        try {
+            await this.waitForElementDisplayed(this.previewTabItem, appConst.mediumTimeout);
+            await this.pause(500);
+            await this.clickOnElement(this.previewTabItem);
+            return await this.waitForElementDisplayed(XPATH.previewTab, appConst.mediumTimeout);
+        } catch (err) {
+            let screenshot = await this.saveScreenshot('err_click_on_preview_tab');
+            throw new Error(`Error occurred during clicking on Preview Tab Item! screenshot: ${screenshot} ` + err);
+        }
     }
 
     async clickOnInsertButton() {
@@ -92,7 +99,7 @@ class InsertMacroModalDialog extends Page {
     async getTextInPreviewTab() {
         let locator = XPATH.previewTab + XPATH.textInPreviewTab;
         await this.waitForElementDisplayed(locator, appConst.mediumTimeout);
-        return this.getText(locator);
+        return await this.getText(locator);
     }
 
     async waitForIframeDisplayed(url) {

--- a/testing/specs/content-types-2/htmlarea.macro.modal.dialog.spec.js
+++ b/testing/specs/content-types-2/htmlarea.macro.modal.dialog.spec.js
@@ -51,7 +51,7 @@ describe('htmlarea.macro.modal.dialog.spec: tests for macro modal dialog', funct
             await insertMacroModalDialog.typeTextInConfigurationTextArea(TEST_TEXT);
             // 5. Verify the text in the 'Preview Tab' of the modal dialog:
             await insertMacroModalDialog.clickOnPreviewTabItem();
-            await studioUtils.saveScreenshot("macro_is_completed");
+            await studioUtils.saveScreenshot('macro_is_completed');
             let text = await insertMacroModalDialog.getTextInPreviewTab();
             assert.equal(text, TEST_TEXT, "Expected text should be displayed in the Preview tab");
             // 6. Click on Insert button
@@ -66,18 +66,18 @@ describe('htmlarea.macro.modal.dialog.spec: tests for macro modal dialog', funct
             let htmlAreaForm = new HtmlAreaForm();
             let contentWizard = new ContentWizard();
             let insertMacroModalDialog = new InsertMacroModalDialog();
-            //1. Open wizard for new htmlArea content:
+            // 1. Open wizard for new htmlArea content:
             await studioUtils.selectSiteAndOpenNewWizard(SITE.displayName, appConst.contentTypes.HTML_AREA_0_1);
             await contentWizard.typeDisplayName(CONTENT_NAME_1);
-            //2. Click on 'Insert Macro' button
+            // 2. Click on 'Insert Macro' button
             await htmlAreaForm.showToolbarAndClickOnInsertMacroButton();
             await insertMacroModalDialog.waitForDialogLoaded();
-            //3. Select the 'Disable macros' option:
-            await insertMacroModalDialog.selectOption("Disable macros");
-            //4. Do not fill the text area but click on Insert button
+            // 3. Select the 'Disable macros' option:
+            await insertMacroModalDialog.selectOption('Disable macros');
+            // 4. Do not fill the text area but click on Insert button
             await insertMacroModalDialog.clickOnInsertButton();
-            await studioUtils.saveScreenshot("macro_is_not_completed");
-            //5. Verify that expected validation recording gets visible:
+            await studioUtils.saveScreenshot('macro_is_not_completed');
+            // 5. Verify that expected validation recording gets visible:
             let recording = await insertMacroModalDialog.getValidationRecording();
             assert.equal(recording, appConst.THIS_FIELD_IS_REQUIRED, "Expected recording should be displayed");
             await insertMacroModalDialog.clickOnPreviewTabItem();
@@ -145,10 +145,10 @@ describe('htmlarea.macro.modal.dialog.spec: tests for macro modal dialog', funct
             await htmlAreaForm.showToolbarAndClickOnInsertMacroButton();
             await insertMacroModalDialog.waitForDialogLoaded();
             // 3. Select the 'Disable macros' option:
-            await insertMacroModalDialog.selectOption("Disable macros");
+            await insertMacroModalDialog.selectOption('Disable macros');
             // 4. insert a macro with parameters:
             await insertMacroModalDialog.typeTextInConfigurationTextArea(MACRO_WIT_ATTRIBUTE);
-            await studioUtils.saveScreenshot("macro_attributes_is_completed");
+            await studioUtils.saveScreenshot('macro_attributes_is_completed');
             // 5.Click on 'Insert' button
             await insertMacroModalDialog.clickOnInsertButton();
             await insertMacroModalDialog.waitForDialogClosed();

--- a/testing/specs/issue/close.issue.by.user.spec.js
+++ b/testing/specs/issue/close.issue.by.user.spec.js
@@ -95,8 +95,8 @@ describe('close.issue.by.user.spec: create a issue for user and close it', funct
             // 5. Click on "Closed" menu item:
             await issueDetailsDialog.clickOncloseTabMenuItem();
             await studioUtils.saveScreenshot('issue_closed');
-            // 6. Verify that the notification message appears:
-            await issueDetailsDialog.waitForNotificationMessage();
+            // 6. Verify that 'The Issue is closed' the notification message appears:
+            await issueDetailsDialog.waitForExpectedNotificationMessage(appConst.NOTIFICATION_MESSAGES.ISSUE_CLOSED_MESSAGE);
             await studioUtils.doCloseAllWindowTabsAndSwitchToHome();
             await studioUtils.doLogout();
         });

--- a/testing/specs/site.duplicate.delete.spec.js
+++ b/testing/specs/site.duplicate.delete.spec.js
@@ -113,10 +113,11 @@ describe('site.duplicate.exclude.child.spec:  tests for Duplicate and Confirm Va
             await contentDuplicateDialog.clickOnDuplicateButton();
             await contentDuplicateDialog.waitForDialogClosed();
             // 3. Verify that site does not have expander icon:
+            // TODO  Verify the issue  https://github.com/enonic/app-contentstudio/issues/7071
             await studioUtils.findAndSelectItem(SITE.displayName + '-copy-2');
-            await studioUtils.saveScreenshot("site_duplicated_no_child");
+            await studioUtils.saveScreenshot('site_duplicated_no_child');
             // 4. Verify - 'Site should be displayed without expand-toggle, because the site has no child items'
-            await contentBrowsePanel.waitForExpandToggleNotDisplayed(SITE.displayName + "-copy-2");
+            await contentBrowsePanel.waitForExpandToggleNotDisplayed(SITE.displayName + '-copy-2');
         });
 
     it("GIVEN 'Confirm Value' dialog is opened WHEN required number to delete has been typed THEN 'Confirm' button gets enabled",


### PR DESCRIPTION
Remove the deprecated methods

Deprecated:
This command is deprecated and we encourage everyone to use switchFrame instead for switching into frames. Read more about this command at https://webdriver.io/docs/api/browser/switchFrame .

![image](https://github.com/user-attachments/assets/da9cb529-3faa-48c7-870c-5a4c2d540568)
