### PR TITLE
Text component should be editable from the Inspect Panel #8162

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/text/HtmlArea.ts
@@ -50,9 +50,6 @@ export class HtmlArea
 
     private blurListeners: ((event: FocusEvent) => void)[] = [];
 
-    private authRequest: Q.Promise<void>;
-    private editableSourceCode: boolean;
-
     private enabledTools: string[];
     private disabledTools: string[];
     private allowHeadingsConfig: string;
@@ -67,11 +64,6 @@ export class HtmlArea
         this.content = config.content;
         this.applicationKeys = this.resolveApplicationKeys();
         this.processInputConfig();
-
-        this.authRequest = HTMLAreaHelper.isSourceCodeEditable().then((value: boolean) => {
-            this.editableSourceCode = value;
-            return Q(null);
-        });
 
         this.onAdded(() => {
             this.refresh();
@@ -159,9 +151,7 @@ export class HtmlArea
         this.editors.push(editor);
 
         textAreaEl.onRendered(() => {
-            this.authRequest.then(() => {
-                this.initEditor(editorId, editor.savedValue, textAreaWrapper).catch(DefaultErrorHandler.handle);
-            });
+            this.initEditor(editorId, editor.savedValue, textAreaWrapper).catch(DefaultErrorHandler.handle);
         });
 
         textAreaEl.onValueChanged((event: ValueChangedEvent) => {
@@ -325,31 +315,33 @@ export class HtmlArea
             }
         };
 
-        const htmlEditorParams: HtmlEditorParams = HtmlEditorParams.create()
-            .setEditorContainerId(id)
-            .setAssetsUri(CONFIG.getString('assetsUri'))
-            .setInline(false)
-            .setCreateDialogHandler(HTMLAreaProxy.createAndOpenDialog)
-            .setFocusHandler(focusHandler)
-            .setBlurHandler(blurHandler)
-            .setKeydownHandler(keydownHandler)
-            .setNodeChangeHandler(editorValueChangedHandler)
-            .setEditorLoadedHandler(editorLoadedHandler)
-            .setEditorReadyHandler(editorReadyHandler)
-            .setSaveHandler(saveHandler)
-            .setContent(this.content)
-            .setApplicationKeys(this.applicationKeys)
-            .setEnabledTools(this.enabledTools)
-            .setDisabledTools(this.disabledTools)
-            .setAllowedHeadings(this.allowHeadingsConfig)
-            .setEditableSourceCode(this.editableSourceCode)
-            .setCustomStylesToBeUsed(true)
-            .setLangDirection(this.getLangDirection())
-            .setProject(this.context.project)
-            .setLabel(this.getInput().getLabel())
-            .build();
+        return HTMLAreaHelper.isSourceCodeEditable().then((editableSourceCode: boolean) => {
+            const htmlEditorParams: HtmlEditorParams = HtmlEditorParams.create()
+                .setEditorContainerId(id)
+                .setAssetsUri(CONFIG.getString('assetsUri'))
+                .setInline(false)
+                .setCreateDialogHandler(HTMLAreaProxy.createAndOpenDialog)
+                .setFocusHandler(focusHandler)
+                .setBlurHandler(blurHandler)
+                .setKeydownHandler(keydownHandler)
+                .setNodeChangeHandler(editorValueChangedHandler)
+                .setEditorLoadedHandler(editorLoadedHandler)
+                .setEditorReadyHandler(editorReadyHandler)
+                .setSaveHandler(saveHandler)
+                .setContent(this.content)
+                .setApplicationKeys(this.applicationKeys)
+                .setEnabledTools(this.enabledTools)
+                .setDisabledTools(this.disabledTools)
+                .setAllowedHeadings(this.allowHeadingsConfig)
+                .setEditableSourceCode(editableSourceCode)
+                .setCustomStylesToBeUsed(true)
+                .setLangDirection(this.getLangDirection())
+                .setProject(this.context.project)
+                .setLabel(this.getInput().getLabel())
+                .build();
 
-        return HtmlEditor.create(htmlEditorParams);
+            return HtmlEditor.create(htmlEditorParams);
+        });
     }
 
     private getTools(enabled: boolean): string[] {

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HTMLAreaHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HTMLAreaHelper.ts
@@ -14,6 +14,8 @@ import {Project} from '../../../settings/data/project/Project';
 
 export class HTMLAreaHelper {
 
+    private static sourceCodeEditablePromise: Q.Promise<boolean>;
+
     private static getConvertedImageSrc(imgSrc: string, contentId: string, project?: Project): string {
         const imageId = HTMLAreaHelper.extractImageIdFromImgSrc(imgSrc);
         const styleParameter = '?style=';
@@ -106,6 +108,14 @@ export class HTMLAreaHelper {
     }
 
     public static isSourceCodeEditable(): Q.Promise<boolean> {
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        HTMLAreaHelper.sourceCodeEditablePromise = HTMLAreaHelper.sourceCodeEditablePromise || HTMLAreaHelper.sendIsCodeEditableRequest();
+
+
+        return HTMLAreaHelper.sourceCodeEditablePromise;
+    }
+
+    private static sendIsCodeEditableRequest(): Q.Promise<boolean> {
         return new IsAuthenticatedRequest().sendAndParse().then((loginResult: LoginResult) => {
             if (loginResult.isContentExpert()) {
                 return Q(true);

--- a/modules/lib/src/main/resources/assets/js/app/page/region/ComponentTextUpdatedEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/app/page/region/ComponentTextUpdatedEvent.ts
@@ -1,18 +1,26 @@
 import {ComponentPath} from './ComponentPath';
 import {ComponentUpdatedEvent} from './ComponentUpdatedEvent';
+import {ComponentTextUpdatedOrigin} from './ComponentTextUpdatedOrigin';
 
 export class ComponentTextUpdatedEvent
     extends ComponentUpdatedEvent {
 
     private readonly text: string;
 
-    constructor(componentPath: ComponentPath, value: string) {
+    private readonly origin: ComponentTextUpdatedOrigin;
+
+    constructor(componentPath: ComponentPath, value: string, origin?: ComponentTextUpdatedOrigin) {
         super(componentPath);
 
         this.text = value;
+        this.origin = origin || 'unknown';
     }
 
     getText(): string {
         return this.text;
+    }
+
+    getOrigin(): ComponentTextUpdatedOrigin {
+        return this.origin;
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/page/region/ComponentTextUpdatedOrigin.ts
+++ b/modules/lib/src/main/resources/assets/js/app/page/region/ComponentTextUpdatedOrigin.ts
@@ -1,0 +1,1 @@
+export type ComponentTextUpdatedOrigin = 'live' | 'inspector' | 'unknown';

--- a/modules/lib/src/main/resources/assets/js/app/page/region/TextComponent.ts
+++ b/modules/lib/src/main/resources/assets/js/app/page/region/TextComponent.ts
@@ -7,6 +7,7 @@ import {TextComponentJson} from './TextComponentJson';
 import {TextComponentType} from './TextComponentType';
 import {ComponentName} from './ComponentName';
 import {ComponentTextUpdatedEvent} from './ComponentTextUpdatedEvent';
+import {ComponentTextUpdatedOrigin} from './ComponentTextUpdatedOrigin';
 
 export class TextComponent
     extends Component {
@@ -27,11 +28,11 @@ export class TextComponent
         return this.text;
     }
 
-    setText(value?: string, silent?: boolean) {
+    setText(value?: string, silent?: boolean, origin?: ComponentTextUpdatedOrigin) {
         this.text = StringHelper.isBlank(value) ? undefined : value;
 
         if (!silent) {
-            this.notifyComponentUpdated(new ComponentTextUpdatedEvent(this.getPath(), value));
+            this.notifyComponentUpdated(new ComponentTextUpdatedEvent(this.getPath(), value, origin));
         }
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/PageEventsManager.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/PageEventsManager.ts
@@ -13,6 +13,7 @@ import {PageTemplateKey} from '../page/PageTemplateKey';
 import {PageControllerSetHandler, PageResetHandler, PageTemplateSetHandler} from '../page/Page';
 import {DescriptorKey} from '../page/DescriptorKey';
 import {PageTemplate} from '../content/PageTemplate';
+import {ComponentTextUpdatedOrigin} from '../page/region/ComponentTextUpdatedOrigin';
 
 
 export class PageEventsManager {
@@ -92,7 +93,7 @@ export class PageEventsManager {
 
     private setFragmentComponentRequestedListeners: ((path: ComponentPath, id: string) => void)[] = [];
 
-    private textComponentUpdateRequestedListeners: ((path: ComponentPath, value: string) => void)[] = [];
+    private textComponentUpdateRequestedListeners: ((path: ComponentPath, value: string, origin?: ComponentTextUpdatedOrigin) => void)[] = [];
 
     private textComponentEditRequestedListeners: ((path: ComponentPath) => void)[] = [];
 
@@ -470,16 +471,16 @@ export class PageEventsManager {
         this.componentDescriptorSetRequestedListeners.forEach((listener) => listener(path, descriptorKey));
     }
 
-    onTextComponentUpdateRequested(listener: ((path: ComponentPath, value: string) => void)): void {
+    onTextComponentUpdateRequested(listener: ((path: ComponentPath, value: string, origin?: ComponentTextUpdatedOrigin) => void)): void {
         this.textComponentUpdateRequestedListeners.push(listener);
     }
 
-    untTextComponentUpdateRequested(listener: ((path: ComponentPath, value: string) => void)): void {
+    untTextComponentUpdateRequested(listener: ((path: ComponentPath, value: string, origin?: ComponentTextUpdatedOrigin) => void)): void {
         this.textComponentUpdateRequestedListeners = this.textComponentUpdateRequestedListeners.filter((curr) => (curr !== listener));
     }
 
-    notifyTextComponentUpdateRequested(path: ComponentPath, value: string): void {
-        this.textComponentUpdateRequestedListeners.forEach((listener) => listener(path, value));
+    notifyTextComponentUpdateRequested(path: ComponentPath, value: string, origin?: ComponentTextUpdatedOrigin): void {
+        this.textComponentUpdateRequestedListeners.forEach((listener) => listener(path, value, origin));
     }
 
     onSetComponentState(listener: ((path: ComponentPath, processing: boolean) => void)): void {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
@@ -695,7 +695,7 @@ export class LiveEditPageProxy
         UpdateTextComponentEvent.on((event: UpdateTextComponentEvent): void => {
             const path: ComponentPath = ComponentPath.fromString(event.getComponentPath().toString());
 
-            PageEventsManager.get().notifyTextComponentUpdateRequested(path, event.getText());
+            PageEventsManager.get().notifyTextComponentUpdateRequested(path, event.getText(), event.getOrigin());
         }, contextWindow);
 
         CustomizePageEvent.on((event: CustomizePageEvent): void => {
@@ -767,7 +767,7 @@ export class LiveEditPageProxy
 
             if (event instanceof ComponentTextUpdatedEvent && event.getText()) {
                 if (this.liveEditWindow) {
-                    new UpdateTextComponentViewEvent(event.getPath(), event.getText()).fire(this.liveEditWindow);
+                    new UpdateTextComponentViewEvent(event.getPath(), event.getText(), event.getOrigin()).fire(this.liveEditWindow);
                 }
             }
         });

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/PageState.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/PageState.ts
@@ -40,6 +40,7 @@ import {ComponentRemovedOnMoveEvent} from '../../page/region/ComponentRemovedOnM
 import {PageTemplate} from '../../content/PageTemplate';
 import {LayoutComponent} from '../../page/region/LayoutComponent';
 import * as Q from 'q';
+import {ComponentTextUpdatedOrigin} from '../../page/region/ComponentTextUpdatedOrigin';
 
 export class PageState {
 
@@ -239,7 +240,7 @@ export class PageStateEventHandler {
             }
         });
 
-        PageEventsManager.get().onTextComponentUpdateRequested((path: ComponentPath, text: string) => {
+        PageEventsManager.get().onTextComponentUpdateRequested((path: ComponentPath, text: string, origin?: ComponentTextUpdatedOrigin) => {
             if (!PageState.getState()) {
                 console.warn('Unable to update text component: Page is not set');
                 return;
@@ -249,7 +250,7 @@ export class PageStateEventHandler {
 
             // updating text component only if text differs
             if (item instanceof TextComponent && !PageHelper.stringEqualsIgnoreEmpty(item.getText(), text)) {
-                item.setText(text);
+                item.setText(text, false, origin);
             }
         });
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/TextInspectionPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/contextwindow/inspect/region/TextInspectionPanel.ts
@@ -1,42 +1,181 @@
+import * as Q from 'q';
 import {NamesAndIconView, NamesAndIconViewBuilder} from '@enonic/lib-admin-ui/app/NamesAndIconView';
-import {NamesAndIconViewSize} from '@enonic/lib-admin-ui/app/NamesAndIconViewSize';
-import {StyleHelper} from '@enonic/lib-admin-ui/StyleHelper';
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
-import {StringHelper} from '@enonic/lib-admin-ui/util/StringHelper';
 import {ItemViewIconClassResolver} from '../../../../../../page-editor/ItemViewIconClassResolver';
 import {TextComponent} from '../../../../../page/region/TextComponent';
+import {NamesAndIconViewSize} from '@enonic/lib-admin-ui/app/NamesAndIconViewSize';
+import {StyleHelper} from '@enonic/lib-admin-ui/StyleHelper';
+import {StringHelper} from '@enonic/lib-admin-ui/util/StringHelper';
 import {TextComponentType} from '../../../../../page/region/TextComponentType';
 import {ComponentInspectionPanel} from './ComponentInspectionPanel';
+import {HtmlEditor} from '../../../../../inputtype/ui/text/HtmlEditor';
+import {HtmlEditorParams} from '../../../../../inputtype/ui/text/HtmlEditorParams';
+import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
+import {TextArea} from '@enonic/lib-admin-ui/ui/text/TextArea';
+import {StylesRequest} from '../../../../../inputtype/ui/text/styles/StylesRequest';
+import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
+import {DivEl} from '@enonic/lib-admin-ui/dom/DivEl';
+import {LiveEditModel} from '../../../../../../page-editor/LiveEditModel';
+import {PageState} from '../../../PageState';
+import {ComponentUpdatedEvent} from '../../../../../page/region/ComponentUpdatedEvent';
+import {HTMLAreaHelper} from '../../../../../inputtype/ui/text/HTMLAreaHelper';
+import {PageEventsManager} from '../../../../PageEventsManager';
+import {ComponentTextUpdatedEvent} from '../../../../../page/region/ComponentTextUpdatedEvent';
+import {HTMLAreaProxy} from '../../../../../inputtype/ui/text/dialog/HTMLAreaProxy';
 
 export class TextInspectionPanel
     extends ComponentInspectionPanel<TextComponent> {
 
-    private readonly namesAndIcon: NamesAndIconView;
+    private namesAndIcon: NamesAndIconView;
+
+    private textArea: TextArea;
+
+    private htmlEditor: HtmlEditor;
+
+    private modelSetListeners: (() => void)[] = [];
 
     constructor() {
         super({
             iconClass: ItemViewIconClassResolver.resolveByType(TextComponentType.get().getShortName(), 'icon-xlarge'),
         });
 
+        this.initElements();
+        this.initListeners();
+    }
+
+    protected initElements(): void {
         this.namesAndIcon =
             new NamesAndIconView(new NamesAndIconViewBuilder().setSize(NamesAndIconViewSize.medium)).setIconClass(
                 ItemViewIconClassResolver.resolveByType('text'));
 
-        this.appendChild(this.namesAndIcon);
+        this.textArea = new TextArea('text-inspection-editor');
+    }
+
+    protected initListeners(): void {
+        this.whenModelSet(() => {
+            this.textArea.whenRendered(() => {
+                StylesRequest.fetchStyles(this.liveEditModel.getContent().getId());
+                this.initHtmlEditor(this.textArea.getId()).then((htmlEditor) => {
+                    this.htmlEditor = htmlEditor;
+                    this.initPageEventsListeners();
+                }).catch(DefaultErrorHandler.handle);
+            });
+        });
+    }
+
+    private initPageEventsListeners(): void {
+        PageState.getEvents().onComponentUpdated((event: ComponentUpdatedEvent) => {
+            if (event instanceof ComponentTextUpdatedEvent) {
+                this.handleTextComponentUpdated(event);
+            }
+        });
+    }
+
+    private handleTextComponentUpdated(event: ComponentTextUpdatedEvent): void {
+        this.updateNamesAndIconView();
+
+        if (event.getOrigin() !== 'inspector' && event.getPath().equals(this.component?.getPath())) {
+            const content = HTMLAreaHelper.convertRenderSrcToPreviewSrc(event.getText(), this.liveEditModel.getContent().getId());
+
+            if (content !== this.getEditorContent()) {
+                this.htmlEditor.setData(content);
+            }
+        }
+    }
+
+    private whenModelSet(listener: () => void): void {
+        if (this.liveEditModel) {
+            listener();
+        } else {
+            this.modelSetListeners.push(listener);
+        }
+    }
+
+    private getEditorContent(): string {
+        return HTMLAreaHelper.convertPreviewSrcToRenderSrc(this.htmlEditor.getData());
+    }
+
+    setModel(liveEditModel: LiveEditModel): void {
+        super.setModel(liveEditModel);
+
+        this.modelSetListeners.forEach((listener) => listener());
+        this.modelSetListeners = [];
+    }
+
+    private initHtmlEditor(editorId: string): Q.Promise<HtmlEditor> {
+        let isFocused = false;
+
+        const focusHandler = () => {
+            isFocused = true;
+        };
+
+        const blurHandler = () => {
+            isFocused = false;
+        };
+
+        const editorValueChangedHandler = () => {
+            if (isFocused) {
+                PageEventsManager.get().notifyTextComponentUpdateRequested(this.component.getPath(), this.getEditorContent(), 'inspector');
+            }
+        };
+
+        return HTMLAreaHelper.isSourceCodeEditable().then((isEditable) => {
+            const htmlEditorParams: HtmlEditorParams = HtmlEditorParams.create()
+                .setEditorContainerId(editorId)
+                .setAssetsUri(CONFIG.getString('assetsUri'))
+                .setCreateDialogHandler(HTMLAreaProxy.createAndOpenDialog)
+                .setInline(false)
+                .setFocusHandler(focusHandler)
+                .setBlurHandler(blurHandler)
+                .setNodeChangeHandler(editorValueChangedHandler)
+                .setEditableSourceCode(isEditable)
+                .setContent(this.liveEditModel.getContent())
+                .setApplicationKeys(this.liveEditModel.getSiteModel().getApplicationKeys())
+                .setCustomStylesToBeUsed(true)
+                .build();
+
+            return HtmlEditor.create(htmlEditorParams);
+        });
     }
 
     setComponent(textComponent: TextComponent) {
+        super.setComponent(textComponent);
+
         if (textComponent) {
-            const text = StringHelper.htmlToString(textComponent.getText()?.trim()).trim() || textComponent.getName().toString();
-            const path = textComponent.getPath();
-            this.namesAndIcon.setMainName(text);
-            this.namesAndIcon.setSubName(path?.isRoot() ? undefined : path?.toString());
-            this.namesAndIcon.setIconClass(StyleHelper.getCommonIconCls(TextComponentType.get().getShortName()));
+            this.updateNamesAndIconView();
+
+            const content = HTMLAreaHelper.convertRenderSrcToPreviewSrc(textComponent.getText(), this.liveEditModel.getContent().getId());
+            this.htmlEditor?.setData(content);
         }
+    }
+
+    private updateNamesAndIconView(): void {
+        if (!this.component) {
+            return;
+        }
+
+        const text = StringHelper.htmlToString(this.component.getText()?.trim()).trim() || this.component.getName().toString();
+        const path = this.component.getPath();
+        this.namesAndIcon.setMainName(text);
+        this.namesAndIcon.setSubName(path?.isRoot() ? undefined : path?.toString());
+        this.namesAndIcon.setIconClass(StyleHelper.getCommonIconCls(TextComponentType.get().getShortName()));
     }
 
     getName(): string {
         return i18n('widget.components.insert.text');
+    }
+
+    doRender(): Q.Promise<boolean> {
+        return super.doRender().then((rendered) => {
+            this.addClass('text-inspection-panel');
+            this.appendChild(this.namesAndIcon);
+
+            const textAreaWrapper = new DivEl('text-inspection-editor-wrapper custom-html-editor-container');
+            textAreaWrapper.appendChildren(new DivEl('sticky-dock'), this.textArea);
+            this.appendChild(textAreaWrapper);
+
+            return rendered;
+        });
     }
 
 }

--- a/modules/lib/src/main/resources/assets/js/page-editor/LiveEditPage.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/LiveEditPage.ts
@@ -453,6 +453,10 @@ export class LiveEditPage {
         PageStateEvent.on(this.pageStateListener);
 
         this.updateTextComponentViewListener = (event: UpdateTextComponentViewEvent): void => {
+            if (event.getOrigin() === 'live') {
+                return;
+            }
+
             const path: ComponentPath = ComponentPath.fromString(event.getComponentPath().toString());
             const view: ItemView = this.getItemViewByPath(path);
 

--- a/modules/lib/src/main/resources/assets/js/page-editor/event/incoming/manipulation/UpdateTextComponentViewEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/event/incoming/manipulation/UpdateTextComponentViewEvent.ts
@@ -1,6 +1,7 @@
 import {Event} from '@enonic/lib-admin-ui/event/Event';
 import {ClassHelper} from '@enonic/lib-admin-ui/ClassHelper';
 import {ComponentPath} from '../../../../app/page/region/ComponentPath';
+import {ComponentTextUpdatedOrigin} from '../../../../app/page/region/ComponentTextUpdatedOrigin';
 
 export class UpdateTextComponentViewEvent
     extends Event {
@@ -9,10 +10,13 @@ export class UpdateTextComponentViewEvent
 
     private readonly text: string;
 
-    constructor(path: ComponentPath, text: string) {
+    private readonly origin: ComponentTextUpdatedOrigin;
+
+    constructor(path: ComponentPath, text: string, origin?: ComponentTextUpdatedOrigin) {
         super();
         this.path = path;
         this.text = text;
+        this.origin = origin || 'unknown';
     }
 
     getComponentPath(): ComponentPath {
@@ -21,6 +25,10 @@ export class UpdateTextComponentViewEvent
 
     getText(): string {
         return this.text;
+    }
+
+    getOrigin(): ComponentTextUpdatedOrigin {
+        return this.origin;
     }
 
     static on(handler: (event: UpdateTextComponentViewEvent) => void, contextWindow: Window = window) {

--- a/modules/lib/src/main/resources/assets/js/page-editor/event/outgoing/manipulation/UpdateTextComponentEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/event/outgoing/manipulation/UpdateTextComponentEvent.ts
@@ -1,6 +1,7 @@
 import {Event} from '@enonic/lib-admin-ui/event/Event';
 import {ClassHelper} from '@enonic/lib-admin-ui/ClassHelper';
 import {ComponentPath} from '../../../../app/page/region/ComponentPath';
+import {ComponentTextUpdatedOrigin} from '../../../../app/page/region/ComponentTextUpdatedOrigin';
 
 export class UpdateTextComponentEvent
     extends Event {
@@ -8,10 +9,14 @@ export class UpdateTextComponentEvent
     private readonly path: ComponentPath;
 
     private readonly text: string;
-    constructor(path: ComponentPath, text: string) {
+
+    private readonly origin: ComponentTextUpdatedOrigin;
+
+    constructor(path: ComponentPath, text: string, origin?: ComponentTextUpdatedOrigin) {
         super();
         this.path = path;
         this.text = text;
+        this.origin = origin || 'unknown';
     }
 
     getComponentPath(): ComponentPath {
@@ -20,6 +25,10 @@ export class UpdateTextComponentEvent
 
     getText(): string {
         return this.text;
+    }
+
+    getOrigin(): ComponentTextUpdatedOrigin {
+        return this.origin;
     }
 
     static on(handler: (event: UpdateTextComponentEvent) => void, contextWindow: Window = window) {

--- a/modules/lib/src/main/resources/assets/styles/inputtype/text/htmlarea/html-area.less
+++ b/modules/lib/src/main/resources/assets/styles/inputtype/text/htmlarea/html-area.less
@@ -1,4 +1,4 @@
-.html-area {
+.html-area, .custom-html-editor-container {
   // next is cke related styles
 
   .sticky-dock {

--- a/modules/lib/src/main/resources/assets/styles/main.less
+++ b/modules/lib/src/main/resources/assets/styles/main.less
@@ -67,6 +67,7 @@
 @import "wizard/page/contextwindow/insertables-panel";
 @import "wizard/page/contextwindow/inspections-panel";
 @import "wizard/page/contextwindow/context-window";
+@import "wizard/page/contextwindow/text-inspection-panel";
 @import "wizard/thumbnail-uploader-el";
 @import "wizard/collaboration";
 @import "dialog/archive-item";

--- a/modules/lib/src/main/resources/assets/styles/wizard/page/contextwindow/text-inspection-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/page/contextwindow/text-inspection-panel.less
@@ -1,0 +1,14 @@
+.text-inspection-panel {
+  .text-inspection-editor-wrapper {
+    margin-top: 16px;
+
+    .cke_top {
+      top: -10px;
+    }
+
+    .cke_bottom {
+      bottom: -10px;
+    }
+  }
+
+}

--- a/testing/page_objects/wizardpanel/site.configurator.dialog.js
+++ b/testing/page_objects/wizardpanel/site.configurator.dialog.js
@@ -77,13 +77,18 @@ class SiteConfiguratorDialog extends Page {
     }
 
     async showToolbarAndClickOnInsertLinkButton() {
-        let areaSelector = `//div[contains(@id,'cke_TextArea')]`;
-        let insertLinkButton = "//a[contains(@class,'cke_button') and contains(@title,'Link')]";
-        await this.waitForElementDisplayed(areaSelector, appConst.mediumTimeout);
-        await this.clickOnElement(areaSelector);
-        await this.waitForElementDisplayed(insertLinkButton, appConst.mediumTimeout);
-        await this.clickOnElement(insertLinkButton);
-        return await this.pause(300);
+        try {
+            let areaSelector = XPATH.container + `//div[contains(@id,'cke_TextArea')]`;
+            let insertLinkButton = XPATH.container + "//a[contains(@class,'cke_button') and contains(@title,'Link')]";
+            await this.waitForElementDisplayed(areaSelector, appConst.mediumTimeout);
+            await this.clickOnElement(areaSelector);
+            await this.waitForElementDisplayed(insertLinkButton, appConst.mediumTimeout);
+            await this.clickOnElement(insertLinkButton);
+            return await this.pause(300);
+        } catch (err) {
+            let screenshot = await this.saveScreenshotUniqueName('err_insert_link_button');
+            throw new Error(`Site Config, insert link button, screenshot: '${screenshot}' ` + err);
+        }
     }
 
     clickOnCancelButton() {


### PR DESCRIPTION
- PageState is working as a mediator between all who update text components and all who listen to those updates
- PageEventsManager works as a mediator between main page events and live edit iframe
- Moved checking of if source code in html editor is editable to HTMLAreaHelper