### PR TITLE
ui-tests issue #8348

### DIFF
--- a/testing/libs/app_const.js
+++ b/testing/libs/app_const.js
@@ -494,7 +494,7 @@ module.exports = Object.freeze({
     },
     PREVIEW_WIDGET: {
         AUTOMATIC: 'Automatic',
-        SITE_ENGINE: 'Site engine',
+        ENONIC_RENDERING: 'Enonic rendering',
         MEDIA: 'Media',
         JSON: 'JSON'
     },

--- a/testing/page_objects/browsepanel/contentItem.preview.panel.js
+++ b/testing/page_objects/browsepanel/contentItem.preview.panel.js
@@ -263,12 +263,17 @@ class ContentItemPreviewPanel extends Page {
 
     // Clicks on the dropdown handle in the 'Preview dropdown' then clicks on a list-item by its name
     async selectOptionInPreviewWidget(optionName) {
-        await this.waitForPreviewWidgetDropdownDisplayed();
-        await this.clickOnElement(this.previewWidgetDropdown);
-        let optionSelector = this.previewWidgetDropdown + lib.DROPDOWN_SELECTOR.listItemByDisplayName(optionName);
-        await this.waitForElementDisplayed(optionSelector, appConst.mediumTimeout);
-        await this.clickOnElement(optionSelector);
-        await this.pause(200);
+        try {
+            await this.waitForPreviewWidgetDropdownDisplayed();
+            await this.clickOnElement(this.previewWidgetDropdown);
+            let optionSelector = this.previewWidgetDropdown + lib.DROPDOWN_SELECTOR.listItemByDisplayName(optionName);
+            await this.waitForElementDisplayed(optionSelector, appConst.mediumTimeout);
+            await this.clickOnElement(optionSelector);
+            await this.pause(200);
+        } catch (err) {
+            let screenshot = await this.saveScreenshotUniqueName('err_preview_widget');
+            throw new Error(`Error occurred during selecting option in Preview Widget, screenshot: ${screenshot} ` + err);
+        }
     }
 
     async waitForPreviewWidgetDropdownDisplayed() {

--- a/testing/specs/browse.panel.toolbar.spec.js
+++ b/testing/specs/browse.panel.toolbar.spec.js
@@ -75,7 +75,7 @@ describe('Browse panel, toolbar spec. Check state of buttons on the grid-toolbar
                 '100% should be selected in emulator dropdown by default');
         });
 
-    it(`WHEN a folder and 'Site engine' have been selected THEN 'Preview' button should be disabled`,
+    it(`WHEN a folder and 'Enonic rendering' have been selected THEN 'Preview' button should be disabled`,
         async () => {
             let contentItemPreviewPanel = new ContentItemPreviewPanel();
             await studioUtils.findAndSelectItem(FOLDER_NAME);

--- a/testing/specs/content-types/shortcut.page.editor.spec.js
+++ b/testing/specs/content-types/shortcut.page.editor.spec.js
@@ -62,13 +62,13 @@ describe('shortcut.page.editor.spec: tests for displaying Page Editor for shortc
             await contentItemPreviewPanel.waitForPreviewButtonDisabled();
         });
 
-    it(`WHEN existing shortcut content has been selected AND 'Site engine' option has been selected THEN 'Preview' button should be disabled in Item Preview Panel`,
+    it(`WHEN existing shortcut content has been selected AND 'Enonic rendering' option has been selected THEN 'Preview' button should be disabled in Item Preview Panel`,
         async () => {
             let contentItemPreviewPanel = new ContentItemPreviewPanel();
             // 1. Select an existing pptx content:
             await studioUtils.findAndSelectItem(SHORTCUT_NAME);
-            // 2. Select 'Site engine' in the Preview widget dropdown:
-            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.SITE_ENGINE);
+            // 2. Select 'Enonic rendering' in the Preview widget dropdown:
+            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.ENONIC_RENDERING);
             // 3. Verify that 'Preview' button is disabled
             await studioUtils.saveScreenshot('engine_preview_button_disabled_for_shortcut');
             await contentItemPreviewPanel.waitForPreviewButtonDisabled();

--- a/testing/specs/content.item.preview.spec.js
+++ b/testing/specs/content.item.preview.spec.js
@@ -54,11 +54,11 @@ describe('content.item.preview.spec - Select a content file and check expected i
             await studioUtils.waitForElementDisplayed("//pre[contains(.,'Belarus')]");
         });
 
-    it(`GIVEN existing *.txt file is selected WHEN 'Site engine' option has been selected THEN 404 should be loaded in Preview Panel`,
+    it(`GIVEN existing *.txt file is selected WHEN 'Enonic rendering' option has been selected THEN 404 should be loaded in Preview Panel`,
         async () => {
             let contentItemPreviewPanel = new ContentItemPreviewPanel();
             await studioUtils.findAndSelectItem(TEXT_CONTENT_NAME);
-            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.SITE_ENGINE);
+            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.ENONIC_RENDERING);
             await studioUtils.saveScreenshot('text_attachment_site_engine_preview');
             // 'Preview' button should be enabled for a text file and MEDIA option
             await contentItemPreviewPanel.waitForPreviewButtonEnabled();
@@ -92,13 +92,13 @@ describe('content.item.preview.spec - Select a content file and check expected i
             await contentItemPreviewPanel.waitForPreviewButtonDisabled();
         });
 
-    it(`WHEN existing 'pptx' content has been selected AND 'Site engine' option has been selected THEN 'Preview' button should be enabled in Item Preview Panel`,
+    it(`WHEN existing 'pptx' content has been selected AND 'Enonic rendering' option has been selected THEN 'Preview' button should be enabled in Item Preview Panel`,
         async () => {
             let contentItemPreviewPanel = new ContentItemPreviewPanel();
             // 1. Select an existing pptx content:
             await studioUtils.findAndSelectItem(PPTX_CONTENT_NAME);
             // 2. Select 'Media' in the Preview widget dropdown:
-            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.SITE_ENGINE);
+            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.ENONIC_RENDERING);
             // 3. Verify that 'Preview' button is disabled
             await studioUtils.saveScreenshot('site_engine_preview_button_disabled_for_pptx');
             await contentItemPreviewPanel.waitForPreviewButtonEnabled();

--- a/testing/specs/image.content.preview.widget.dropdown.spec.js
+++ b/testing/specs/image.content.preview.widget.dropdown.spec.js
@@ -99,19 +99,19 @@ describe('image.content.preview.widget.dropdown.spec - Tests for Live View', fun
             await contentItemPreviewPanel.waitForPreviewButtonEnabled();
         });
 
-    it("GIVEN an image is selected WHEN 'Site engine' has been selected in the 'Preview widget dropdown' THEN 404 error should be displayed in the iframe in Item Preview Panel",
+    it("GIVEN an image is selected WHEN 'Enonic rendering' has been selected in the 'Preview widget dropdown' THEN 404 error should be displayed in the iframe in Item Preview Panel",
         async () => {
             let contentItemPreviewPanel = new ContentItemPreviewPanel();
             // 1. Select an image:
             await studioUtils.findAndSelectItem(appConst.TEST_IMAGES.RENAULT);
-            // 2. Select 'Site engine' in the Preview widget dropdown:
-            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.SITE_ENGINE);
-            await studioUtils.saveScreenshot('image_selected_site_engine_selected');
+            // 2. Select 'Enonic rendering' in the Preview widget dropdown:
+            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.ENONIC_RENDERING);
+            await studioUtils.saveScreenshot('image_selected_enonic_rendering_selected');
             // 3. Switch to the iframe and verify that 404 error is displayed in the iframe in Item Preview Panel:
             await contentItemPreviewPanel.switchToLiveViewFrame();
             await contentItemPreviewPanel.waitFor404ErrorDisplayed();
             await contentItemPreviewPanel.switchToParentFrame();
-            // 4. Verify that 'Preview' button should be enabled when an image and 'Site engine' are selected
+            // 4. Verify that 'Preview' button should be enabled when an image and 'Enonic rendering' are selected
             await contentItemPreviewPanel.waitForPreviewButtonEnabled();
         });
 

--- a/testing/specs/misc/text.component.download.link.spec.js
+++ b/testing/specs/misc/text.component.download.link.spec.js
@@ -95,14 +95,14 @@ describe('Text Component with CKE - insert download-link specification', functio
             await contentWizard.waitForNotificationMessage();
         });
 
-    it(`GIVEN the site with download link in the text component is selected WHEN 'Site Engine' is selected THEN download-link should be present in the page`,
+    it(`GIVEN the site with download link in the text component is selected WHEN 'Enonic rendering' is selected THEN download-link should be present in the page`,
         async () => {
             let contentItemPreviewPanel = new ContentItemPreviewPanel();
             // 1. Select the site:
             await studioUtils.findAndSelectItem(SITE.displayName);
-            // 2.  'Site Engine' has been selected in the Preview widget dropdown:
-            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.SITE_ENGINE);
-            await studioUtils.saveScreenshot('site_engine_download_link');
+            // 2.  'Enonic rendering' has been selected in the Preview widget dropdown:
+            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.ENONIC_RENDERING);
+            await studioUtils.saveScreenshot('enonic_rendering_download_link');
             await contentItemPreviewPanel.switchToTextFrame();
             // 3. Verify that new added link is present
             let result = await contentItemPreviewPanel.getTextFromTextComponent(0);
@@ -121,12 +121,12 @@ describe('Text Component with CKE - insert download-link specification', functio
             assert.equal(result, LINK_TEXT, "expected link should be present in the Preview Panel");
         });
 
-    it(`GIVEN site is selected WHEN 'Site Engine' is selected AND 'Preview' button has been pressed THEN download-link should be present in the page`,
+    it(`GIVEN site is selected WHEN 'Enonic rendering' is selected AND 'Preview' button has been pressed THEN download-link should be present in the page`,
         async () => {
             let contentItemPreviewPanel = new ContentItemPreviewPanel();
             // 1. Select the site and click on 'Preview' button
             await studioUtils.findAndSelectItem(SITE.displayName);
-            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.SITE_ENGINE);
+            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.ENONIC_RENDERING);
             await contentItemPreviewPanel.clickOnPreviewButton();
             await studioUtils.switchToContentTabWindow(SITE.displayName);
             // 2. Verify that new added link is present

--- a/testing/specs/page-editor/app.generic.custom.error.handling.spec.js
+++ b/testing/specs/page-editor/app.generic.custom.error.handling.spec.js
@@ -50,13 +50,13 @@ describe('Custom error handling - specification. Verify that application error p
             await contentItemPreviewPanel.waitForPreviewButtonDisabled();
         });
 
-    it(`GIVEN existing site(controller has a error) has been selected WHEN 'Site engine' has been selected in Preview Dropdown THEN expected error message should be displayed in the Preview Panel`,
+    it(`GIVEN existing site(controller has a error) has been selected WHEN 'Enonic rendering' has been selected in Preview Dropdown THEN expected error message should be displayed in the Preview Panel`,
         async () => {
             let contentItemPreviewPanel = new ContentItemPreviewPanel();
             // 1. Select the site:
             await studioUtils.findAndSelectItem(SITE.displayName);
-            // 2. Select 'Site Engine' in the Preview Dropdown:
-            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.SITE_ENGINE);
+            // 2. Select 'Enonic rendering' in the Preview Dropdown:
+            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.ENONIC_RENDERING);
             // 3. Verify the error message in the Preview Panel:
             await contentItemPreviewPanel.switchToLiveViewFrame();
             let actualResult = await contentItemPreviewPanel.get500ErrorText();

--- a/testing/specs/page-editor/fragment.move.spec.js
+++ b/testing/specs/page-editor/fragment.move.spec.js
@@ -81,13 +81,13 @@ describe('Move Fragment specification', function () {
             assert.equal(result, TEST_TEXT_FRAGMENT, "expected text should be present in the Preview Panel");
         });
 
-    it(`WHEN existing fragment is selected AND 'Site engine' is selected in Preview Panel THEN expected text-fragment should be displayed in Preview Panel`,
+    it(`WHEN existing fragment is selected AND 'Enonic rendering' is selected in Preview Panel THEN expected text-fragment should be displayed in Preview Panel`,
         async () => {
             let contentItemPreviewPanel = new ContentItemPreviewPanel();
             // 1. Select the fragment-content:
             await studioUtils.findAndSelectItemByDisplayName(TEST_TEXT_FRAGMENT);
-            // 2. Select 'Site engine' in the dropdown
-            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.SITE_ENGINE);
+            // 2. Select 'Enonic rendering' in the dropdown
+            await contentItemPreviewPanel.selectOptionInPreviewWidget(appConst.PREVIEW_WIDGET.ENONIC_RENDERING);
             // 3. Verify the Preview button should be enabled:
             await contentItemPreviewPanel.waitForPreviewButtonEnabled();
             // 4. Verify the text-fragment should be displayed in the Preview Panel


### PR DESCRIPTION
Site engine should be replaced with Enonic rendering option 