### PR TITLE
Fix the reason for shred-socket not working in Safari #8363

### DIFF
--- a/modules/app/src/main/resources/assets/shared-socket/worker/ports.ts
+++ b/modules/app/src/main/resources/assets/shared-socket/worker/ports.ts
@@ -44,7 +44,7 @@ export function sendToId<T extends OutWorkerMessage>(id: string, message: T): vo
 }
 
 export function broadcast(message: OutWorkerMessage): void {
-    ports.keys().forEach(port => port.postMessage(message));
+    Array.from(ports.keys()).forEach(port => port.postMessage(message));
 }
 
 //


### PR DESCRIPTION
Wrapped `Iterator.forEach()` with `Array.from()`, as utility functions are not supported by Safari and some mobile browsers.