### PR TITLE
Options are not cleared in content selector with tree mode #8379

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentTreeSelectionWrapper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentTreeSelectionWrapper.ts
@@ -82,4 +82,12 @@ export class ContentTreeSelectionWrapper
     getNavigator(): SelectableListBoxNavigator<ContentTreeSelectorItem> {
         return this.selectionNavigator;
     }
+
+    unSelectAllExcept(ids: string[]): void {
+        this.getSelectedItems().find((selectedItem) => {
+            if (!ids.some((id) => id === selectedItem.getId())) {
+                this.deselect(selectedItem, true);
+            }
+        });
+    }
 }

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentTreeSelectorDropdown.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentTreeSelectorDropdown.ts
@@ -108,6 +108,8 @@ export class ContentTreeSelectorDropdown
             selectionChange.deselected?.forEach((item: ContentTreeSelectorItem) => {
                 this.treeSelectionWrapper.deselect(item, true);
             });
+
+            this.treeSelectionWrapper.unSelectAllExcept(this.getSelectedItems().map(item => item.getId()));
         });
     }
 
@@ -182,8 +184,8 @@ export class ContentTreeSelectorDropdown
             const id = item.getId();
 
             if (selectedItems.indexOf(id) >= 0) {
-                // Don't select item if it's unselected before loaded
                 this.treeSelectionWrapper.select(item, true);
+                this.select(item, true);
             }
         });
     }

--- a/testing/page_objects/issue/publish.request.details.dialog.js
+++ b/testing/page_objects/issue/publish.request.details.dialog.js
@@ -59,8 +59,8 @@ class PublishRequestDetailsDialog extends BaseDetailsDialog {
             await this.clickOnElement(selector);
             return this.pause(1000);
         } catch (err) {
-            await this.saveScreenshot('err_click_on_include_children');
-            throw new Error('Error when clicking on Include Child ' + displayName + ' ' + err);
+            let screenshot = await this.saveScreenshotUniqueName('err_click_on_include_children');
+            throw new Error(`Error when clicking on Include Child screenshot: ${screenshot} ` + err);
         }
     }
 
@@ -72,7 +72,7 @@ class PublishRequestDetailsDialog extends BaseDetailsDialog {
             await publishContentDialog.waitForDialogOpened();
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_publish_button');
-            throw new Error('Error when clicking on Publish button, screenshot: ' + screenshot + "  " + err);
+            throw new Error(`Error when clicking on Publish button, screenshot: screenshot: ${screenshot} ` + err);
         }
     }
 
@@ -128,7 +128,7 @@ class PublishRequestDetailsDialog extends BaseDetailsDialog {
             return await this.pause(1000);
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_remove');
-            throw new Error('error when clicking on `remove icon`: ' + err)
+            throw new Error(`error when clicking on remove icon  screenshot: ${screenshot} ` + err)
         }
     }
 
@@ -163,8 +163,8 @@ class PublishRequestDetailsDialog extends BaseDetailsDialog {
             await this.clickOnElement(this.closeRequestButton);
             return await this.pause(1000);
         } catch (err) {
-            await this.saveScreenshot('err_click_on_close_request');
-            throw new Error('Error when clicking on Close Request ' + err);
+            let screenshot = await this.saveScreenshotUniqueName('err_click_on_close_request');
+            throw new Error(`Error when clicking on Close Request, screenshot:${screenshot} ` + err);
         }
     }
 
@@ -174,8 +174,8 @@ class PublishRequestDetailsDialog extends BaseDetailsDialog {
             await this.clickOnElement(this.reopenRequestButton);
             return this.pause(1000);
         } catch (err) {
-            await this.saveScreenshot('err_click_on_reopen_request');
-            throw new Error('Error when clicking on Reopen Request ' + err);
+            let screenshot = await this.saveScreenshotUniqueName('err_click_on_reopen_request');
+            throw new Error(`Error when clicking on Reopen Request screenshot: ${screenshot} ` + err);
         }
     }
 
@@ -185,8 +185,8 @@ class PublishRequestDetailsDialog extends BaseDetailsDialog {
             await this.clickOnElement(this.publishNowButton);
             return this.pause(1000);
         } catch (err) {
-            await this.saveScreenshot('err_click_on_publish_request_now');
-            throw new Error('Error when clicking on Publish Now (Request) ' + err);
+            let screenshot = await this.saveScreenshotUniqueName('err_click_on_publish_request_now');
+            throw new Error(`Error when clicking on Publish Now (Request) screenshot:${screenshot} ` + err);
         }
     }
 
@@ -195,7 +195,8 @@ class PublishRequestDetailsDialog extends BaseDetailsDialog {
             await this.waitForElementNotDisplayed(xpath.container, appConst.shortTimeout);
             await this.pause(500);
         } catch (err) {
-            throw new Error("Request Details dialog should be closed: " + err);
+            let screenshot = await this.saveScreenshotUniqueName('err_publish_request_details_closed');
+            throw new Error(`Request Details dialog should be closed: screenshot:${screenshot}` + err);
         }
     }
 }

--- a/testing/page_objects/wizardpanel/content.selector.form.js
+++ b/testing/page_objects/wizardpanel/content.selector.form.js
@@ -87,7 +87,7 @@ class ContentSelectorForm extends BaseSelectorForm {
     }
 
     // Selects an option by the display-name then click on Apply selection  button:
-    async selectOption(optionDisplayName) {
+    async clickOnOptionByDisplayNameAndApply(optionDisplayName) {
         try {
             let contentSelectorDropdown = new ContentSelectorDropdown();
             await contentSelectorDropdown.clickOnFilteredByDisplayNameItemAndClickOnApply(optionDisplayName);
@@ -122,6 +122,29 @@ class ContentSelectorForm extends BaseSelectorForm {
     async getOptionsMode() {
         let contentSelector = new ContentSelectorDropdown();
         return await contentSelector.getMode(XPATH.container);
+    }
+
+    async getCheckedOptionsDisplayNameInDropdownList() {
+        let locator = XPATH.container + lib.DROPDOWN_SELECTOR.DROPDOWN_DIV_ITEM;
+        let optionElements = await this.findElements(locator);
+        let checkedOptionElements = await this.doFilterCheckedOptionsElements(optionElements);
+        let pr = await checkedOptionElements.map(async (el)=>{
+            let e= await el.$(".//h6[contains(@class,'main-name')]");
+            return await e.getText();
+        });
+        let result = await Promise.all(pr);
+        return result;
+    }
+
+    async doFilterCheckedOptionsElements(elements) {
+        let pr = await elements.map(async (el) => await this.isOptionItemChecked(el));
+        let result = await Promise.all(pr);
+        return elements.filter((el, i) => result[i]);
+    }
+
+    async isOptionItemChecked(el) {
+        let value= await el.getAttribute('class');
+        return value.includes('checked');
     }
 }
 

--- a/testing/page_objects/wizardpanel/content.wizard.panel.js
+++ b/testing/page_objects/wizardpanel/content.wizard.panel.js
@@ -489,7 +489,7 @@ class ContentWizardPanel extends Page {
             await this.waitForSaveButtonEnabled();
             await this.clickOnElement(this.saveButton);
             await this.waitForSavingButtonNotVisible();
-            return await this.pause(1200);
+            return await this.pause(1000);
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_save_content');
             throw new Error(`Error in waitAndClickOnSave: screenshot ${screenshot}   ` + err);

--- a/testing/specs/content-types-2/content.selector.spec.js
+++ b/testing/specs/content-types-2/content.selector.spec.js
@@ -45,7 +45,7 @@ describe('content.selector.spec: content-selector specification', function () {
             await studioUtils.selectSiteAndOpenNewWizard(SITE.displayName, appConst.contentTypes.CUSTOM_RELATIONSHIP);
             await contentWizard.typeDisplayName(RELATIONSHIP_NAME);
             // 2. Select the article in options -  type the name of the article and click on the filtered option:
-            await customRelationshipForm.selectOption(ARTICLE_NAME_1);
+            await customRelationshipForm.clickOnOptionByDisplayNameAndApply(ARTICLE_NAME_1);
             await contentWizard.waitAndClickOnSave();
             // 3. Verify the selected option:
             await studioUtils.saveScreenshot('custom_rel_option_selected');

--- a/testing/specs/project-2/layer.with.app.spec.js
+++ b/testing/specs/project-2/layer.with.app.spec.js
@@ -51,7 +51,7 @@ describe('layer.with.app.spec - tests for layer with applications', function () 
             await newContentDialog.waitForOpened();
             await studioUtils.clickOnItemInNewContentDialog(appConst.contentTypes.CUSTOM_RELATIONSHIP);
             // 4. Verify that just created article content is available in the selector
-            await customRelationshipForm.selectOption(articleContent.displayName);
+            await customRelationshipForm.clickOnOptionByDisplayNameAndApply(articleContent.displayName);
             await studioUtils.saveScreenshot('custom_rel_root_dir');
             let result = await customRelationshipForm.getSelectedOptions();
             assert.ok(result[0].includes(articleContent.displayName), 'Expected option should be selected');


### PR DESCRIPTION
- There's a main selection wrapper of a flat list and a secondary one for the tree, so they need to be synced properly