### PR TITLE
Path is not updated after Juke inserts translated display name #8362

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/ai/AiContentDataHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ai/AiContentDataHelper.ts
@@ -37,6 +37,9 @@ export class AiContentDataHelper {
 
     setValue(path: string, text: string): void {
         if (this.isTopicPath(path)) {
+            if (!StringHelper.isBlank(text)) {
+                this.contentHeader?.setName('', true); // resetting name to trigger name generation after updating displayName
+            }
             this.contentHeader?.setDisplayName(text);
         } else if (this.isXDataPath(path)) {
             this.handleXDataEvent(path, text);


### PR DESCRIPTION
- Implemented a workaround: emptying a path before inserting a generated display name, thus path gets generated always