### PR TITLE
Find and replace dialog is incorrectly positioned in Inspect Panel #8216

### DIFF
--- a/modules/lib/src/main/resources/assets/styles/wizard/page/contextwindow/text-inspection-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/page/contextwindow/text-inspection-panel.less
@@ -11,4 +11,8 @@
     }
   }
 
+  .fnr-panel {
+    max-width: 100%;
+    margin-left: 0;
+  }
 }


### PR DESCRIPTION
- Adjusting the dialog always to the left in Inspection Panel