### PR TITLE
Fix improper usage of promise void returns #8680

### DIFF
--- a/modules/app/src/main/resources/assets/js/main.ts
+++ b/modules/app/src/main/resources/assets/js/main.ts
@@ -278,8 +278,6 @@ const handleCurrentProjectDeleted = () => {
         } else {
             ProjectContext.get().setNotAvailable();
         }
-
-        return Q.resolve();
     }).catch(DefaultErrorHandler.handle);
 };
 
@@ -608,23 +606,21 @@ function initProjectContext(application: Application): Q.Promise<void> {
 
             if (currentProject) {
                 ProjectContext.get().setProject(currentProject);
-                return Q(null);
+                return;
             }
         }
 
         if (projects.length === 1 && ProjectHelper.isAvailable(projects[0])) {
             ProjectContext.get().setProject(projects[0]);
-            return Q(null);
+            return;
         }
 
         if (projects.length === 0) {
             ProjectContext.get().setNotAvailable();
-            return Q.resolve();
+            return;
         }
 
         ProjectSelectionDialog.get().open();
-
-        return Q(null);
     });
 }
 

--- a/modules/lib/src/main/resources/assets/js/app/bar/ContentAppBar.ts
+++ b/modules/lib/src/main/resources/assets/js/app/bar/ContentAppBar.ts
@@ -65,8 +65,6 @@ export class ContentAppBar
             const project: Project = projects.find((p: Project) => p.getName() === currentProjectName);
             this.selectedProjectViewer.setObject(project);
             this.selectedProjectViewer.toggleClass('multi-projects', projects.length > 1);
-
-            return Q.resolve();
         }).catch(DefaultErrorHandler.handle);
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeActions.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeActions.ts
@@ -212,7 +212,7 @@ export class ContentTreeActions implements TreeGridActions<ContentSummaryAndComp
 
             if (items.length === 0) {
                 this.toggleVisibilityNoItemsSelected();
-                return Q(null);
+                return;
             }
 
             this.toggleVisibility(state);
@@ -286,8 +286,6 @@ export class ContentTreeActions implements TreeGridActions<ContentSummaryAndComp
                     this.getAction(ActionName.SHOW_NEW_DIALOG).setEnabled(false);
                     this.getAction(ActionName.SORT).setEnabled(false);
                 }
-
-                return Q();
             }));
         }
 

--- a/modules/lib/src/main/resources/assets/js/app/browse/action/ContentLocalizer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/action/ContentLocalizer.ts
@@ -13,7 +13,7 @@ export class ContentLocalizer {
 
     localizeAndEdit(contents: ContentSummaryAndCompareStatus[]): Q.Promise<void> {
         if (!contents || contents.length === 0) {
-            return Q.resolve();
+            return Q();
         }
 
         this.contents = contents;
@@ -47,11 +47,9 @@ export class ContentLocalizer {
                         updatedItems.map((item: ContentSummary) => ContentSummaryAndCompareStatus.fromContentSummary(item));
                     ContentEventsProcessor.handleEdit(new EditContentEvent(itemsToOpen).setIsLocalized(true));
                 }
-
-                return Q.resolve();
             });
         }
 
-        return Q.resolve();
+        return Q();
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/browse/filter/AggregationsDisplayNamesResolver.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/filter/AggregationsDisplayNamesResolver.ts
@@ -93,7 +93,7 @@ export class AggregationsDisplayNamesResolver {
             .map((bucket: Bucket) => PrincipalKey.fromString(bucket.getKey()));
 
         if (unknownPrincipals.length === 0) {
-            return Q.resolve();
+            return Q();
         }
 
         return new GetPrincipalsByKeysRequest(unknownPrincipals).sendAndParse().then((principals: Principal[]) => {
@@ -104,8 +104,6 @@ export class AggregationsDisplayNamesResolver {
             });
 
             this.updateKnownPrincipals(principalsAggregation);
-
-            return Q.resolve();
         });
     }
 
@@ -126,7 +124,7 @@ export class AggregationsDisplayNamesResolver {
                 }
             });
 
-            return Q.resolve();
+            return Q();
         }
 
         return new GetLocalesRequest().sendAndParse().then((locales: Locale[]) => {
@@ -147,7 +145,7 @@ export class AggregationsDisplayNamesResolver {
                 bucket.setDisplayName(this.contentTypes.get(bucket.getKey()) || bucket.getKey());
             });
 
-            return Q.resolve();
+            return Q();
         }
 
         return new GetAllContentTypesRequest().sendAndParse().then((items: ContentTypeSummary[]) => {

--- a/modules/lib/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -213,7 +213,7 @@ export class ContentBrowseFilterPanel
 
         return this.getAndUpdateAggregations().then((aggregationsQueryResult: AggregationsQueryResult) => {
             if (aggregationsQueryResult.getMetadata().getTotalHits() > 0) {
-                return Q.resolve();
+                return;
             }
 
             if (this.dependenciesSection.isActive()) {
@@ -231,7 +231,6 @@ export class ContentBrowseFilterPanel
 
         return this.getAndUpdateAggregations().then(() => {
             this.notifySearchEvent(this.aggregationsFetcher.createContentQuery(this.getSearchInputValues()));
-            return Q.resolve();
         });
     }
 
@@ -273,7 +272,6 @@ export class ContentBrowseFilterPanel
 
         return this.displayNamesResolver.updateAggregationsDisplayNames(aggregations, this.getCurrentUserKeyAsString()).then(() => {
             this.updateAggregations(aggregations);
-            return Q.resolve();
         });
     }
 
@@ -307,8 +305,6 @@ export class ContentBrowseFilterPanel
             if (!suppressEvent) {
                 this.notifySearchEvent();
             }
-
-            return Q.resolve();
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/browse/sort/dialog/SortContentDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/sort/dialog/SortContentDialog.ts
@@ -193,7 +193,7 @@ export class SortContentDialog
                 if (!!result.getContentsExistMap()[this.selectedContent.getId()]) {
                     return new ContentSummaryAndCompareStatusFetcher().fetch(this.selectedContent.getContentId(), parentProject);
                 } else {
-                    return Q(null);
+                    return null;
                 }
             });
     }

--- a/modules/lib/src/main/resources/assets/js/app/content/ContentSummaryListViewer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/content/ContentSummaryListViewer.ts
@@ -71,7 +71,6 @@ export class ContentSummaryListViewer
 
         return request.sendAndGet().then((imageResponse: ImageResponse) => {
             this.handleImageResponse(imageResponse);
-            return Q(null);
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/dialog/CompareWithPublishedVersionDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/CompareWithPublishedVersionDialog.ts
@@ -183,7 +183,7 @@ export class CompareWithPublishedVersionDialog
         if (updateDiff) {
             return this.displayDiff();
         } else {
-            return Q.resolve();
+            return Q();
         }
     }
 
@@ -193,7 +193,7 @@ export class CompareWithPublishedVersionDialog
         if (updateDiff) {
             return this.displayDiff();
         } else {
-            return Q.resolve();
+            return Q();
         }
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/dialog/CompareWithPublishedVersionDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/CompareWithPublishedVersionDialog.ts
@@ -182,9 +182,9 @@ export class CompareWithPublishedVersionDialog
 
         if (updateDiff) {
             return this.displayDiff();
-        } else {
-            return Q();
         }
+
+        return Q();
     }
 
     private setPublishedVersion(version: string, updateDiff: boolean = true): Q.Promise<void> {
@@ -192,9 +192,9 @@ export class CompareWithPublishedVersionDialog
 
         if (updateDiff) {
             return this.displayDiff();
-        } else {
-            return Q();
-        }
+    }
+
+        return Q();
     }
 
     private displayDiff(): Q.Promise<void> {

--- a/modules/lib/src/main/resources/assets/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/DependantItemsDialog.ts
@@ -331,8 +331,6 @@ export abstract class DependantItemsDialog
         return this.resolveDescendants().then((resolvedIds: ContentId[]) => {
             this.resolvedIds = resolvedIds;
             this.dependantIds = resolvedIds.filter((resolveId: ContentId) => !ids.some((id: ContentId) => id.equals(resolveId)));
-
-            return Q(null);
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/dialog/DependantItemsWithReferencesDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/DependantItemsWithReferencesDialog.ts
@@ -196,7 +196,6 @@ export abstract class DependantItemsWithReferencesDialog extends DependantItemsW
 
             return this.cleanLoadDescendants().then((descendants: ContentSummaryAndCompareStatus[]) => {
                 this.setDependantItems(descendants);
-                return Q(null);
             }).finally(() => {
                 this.notifyResize();
                 this.hideLoadMask();

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/selector/ContentSelector.ts
@@ -293,8 +293,6 @@ export class ContentSelector
             if (isNewButtonToBeAdded) {
                 this.addNewContentButton();
             }
-
-            return Q.resolve();
         }).catch(DefaultErrorHandler.handle);
     }
 
@@ -328,7 +326,7 @@ export class ContentSelector
         this.setLayoutInProgress(false);
         this.setupSortable();
 
-        return Q.resolve();
+        return Q();
     }
 
     protected createOptionDataLoaderBuilder(): ContentSummaryOptionDataLoaderBuilder {

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -90,7 +90,7 @@ export class SiteConfigurator
         const appKeys = this.getKeysFromPropertyArray(propertyArray);
 
         if (!appKeys?.length) {
-            return Q.resolve();
+            return Q();
         }
 
         return new GetApplicationsRequest(appKeys).sendAndParse().then((apps: Application[]) => {

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/LinkModalDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/dialog/LinkModalDialog.ts
@@ -184,15 +184,13 @@ export class LinkModalDialog
 
     private fetchParentSite(): Q.Promise<void> {
         if (!this.contentId) {
-            return Q.resolve();
+            return Q();
         }
 
         return new GetNearestSiteRequest(this.contentId).sendAndParse().then((parentSite: Site) => {
             if (parentSite) {
                 this.parentSitePath = parentSite.getPath().toString();
             }
-
-            return Q.resolve();
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/issue/view/IssueCommentsList.ts
+++ b/modules/lib/src/main/resources/assets/js/app/issue/view/IssueCommentsList.ts
@@ -52,7 +52,6 @@ export class IssueCommentsList
 
         return new ListIssueCommentsRequest(issue.getId()).sendAndParse().then((response: ListIssueCommentsResponse) => {
             this.setItems(response.getIssueComments());
-            return Q(null);
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/issue/view/IssueList.ts
+++ b/modules/lib/src/main/resources/assets/js/app/issue/view/IssueList.ts
@@ -167,7 +167,7 @@ export class IssueList
     private fetchItems(append?: boolean): Q.Promise<void> {
         const skipLoad = !this.needToLoad();
         if (skipLoad) {
-            return Q(null);
+            return Q();
         }
 
         this.showLoadMask();

--- a/modules/lib/src/main/resources/assets/js/app/move/MoveContentDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/move/MoveContentDialog.ts
@@ -172,7 +172,7 @@ export class MoveContentDialog
         });
     }
 
-    private getTargetContentSite(targetContent: ContentTreeSelectorItem): Q.Promise<ContentSummary> {
+    private getTargetContentSite(targetContent: ContentTreeSelectorItem): Q.Promise<ContentSummary | null> {
         if (!targetContent) {
             return Q(null);
         }
@@ -184,7 +184,7 @@ export class MoveContentDialog
         return this.getParentSite(targetContent.getContent());
     }
 
-    private getContentParentSite(content: ContentSummary): Q.Promise<ContentSummary> {
+    private getContentParentSite(content: ContentSummary): Q.Promise<ContentSummary | null> {
         if (content.isSite()) {
             return Q(null);
         }

--- a/modules/lib/src/main/resources/assets/js/app/settings/browse/statistics/view/project/ProjectStatisticsViewer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/browse/statistics/view/project/ProjectStatisticsViewer.ts
@@ -85,13 +85,12 @@ export class ProjectStatisticsViewer
 
     private loadAllProjects(): Q.Promise<void> {
         if (this.allProjects && !this.projectsUpdateRequired) {
-            return Q(null);
+            return Q();
         }
 
         return new ProjectListWithMissingRequest().sendAndParse().then((projects: Project[]) => {
             this.allProjects = projects;
             this.projectsUpdateRequired = false;
-            return Q(null);
         });
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/settings/dialog/project/create/ProjectWizardDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/dialog/project/create/ProjectWizardDialog.ts
@@ -64,7 +64,7 @@ export class ProjectWizardDialog
 
     private setParentProjectsInDialogStep(step: ProjectDialogStep): Q.Promise<void> {
         if (!(step instanceof ProjectDialogStep)) {
-            return Q(null);
+            return Q();
         }
 
         if (step instanceof ProjectApplicationsDialogStep) {
@@ -75,7 +75,7 @@ export class ProjectWizardDialog
         if (this.isParentProjectStep(step)) {
             this.config.parentProjects = null;
         }
-        return Q(null);
+        return Q();
     }
 
     protected displayStep(step: ProjectDialogStep): Q.Promise<void> {
@@ -148,7 +148,6 @@ export class ProjectWizardDialog
                     this.close();
 
                     showFeedback(i18n('notify.settings.project.created', project.getName()));
-                    return Q.resolve();
                 });
             });
         }).catch(DefaultErrorHandler.handle).finally(() => this.unlock());
@@ -186,7 +185,7 @@ export class ProjectWizardDialog
         const readAccess: ProjectAccessDialogStepData = this.getReadAccess();
 
         if (permissions.isEmpty() && readAccess.getAccess() !== ProjectReadAccessType.CUSTOM) {
-            return Q.resolve();
+            return Q();
         }
 
         return this.updateProjectPermissions(projectName, permissions, readAccess);

--- a/modules/lib/src/main/resources/assets/js/app/settings/dialog/project/create/step/ProjectApplicationsDialogStep.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/dialog/project/create/step/ProjectApplicationsDialogStep.ts
@@ -54,7 +54,7 @@ export class ProjectApplicationsDialogStep
         super.setParentProjects(projects);
 
         if (!this.getProjectApplicationsComboBox()) {
-            return Q(null);
+            return Q();
         }
 
         return this.getProjectApplicationsComboBox().setParentProjects(projects);

--- a/modules/lib/src/main/resources/assets/js/app/settings/resource/ProjectsTreeBuilder.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/resource/ProjectsTreeBuilder.ts
@@ -28,7 +28,7 @@ export class ProjectsTreeBuilder {
 
     private fetchTree(project: Project): Q.Promise<void> {
         if (!project) {
-            return Q(null);
+            return Q();
         }
 
         if (this.hasParent(project)) {

--- a/modules/lib/src/main/resources/assets/js/app/settings/tree/SettingsTreeActions.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/tree/SettingsTreeActions.ts
@@ -41,7 +41,7 @@ export class SettingsTreeActions
             this.SYNC.updateState();
         }
 
-        return Q.resolve();
+        return Q();
     }
 
     private isEditAllowed(selectedItems: SettingsViewItem[]): boolean {

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/ProjectWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/ProjectWizardPanel.ts
@@ -261,10 +261,10 @@ export class ProjectWizardPanel
     private updateAccessAndPermissionsForExistingProject(project: Project, language: string): Q.Promise<Project> {
         return this.updatePermissionsIfNeeded(project).then(() => {
             const readAccess: ProjectReadAccess = this.readAccessWizardStepForm.getReadAccess();
-            const readAccessPromise: Q.Promise<TaskId> = this.isReadAccessChanged() ?
+            const readAccessPromise: Q.Promise<TaskId | null> = this.isReadAccessChanged() ?
                                                          this.updateProjectReadAccess(project.getName(), readAccess) : Q(null);
 
-            return readAccessPromise.then((taskId: TaskId) => {
+            return readAccessPromise.then((taskId: TaskId | null) => {
                 const result = Q.defer<Project>();
                 if (taskId) {
                     let taskState;

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/SettingsDataItemWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/SettingsDataItemWizardPanel.ts
@@ -296,11 +296,7 @@ export abstract class SettingsDataItemWizardPanel<ITEM extends SettingsDataViewI
     protected abstract getIconClass(): string;
 
     protected doLoadData(): Q.Promise<ITEM> {
-        if (!this.getPersistedItem()) {
-            return Q(null);
-        } else {
-            return Q(this.getPersistedItem());
-        }
+        return Q(this.getPersistedItem());
     }
 
     protected abstract createStepsForms(persistedItem?: ITEM): SettingDataItemWizardStepForm<ITEM>[];

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/ProjectApplicationsWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/ProjectApplicationsWizardStepForm.ts
@@ -33,7 +33,7 @@ export class ProjectApplicationsWizardStepForm
 
     layout(item: ProjectViewItem): Q.Promise<void> {
         if (!item) {
-            return Q.resolve();
+            return Q();
         }
 
         return this.applicationsFormItem.layout(item);

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/ProjectItemNameWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/ProjectItemNameWizardStepForm.ts
@@ -99,16 +99,14 @@ export class ProjectItemNameWizardStepForm
     }
 
     layout(item: ProjectViewItem): Q.Promise<void> {
-        if (!item) {
-            return Q(null);
+        if (item) {
+            this.descriptionInput.setValue(item.getDescription(), true);
+            this.nameFormItem.setValue(item.getName(), true);
+            this.disableProjectNameHelpText();
+            this.disableProjectNameInput();
         }
 
-        this.descriptionInput.setValue(item.getDescription(), true);
-        this.nameFormItem.setValue(item.getName(), true);
-        this.disableProjectNameHelpText();
-        this.disableProjectNameInput();
-
-        return Q(null);
+        return Q();
     }
 
     disableParentProjectElements() {

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/ProjectReadAccessWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/ProjectReadAccessWizardStepForm.ts
@@ -22,7 +22,7 @@ export class ProjectReadAccessWizardStepForm
 
     layout(item: ProjectViewItem): Q.Promise<void> {
         if (!item) {
-            return Q(null);
+            return Q();
         }
 
         const layoutPromises: Q.Promise<void>[] = [];
@@ -32,12 +32,12 @@ export class ProjectReadAccessWizardStepForm
             this.readAccessFormItem.layoutReadAccess(item.getReadAccess(), item.getPermissions())
         );
 
-        return Q.all(layoutPromises).spread(() => Q());
+        return Q.all(layoutPromises).spread(Q);
     }
 
     private layoutLanguage(language: string): Q.Promise<void> {
         if (!language) {
-            return Q(null);
+            return Q();
         }
 
         this.localeFormItem.getLocaleCombobox().setSelectedLocale(language);

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/ProjectRolesWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/ProjectRolesWizardStepForm.ts
@@ -39,7 +39,7 @@ export class ProjectRolesWizardStepForm
 
     layout(item: ProjectViewItem): Q.Promise<void> {
         if (!item) {
-            return Q(null);
+            return Q();
         }
 
         return this.rolesFormItem.layoutAccessCombobox(item.getPermissions());

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectApplicationSelectedOptionView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectApplicationSelectedOptionView.ts
@@ -42,7 +42,7 @@ export class ProjectApplicationSelectedOptionView
         this.appendChild(this.projectApplicationViewer);
         this.appendActionButtons();
 
-        return Q.resolve();
+        return Q(true);
     }
 
     layoutForm(): Q.Promise<void> {

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectApplicationsComboBox.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectApplicationsComboBox.ts
@@ -126,7 +126,7 @@ export class ProjectApplicationsComboBox
     layout(item: ProjectViewItem): Q.Promise<void> {
         const siteConfigs = item.getSiteConfigs();
         if (!item || siteConfigs.length === 0) {
-            return Q(null);
+            return Q();
         }
 
         return this.layoutSiteConfigs(siteConfigs);

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectOptionDataLoader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectOptionDataLoader.ts
@@ -55,7 +55,7 @@ export class ProjectOptionDataLoader
         const innerListener = (event: LoadedDataEvent<Project>) => {
             listener(event.getData());
             this.unLoadedData(innerListener);
-            return Q.resolve();
+            return Q();
         };
 
         this.onLoadedData(innerListener);

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectReadAccessFormItem.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectReadAccessFormItem.ts
@@ -71,8 +71,6 @@ export class ProjectReadAccessFormItem
 
         return new GetPrincipalsByKeysRequest(readAccess.getPrincipalsKeys()).sendAndParse().then((principals: Principal[]) => {
             this.getPrincipalComboBox().select(principals, silent);
-
-            return Q(null);
         }).catch(DefaultErrorHandler.handle);
     }
 
@@ -147,7 +145,6 @@ export class ProjectReadAccessFormItem
         const parentProject = this.parentProjects[0];
         this.layoutReadAccess(parentProject.getReadAccess(), parentProject.getPermissions(), false).then(() => {
             this.notifyAccessCopiedFromParent();
-            return Q.resolve();
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/util/PageHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/util/PageHelper.ts
@@ -26,13 +26,11 @@ export class PageHelper {
 
     public static fetchAndInjectLayoutRegions(layout: LayoutComponent): Q.Promise<void> {
         if (!layout?.hasDescriptor()) {
-            return Q.resolve();
+            return Q();
         }
 
         return this.loadDescriptor(layout.getDescriptorKey(), LayoutComponentType.get()).then((descriptor: Descriptor) => {
             layout.setDescriptor(descriptor);
-
-            return Q.resolve();
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/view/context/ContextView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/ContextView.ts
@@ -330,7 +330,6 @@ export class ContextView
 
         return this.activeWidget.updateWidgetItemViews().then(() => {
             this.activeWidget.slideIn();
-            return Q.resolve();
         }).catch(DefaultErrorHandler.handle);
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/view/context/widget/details/PropertiesWidgetItemView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/widget/details/PropertiesWidgetItemView.ts
@@ -50,10 +50,9 @@ export abstract class PropertiesWidgetItemView
             }
 
             this.hide();
-            return Q.resolve();
         }
 
-        return Q.resolve();
+        return Q();
     }
 
     protected isAllowedToBeShown(): boolean {
@@ -72,16 +71,13 @@ export abstract class PropertiesWidgetItemView
                 return this.fetchExtraData().then(() => {
                     this.layoutProperties();
                     this.layoutEditLink();
-                    return Q.resolve();
                 });
             }
-
-            return Q.resolve();
         });
     }
 
     protected fetchExtraData(): Q.Promise<void> {
-        return Q.resolve();
+        return Q();
     }
 
     protected layoutProperties(): void {

--- a/modules/lib/src/main/resources/assets/js/app/view/context/widget/details/PropertiesWidgetItemViewHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/widget/details/PropertiesWidgetItemViewHelper.ts
@@ -24,8 +24,6 @@ export abstract class PropertiesWidgetItemViewHelper {
                 if (isAllowed) {
                     result.push(PropertiesWizardStepFormFactory.getWizardStepForm(formType));
                 }
-
-                return Q.resolve();
             });
 
             resultPromises.push(p);

--- a/modules/lib/src/main/resources/assets/js/app/view/context/widget/version/VersionHistoryView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/widget/version/VersionHistoryView.ts
@@ -118,11 +118,9 @@ export class VersionHistoryView extends WidgetItemView {
 
                 this.versionListView.setContent(this.content);
                 this.versionListView.setItems(items);
-
-                return Q.resolve();
             });
         }
 
-        return Q.resolve();
+        return Q();
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/CollaborationEl.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/CollaborationEl.ts
@@ -164,8 +164,6 @@ export class CollaborationEl
             }
 
             this.addCollaborators(collaborators);
-
-            return Q(null);
         }).catch(DefaultErrorHandler.handle);
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardDataLoader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardDataLoader.ts
@@ -75,18 +75,15 @@ export class ContentWizardDataLoader {
     private loadDataForEdit(params: ContentWizardPanelParams): Q.Promise<ContentWizardDataLoader> {
         const sitePromise: Q.Promise<void> = this.loadSite(params.contentId).then((loadedSite: Site) => {
             this.siteContent = loadedSite;
-            return Q(null);
         });
 
         const contentPromise: Q.Promise<void> = this.loadContent(params.contentId).then((loadedContent: Content) => {
             this.content = loadedContent;
-            return Q(null);
         });
 
         const modelsPromise: Q.Promise<void> = Q.all([sitePromise, contentPromise]).then(() => {
             return ContentWizardDataLoader.loadDefaultModels(this.siteContent, this.content.getType()).then((defaultModels) => {
                 this.defaultModels = defaultModels;
-                return Q(null);
             });
         });
 
@@ -107,8 +104,6 @@ export class ContentWizardDataLoader {
                         this.compareStatus = compareStatus.getCompareStatus();
                         this.publishStatus = compareStatus.getPublishStatus();
                     }
-
-                    return Q(null);
                 });
         });
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardHeader.ts
@@ -119,8 +119,6 @@ export class ContentWizardHeader
                     if (this.asyncNameChecksRunning === 1 && exists === this.isNameUnique) {
                         this.updateIsNameUnique(!exists || !this.isNameChanged());
                     }
-
-                    return Q();
                 }).catch(DefaultErrorHandler.handle).finally(() => {
                     this.asyncNameChecksRunning--;
                     this.unlock();

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -932,23 +932,14 @@ export class ContentWizardPanel
             return Q();
         }
 
+        this.liveEditModel = null;
+
         if (this.getPersistedItem().getPage()) {
             this.updateLiveEditModel(contentClone);
-            return this.handleNonRenderablePage();
+        } else {
+            this.livePanel.unloadPage();
+            this.removePCV();
         }
-
-        return this.unloadPage();
-    }
-
-    private handleNonRenderablePage(): Q.Promise<void> {
-        this.liveEditModel = null;
-        return Q();
-    }
-
-    private unloadPage(): Q.Promise<void> {
-        this.liveEditModel = null;
-        this.livePanel.unloadPage();
-        this.removePCV();
 
         return Q();
     }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -595,7 +595,6 @@ export class ContentWizardPanel
 
         return pagePromise.then((page: Page | null) => {
             PageState.setState(page);
-            return Q.resolve();
         });
     }
 
@@ -617,7 +616,7 @@ export class ContentWizardPanel
             className: 'content-wizard-toolbar',
             compareVersionsPreHook: () => {
                 if (!this.hasUnsavedChanges()) {
-                    return Q.resolve();
+                    return Q();
                 }
 
                 return this.saveChangesWithoutValidation().thenResolve(undefined);
@@ -878,7 +877,7 @@ export class ContentWizardPanel
             });
         }
 
-        return Q.resolve();
+        return Q();
     }
 
     private doUpdateModifiedPersistedContent(viewedContent: Content, newPersistedContent: Content): void {
@@ -919,7 +918,7 @@ export class ContentWizardPanel
 
     private resetLivePanel(contentClone: Content): Q.Promise<void> {
         if (!this.livePanel) {
-            return Q.resolve();
+            return Q();
         }
 
         this.getLivePanel().setHasPage(!!contentClone.getPage());
@@ -930,7 +929,7 @@ export class ContentWizardPanel
                 this.updateLiveEditModel(contentClone);
             }
 
-            return Q.resolve();
+            return Q();
         }
 
         if (this.getPersistedItem().getPage()) {
@@ -943,7 +942,7 @@ export class ContentWizardPanel
 
     private handleNonRenderablePage(): Q.Promise<void> {
         this.liveEditModel = null;
-        return Q.resolve();
+        return Q();
     }
 
     private unloadPage(): Q.Promise<void> {
@@ -951,7 +950,7 @@ export class ContentWizardPanel
         this.livePanel.unloadPage();
         this.removePCV();
 
-        return Q.resolve();
+        return Q();
     }
 
     private availableSizeChangedHandler(item: ResponsiveItem) {
@@ -1815,7 +1814,7 @@ export class ContentWizardPanel
         this.updateMissingOrStoppedApplications().catch(DefaultErrorHandler.handle);
 
         if (!this.getLivePanel()) {
-            return Q(null);
+            return Q();
         }
 
         this.setupWizardLiveEdit();
@@ -1825,11 +1824,11 @@ export class ContentWizardPanel
 
         if (this.isRenderable() && !this.isWithinSite()) {
             this.debouncedEditorReload(false);
-            return Q.resolve();
+            return Q();
         }
 
         this.updateLiveEditModel(content);
-        return Q.resolve();
+        return Q();
     }
 
     // sync persisted content extra data with xData
@@ -1970,8 +1969,6 @@ export class ContentWizardPanel
                         const debouncedUpdate: () => void = AppHelper.debounce(this.updatePublishStatusOnDataChange.bind(this), 100);
 
                         this.onPageStateChanged(debouncedUpdate);
-
-                        return Q(null);
                     });
                 });
             });
@@ -2133,7 +2130,6 @@ export class ContentWizardPanel
 
         return xDataStepForm.layout(formContext, data, xDataForm).then(() => {
             this.syncPersistedItemWithXData(xDataStepForm.getXDataName(), data);
-            return Q(null);
         });
     }
 
@@ -2158,8 +2154,8 @@ export class ContentWizardPanel
         return Q(persistedContent);
     }
 
-    private produceCreateContentRequest(): Q.Promise<CreateContentRequest> {
-        return this.contentType.getContentTypeName().isMedia() ? Q(null) : Q.resolve(this.doCreateContentRequest());
+    private produceCreateContentRequest(): Q.Promise<CreateContentRequest | null> {
+        return this.contentType.getContentTypeName().isMedia() ? Q(null) : Q(this.doCreateContentRequest());
     }
 
     private doCreateContentRequest(): CreateContentRequest {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardStepForm.ts
@@ -68,8 +68,6 @@ export class ContentWizardStepForm
             if (form.getFormItems().length === 0) {
                 this.hide();
             }
-
-            return Q(null);
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardToolbar.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardToolbar.ts
@@ -164,7 +164,6 @@ export class ContentWizardToolbar
     private fetchProjectInfo() {
         new ProjectListRequest().sendAndParse().then((projects: Project[]) => {
             this.initProjectViewer(projects);
-            return Q.resolve();
         }).catch((reason) => {
             this.initProjectViewer([
                 Project.create()

--- a/modules/lib/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/PageComponentsView.ts
@@ -650,8 +650,6 @@ export class PageComponentsView
                     PageEventsManager.get().notifyTextComponentEditRequested(path);
                 }
             }
-
-            return Q.resolve();
         });
     }
 
@@ -713,12 +711,8 @@ export class PageComponentsView
                 if (item) {
                     this.pageComponentsWrapper.select(item);
                 }
-
-                return Q.resolve();
             });
         }
-
-        return Q.resolve();
     }
 
     private scrollToItem(path: ComponentPath): void {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/PageComponentsViewExpandHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/PageComponentsViewExpandHelper.ts
@@ -10,17 +10,17 @@ export class PageComponentsViewExpandHelper {
     }
 
     loadAndExpandToItemRecursively(target: ComponentPath, currentList: PageComponentsTreeGrid,
-                                   currentPathToExpand: ComponentPath): Q.Promise<ComponentsTreeItem> {
+                                   currentPathToExpand: ComponentPath): Q.Promise<ComponentsTreeItem | null> {
         const listElement = currentList.getItemViews().find(
             (view: PageComponentsListElement) => view.getComponentPath().equals(currentPathToExpand)) as PageComponentsListElement;
 
         if (listElement) {
             if (target.equals(currentPathToExpand)) {
-                return Q.resolve(listElement.getItem());
+                return Q(listElement.getItem());
             }
 
             if (!listElement.hasChildren()) {
-                return Q.resolve();
+                return Q(null);
             }
 
             listElement.expand();
@@ -31,7 +31,7 @@ export class PageComponentsViewExpandHelper {
             });
         }
 
-        return Q.resolve();
+        return Q(null);
     }
 
     private waitForListItemsAdded(listElement: PageComponentsListElement): Q.Promise<void> {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/PersistNewContentRoutine.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/PersistNewContentRoutine.ts
@@ -7,7 +7,7 @@ import {Content} from '../content/Content';
 export class PersistNewContentRoutine
     extends Flow {
 
-    private createContentRequestProducer: () => Q.Promise<CreateContentRequest>;
+    private createContentRequestProducer: () => Q.Promise<CreateContentRequest | null>;
 
     private doneHandledContent: boolean = false;
 
@@ -15,7 +15,7 @@ export class PersistNewContentRoutine
         super(thisOfProducer);
     }
 
-    public setCreateContentRequestProducer(producer: () => Q.Promise<CreateContentRequest>): PersistNewContentRoutine {
+    public setCreateContentRequestProducer(producer: () => Q.Promise<CreateContentRequest | null>): PersistNewContentRoutine {
         this.createContentRequestProducer = producer;
         return this;
     }
@@ -41,7 +41,7 @@ export class PersistNewContentRoutine
         }
     }
 
-    private doHandleCreateContent(context: RoutineContext): Q.Promise<void> {
+    private doHandleCreateContent(context: RoutineContext | null): Q.Promise<void> {
 
         if (this.createContentRequestProducer != null) {
 
@@ -55,6 +55,6 @@ export class PersistNewContentRoutine
             });
         }
 
-        return Q(null);
+        return Q();
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/UpdatePersistedContentRoutine.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/UpdatePersistedContentRoutine.ts
@@ -45,7 +45,7 @@ export class UpdatePersistedContentRoutine
         if (isContentChanged || this.hasNamesChanged()) {
             promise = this.doHandleUpdateContent(context, isContentChanged);
         } else {
-            promise = Q(null);
+            promise = Q();
         }
 
         if (isPageChanged) {
@@ -74,15 +74,15 @@ export class UpdatePersistedContentRoutine
     private doHandlePage(context: RoutineContext): Q.Promise<void> {
         const pageCUDRequest: PageCUDRequest = this.producePageCUDRequest(context.content, this.viewedContent);
 
-        if (pageCUDRequest != null) {
-            return pageCUDRequest.sendAndParse()
-                .then((content: Content): void => {
-                    context.content = content;
-                    context.pageUpdated = true;
-                });
-        } else {
-            return Q(null);
+        if (pageCUDRequest == null) {
+            return Q();
         }
+
+        return pageCUDRequest.sendAndParse()
+            .then((content: Content): void => {
+                context.content = content;
+                context.pageUpdated = true;
+            });
     }
 
     private hasNamesChanged(): boolean {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/XDataWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/XDataWizardStepForm.ts
@@ -69,7 +69,7 @@ export class XDataWizardStepForm
     resetForm(): Q.Promise<void> {
         this.resetData();
 
-        return this.enabled ? this.doLayout(this.form, this.data) : Q(null);
+        return this.enabled ? this.doLayout(this.form, this.data) : Q();
     }
 
     layout(formContext: ContentFormContext, data: PropertyTree, form: Form): Q.Promise<void> {
@@ -84,7 +84,7 @@ export class XDataWizardStepForm
             this.formView = new FormView(this.formContext, form, data.getRoot());
         }
 
-        return Q(null);
+        return Q();
     }
 
     update(data: PropertyTree, unchangedOnly: boolean = true): Q.Promise<void> {
@@ -113,7 +113,7 @@ export class XDataWizardStepForm
         this.setVisible(this.enabled);
 
         if (!changed) {
-            return Q(null);
+            return Q();
         }
 
         let promise: Q.Promise<void>;
@@ -125,7 +125,6 @@ export class XDataWizardStepForm
 
                 promise = this.doLayout(this.form, this.data).then(() => {
                     this.validate();
-                    return Q(null);
                 });
             }
         } else {
@@ -148,7 +147,7 @@ export class XDataWizardStepForm
             this.notifyEnableChanged(value);
         }
 
-        return promise != null ? promise : Q(null);
+        return promise != null ? promise : Q();
     }
 
     onEnableChanged(listener: (value: boolean) => void) {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/action/ContentWizardActions.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/action/ContentWizardActions.ts
@@ -293,7 +293,7 @@ export class ContentWizardActions
                   !existing.isDataInherited()
         });
 
-        return Q.resolve();
+        return Q();
     }
 
     setDeleteOnlyMode(content: Content, valueOn: boolean = true) {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -228,8 +228,6 @@ export class LiveFormPanel
             if (isChanged) {
                 this.debouncedUpdateFunc();
             }
-
-            return Q.resolve();
         }).catch(DefaultErrorHandler.handle);
     }
 

--- a/modules/lib/src/main/resources/assets/js/page-editor/PagePlaceholder.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/PagePlaceholder.ts
@@ -80,8 +80,6 @@ export class PagePlaceholder
             this.infoBlock.setEmptyText();
             this.infoBlock.addClass('empty');
         }
-
-        return Q.resolve();
     };
 
     remove() {

--- a/modules/lib/src/main/resources/assets/styles/content/content-summary-and-compare-status-viewer.less
+++ b/modules/lib/src/main/resources/assets/styles/content/content-summary-and-compare-status-viewer.less
@@ -13,15 +13,15 @@
   }
 
   &.invalid .names-and-icon-view .@{_COMMON_PREFIX}wrapper {
-    .icon-state-invalid;
+    .icon-state-invalid();
   }
 
   &.ready .names-and-icon-view .@{_COMMON_PREFIX}wrapper {
-    .icon-state-ready;
+    .icon-state-ready();
   }
 
   &.in-progress .names-and-icon-view .@{_COMMON_PREFIX}wrapper {
-    .icon-state-in-progress;
+    .icon-state-in-progress();
   }
 
   &.icon-variant.has-origin-project {

--- a/modules/lib/src/main/resources/assets/styles/content/content-summary-viewer.less
+++ b/modules/lib/src/main/resources/assets/styles/content/content-summary-viewer.less
@@ -1,7 +1,7 @@
 .content-summary-viewer {
   &.invalid .names-and-icon-view {
     .@{_COMMON_PREFIX}wrapper {
-      .icon-state-invalid;
+      .icon-state-invalid();
     }
 
     &.small .@{_COMMON_PREFIX}wrapper::before {

--- a/modules/lib/src/main/resources/assets/styles/content/content-tree-selector-item-viewer.less
+++ b/modules/lib/src/main/resources/assets/styles/content/content-tree-selector-item-viewer.less
@@ -12,7 +12,7 @@
 
   &.invalid .names-and-icon-view {
     .@{_COMMON_PREFIX}wrapper {
-      .icon-state-invalid;
+      .icon-state-invalid();
 
       &:before {
         width: 14px;

--- a/modules/lib/src/main/resources/assets/styles/dialog/archive-item.less
+++ b/modules/lib/src/main/resources/assets/styles/dialog/archive-item.less
@@ -1,7 +1,7 @@
 .archive-item {
   &.has-inbound {
     .names-and-icon-viewer .names-and-icon-view .@{_COMMON_PREFIX}wrapper {
-      .icon-big-plus;
+      .icon-big-plus();
 
       &::before {
         top: -1px;

--- a/modules/lib/src/main/resources/assets/styles/main-app-wrapper.less
+++ b/modules/lib/src/main/resources/assets/styles/main-app-wrapper.less
@@ -152,13 +152,13 @@
     }
 
     .lines {
-      .line;
+      .line();
       position: relative;
       top: -3px;
 
       &::before,
       &::after {
-        .line;
+        .line();
         transition: top 0.3s;
         position: absolute;
         left: 0;

--- a/modules/lib/src/main/resources/assets/styles/view/content-status-toolbar.less
+++ b/modules/lib/src/main/resources/assets/styles/view/content-status-toolbar.less
@@ -17,8 +17,8 @@
     }
 
     .show-changes {
-      .icon-compare;
-      .icon-medium;
+      .icon-compare();
+      .icon-medium();
       margin-left: 5px;
       padding-top: 3px;
       border: none;

--- a/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-toolbar.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-toolbar.less
@@ -92,15 +92,15 @@
     }
 
     &.invalid {
-      .icon-state-invalid;
+      .icon-state-invalid();
     }
 
     &.ready {
-      .icon-state-ready;
+      .icon-state-ready();
     }
 
     &.in-progress {
-      .icon-state-in-progress;
+      .icon-state-in-progress();
     }
 
     &.status-hidden {


### PR DESCRIPTION
Further refactoring related to #8677 and #8679 fixes. 
Makes code a little bit secure by returning void explicitly, instead of any. Also removes invalid or redundant code, that is not type checked due to current TSConfig. 