### PR TITLE
Fix missing test dependencies in rest module #8741

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'com.enonic.defaults' version '2.0.1' apply false
-    id 'com.enonic.xp.app' version '3.2.0' apply false
-    id 'com.enonic.xp.base' version '3.2.0' apply false
-    id 'com.github.node-gradle.node' version '3.4.0' apply false
-    id 'org.asciidoctor.jvm.convert' version '3.3.2'
-    id 'org.aim42.htmlSanityCheck' version '1.1.6'
+    alias(libs.plugins.enonic.defaults) apply false
+    alias(libs.plugins.enonic.xp.app) apply false
+    alias(libs.plugins.enonic.xp.base) apply false
+    alias(libs.plugins.node.gradle) apply false
+    alias(libs.plugins.asciidoctor.jvm)
+    alias(libs.plugins.htmlSanityCheck)
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,13 @@ subprojects {
     targetCompatibility = sourceCompatibility
 
     dependencies {
-        testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.2"
-        testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.1"
-        testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.1"
-        testImplementation "org.mockito:mockito-core:5.12.0"
-        testImplementation "org.mockito:mockito-junit-jupiter:5.12.0"
-        testImplementation "org.assertj:assertj-core:3.23.1"
+        testImplementation platform(libs.junit.bom)
+        testImplementation libs.junit.jupiter
+        testRuntimeOnly  libs.junit.launcher
+
+        testImplementation libs.mockito.core
+        testImplementation libs.mockito.jupiter
+        testImplementation libs.assertj.core
     }
 
     repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,21 @@ junit = "5.12.2"
 junit-launcher = "1.12.2"
 mockito = "5.17.0"
 assertj = "3.23.1"
+enonicDefaults = "2.0.1"
+xpApp = "3.2.0"
+xpBase = "3.2.0"
+nodeGradle = "3.4.0"
+asciidoctor = "3.3.2"
+htmlSanityCheck = "1.1.6"
+
+# App
+commonsText = "1.13.1"
+libTextEncoding = "2.1.1"
+libMustache = "2.1.1"
+libHttpClient = "3.2.2"
+
+# Rest
+jacksonJrObjects = "2.19.0"
 
 [libraries]
 
@@ -16,3 +31,20 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+
+# App
+commons-text = { module = "org.apache.commons:commons-text", version.ref = "commonsText" }
+lib-text-encoding = { module = "com.enonic.lib:lib-text-encoding", version.ref = "libTextEncoding" }
+lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "libMustache" }
+lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "libHttpClient" }
+
+# Rest
+jackson-jr-objects = { module = "com.fasterxml.jackson.jr:jackson-jr-objects", version.ref = "jacksonJrObjects" }
+
+[plugins]
+enonic-defaults = { id = "com.enonic.defaults", version.ref = "enonicDefaults" }
+enonic-xp-app = { id = "com.enonic.xp.app", version.ref = "xpApp" }
+enonic-xp-base = { id = "com.enonic.xp.base", version.ref = "xpBase" }
+node-gradle = { id = "com.github.node-gradle.node", version.ref = "nodeGradle" }
+asciidoctor-jvm = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }
+htmlSanityCheck = { id = "org.aim42.htmlSanityCheck", version.ref = "htmlSanityCheck" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,18 @@
+[versions]
+
+junit = "5.12.2"
+junit-launcher = "1.12.2"
+mockito = "5.17.0"
+assertj = "3.23.1"
+
+[libraries]
+
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-launcher" }
+
+mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }

--- a/modules/app/build.gradle
+++ b/modules/app/build.gradle
@@ -29,24 +29,24 @@ dependencies {
     implementation "com.enonic.xp:admin-api:${xpVersion}"
     implementation "com.enonic.xp:portal-api:${xpVersion}"
 
-    include "org.apache.commons:commons-text:1.13.1"
+    include "com.enonic.lib:lib-admin-ui:${libAdminUiVersion}"
     include "com.enonic.xp:lib-admin:${xpVersion}"
     include "com.enonic.xp:lib-portal:${xpVersion}"
     include "com.enonic.xp:lib-context:${xpVersion}"
     include "com.enonic.xp:lib-project:${xpVersion}"
-    include "com.enonic.lib:lib-text-encoding:2.1.1"
     include "com.enonic.xp:lib-content:${xpVersion}"
     include "com.enonic.xp:lib-grid:${xpVersion}"
     include "com.enonic.xp:lib-event:${xpVersion}"
     include "com.enonic.xp:lib-app:${xpVersion}"
     include "com.enonic.xp:lib-schema:${xpVersion}"
     include "com.enonic.xp:lib-i18n:${xpVersion}"
-    include "com.enonic.lib:lib-admin-ui:${libAdminUiVersion}"
-    include "com.enonic.lib:lib-mustache:2.1.1"
-    include "com.enonic.lib:lib-http-client:3.2.2"
     include "com.enonic.xp:lib-auth:${xpVersion}"
     include "com.enonic.xp:lib-node:${xpVersion}"
-    include "com.enonic.lib:lib-http-client:3.2.2"
+    include libs.commons.text
+    include libs.lib.mustache
+    include libs.lib.http.client
+    include libs.lib.text.encoding
+
     include project( ':lib-contentstudio' )
     include project( ':rest' )
     devResources project( path: ':lib-contentstudio', configuration: 'devResources' )

--- a/modules/rest/build.gradle
+++ b/modules/rest/build.gradle
@@ -1,13 +1,12 @@
 archivesBaseName = 'lib-contentstudio-rest'
 
 dependencies {
-    implementation "com.fasterxml.jackson.jr:jackson-jr-objects:2.19.0"
+    implementation libs.jackson.jr.objects
     compileOnly "com.enonic.xp:core-api:${xpVersion}"
     compileOnly "com.enonic.xp:jaxrs-api:${xpVersion}"
     compileOnly "com.enonic.xp:admin-api:${xpVersion}"
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testImplementation "com.enonic.xp:admin-api:${xpVersion}"
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation( testFixtures( "com.enonic.xp:jaxrs-impl:${xpVersion}" ) )
     testImplementation( testFixtures( "com.enonic.xp:core-api:${xpVersion}" ) )
     testImplementation( testFixtures( "com.enonic.xp:core-app:${xpVersion}" ) )


### PR DESCRIPTION
Added missing junit-platform-launcher dependency.
Moved all non-xp test dependencies to single toml file.
Removed duplicated dependencies.

_No longer fixes the tests, as fix was merged separatelly in different [PR](https://github.com/enonic/app-contentstudio/pull/8740), but rather moves and reorganizes dependencies._