### PR TITLE
Support baseUrl in Content Studio #8479

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigProviderRegistry.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigProviderRegistry.ts
@@ -1,0 +1,18 @@
+import {ApplicationConfigProvider} from '@enonic/lib-admin-ui/form/inputtype/appconfig/ApplicationConfigProvider';
+
+export class SiteConfigProviderRegistry {
+
+    private static siteConfigProvider: ApplicationConfigProvider;
+
+    private constructor() {
+        //
+    }
+
+    public static setConfigProvider(siteConfigProvider: ApplicationConfigProvider): void {
+        SiteConfigProviderRegistry.siteConfigProvider = siteConfigProvider;
+    }
+
+    public static getConfigProvider(): ApplicationConfigProvider | undefined {
+        return SiteConfigProviderRegistry.siteConfigProvider;
+    }
+}

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -15,6 +15,7 @@ import {ApplicationConfig} from '@enonic/lib-admin-ui/application/ApplicationCon
 import {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
 import {ApplicationEvent} from '@enonic/lib-admin-ui/application/ApplicationEvent';
 import {ApplicationConfigProvider} from '@enonic/lib-admin-ui/form/inputtype/appconfig/ApplicationConfigProvider';
+import {SiteConfigProviderRegistry} from './SiteConfigProviderRegistry';
 import {SiteConfiguratorComboBox} from './SiteConfiguratorComboBox';
 import {SiteConfiguratorSelectedOptionView} from './SiteConfiguratorSelectedOptionView';
 import {ContentInputTypeViewContext} from '../ContentInputTypeViewContext';
@@ -62,8 +63,8 @@ export class SiteConfigurator
     layout(input: Input, propertyArray: PropertyArray): Q.Promise<void> {
         return super.layout(input, propertyArray).then(() => {
             let deferred = Q.defer<void>();
-
             this.siteConfigProvider = new ApplicationConfigProvider(propertyArray);
+            SiteConfigProviderRegistry.setConfigProvider(this.siteConfigProvider);
             // ignore changes made to property by siteConfigProvider
             this.siteConfigProvider.onBeforePropertyChanged(() => this.ignorePropertyChange(true));
             this.siteConfigProvider.onAfterPropertyChanged(() => this.ignorePropertyChange(false));

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionsView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionsView.ts
@@ -62,6 +62,10 @@ export class SiteConfiguratorSelectedOptionsView
             this.notifySiteConfigFormDisplayed(applicationKey, optionView.getFormView());
         });
 
+        if (key.isSystemReserved()) {
+            optionView.addClass('system-app');
+        }
+
         this.items.push(optionView);
 
         return new SelectedOption<Application>(optionView, this.count());

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/ProjectWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/ProjectWizardPanel.ts
@@ -1,3 +1,4 @@
+import {AppHelper} from '@enonic/lib-admin-ui/util/AppHelper';
 import {SettingsDataItemWizardPanel} from './SettingsDataItemWizardPanel';
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import * as Q from 'q';
@@ -97,6 +98,13 @@ export class ProjectWizardPanel
             this.hasChildrenLayers = value;
             this.updateToolbarActions();
         }
+    }
+
+    doLayout(persistedItem: ProjectViewItem): Q.Promise<void> {
+        return super.doLayout(persistedItem).then(() => {
+            const baseUrlHandler = () => this.applicationsWizardStepForm.updateBaseUrlInSiteConfig(this.projectWizardStepForm.getBaseUrl());
+            this.projectWizardStepForm.onBaseUrlChanged(AppHelper.debounce(baseUrlHandler, 300));
+        });
     }
 
     protected checkIfEditIsAllowed(): Q.Promise<boolean> {

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/ProjectApplicationsWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/ProjectApplicationsWizardStepForm.ts
@@ -1,3 +1,4 @@
+import {StringHelper} from '@enonic/lib-admin-ui/util/StringHelper';
 import {ProjectWizardStepForm} from './ProjectWizardStepForm';
 import {FormItem} from '@enonic/lib-admin-ui/ui/form/FormItem';
 import {ProjectViewItem} from '../../../view/ProjectViewItem';
@@ -46,6 +47,15 @@ export class ProjectApplicationsWizardStepForm
     getNonInheritedApplicationConfigs(): ApplicationConfig[] {
         return this.applicationsFormItem?.getNonInheritedApplicationConfigs() || [];
     }
+
+    updateBaseUrlInSiteConfig(baseUrl: string): void {
+        if (StringHelper.isBlank(baseUrl)) {
+            this.applicationsFormItem.getComboBox().removePortalApp();
+        } else {
+            this.applicationsFormItem.getComboBox().addAndUpdatePortalApp(baseUrl);
+        }
+    }
+
 
     setParentProjects(projects: Project[]) {
         super.setParentProjects(projects);

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectApplicationSelectedOptionView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectApplicationSelectedOptionView.ts
@@ -29,6 +29,8 @@ export class ProjectApplicationSelectedOptionView
 
     private dataChangedHandler?: () => void;
 
+    private formViewCreatedListeners: (() => void)[] = [];
+
     constructor(builder: ProjectApplicationSelectedOptionViewBuilder) {
         super(builder);
 
@@ -48,10 +50,20 @@ export class ProjectApplicationSelectedOptionView
     layoutForm(): Q.Promise<void> {
         if (!this.formView) {
             this.formView = this.createFormView();
+            this.formViewCreatedListeners.forEach(callBack => callBack());
+            this.formViewCreatedListeners = [];
             return this.formView.layout();
         }
 
         return this.revertFormView();
+    }
+
+    whenFormLayoutFinished(callback: () => void): void {
+        if (this.formView) {
+            this.formView.whenLayoutFinished(callback);
+        } else {
+            this.formViewCreatedListeners.push(() => this.formView.whenLayoutFinished(callback));
+        }
     }
 
     setConfig(config: PropertySet): ProjectApplicationSelectedOptionView {

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectApplicationsSelectedOptionsView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/form/element/ProjectApplicationsSelectedOptionsView.ts
@@ -39,6 +39,7 @@ export class ProjectApplicationsSelectedOptionsView
         const selectedOption = new SelectedOption<Application>(new ProjectApplicationSelectedOptionView(builder), this.count());
         selectedOption.getOptionView().toggleClass('non-editable', !isEditable);
         selectedOption.getOptionView().toggleClass('non-removable', !isRemovable);
+        selectedOption.getOptionView().toggleClass('system-app', option.getDisplayValue().getApplicationKey().isSystemReserved());
 
         return selectedOption;
     }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/SiteContentWizardStepForm.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/SiteContentWizardStepForm.ts
@@ -1,0 +1,160 @@
+import {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
+import {PropertyEvent} from '@enonic/lib-admin-ui/data/PropertyEvent';
+import {PropertyPath} from '@enonic/lib-admin-ui/data/PropertyPath';
+import {PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
+import {PropertyValueChangedEvent} from '@enonic/lib-admin-ui/data/PropertyValueChangedEvent';
+import {Value} from '@enonic/lib-admin-ui/data/Value';
+import {ValueTypes} from '@enonic/lib-admin-ui/data/ValueTypes';
+import {Form, FormBuilder} from '@enonic/lib-admin-ui/form/Form';
+import {Input, InputBuilder} from '@enonic/lib-admin-ui/form/Input';
+import {TextLine} from '@enonic/lib-admin-ui/form/inputtype/text/TextLine';
+import {OccurrencesBuilder} from '@enonic/lib-admin-ui/form/Occurrences';
+import {AppHelper} from '@enonic/lib-admin-ui/util/AppHelper';
+import {i18n} from '@enonic/lib-admin-ui/util/Messages';
+import {StringHelper} from '@enonic/lib-admin-ui/util/StringHelper';
+import Q from 'q';
+import {ContentFormContext} from '../ContentFormContext';
+import {SiteConfigProviderRegistry} from '../inputtype/siteconfigurator/SiteConfigProviderRegistry';
+import {ContentWizardStepForm} from './ContentWizardStepForm';
+
+export class SiteContentWizardStepForm
+    extends ContentWizardStepForm {
+
+    private static BASE_URL_INPUT_PROP = 'portalBaseUrl';
+
+    private readonly dataChangeListener: () => void;
+
+    private readonly debouncedBaseUrlChangeHandler: (event: PropertyValueChangedEvent) => void;
+
+    constructor() {
+        super();
+
+        this.dataChangeListener = this.handleDataChange.bind(this);
+        this.debouncedBaseUrlChangeHandler =
+            AppHelper.debounce((event: PropertyValueChangedEvent) => this.doHandleBaseUrlChange(event), 500);
+    }
+
+    layout(formContext: ContentFormContext, data: PropertyTree, form: Form): Q.Promise<void> {
+        return super.layout(formContext, data, this.createFormWithBaseUrl(form)).then(() => {
+            const baseUrl = this.getBaseUrlValue();
+
+            if (!StringHelper.isBlank(baseUrl)) { // Setting baseUrl input value from the site config
+                const prop = data.getProperty(`.${SiteContentWizardStepForm.BASE_URL_INPUT_PROP}`);
+                prop?.setValue(new Value(baseUrl, ValueTypes.STRING));
+            }
+
+            this.initBaseUrlListeners();
+        });
+    }
+
+    update(data: PropertyTree, unchangedOnly: boolean = true): Q.Promise<void> {
+        this.removeBaseUrlListeners();
+
+        return super.update(data, unchangedOnly).then(() => {
+            const baseUrl = this.getBaseUrlValue();
+
+            if (!StringHelper.isBlank(baseUrl)) { // Setting baseUrl input value from the site config
+                const prop = data.getProperty(`.${SiteContentWizardStepForm.BASE_URL_INPUT_PROP}`);
+                prop?.setValue(new Value(baseUrl, ValueTypes.STRING));
+            }
+
+            this.initBaseUrlListeners();
+        });
+    }
+
+    getData(): PropertyTree {
+        const data = super.getData();
+        const clonedData: PropertyTree = new PropertyTree(data.getRoot()); // copy
+        clonedData.removeProperty(SiteContentWizardStepForm.BASE_URL_INPUT_PROP, 0); // Ensure the property is removed from the data tree
+        this.movePortalSiteConfigFirst(clonedData);
+        return clonedData;
+    }
+
+    private movePortalSiteConfigFirst(data: PropertyTree): void {
+        const siteConfigs = data.getPropertyArray('siteConfig');
+
+        const portalProp = siteConfigs?.getProperties().find((prop) => {
+            return prop.getPropertySet().getString('applicationKey') === ApplicationKey.PORTAL.toString();
+        });
+
+        if (portalProp && portalProp.getIndex() !== 0) {
+            siteConfigs.move(portalProp.getIndex(), 0); // Move portal config to the top
+        }
+    }
+
+    private removeBaseUrlListeners(): void {
+        this.data?.unChanged(this.dataChangeListener);
+    }
+
+    private initBaseUrlListeners(): void {
+        this.data?.onChanged(this.dataChangeListener);
+    }
+
+    private handleDataChange(event: PropertyEvent): void {
+        if (this.isBaseUrlInputPath(event.getPath()) && event instanceof PropertyValueChangedEvent) {
+            this.debouncedBaseUrlChangeHandler(event);
+        }
+    }
+
+    private doHandleBaseUrlChange(event: PropertyValueChangedEvent): void {
+        const newValue = event.getNewValue();
+
+        if (newValue.isNull()) {
+            this.removePortalConfigIfEmpty();
+        } else {
+            this.addBaseUrlSiteConfig(newValue.getString());
+        }
+    }
+
+    private isBaseUrlInputPath(path: PropertyPath): boolean {
+        return path.toString() === `.${SiteContentWizardStepForm.BASE_URL_INPUT_PROP}`;
+    }
+
+    private createFormWithBaseUrl(siteForm: Form): Form { // Inserting baseUrl input between Description and Site Configurator
+        const formBuilder = new FormBuilder().addFormItems(
+            [siteForm.getFormItems()[0], this.createBaseUrlFormItem(), ...siteForm.getFormItems().slice(1)]);
+
+        return new Form(formBuilder);
+    }
+
+    private createBaseUrlFormItem(): Input {
+        return new InputBuilder().setName(SiteContentWizardStepForm.BASE_URL_INPUT_PROP).setInputType(TextLine.getName()).setLabel(
+            i18n('field.baseUrl')).setHelpText(i18n('field.baseUrl.help')).setOccurrences(
+            new OccurrencesBuilder().setMinimum(0).setMaximum(1).build()).build();
+    }
+
+    private getBaseUrlValue(): string {
+        const portalConfig = SiteConfigProviderRegistry.getConfigProvider()?.getConfig(ApplicationKey.PORTAL);
+
+        return portalConfig?.getConfig().getString('baseUrl');
+    }
+
+    private removePortalConfigIfEmpty(): void {
+        const registry = SiteConfigProviderRegistry.getConfigProvider();
+
+        if (registry) {
+            const portalAppConfig = registry.getConfig(ApplicationKey.PORTAL);
+
+            if (portalAppConfig) {
+                const prop = portalAppConfig.getConfig().getProperty('baseUrl');
+
+                if (prop) {
+                    portalAppConfig.getConfig().removeProperties([prop]);
+                }
+
+                if (portalAppConfig.getConfig().getSize() === 0) {
+                    registry.removeConfig(ApplicationKey.PORTAL);
+                }
+            }
+        }
+    }
+
+    private addBaseUrlSiteConfig(baseUrl: string): void {
+        const registry = SiteConfigProviderRegistry.getConfigProvider();
+
+        if (registry) {
+            const portalAppConfig = registry.getConfig(ApplicationKey.PORTAL) || registry.addConfig(ApplicationKey.PORTAL);
+            portalAppConfig.getConfig().setString('baseUrl', 0, baseUrl);
+        }
+    }
+}

--- a/modules/lib/src/main/resources/assets/styles/inputtype/siteconfigurator/site-configurator.less
+++ b/modules/lib/src/main/resources/assets/styles/inputtype/siteconfigurator/site-configurator.less
@@ -16,4 +16,10 @@
       }
     }
   }
+
+  .selected-options {
+    .system-app {
+      display: none;
+    }
+  }
 }

--- a/modules/lib/src/main/resources/assets/styles/settings/wizard/panel/form/element/project-applications-form-item.less
+++ b/modules/lib/src/main/resources/assets/styles/settings/wizard/panel/form/element/project-applications-form-item.less
@@ -44,6 +44,10 @@
           }
         }
       }
+
+      &.system-app {
+        display: none;
+      }
     }
   }
 }

--- a/modules/lib/src/main/resources/i18n/phrases.properties
+++ b/modules/lib/src/main/resources/i18n/phrases.properties
@@ -279,6 +279,8 @@ field.modifier=Last Modified by
 field.content.showEntire=Show entire content
 field.root=Project root
 field.displayName=Display Name
+field.baseUrl=Base URL
+field.baseUrl.help=Override the default base URL
 
 #
 #   Status


### PR DESCRIPTION
- Added SiteContentWizardStepForm.ts for sites to intercept content form creation to handle a new "Base URL" field below "Description". It acts as a proxy for a hidden SiteConfig property so need to add/remove according to changes in Base URL field