### PR TITLE
Publish button is blocked when an outbound reference is missing #8834

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/resource/ResolvePublishDependenciesResult.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/ResolvePublishDependenciesResult.ts
@@ -12,6 +12,7 @@ export class ResolvePublishDependenciesResult {
     invalidContents: ContentId[];
     notReadyContents: ContentId[];
     nextDependentContents: ContentId[];
+    notFoundOutboundContents: ContentId[];
 
     constructor(builder: Builder) {
         this.dependentContents = builder.dependentContents;
@@ -23,6 +24,7 @@ export class ResolvePublishDependenciesResult {
         this.invalidContents = builder.invalidContents;
         this.notReadyContents = builder.notReadyContents;
         this.nextDependentContents = builder.nextDependentContents;
+        this.notFoundOutboundContents = builder.notFoundOutboundContents;
     }
 
     getDependants(): ContentId[] {
@@ -61,6 +63,10 @@ export class ResolvePublishDependenciesResult {
         return this.nextDependentContents;
     }
 
+    getNotFoundOutboundContents(): ContentId[] {
+        return this.notFoundOutboundContents;
+    }
+
     static fromJson(json: ResolvePublishContentResultJson): ResolvePublishDependenciesResult {
 
         const dependants: ContentId[] = json.dependentContents
@@ -74,6 +80,7 @@ export class ResolvePublishDependenciesResult {
         const invalidIds: ContentId[] = json.invalidContents?.map(dependant => new ContentId(dependant.id)) ?? [];
         const notReadyIds: ContentId[] = json.notReadyContents?.map(dependant => new ContentId(dependant.id)) ?? [];
         const nextDependentContents: ContentId[] = json.nextDependentContents?.map(dependant => new ContentId(dependant.id)) ?? [];
+        const notFoundOutboundContents: ContentId[] = json.notFoundOutboundContents?.map(dependant => new ContentId(dependant.id)) ?? [];
 
         return ResolvePublishDependenciesResult.create().setDependentContents(dependants).setRequestedContents(
             requested)
@@ -84,6 +91,7 @@ export class ResolvePublishDependenciesResult {
             .setInvalidContents(invalidIds)
             .setNotReadyContents(notReadyIds)
             .setNextDependentContents(nextDependentContents)
+            .setNotFoundOutboundContents(notFoundOutboundContents)
             .build();
     }
 
@@ -102,6 +110,7 @@ export class Builder {
     invalidContents: ContentId[];
     notReadyContents: ContentId[];
     nextDependentContents: ContentId[];
+    notFoundOutboundContents: ContentId[];
 
     setDependentContents(value: ContentId[]): Builder {
         this.dependentContents = value;
@@ -145,6 +154,11 @@ export class Builder {
 
     setNextDependentContents(value: ContentId[]): Builder {
         this.nextDependentContents = value;
+        return this;
+    }
+
+    setNotFoundOutboundContents(value: ContentId[]): Builder {
+        this.notFoundOutboundContents = value;
         return this;
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/resource/json/ResolvePublishContentResultJson.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/json/ResolvePublishContentResultJson.ts
@@ -10,4 +10,5 @@ export interface ResolvePublishContentResultJson {
     invalidContents: ContentIdBaseItemJson[];
     notReadyContents: ContentIdBaseItemJson[];
     nextDependentContents: ContentIdBaseItemJson[];
+    notFoundOutboundContents: ContentIdBaseItemJson[];
 }

--- a/modules/lib/src/main/resources/i18n/dialogs.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs.properties
@@ -50,6 +50,7 @@ dialog.select.all=All ({0})
 dialog.publish.excluded.show=Show excluded
 dialog.publish.excluded.hide=Hide excluded
 dialog.publish.excludeFromPublishing=Exclude from publishing
+dialog.publish.outbound.missing=Outbound reference(s) with id(s) [{0}] not found
 dialog.requestPublish=Request Publishing
 dialog.requestPublish.subname1=Request publishing from another user
 dialog.requestPublish.subname2=Complete request details

--- a/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/rest/resource/content/ContentResource.java
+++ b/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/rest/resource/content/ContentResource.java
@@ -697,7 +697,7 @@ public final class ContentResource
             .isAllowedFor( ContextAccessor.current().getAuthInfo().getPrincipals(), Permission.PUBLISH );
 
         //Get all outbound dependencies for current requested and required
-        final ContentIds nextDependencies = this.getOutboundDependenciesIds( fullPublishList );
+        final OutboundDependenciesIds outboundDependenciesIds = this.getOutboundDependenciesIds( fullPublishList );
 
         //check if user has access to publish every content
         final ContentIds notPublishableContentIds = authInfo.hasRole( RoleKeys.ADMIN )
@@ -737,11 +737,12 @@ public final class ContentResource
             .setInvalidContents( notValidContentIds )
             .setContainsNotReady( !notReadyContentIds.isEmpty() )
             .setNotReadyContents( notReadyContentIds )
-            .setNextDependentContents( nextDependencies )
+            .setNextDependentContents( outboundDependenciesIds.getExistingOutboundIds() )
+            .setNotFoundOutboundContents( outboundDependenciesIds.getNonExistingOutboundIds() )
             .build();
     }
 
-    private ContentIds getOutboundDependenciesIds( final ContentIds contentIds )
+    private OutboundDependenciesIds getOutboundDependenciesIds( final ContentIds contentIds )
     {
         final ContentIds allOutboundIds = ContentIds.from( contentIds.stream().map( id -> {
             try
@@ -752,17 +753,22 @@ public final class ContentResource
             {
                 return ContentIds.empty();
             }
-        } ).flatMap( ContentIds::stream ).filter( id -> !contentIds.contains( ContentId.from( id ) ) ).collect( Collectors.toList() ) );
+        } ).flatMap( ContentIds::stream ).filter( id -> !contentIds.contains( id ) ).collect( Collectors.toList() ) );
 
         final ContentIds existingOutboundIds = sortContentIds( allOutboundIds, "_path" );
+        final ContentIds nonExistingOutboundIds =
+            ContentIds.from( allOutboundIds.stream().filter( id -> !existingOutboundIds.contains( id ) )
+            .collect( Collectors.toList() ) );
 
         final CompareContentResults compareResults =
             contentService.compare( CompareContentsParams.create().contentIds( existingOutboundIds ).build() );
 
-        return ContentIds.from( compareResults.stream()
+        final ContentIds existingWithoutMoved = ContentIds.from( compareResults.stream()
                                     .filter( result -> result.getCompareStatus() != CompareStatus.EQUAL )
                                     .map( CompareContentResult::getContentId )
                                     .collect( Collectors.toList() ) );
+
+        return new OutboundDependenciesIds( existingWithoutMoved, nonExistingOutboundIds );
     }
 
     private ContentIds sortContentIds( final ContentIds contentIds, final String field )

--- a/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/rest/resource/content/OutboundDependenciesIds.java
+++ b/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/rest/resource/content/OutboundDependenciesIds.java
@@ -1,0 +1,27 @@
+package com.enonic.xp.app.contentstudio.rest.resource.content;
+
+import com.enonic.xp.content.ContentIds;
+
+class OutboundDependenciesIds
+{
+    private final ContentIds existingOutboundIds;
+
+    private final ContentIds nonExistingOutboundIds;
+
+    OutboundDependenciesIds( final ContentIds existingIds, final ContentIds nonExistingIds )
+    {
+        this.existingOutboundIds = existingIds;
+        this.nonExistingOutboundIds = nonExistingIds;
+    }
+
+    ContentIds getExistingOutboundIds()
+    {
+        return existingOutboundIds;
+    }
+
+    ContentIds getNonExistingOutboundIds()
+    {
+        return nonExistingOutboundIds;
+    }
+
+}

--- a/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/rest/resource/content/json/ResolvePublishContentResultJson.java
+++ b/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/rest/resource/content/json/ResolvePublishContentResultJson.java
@@ -28,6 +28,8 @@ public class ResolvePublishContentResultJson
 
     private final List<ContentIdJson> notReadyContents;
 
+    private final List<ContentIdJson> notFoundOutboundContents;
+
     private ResolvePublishContentResultJson( Builder builder )
     {
         requestedContents = builder.requestedContents.stream().map( ContentIdJson::new ).collect( Collectors.toList() );
@@ -40,6 +42,7 @@ public class ResolvePublishContentResultJson
         invalidContents = builder.invalidContents.stream().map( ContentIdJson::new ).collect( Collectors.toList() );
         notReadyContents = builder.notReadyContents.stream().map( ContentIdJson::new ).collect( Collectors.toList() );
         nextDependentContents = builder.nextDependentContents.stream().map( ContentIdJson::new ).collect( Collectors.toList() );
+        notFoundOutboundContents = builder.notFoundOutboundContents.stream().map( ContentIdJson::new ).collect( Collectors.toList() );
     }
 
     public static Builder create()
@@ -100,6 +103,11 @@ public class ResolvePublishContentResultJson
         return nextDependentContents;
     }
 
+    public List<ContentIdJson> getNotFoundOutboundContents()
+    {
+        return notFoundOutboundContents;
+    }
+
     public static final class Builder
     {
 
@@ -122,6 +130,8 @@ public class ResolvePublishContentResultJson
         private ContentIds notReadyContents;
 
         private ContentIds nextDependentContents;
+
+        private ContentIds notFoundOutboundContents;
 
         private Builder()
         {
@@ -184,6 +194,12 @@ public class ResolvePublishContentResultJson
         public Builder setNextDependentContents( final ContentIds items )
         {
             this.nextDependentContents = items;
+            return this;
+        }
+
+        public Builder setNotFoundOutboundContents( final ContentIds items )
+        {
+            this.notFoundOutboundContents = items;
             return this;
         }
 

--- a/modules/rest/src/test/resources/com/enonic/xp/app/contentstudio/rest/resource/content/resolve_publish_content.json
+++ b/modules/rest/src/test/resources/com/enonic/xp/app/contentstudio/rest/resource/content/resolve_publish_content.json
@@ -16,6 +16,11 @@
             "id": "next-contentId"
         }
     ],
+    "notFoundOutboundContents": [
+        {
+            "id": "next-missing-contentId"
+        }
+    ],
   "notPublishableContents" : [
     {
       "id" : "dependant-contentId"


### PR DESCRIPTION
- Showing and keeping a warning message with missing outbound dependencies until the dialog is open again or there was a click over the notification msg