### PR TITLE
Content preview doesn't work in the Archive

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/view/ContentItemPreviewPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/ContentItemPreviewPanel.ts
@@ -33,7 +33,7 @@ export class ContentItemPreviewPanel
         this.contentRootPath = contentRootPath || ContentResourceRequest.CONTENT_PATH;
         this.debouncedSetItem = AppHelper.runOnceAndDebounce(this.doSetItem.bind(this), 300);
 
-        this.widgetRenderingHandler = new WidgetRenderingHandler(this);
+        this.widgetRenderingHandler = new WidgetRenderingHandler(this, this.getToolbar()?.getPreviewActionHelper());
 
         this.setupListeners();
     }

--- a/modules/lib/src/main/resources/assets/js/app/view/WidgetRenderingHandler.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/WidgetRenderingHandler.ts
@@ -48,10 +48,10 @@ export class WidgetRenderingHandler {
     protected renderableChangedListeners: ((isRenderable: boolean, wasRenderable: boolean) => void)[] = [];
 
 
-    constructor(renderer: WidgetRenderer) {
+    constructor(renderer: WidgetRenderer, previewHelper?: PreviewActionHelper) {
         this.renderer = renderer;
         this.mode = RenderingMode.INLINE;
-        this.previewHelper = new PreviewActionHelper();
+        this.previewHelper = previewHelper || new PreviewActionHelper();
         this.emptyView = this.createEmptyView();
         this.messageView = this.createErrorView();
     }


### PR DESCRIPTION
The fix is to not create a new `PreviewHelper` every time in [WidgetRenderer](https://github.com/enonic/app-contentstudio/pull/8926/files#diff-76b92e8f844a9cc83d019b994cd53aa59d405915241166920973c45f92826cf9R54), but to use the one that was already created and passed to the [PreviewToolbar](https://github.com/enonic/app-contentstudio/blob/master/modules/lib/src/main/resources/assets/js/app/view/ContentItemPreviewPanel.ts#L127).