### PR TITLE
Fix missing path parameter in assetUrl calls #8957

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ build/
 target/
 .gradle/
 node_modules/
+modules/app/bin/
+modules/lib/bin/
+modules/rest/bin/
 *.iws
 *.ids
 *.iml
@@ -23,3 +26,4 @@ testing/allure-results
 .enonic
 .eslintcache
 .bin
+

--- a/modules/app/src/main/resources/admin/tools/main/main.js
+++ b/modules/app/src/main/resources/admin/tools/main/main.js
@@ -48,8 +48,8 @@ exports.getParams = function (path, locales) {
             bundles: ['i18n/phrases'],
             locale: locales
         }),
-        aiContentOperatorAssetsUrl: isAiContentOperatorEnabled ? portal.assetUrl({application: AI_CONTENT_OPERATOR_APP_KEY}) : undefined,
-        aiTranslatorAssetsUrl: isAiTranslatorEnabled ? portal.assetUrl({application: AI_TRANSLATOR_APP_KEY}) : undefined,
+        aiContentOperatorAssetsUrl: isAiContentOperatorEnabled ? portal.assetUrl({path: '', application: AI_CONTENT_OPERATOR_APP_KEY}) : undefined,
+        aiTranslatorAssetsUrl: isAiTranslatorEnabled ? portal.assetUrl({path: '', application: AI_TRANSLATOR_APP_KEY}) : undefined,
         configScriptId: configLib.configJsonId,
         configAsJson: JSON.stringify(configLib.getConfig(locales, isAiEnabled), null, 4).replace(/<(\/?script|!--)/gi, "\\u003C$1"),
         isBrowseMode: isBrowseMode,


### PR DESCRIPTION
Fixed absent `path` property in arguments of assetUrl.
Added `bin/` folder to ignore, as a temporary folder for some Java tools.