### PR TITLE
Remove chuncks for CKEditor plugins

### DIFF
--- a/modules/lib/webpack.config.js
+++ b/modules/lib/webpack.config.js
@@ -80,19 +80,6 @@ module.exports = {
                 }
             })
         ],
-        splitChunks: {
-            chunks: 'all',
-            cacheGroups: {
-                default: false,
-                defaultVendors: {
-                    test: /[\\/]node_modules[\\/]/,
-                    reuseExistingChunk: true,
-                    minChunks: 2,
-                    priority: -10,
-                    filename: 'js/vendors.main~editor.js'
-                }
-            }
-        }
     },
     plugins: [
         new ProvidePlugin({


### PR DESCRIPTION
Removed chunks from dev builds, because it was creating inaccessible code, that prevented custom CKEditor plugins from loading correctly.