### PR TITLE
Disable frozen lock files on CI #9031

### DIFF
--- a/gradle/node.gradle
+++ b/gradle/node.gradle
@@ -6,12 +6,12 @@ node {
     download = true
 }
 
-tasks.register('copyDevResources') {
+tasks.register( 'copyDevResources' ) {
     onlyIf {
-        configurations.hasProperty('devResources')
+        configurations.hasProperty( 'devResources' )
     }
     doLast {
-        if (configurations.hasProperty('devResources')) {
+        if ( configurations.hasProperty( 'devResources' ) ) {
             copy {
                 from configurations.devResources.files.collect { zipTree( it ) }
                 include 'dev/**'
@@ -21,9 +21,12 @@ tasks.register('copyDevResources') {
     }
 }
 
-// Configure pnpmInstall dependency lazily
-tasks.named('pnpmInstall').configure {
-    if (configurations.hasProperty('devResources')) {
-        dependsOn tasks.named('copyDevResources')
+tasks.named( 'pnpmInstall' ).configure {
+    if ( configurations.hasProperty( 'devResources' ) ) {
+        dependsOn tasks.named( 'copyDevResources' )
+    }
+    //! Temporary fix for CI environment, back to npm-like behavior
+    if ( System.getenv( 'CI' ) == 'true' || project.hasProperty( 'ci' ) ) {
+        pnpmCommand.set(['install', '--no-frozen-lockfile'])
     }
 }

--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -174,12 +174,6 @@ importers:
       mousetrap:
         specifier: ^1.6.5
         version: 1.6.5
-      nanoid:
-        specifier: ^5.1.5
-        version: 5.1.5
-      nanostores:
-        specifier: ^1.0.1
-        version: 1.0.1
       q:
         specifier: ^1.5.1
         version: 1.5.1
@@ -2244,18 +2238,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.5:
-    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-
   nanostores@0.11.4:
     resolution: {integrity: sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
-
-  nanostores@1.0.1:
-    resolution: {integrity: sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==}
-    engines: {node: ^20.0.0 || >=22.0.0}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -4859,11 +4844,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@5.1.5: {}
-
   nanostores@0.11.4: {}
-
-  nanostores@1.0.1: {}
 
   natural-compare@1.4.0: {}
 

--- a/modules/lib/pnpm-lock.yaml
+++ b/modules/lib/pnpm-lock.yaml
@@ -144,12 +144,6 @@ importers:
       mousetrap:
         specifier: ^1.6.5
         version: 1.6.5
-      nanoid:
-        specifier: ^5.1.5
-        version: 5.1.5
-      nanostores:
-        specifier: ^1.0.1
-        version: 1.0.1
       q:
         specifier: ^1.5.1
         version: 1.5.1
@@ -2031,18 +2025,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.5:
-    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-
   nanostores@0.11.4:
     resolution: {integrity: sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
-
-  nanostores@1.0.1:
-    resolution: {integrity: sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==}
-    engines: {node: ^20.0.0 || >=22.0.0}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -4550,11 +4535,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@5.1.5: {}
-
   nanostores@0.11.4: {}
-
-  nanostores@1.0.1: {}
 
   natural-compare@1.4.0: {}
 

--- a/modules/lib/pnpm-workspace.yaml
+++ b/modules/lib/pnpm-workspace.yaml
@@ -5,3 +5,5 @@ packages:
 onlyBuiltDependencies:
   - '@swc/core'
   - esbuild
+  - edgedriver
+  - geckodriver

--- a/testing/package.json
+++ b/testing/package.json
@@ -27,13 +27,6 @@
     "properties-reader": "2.3.0",
     "webdriverio": "9.19.1"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "edgedriver",
-      "esbuild",
-      "geckodriver"
-    ]
-  },
   "engines": {
     "node": ">=22.18.0",
     "npm": ">=10.9.2",


### PR DESCRIPTION
- Updated lock files with latest changes in the LibAdminUI.
- Made `pnpmInstall` to be executed with `--no-frozen-lockfile` as a temporary fix, reverting the behavior to the old npm-like. 

_A better solution would require adding a bot similar to dependabot, that will trigger `pnpm-lock.yaml` updates from LibAdminUI after `package.json` there changes._