### PR TITLE
Add ui-tests for empty project #9068

### DIFF
--- a/testing/libs/elements.js
+++ b/testing/libs/elements.js
@@ -224,9 +224,11 @@ module.exports = Object.freeze({
     VERSIONS_SHOW_CHANGES_BUTTON: `//button[contains(@id,'ActionButton') and @title='Show changes']`,
     LIVE_EDIT_FRAME: "//div[contains(@id,'FrameContainer')]//iframe[contains(@class,'text') or contains(@class,'application')]",
     APP_MODE_SWITCHER_TOGGLER: "//div[contains(@id,'AppWrapper')]//button[contains(@id,'ToggleIcon')]",
-    SETTINGS_BUTTON: "//button[contains(@id,'WidgetButton') and child::span[text()='Settings']]",
-    MODE_CONTENT_BUTTON: "//button[contains(@id,'WidgetButton') and @title='Content']",
 
+    WIDGET_SIDEBAR: {
+        SETTINGS_BUTTON: "//button[contains(@id,'WidgetButton') and child::span[text()='Settings']]",
+        MODE_CONTENT_BUTTON: "//button[contains(@id,'WidgetButton') and @title='Content']",
+    },
     PUBLISH_DIALOG: {
         EXCLUDE_BTN: "//button[child::span[contains(.,'Exclude')]]",
     },

--- a/testing/libs/studio.utils.js
+++ b/testing/libs/studio.utils.js
@@ -921,8 +921,8 @@ module.exports = {
         try {
             let settingsBrowsePanel = new SettingsBrowsePanel();
             await this.openContentStudioMenu();
-            await this.waitForElementDisplayed(lib.SETTINGS_BUTTON, appConst.mediumTimeout);
-            await this.clickOnElement(lib.SETTINGS_BUTTON);
+            await this.waitForElementDisplayed(lib.WIDGET_SIDEBAR.SETTINGS_BUTTON, appConst.mediumTimeout);
+            await this.clickOnElement(lib.WIDGET_SIDEBAR.SETTINGS_BUTTON);
             await this.getBrowser().pause(300);
             await settingsBrowsePanel.waitForGridLoaded(appConst.mediumTimeout);
             return settingsBrowsePanel;
@@ -932,7 +932,7 @@ module.exports = {
         }
     },
     async switchToContentMode() {
-        await this.clickOnElement(lib.MODE_CONTENT_BUTTON);
+        await this.clickOnElement(lib.WIDGET_SIDEBAR.MODE_CONTENT_BUTTON);
         await this.getBrowser().pause(200);
         return new ContentBrowsePanel();
     },

--- a/testing/specs/content-types-2/changing.part.inside.fragment.spec.js
+++ b/testing/specs/content-types-2/changing.part.inside.fragment.spec.js
@@ -41,7 +41,7 @@ describe('changing.part.inside.fragment.spec - Tests for changing a part inside 
             await studioUtils.selectAndOpenContentInWizard(SITE.displayName);
             // 2. Click on the 'main' item and open Context Menu:
             await pageComponentsWizardStepForm.openMenu('main');
-            await pageComponentsWizardStepForm.selectMenuItem(['Insert', 'Part']);
+            await pageComponentsWizardStepForm.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Part']);
             // 3. Select the part with a config
             await liveFormPanel.selectPartByDisplayName(PART_DISPLAY_NAME);
             await contentWizard.switchToMainFrame();

--- a/testing/specs/content-types-2/content.selector.partinspection.spec.js
+++ b/testing/specs/content-types-2/content.selector.partinspection.spec.js
@@ -42,7 +42,7 @@ describe('my.first.site.country.spec - Create a site with country content', func
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3.Click on the 'Main' region-item and open Context Menu:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Part']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Part']);
             // 4. Select the part with a config
             await liveFormPanel.selectPartByDisplayName(appConst.PART_NAME.MY_FIRST_APP_CITY_LIST);
             await contentWizard.switchToMainFrame();
@@ -106,11 +106,11 @@ describe('my.first.site.country.spec - Create a site with country content', func
             let cityCreationPartInspectionPanel = new CityCreationPartInspectionPanel();
             // 1. Open the site:
             await studioUtils.selectAndOpenContentInWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3.Click on the 'Main' item and open Context Menu:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Part']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Part']);
             // 4. Select the part with image-selector in config
             await liveFormPanel.selectPartByDisplayName(appConst.PART_NAME.MY_FIRST_APP_CITY_CREATION);
             await contentWizard.switchToMainFrame();

--- a/testing/specs/exclude-dependencies/publish.wizard.non.required.dependencies.spec.js
+++ b/testing/specs/exclude-dependencies/publish.wizard.non.required.dependencies.spec.js
@@ -45,11 +45,11 @@ describe('publish.wizard.non.required.dependencies.spec - tests for config with 
             let textComponentCke = new TextComponentCke();
             // 1. Open existing site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert a text-component in PCV modal dialog:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             // 4. Close the details panel
             await contentWizard.clickOnDetailsPanelToggleButton();
             await textComponentCke.switchToLiveEditFrame();

--- a/testing/specs/misc/text.component.anchor.spec.js
+++ b/testing/specs/misc/text.component.anchor.spec.js
@@ -37,11 +37,11 @@ describe('Text Component with CKE - insert Anchor specification', function () {
             let insertAnchorDialog = new InsertAnchorDialog();
             // 1. Open existing site and open 'Page Component View':
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert new text-component:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await textComponentCke.switchToLiveEditFrame();
             // 4. Open 'Insert Anchor' dialog and type the text:
             await textComponentCke.clickOnInsertAnchorButton();
@@ -66,7 +66,7 @@ describe('Text Component with CKE - insert Anchor specification', function () {
             // 1. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await textComponentCke.switchToLiveEditFrame();
             // Open Insert Anchor modal dialog:
             await textComponentCke.clickOnInsertAnchorButton();
@@ -87,7 +87,7 @@ describe('Text Component with CKE - insert Anchor specification', function () {
             // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await textComponentCke.switchToLiveEditFrame();
             // Open Insert Anchor modal dialog and type not correct value:
             await textComponentCke.clickOnInsertAnchorButton();
@@ -110,11 +110,11 @@ describe('Text Component with CKE - insert Anchor specification', function () {
             let textComponentCke = new TextComponentCke();
             // 1. Open existing site and open 'Page Component View':
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert new text-component:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             // 4. Open 'Insert Anchor' dialog and type the text:
             await textComponentCke.typeTextInCkeEditor(TEST_TEXT);
             let actualComponents = await pageComponentView.getTextComponentsDisplayName();

--- a/testing/specs/misc/text.component.cke.email.link.spec.js
+++ b/testing/specs/misc/text.component.cke.email.link.spec.js
@@ -40,11 +40,11 @@ describe('Text Component with CKE - insert email link  specification', function 
             let pageComponentView = new PageComponentView();
             // 1. Open existing site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert new text-component
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await textComponentCke.switchToLiveEditFrame();
             // 4. Open 'Insert Link' dialog and insert email-link:
             await textComponentCke.clickOnInsertLinkButton();
@@ -83,11 +83,11 @@ describe('Text Component with CKE - insert email link  specification', function 
             let pageComponentView = new PageComponentView();
             // 1. Open existing site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert new text-component
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await textComponentCke.switchToLiveEditFrame();
             // 4. Verify B/I/U buttons
             await studioUtils.saveScreenshot('bold_italic_buttons_text_component');
@@ -108,10 +108,10 @@ describe('Text Component with CKE - insert email link  specification', function 
             await studioUtils.openContentWizard(appConst.contentTypes.SITE);
             await siteFormPanel.addApplications([appConst.APP_CONTENT_TYPES]);
             await contentWizard.selectPageDescriptor(CONTROLLER_NAME);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             // 3. Verify that the text area is focused:
             await studioUtils.saveScreenshot('text_component_focused');
             let isFocused = await textComponent.isTextAreaFocused();

--- a/testing/specs/misc/text.component.cke.url.link.spec.js
+++ b/testing/specs/misc/text.component.cke.url.link.spec.js
@@ -37,11 +37,11 @@ describe('Text Component with CKE - insert link and table specification', functi
             let textComponentCke = new TextComponentCke();
             let pageComponentView = new PageComponentView();
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 1. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 1. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 2. Insert a text-component:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             // Close the details panel
             await contentWizard.clickOnDetailsPanelToggleButton();
             await textComponentCke.switchToLiveEditFrame();
@@ -60,11 +60,11 @@ describe('Text Component with CKE - insert link and table specification', functi
             let insertLinkDialogUrlPanel = new InsertLinkDialogUrlPanel();
             // 1. Open the site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler  expand Live Edit and show Page Component modal dialog:
+            // 2. Click on minimize-toggle  expand Live Edit and show Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert a text component and type an invalid URL:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             // 4. Close the details panel
             await contentWizard.clickOnDetailsPanelToggleButton();
             await textComponentCke.switchToLiveEditFrame();
@@ -91,11 +91,11 @@ describe('Text Component with CKE - insert link and table specification', functi
             let textComponentCke = new TextComponentCke();
             // 1. Open the site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler  expand Live Edit and show Page Component modal dialog:
+            // 2. Click on minimize-toggle  expand Live Edit and show Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert a text component:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(["Insert", "Text"]);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             // 4. Close the details panel
             await contentWizard.clickOnDetailsPanelToggleButton();
             await textComponentCke.switchToLiveEditFrame();

--- a/testing/specs/misc/text.component.content.link.spec.js
+++ b/testing/specs/misc/text.component.content.link.spec.js
@@ -38,11 +38,11 @@ describe('Text Component with CKE - insert content-link specification', function
             let textComponentCke = new TextComponentCke();
             // 1. Open existing site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert text-component:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             // Close the details panel
             await contentWizard.clickOnDetailsPanelToggleButton();
             await textComponentCke.switchToLiveEditFrame();

--- a/testing/specs/misc/text.component.download.link.spec.js
+++ b/testing/specs/misc/text.component.download.link.spec.js
@@ -59,11 +59,11 @@ describe('Text Component with CKE - insert download-link specification', functio
             let insertLinkDialogContentPanel = new InsertLinkDialogContentPanel();
             // 1. Open existing site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             await pageComponentView.openMenu('main');
             // 3. Insert text component:
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             //Close the details panel
             await contentWizard.clickOnDetailsPanelToggleButton();
             await textComponentCke.switchToLiveEditFrame();

--- a/testing/specs/misc/text.component.image.caption.spec.js
+++ b/testing/specs/misc/text.component.image.caption.spec.js
@@ -40,11 +40,11 @@ describe("text.component.image.caption.spec: Inserts a text component with an im
             // 1. Open existing site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
             //automatic template does not exist, so no need to unlock the editor
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert new text component:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await contentWizard.switchToLiveEditFrame();
             await textComponent.clickOnInsertImageButton();
             // 4. Insert an image in the text component:
@@ -63,7 +63,7 @@ describe("text.component.image.caption.spec: Inserts a text component with an im
             await contentWizard.switchToParentFrame();
             // Remove the text component by caption text
             await pageComponentView.openMenu(CAPTION);
-            await pageComponentView.selectMenuItem(['Remove']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.REMOVE]);
             await contentWizard.waitAndClickOnSave();
             await contentWizard.waitForNotificationMessage();
         });
@@ -78,11 +78,11 @@ describe("text.component.image.caption.spec: Inserts a text component with an im
             let insertImageDialog = new InsertImageDialog();
             // 1. Open existing site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert new text component:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await contentWizard.switchToLiveEditFrame();
             // 4. Open Insert Image modal dialog:
             await textComponent.clickOnInsertImageButton();
@@ -102,11 +102,11 @@ describe("text.component.image.caption.spec: Inserts a text component with an im
             let liveFormPanel = new LiveFormPanel();
             // 1. Open the existing site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert new text-component
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await textComponentCke.switchToLiveEditFrame();
             // 4. Open 'Insert Image' dialog and insert an image in htmlArea:
             await textComponentCke.clickOnInsertImageButton();

--- a/testing/specs/misc/text.component.image.outbound.spec.js
+++ b/testing/specs/misc/text.component.image.outbound.spec.js
@@ -41,11 +41,11 @@ describe("text.component.image.outbound.spec: Inserts a text component with an i
             // 1. Open existing site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
             // automatic template does not exist, so no need to unlock the editor
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert new text component:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await contentWizard.switchToLiveEditFrame();
             await textComponent.clickOnInsertImageButton();
             // 4. Insert an image in the text component:

--- a/testing/specs/misc/text.component.insert.macro.spec.js
+++ b/testing/specs/misc/text.component.insert.macro.spec.js
@@ -36,11 +36,11 @@ describe('Text Component - insert embed iframe and preview the site', function (
             let insertMacroModalDialog = new InsertMacroDialog();
             // 1. Open the site:
             await studioUtils.selectContentAndOpenWizard(SITE.displayName);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert a text component and type the not valid URL:
             await pageComponentView.openMenu('main');
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             // 4. Close the details panel
             await contentWizard.clickOnDetailsPanelToggleButton();
             await textComponentCke.switchToLiveEditFrame();

--- a/testing/specs/misc/text.component.insert.table.spec.js
+++ b/testing/specs/misc/text.component.insert.table.spec.js
@@ -37,8 +37,8 @@ describe('Text Component with CKE - insert html table', function () {
             // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert a text-component:
-            await pageComponentView.openMenu("main");
-            await pageComponentView.selectMenuItem(["Insert", "Text"]);
+            await pageComponentView.openMenu('main');
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await textComponentCke.switchToLiveEditFrame();
             // 4. Click on 'Insert Table' menu-button:
             await textComponentCke.clickOnInsertTableButton();

--- a/testing/specs/page-editor/fragment.save.detach.spec.js
+++ b/testing/specs/page-editor/fragment.save.detach.spec.js
@@ -182,7 +182,7 @@ describe('Menu Items: Save as fragment and Detach from Fragment specification', 
             // 2. Select the fragment and open the context-menu:
             await pageComponentView.openMenu('Text');
             // 3. Open this fragment in new browser-tab:
-            await pageComponentView.selectMenuItem(['Edit']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.EDIT]);
             await studioUtils.doSwitchToNextTab();
             let result = await contentWizard.isWizardStepPresent('Fragment');
             assert.ok(result, "'Fragment' Wizard Step should be present in the toolbar");

--- a/testing/specs/page-editor/site.reset.template.menu.item.spec.js
+++ b/testing/specs/page-editor/site.reset.template.menu.item.spec.js
@@ -55,12 +55,12 @@ describe('site.reset.template.menu.item.spec - resets a site to default template
             // 2. Unlock the LiveEdit- click on 'Customize' menu item:
             await contentWizard.doUnlockLiveEditor();
             await contentWizard.switchToMainFrame();
-            // 3. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 3. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 4. Click on the item and open Context Menu:
             await pageComponentView.openMenu(TEST_TEXT);
             // 5. Remove the text component and save it
-            await pageComponentView.selectMenuItem(['Remove']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.REMOVE]);
             await contentWizard.waitAndClickOnSave();
             await contentWizard.waitForNotificationMessage();
             await studioUtils.saveScreenshot('site_txt_component_customized');
@@ -69,7 +69,7 @@ describe('site.reset.template.menu.item.spec - resets a site to default template
             assert.equal(result1.length, 2, "Number of items in Component View should be reduced after the removing");
             // 7. Expand the controller's menu(the root element) and click on 'Reset' item
             await pageComponentView.openMenu(CONTROLLER_NAME);
-            await pageComponentView.selectMenuItem(['Reset']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.RESET]);
             await pageComponentView.pause(4000);
             // 8. Click on 'Customize' menu item in Live Edit frame:
             await contentWizard.doUnlockLiveEditor();

--- a/testing/specs/page-editor/template.config.spec.js
+++ b/testing/specs/page-editor/template.config.spec.js
@@ -138,7 +138,7 @@ describe('template.config.spec: template config should be displayed in the Inspe
             await contentWizard.switchToMainFrame();
             // 3. Remove the text component and save it
             await pageComponentsWizardStepForm.openMenu(TEST_TEXT);
-            await pageComponentsWizardStepForm.selectMenuItem(['Remove']);
+            await pageComponentsWizardStepForm.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.REMOVE]);
             await studioUtils.saveScreenshot('component_step_form_txt_removed');
             await contentWizard.waitAndClickOnSave();
             await contentWizard.pause(1500);
@@ -156,7 +156,7 @@ describe('template.config.spec: template config should be displayed in the Inspe
             await studioUtils.selectAndOpenContentInWizard(ARTICLE_NAME);
             // 2. Click on 'Reset' menu item in the wizard step form:
             await pageComponentsWizardStepForm.openMenu('Page');
-            await pageComponentsWizardStepForm.selectMenuItem(['Reset']);
+            await pageComponentsWizardStepForm.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.RESET]);
             await studioUtils.saveScreenshot('component_step_form_reset');
             // 3. The content should be saved automatically:
             await contentWizard.waitForNotificationMessage();

--- a/testing/specs/page-editor/update.fragment.spec.js
+++ b/testing/specs/page-editor/update.fragment.spec.js
@@ -36,7 +36,7 @@ describe('Test for updating text in fragment', function () {
             await siteFormPanel.filterOptionsAndSelectApplication(appConst.TEST_APPS_NAME.SIMPLE_SITE_APP);
             await contentWizard.pause(2000);
             await contentWizard.selectPageDescriptor(CONTROLLER_NAME);
-            // 2. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 2. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             // 3. Insert new text-component
             await pageComponentView.openMenu('main');
@@ -48,7 +48,7 @@ describe('Test for updating text in fragment', function () {
             await contentWizard.pause(700);
             // 5. Switch to Fragment wizard:
             await studioUtils.doSwitchToNewWizard();
-            // 6. Click on minimize-toggler, expand Live Edit and open Page Component modal dialog:
+            // 6. Click on minimize-toggle, expand Live Edit and open Page Component modal dialog:
             await contentWizard.clickOnMinimizeLiveEditToggler();
             await pageComponentView.openMenu(GENERATED_TEXT_1);
             // 7. Update the text in the fragment

--- a/testing/specs/project-2/change.access.mode.spec.js
+++ b/testing/specs/project-2/change.access.mode.spec.js
@@ -26,7 +26,7 @@ describe('change.access.mode.spec - Update Access Mode in project wizard', funct
             // 1. Navigate to Settings Panel:
             await studioUtils.openSettingsPanel();
             // 2. Save new project (mode access is Private):
-            await projectUtils.saveTestProject(PROJECT_DISPLAY_NAME, "test description", null, null, "Private");
+            await projectUtils.saveTestProject(PROJECT_DISPLAY_NAME, 'test description', null, null, 'Private');
         });
 
     it("Precondition: new folder should be added in existing project(Private mode access)",
@@ -48,8 +48,8 @@ describe('change.access.mode.spec - Update Access Mode in project wizard', funct
             await settingsBrowsePanel.clickOnRowByDisplayName(PROJECT_DISPLAY_NAME);
             await settingsBrowsePanel.clickOnEditButton();
             await projectWizard.waitForLoaded();
-            // 2. Click on Public radio and confirm the changes:
-            await projectWizard.clickOnAccessModeRadio("Public");
+            // 2. Click on 'Public' radio and confirm the changes:
+            await projectWizard.clickOnAccessModeRadio('Public');
             await confirmationDialog.waitForDialogOpened();
             await confirmationDialog.clickOnYesButton();
             await confirmationDialog.waitForDialogClosed();
@@ -59,8 +59,8 @@ describe('change.access.mode.spec - Update Access Mode in project wizard', funct
             // 4. Verify that 2  notification messages appear: 'Project is modified' and 'Permissions are applied'
             await studioUtils.saveScreenshot('project_access_mode_updated');
             assert.equal(actualMessages[1], appConst.projectModifiedMessage(PROJECT_DISPLAY_NAME));
-            assert.ok(actualMessages[0].includes('Permissions'), "Permissions are applied - the second expected notification message");
-            assert.ok(actualMessages[0].includes('are applied'), "Permissions are applied - the second expected notification message");
+            assert.ok(actualMessages[0].includes('Permissions'), 'Permissions are applied - the second expected notification message');
+            assert.ok(actualMessages[0].includes('are applied'), 'Permissions are applied - the second expected notification message');
         });
 
     // Verifies https://github.com/enonic/app-contentstudio/issues/1889
@@ -75,7 +75,7 @@ describe('change.access.mode.spec - Update Access Mode in project wizard', funct
             await settingsBrowsePanel.clickOnEditButton();
             await projectWizard.waitForLoaded();
             // 2. Verify that 'Public' radio is selected:
-            let isSelected = await projectWizard.isAccessModeRadioSelected("Public");
+            let isSelected = await projectWizard.isAccessModeRadioSelected('Public');
             assert.ok(isSelected, "'Public' radio button should be selected");
             isSelected = await projectWizard.isAccessModeRadioSelected("Private");
             assert.ok(isSelected === false, "'Private' radio button should not be selected");

--- a/testing/specs/project-2/edit.project.spec.js
+++ b/testing/specs/project-2/edit.project.spec.js
@@ -177,7 +177,8 @@ describe('edit.project.spec - ui-tests for editing a project', function () {
             // 2. Switch to the empty project:
             await studioUtils.openProjectSelectionDialogAndSelectContext(emptyProject);
             // 3. Verify that browse toolbar is reset
-            await contentBrowsePanel.waitForNewButtonDisabled();
+            await contentBrowsePanel.waitForEditButtonDisabled();
+            await contentBrowsePanel.waitForArchiveButtonDisabled();
             // 4. Preview panel should be reset as well
             await contentItemPreviewPanel.waitForToolbarNotDisplayed();
         });

--- a/testing/specs/project-2/edit.project.spec.js
+++ b/testing/specs/project-2/edit.project.spec.js
@@ -9,6 +9,8 @@ const SettingsBrowsePanel = require('../../page_objects/project/settings.browse.
 const ProjectWizard = require('../../page_objects/project/project.wizard.panel');
 const ConfirmationDialog = require('../../page_objects/confirmation.dialog');
 const appConst = require('../../libs/app_const');
+const ContentBrowsePanel = require('../../page_objects/browsepanel/content.browse.panel');
+const ContentItemPreviewPanel = require('../../page_objects/browsepanel/contentItem.preview.panel');
 
 describe('edit.project.spec - ui-tests for editing a project', function () {
     this.timeout(appConst.SUITE_TIMEOUT);
@@ -22,6 +24,8 @@ describe('edit.project.spec - ui-tests for editing a project', function () {
     const PROJ_IDENTIFIER = studioUtils.generateRandomName('id');
     const PROJECT_WIZARD_TOOLBAR_ROLE = 'toolbar';
     const ARIA_LABEL_TOOLBAR = 'Main menu bar';
+    const IMPORTED_SITE = 'site040269';
+    const IMPORTED_PROJECT = 'Default';
 
     // Verifies:  Project identifier field is editable issue#2923
     it(`WHEN existing project is opened THEN expected identifier, description and language should be displayed`,
@@ -136,7 +140,7 @@ describe('edit.project.spec - ui-tests for editing a project', function () {
             await projectUtils.saveTestProject(PROJECT2_DISPLAY_NAME, null, null, null, appConst.PROJECT_ACCESS_MODE.PRIVATE);
         });
 
-    //Verifies - Access mode should not be changed after canceling changes in Confirmation modal dialog #2295
+    // Verifies - Access mode should not be changed after canceling changes in Confirmation modal dialog #2295
     it("GIVEN access mode has been changed WHEN 'Cancel top' button has been clicked in the 'Confirmation' dialog THEN access mode returns to the initial state",
         async () => {
             let settingsBrowsePanel = new SettingsBrowsePanel();
@@ -152,11 +156,30 @@ describe('edit.project.spec - ui-tests for editing a project', function () {
             await confirmationDialog.waitForDialogOpened();
             // 4.Click on 'Cancel top' button:
             await confirmationDialog.clickOnCancelTopButton();
-            let isSelected = await projectWizard.isAccessModeRadioSelected("Private");
+            let isSelected = await projectWizard.isAccessModeRadioSelected('Private');
             // 5. Verify that access mode returns to the initial state:
             assert.ok(isSelected, "Private mode should be reverted in the Access Mode form");
             // 6. Verify that 'Save' button is disabled
             await projectWizard.waitForSaveButtonDisabled();
+        });
+
+    // Switching to an empty project doesn't reset Preview/Context panels #8987
+    // https://github.com/enonic/app-contentstudio/issues/8987
+    it("GIVEN a site has been selected in a project WHEN context has been switch to an empty project THEN Preview panel should be reset",
+        async () => {
+            let contentItemPreviewPanel = new ContentItemPreviewPanel();
+            const emptyProject = PROJECT2_DISPLAY_NAME;
+            let contentBrowsePanel = new ContentBrowsePanel();
+            await studioUtils.switchToContentMode();
+            // 1. Switch to the imported project and select a site
+            await studioUtils.openProjectSelectionDialogAndSelectContext(IMPORTED_PROJECT);
+            await contentBrowsePanel.clickOnRowByDisplayName(IMPORTED_SITE);
+            // 2. Switch to the empty project:
+            await studioUtils.openProjectSelectionDialogAndSelectContext(emptyProject);
+            // 3. Verify that browse toolbar is reset
+            await contentBrowsePanel.waitForNewButtonDisabled();
+            // 4. Preview panel should be reset as well
+            await contentItemPreviewPanel.waitForToolbarNotDisplayed();
         });
 
     it("Layer and its parent project are successively deleted",

--- a/testing/specs/publish/publish.work.in.progress.spec.js
+++ b/testing/specs/publish/publish.work.in.progress.spec.js
@@ -117,7 +117,7 @@ describe('publish.work.in.progress.spec - publishes work in progress content', f
             await contentWizard.clickOnMinimizeLiveEditToggler();
             await pageComponentView.openMenu('main');
             // 3. Insert Text Component with test text and save it:
-            await pageComponentView.selectMenuItem(['Insert', 'Text']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.INSERT, 'Text']);
             await textComponentCke.typeTextInCkeEditor('test text');
             await contentWizard.waitAndClickOnSave();
             // minimize Live Edit, workflow icon gets visible:

--- a/testing/specs/remove.app.in.site.with.descriptor.spec.js
+++ b/testing/specs/remove.app.in.site.with.descriptor.spec.js
@@ -50,7 +50,7 @@ describe('remove_app.in.site.with.descriptor.spec: replace an application and ch
             assert.equal(apps[0], APP_2, 'application should be updated in the form');
             // 6. Verify that the controller from the previous application remains visible in PCV:
             await pageComponentsWizardStepForm.openMenu(CONTROLLER_APP_1);
-            await pageComponentsWizardStepForm.selectMenuItem(['Reset']);
+            await pageComponentsWizardStepForm.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.RESET]);
             await studioUtils.saveScreenshot('app_replaced_in_site_wizard');
             // 7. Verify that 'Controller Options Filter' input gets visible in the wizard-page:
             await contentWizard.waitForControllerOptionFilterInputVisible();

--- a/testing/specs/site.controller.preview.spec.js
+++ b/testing/specs/site.controller.preview.spec.js
@@ -107,7 +107,7 @@ describe('site.controller.preview.spec: checks Preview button and options in sel
             // 2. Expand the menu:
             await pageComponentView.openMenu(CONTROLLER_NAME);
             // 3. Click on the 'Reset' menu item:
-            await pageComponentView.selectMenuItem(['Reset']);
+            await pageComponentView.selectMenuItem([appConst.COMPONENT_VIEW_MENU_ITEMS.RESET]);
             // 4. Verify that 'Preview' button gets disabled in the Preview wizard toolbar:
             await contentWizard.waitForPreviewButtonDisabled();
             // 5. Verify that Controller Options Filter input gets visible:


### PR DESCRIPTION
Verify the bug  - Switching to an empty project doesn't reset Preview/Context panels https://github.com/enonic/app-contentstudio/issues/8987