### PR TITLE
new ui-tests for switching projects #9125

### DIFF
--- a/testing/specs/browse.panel.selections.spec.js
+++ b/testing/specs/browse.panel.selections.spec.js
@@ -152,7 +152,7 @@ describe('browse.panel.selections.spec - tests for selection items in Browse Pan
             // 3. Click on 'Selection Controller' checkbox:
             await contentBrowsePanel.clickOnSelectionControllerCheckbox();
             await studioUtils.saveScreenshot('after_sel_controller');
-            // 4. Verify that no selected rows now: (the row gets unselected)
+            // 4. Verify that there are no selected rows in the browse panel at the moment. : (the row gets unselected)
             let number2 = await contentBrowsePanel.getNumberOfCheckedRows();
             assert.equal(number2, 0, 'There should be no selected rows');
             // 5. Verify that Selection toggle(circle) gets not visible:
@@ -173,7 +173,7 @@ describe('browse.panel.selections.spec - tests for selection items in Browse Pan
             await contentBrowsePanel.waitForNewButtonEnabled();
             await contentBrowsePanel.waitForArchiveButtonDisabled();
             await contentBrowsePanel.waitForDuplicateButtonDisabled();
-            // PreviewPanel toolbar gets not visible!
+            // 4 . Verify that PreviewPanel toolbar gets not visible!
             await contentItemPreviewPanel.waitForPreviewToolbarNotDisplayed();
             await contentBrowsePanel.waitForSortButtonDisabled();
             await contentBrowsePanel.waitForMoveButtonDisabled();
@@ -205,12 +205,12 @@ describe('browse.panel.selections.spec - tests for selection items in Browse Pan
             // 2. expected content should be highlighted:
             assert.equal(actualName, appConst.TEST_FOLDER_WITH_IMAGES, "expected content should be highlighted");
             let number = await contentBrowsePanel.getNumberOfSelectedRows();
-            assert.equal(number, 1, "One row should be highlighted");
+            assert.equal(number, 1, 'One row should be highlighted');
             // 3. But there are no any checked rows:
             let number2 = await contentBrowsePanel.getNumberOfCheckedRows();
-            assert.equal(number2, 0, "the number of checked rows is 0");
+            assert.equal(number2, 0, 'The number of checked rows is 0');
             let isVisible = await contentBrowsePanel.waitForSelectionTogglerVisible();
-            assert.ok(isVisible === false, "'Selection Toggler' should not be visible in the toolbar");
+            assert.ok(isVisible === false, `'Selection Toggle' should not be visible in the toolbar`);
         });
 
     it("WHEN one row with content has been checked THEN the row gets checked AND 'Selection Toggler' gets visible",
@@ -221,9 +221,9 @@ describe('browse.panel.selections.spec - tests for selection items in Browse Pan
             await contentBrowsePanel.clickCheckboxAndSelectRowByDisplayName(appConst.TEST_FOLDER_WITH_IMAGES);
             let number1 = await contentBrowsePanel.getNumberOfSelectedRows();
             await studioUtils.saveScreenshot('one_row_checked');
-            assert.equal(number1, 0, "no one row should be highlighted");
+            assert.equal(number1, 0, 'no one row should be highlighted');
             let number2 = await contentBrowsePanel.getNumberOfCheckedRows();
-            assert.ok(number2 === 1, "One row should be checked");
+            assert.ok(number2 === 1, 'One row should be checked');
             let isVisible = await contentBrowsePanel.waitForSelectionTogglerVisible();
             assert.ok(isVisible, "Selection Toggle should appear in the toolbar");
         });
@@ -238,7 +238,7 @@ describe('browse.panel.selections.spec - tests for selection items in Browse Pan
             await contentBrowsePanel.pause(500);
             let number = await contentBrowsePanel.getNumberOfSelectedRows();
             await studioUtils.saveScreenshot('two_rows_checked');
-            assert.equal(number, 0, 'the number of highlighted rows should be 0');
+            assert.equal(number, 0, 'The number of highlighted rows should be 0');
             let number2 = await contentBrowsePanel.getNumberOfCheckedRows();
             assert.equal(number2, 2, 'Two rows should be checked');
         });
@@ -255,9 +255,9 @@ describe('browse.panel.selections.spec - tests for selection items in Browse Pan
             await contentBrowsePanel.pause(1000);
             let numberOfHighlighted = await contentBrowsePanel.getNumberOfSelectedRows();
             await studioUtils.saveScreenshot('check_row_unselected');
-            assert.equal(numberOfHighlighted, 0, 'number of highlighted rows should be 0');
+            assert.equal(numberOfHighlighted, 0, 'The number of highlighted rows should be 0');
             let numberOfChecked = await contentBrowsePanel.getNumberOfCheckedRows();
-            assert.equal(numberOfChecked, 0, "number of checked rows should be 0");
+            assert.equal(numberOfChecked, 0, 'The number of checked rows should be 0');
         });
 
     beforeEach(() => studioUtils.navigateToContentStudioApp());

--- a/testing/specs/project-2/create.content.in.project.spec.js
+++ b/testing/specs/project-2/create.content.in.project.spec.js
@@ -19,8 +19,8 @@ describe('create.content.in.project.spec - create new content in the selected co
     if (typeof browser === 'undefined') {
         webDriverHelper.setupBrowser();
     }
-    let TEST_FOLDER_NAME = studioUtils.generateRandomName('folder');
 
+    let TEST_FOLDER_NAME = studioUtils.generateRandomName('folder');
     let PROJECT_DISPLAY_NAME = studioUtils.generateRandomName('project');
     let TEST_DESCRIPTION = 'test description';
 
@@ -67,7 +67,7 @@ describe('create.content.in.project.spec - create new content in the selected co
             assert.equal(actualProjectName, PROJECT_DISPLAY_NAME + '(no)', 'Actual and expected display name should be equal');
         });
 
-    it(`WHEN new folder wizard has been saved THEN expected project-ACL entries should be present in Access form`,
+    it(`WHEN Edit Permissions modal dialog has been opened THEN expected project-ACL entries should be present in Access form`,
         async () => {
             let editPermissionsGeneralStep = new EditPermissionsGeneralStep();
             let contentWizardPanel = new ContentWizardPanel();
@@ -82,7 +82,7 @@ describe('create.content.in.project.spec - create new content in the selected co
             // 3. Open Edit Permissions Dialog:
             await userAccessWidget.clickOnEditPermissionsLink();
             await editPermissionsGeneralStep.waitForLoaded();
-            // 4. Open Edit Permissions Dialog
+            // 4. Verify the list of principals:
             let result = await editPermissionsGeneralStep.getDisplayNameOfSelectedPrincipals();
             assert.ok(result.includes(PROJECT_DISPLAY_NAME + ' - Owner'), 'Expected Acl should be present');
             assert.ok(result.includes(PROJECT_DISPLAY_NAME + ' - Editor'), 'Expected Acl should be present');
@@ -102,7 +102,7 @@ describe('create.content.in.project.spec - create new content in the selected co
             await studioUtils.openBrowseDetailsPanel();
             let actualHeader = await userAccessWidget.getHeader();
             assert.equal(actualHeader, appConst.ACCESS_WIDGET_HEADER.RESTRICTED_ACCESS,
-                "'Restricted access to item' - header should be displayed");
+                `'Restricted access to item' - header should be displayed`);
 
         });
 
@@ -129,6 +129,29 @@ describe('create.content.in.project.spec - create new content in the selected co
             await studioUtils.saveScreenshot('switch_to_default_context');
             let result = await contentBrowsePanel.getDisplayNamesInGrid();
             assert.equal(result.length, 0, 'Filtered grid should be empty');
+        });
+
+    // Selection controller is not updated after switching projects #8922
+    // https://github.com/enonic/app-contentstudio/issues/8922
+    it(`GIVEN existing folder is checked in new created project is selected WHEN the context has been switched to 'Default' project THEN 'Selection Toggle' should not be not be visible in tree-grid-toolbar`,
+        async () => {
+            let contentBrowsePanel = new ContentBrowsePanel();
+            let browseDetailsPanel = new BrowseDetailsPanel();
+            let contentWidget = new ContentWidgetView();
+            // 1. Select the just created project in 'Select Context' dialog:
+            await studioUtils.openProjectSelectionDialogAndSelectContext(PROJECT_DISPLAY_NAME);
+            // 2. Check the folder in the current context:
+            await contentBrowsePanel.clickOnCheckboxAndSelectRowByName(TEST_FOLDER_NAME);
+            // 3. Verify that 'Selection Toggle' gets visible in tree-grid-toolbar
+            await contentBrowsePanel.waitForSelectionTogglerVisible();
+            // 4. Switch to 'Default' project:
+            await contentBrowsePanel.selectContext('Default');
+            // 5. Verify that 'Selection Toggle' is not visible in another context:
+            await contentBrowsePanel.waitForSelectionTogglerNotVisible();
+            // 6. Switch to the new crated project's context again:
+            await studioUtils.openProjectSelectionDialogAndSelectContext(PROJECT_DISPLAY_NAME);
+            // 7. Verify that 'Selection Toggle' was reset as well:
+            await contentBrowsePanel.waitForSelectionTogglerNotVisible();
         });
 
     it('Post conditions: the project should be deleted',


### PR DESCRIPTION
Tests to verify   bug Selection controller is not updated after switching projects https://github.com/enonic/app-contentstudio/issues/8922