### PR TITLE
Fix build problems on Windows #9191

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ testing/allure-results
 .enonic
 .eslintcache
 .bin
-
+.pnpm-store
+**/.webpack-cache

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Performance optimizations for Windows
+package-import-method=copy
+side-effects-cache=true
+
+# Reduce defender scanning overhead
+node-linker=hoisted

--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -25,6 +25,7 @@
     "jquery": "^3.7.1",
     "jquery-simulate": "^1.0.2",
     "jquery-ui": "^1.14.1",
+    "jsondiffpatch": "^0.7.3",
     "lib-contentstudio": "workspace:*",
     "nanostores": "^0.11.4",
     "q": "^1.5.1"

--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       jquery-ui:
         specifier: ^1.14.1
         version: 1.14.1
+      jsondiffpatch:
+        specifier: ^0.7.3
+        version: 0.7.3
       lib-contentstudio:
         specifier: workspace:*
         version: link:.xp/dev/lib-contentstudio

--- a/modules/app/webpack.config.js
+++ b/modules/app/webpack.config.js
@@ -12,6 +12,13 @@ const path = require('path');
 const isProd = process.env.NODE_ENV === 'production';
 
 module.exports = {
+    cache: {
+        type: 'filesystem',
+        cacheDirectory: path.resolve(__dirname, '.webpack-cache'),
+        buildDependencies: {
+            config: [__filename]
+        }
+    },
     context: path.join(__dirname, '/src/main/resources/assets'),
     entry: {
         'js/main': './js/main.ts',

--- a/modules/lib/package.json
+++ b/modules/lib/package.json
@@ -15,7 +15,7 @@
     "build:dev:client": "tsc --pretty --inlineSourceMap --inlineSources",
     "build:dev:lib": "webpack --color --stats-error-details",
     "check": "pnpm --color /^check:.*$/",
-    "check:types": "tsc --skipLibCheck --emitDeclarationOnly --declaration",
+    "check:types": "tsc --skipLibCheck --declaration --noEmit",
     "check:lint": "eslint **/*.ts --quiet --cache"
   },
   "dependencies": {

--- a/modules/lib/webpack.config.js
+++ b/modules/lib/webpack.config.js
@@ -12,6 +12,13 @@ const MiniCssExtractPluginCleanup = require('./util/MiniCssExtractPluginCleanup'
 const isProd = process.env.NODE_ENV === 'production';
 
 module.exports = {
+    cache: {
+        type: 'filesystem',
+        cacheDirectory: path.resolve(__dirname, '.webpack-cache'),
+        buildDependencies: {
+            config: [__filename]
+        }
+    },
     context: path.join(__dirname, '/src/main/resources/assets'),
     entry: {
         'styles/contentlib': './styles/main.less',


### PR DESCRIPTION
Added jsondiffpatch as direct dependency of modules/app. In some scenarios, jsondiffpatch is not found in lib-contentstudio during the build time. This is a straightforward attempt to make it available directly. 
Added webpack build caching.
Added JVM args to prevent failing during heavy loads. 
Enabled file system watching to speed up changes detection. Added various flags for pnpm:
  - package-import-method=copy: copy packages from the store instead of hardlinking.
  - side-effects-cache=true: enable caching of build artifacts from postinstall scripts.
  - node-linker: Uses a hoisted node_modules layout (fewer/deeper symlinks vs isolated).