### PR TITLE
Fix build problems on Windows #9191

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,0 @@
-# Performance optimizations for Windows
-package-import-method=copy
-side-effects-cache=true
-
-# Reduce defender scanning overhead
-node-linker=hoisted

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,4 @@ version=6.0.0-SNAPSHOT
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.daemon=true
+org.gradle.vfs.watch.ignore.path=**/node_modules/**

--- a/gradle/node.gradle
+++ b/gradle/node.gradle
@@ -6,27 +6,48 @@ node {
     download = true
 }
 
-tasks.register( 'copyDevResources' ) {
+tasks.register( 'copyDevResources', Copy ) {
     onlyIf {
         configurations.hasProperty( 'devResources' )
     }
-    doLast {
-        if ( configurations.hasProperty( 'devResources' ) ) {
-            copy {
-                from configurations.devResources.files.collect { zipTree( it ) }
-                include 'dev/**'
-                into '.xp'
-            }
-        }
-    }
+
+    from configurations.findByName( 'devResources' ).files.collect { zipTree( it ) }
+    include 'dev/**'
+    into '.xp'
+
+    outputs.dir '.xp'
 }
 
+// PNPM Optimizations
+
 tasks.named( 'pnpmInstall' ).configure {
+    // Don't track state or cache, save Gradle time, make pnpm do its thing
+    doNotTrackState 'pnpmInstall must not be tracked'
+
     if ( configurations.hasProperty( 'devResources' ) ) {
         dependsOn tasks.named( 'copyDevResources' )
     }
-    //! Temporary fix for CI environment, back to npm-like behavior
+    // Fix for CI: make it work with dynamic lib-admin-ui version, back to npm-like behavior
     if ( System.getenv( 'CI' ) == 'true' || project.hasProperty( 'ci' ) ) {
         pnpmCommand.set(['install', '--no-frozen-lockfile'])
     }
+
+    // I/O only necessary files
+    inputs.file 'package.json'
+    inputs.file 'pnpm-lock.yaml'
+    if (file( '.npmrc' ).exists()) {
+        inputs.file '.npmrc'
+    }
+    outputs.dir 'node_modules'
 }
+
+// Exclude heavy Node caches in Copy tasks from tracking by Gradle
+tasks.withType( Copy ).configureEach {
+    exclude '**/node_modules/**', '**/.webpack-cache/**', '**/dist/**', '**/coverage/**'
+}
+
+// Exclude node_modules in SourceTasks from tracking by Gradle, except for pnpmInstall
+tasks.matching { it.name != 'pnpmInstall' && it instanceof org.gradle.api.tasks.SourceTask }.configureEach {
+    exclude '**/node_modules/**'
+}
+

--- a/modules/app/.npmrc
+++ b/modules/app/.npmrc
@@ -1,1 +1,8 @@
 ignore-workspace-root-check=true
+
+# Performance optimizations for Windows
+package-import-method=copy
+side-effects-cache=true
+
+# Reduce defender scanning overhead
+node-linker=hoisted

--- a/modules/app/build.gradle
+++ b/modules/app/build.gradle
@@ -58,8 +58,12 @@ dependencies {
 }
 
 // Use task configuration avoidance
-tasks.named('copyDevResources').configure {
+tasks.named( 'copyDevResources' ).configure {
     dependsOn project(':lib-contentstudio').tasks.named('devJar')
+}
+
+tasks.named( 'pnpmInstall' ).configure {
+    mustRunAfter project(':lib-contentstudio').tasks.named('pnpmInstall')
 }
 
 tasks.register( 'checkTypes', PnpmTask ) {

--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -25,7 +25,6 @@
     "jquery": "^3.7.1",
     "jquery-simulate": "^1.0.2",
     "jquery-ui": "^1.14.1",
-    "jsondiffpatch": "^0.7.3",
     "lib-contentstudio": "workspace:*",
     "nanostores": "^0.11.4",
     "q": "^1.5.1"

--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       jquery-ui:
         specifier: ^1.14.1
         version: 1.14.1
-      jsondiffpatch:
-        specifier: ^0.7.3
-        version: 0.7.3
       lib-contentstudio:
         specifier: workspace:*
         version: link:.xp/dev/lib-contentstudio

--- a/modules/lib/.npmrc
+++ b/modules/lib/.npmrc
@@ -1,1 +1,8 @@
 ignore-workspace-root-check=true
+
+# Performance optimizations for Windows
+package-import-method=copy
+side-effects-cache=true
+
+# Reduce defender scanning overhead
+node-linker=hoisted


### PR DESCRIPTION
- Disabled vfs watch for `node_modules` via gradle properties. The reason is that previously the file system watching feature would fail with an overflow error somewhere around the second `pnpmInstall` task after even more modules were installed:
  ```log
  Detected overflow for /Users/.../app-contentstudio
  Overflow detected (type: OPERATING_SYSTEM) for watched path '.../app-contentstudio', invalidating
  Not watching anything anymore 
  ```
- Made `copyDevResources` task a copy subtask and moved code from `doLast` to enable proper caching for it. Also made `.xp` output-only to prevent unnecessary caching and watching. A small but visible improvement for that specific task.
- Disabled state tracking and caching for the `pnpmInstall` task by Gradle (pnpm is already doing this pretty fast) to avoid caching speed degradation due to lots of unnecessary files in cache. After long debugging it was discovered that `pnpm` was fast and even the Gradle task itself reported finishing in `doLast` really quickly, but Gradle would still hold the task for 20–40s just to update the cache (we enabled caching and parallel executions some time ago in build improvements).
- Reworked what files are actually handled by the `pnpmInstall` task to make it properly configured by Gradle.
- Removed `node_modules` from different `Copy` and `SourceTask` tasks for the same reason: cache and watch. 
- Made `:contentstudio:pnpmInstall` task run only after `:lib-contentstudio:pnpmInstall` (to prevent parallel calls) and `:lib-contentstudio:copyDevResources` (to make sure `.xp` is handled by pnpm properly). 
- Moved `.npmrc` to modules where pnpm is actually called. Now it works as intended. Sadly, no performance optimizations are introduced by pnpm by default, so expect ~25s clean install (with cache) instead of ~5s, because all dependencies must be copied instead of linked. On the other hand, it should not trigger Windows Defender. 
- Reverted `jsondiffpatch` dependency from the app module. After changes to `.npmrc`, all the dependencies from subfolders will be present in the root (`/modules/app/node_modules`) in a flat structure anyway.

---

Tested it dozens of times in different configurations. 
- Can't guarantee that the problem with missing dependencies is fixed, but tried to safeguard all the possible causes.
- The `pnpmInstall` must not hang for long anymore (even though the actual task has finished), but a clean run will be slow and has increased from **~5s** to the old **~25s**.
- Slower pnpm install and the "copy" strategy instead of linking should not trigger Windows Defender.
- Clean builds (removed `.gradle` cache; deleted `node_modules`, `.xp`, `build` folders in modules; pnpm cache enabled; stopped `./gradlew --stop` daemon) still show improvement (on throttled Max M2): from **3m 30s** to **2m 20s**.
- Consecutive `./gradlew clean build` with only dev folders (`node_modules`, `.xp`, `build`) removed: **~1m 30s**
- Consecutive `./gradlew clean build`: **~35s**
