### PR TITLE
Enonic UI: Externalize Projects Data Management #9285

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/dialog/ProjectSelectionDialog.ts
+++ b/modules/lib/src/main/resources/assets/js/app/dialog/ProjectSelectionDialog.ts
@@ -12,6 +12,7 @@ import {ProjectContext} from '../project/ProjectContext';
 import {Project} from '../settings/data/project/Project';
 import {ProjectHelper} from '../settings/data/project/ProjectHelper';
 import {ProjectListRequest} from '../settings/resource/ProjectListRequest';
+import {setActiveProject} from '../../v6/features/store/projects.store';
 
 export class ProjectSelectionDialog
     extends ModalDialog {
@@ -47,6 +48,8 @@ export class ProjectSelectionDialog
             itemView.onClicked((event: MouseEvent) => {
                 if (!event.ctrlKey && !event.shiftKey) {
                     if (itemView.isSelectable()) {
+                        setActiveProject(itemView.getProject());
+                        // TODO: Enonic UI - Remove once ProjectContext is replaced by projects store
                         ProjectContext.get().setProject(itemView.getProject());
                         this.close();
                     }
@@ -75,10 +78,13 @@ export class ProjectSelectionDialog
     close() {
         super.close();
 
+        // TODO: Enonic UI - Change to $isInitialized from projects store once ProjectContext is replaced by projects store
         if (!ProjectContext.get().isInitialized()) {
             const project: Project = this.getDefaultProject();
 
             if (project) {
+                setActiveProject(project);
+                // TODO: Enonic UI - Remove once ProjectContext is replaced by projects store
                 ProjectContext.get().setProject(project);
             } else {
                 Body.get().addClass('no-projects');
@@ -106,11 +112,11 @@ export class ProjectSelectionDialog
         this.mask();
 
         return new ProjectListRequest(true).sendAndParse().then((projects: Project[]) => {
-            this.setProjects(projects);
-            this.showItems();
+                this.setProjects(projects);
+                this.showItems();
         }).catch(DefaultErrorHandler.handle).finally(() => {
-            this.unmask();
-        });
+                this.unmask();
+            });
     }
 
     private showItems() {

--- a/modules/lib/src/main/resources/assets/js/app/project/ProjectContext.ts
+++ b/modules/lib/src/main/resources/assets/js/app/project/ProjectContext.ts
@@ -1,8 +1,10 @@
 import {Project} from '../settings/data/project/Project';
 import {Store} from '@enonic/lib-admin-ui/store/Store';
 
+/**
+ * @deprecated The class due to be replaced by the projects.store
+ */
 export class ProjectContext {
-
     public static LOCAL_STORAGE_KEY: string = 'contentstudio:defaultProject';
 
     private currentProject: Project;
@@ -14,7 +16,7 @@ export class ProjectContext {
     private noProjectsAvailableListeners: (() => void)[] = [];
 
     private constructor() {
-    //
+        //
     }
 
     static get(): ProjectContext {
@@ -97,5 +99,7 @@ export class ProjectContext {
 }
 
 enum State {
-    INITIALIZED, NOT_INITIALIZED, NOT_AVAILABLE
+    INITIALIZED,
+    NOT_INITIALIZED,
+    NOT_AVAILABLE,
 }

--- a/modules/lib/src/main/resources/assets/js/app/settings/SettingsAppPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/SettingsAppPanel.ts
@@ -32,7 +32,7 @@ export class SettingsAppPanel
     private deletedIds: string[] = [];
 
     constructor() {
-        // TODO: Enonic UI Hack
+        // TODO: Enonic UI
         // When possible, remove ContentAppBar dependency or migrate to AppBarElement
         super(ContentAppBar.getInstance());
     }

--- a/modules/lib/src/main/resources/assets/js/v6/features/layout/AppShell/AppBar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/layout/AppShell/AppBar.tsx
@@ -6,11 +6,11 @@ import {ProjectSelectionDialog} from '../../../../app/dialog/ProjectSelectionDia
 import {Store} from '@enonic/lib-admin-ui/store/Store';
 import {ShowIssuesDialogEvent} from '../../../../app/browse/ShowIssuesDialogEvent';
 import {useI18n} from '../../../../app/ui2/hooks/useI18n';
-import {$activeProjectName} from '../../store/projects.store';
 import {useStore} from '@nanostores/preact';
+import {$activeProjectName} from '../../store/projects.store';
 
 const AppBar = (): ReactElement => {
-    useStore($activeProjectName);
+    const activeProjectName = useStore($activeProjectName);
 
     return (
         <header className="bg-surface-neutral h-15 px-5 py-2 flex items-center gap-2.5 border-b border-bdr-soft">
@@ -22,7 +22,7 @@ const AppBar = (): ReactElement => {
                     ProjectSelectionDialog.get().open();
                 }}
                 aria-label={useI18n('wcag.appbar.project.label')}
-                label={$activeProjectName.get()}
+                label={activeProjectName}
             />
 
             <Button

--- a/modules/lib/src/main/resources/assets/js/v6/features/layout/AppShell/AppBar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/layout/AppShell/AppBar.tsx
@@ -6,8 +6,12 @@ import {ProjectSelectionDialog} from '../../../../app/dialog/ProjectSelectionDia
 import {Store} from '@enonic/lib-admin-ui/store/Store';
 import {ShowIssuesDialogEvent} from '../../../../app/browse/ShowIssuesDialogEvent';
 import {useI18n} from '../../../../app/ui2/hooks/useI18n';
+import {$activeProjectName} from '../../store/projects.store';
+import {useStore} from '@nanostores/preact';
 
 const AppBar = (): ReactElement => {
+    useStore($activeProjectName);
+
     return (
         <header className="bg-surface-neutral h-15 px-5 py-2 flex items-center gap-2.5 border-b border-bdr-soft">
             <Button
@@ -18,9 +22,8 @@ const AppBar = (): ReactElement => {
                     ProjectSelectionDialog.get().open();
                 }}
                 aria-label={useI18n('wcag.appbar.project.label')}
-            >
-                Default Project
-            </Button>
+                label={$activeProjectName.get()}
+            />
 
             <Button
                 className="max-sm:hidden"
@@ -30,9 +33,8 @@ const AppBar = (): ReactElement => {
                     new ShowIssuesDialogEvent().fire();
                 }}
                 aria-label={useI18n('wcag.appbar.issues.label')}
-            >
-                Issues
-            </Button>
+                label="Issues"
+            />
 
             <IconButton
                 size="sm"

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
@@ -16,13 +16,13 @@ export const $projects = map<ProjectsStore>({
 });
 
 export function setActiveProject(project: Readonly<Project> | undefined): void {
-    const isProjectInStore = $projects.get().projects.some((p) => getProjectKey(p) === getProjectKey(project));
-    if (!isProjectInStore) throw new Error('Project not found in store');
-    $projects.setKey('activeProjectId', getProjectKey(project));
+    const existsInStore = $projects.get().projects.some((p) => getProjectId(p) === getProjectId(project));
+    if (!existsInStore) return;
+    $projects.setKey('activeProjectId', getProjectId(project));
 }
 
 export const $activeProject = computed($projects, (store) => {
-    return store.projects.find((p) => getProjectKey(p) === store.activeProjectId);
+    return store.projects.find((p) => getProjectId(p) === store.activeProjectId);
 });
 
 export const $activeProjectName = computed($activeProject, (activeProject) => {
@@ -38,7 +38,7 @@ export const $isInitialized = computed($projects, (store) => {
 //
 // * Utilities
 //
-export function getProjectKey(project: Readonly<Project> | undefined): string | undefined {
+export function getProjectId(project: Readonly<Project> | undefined): string | undefined {
     return project?.getName();
 }
 
@@ -98,7 +98,7 @@ ProjectCreatedEvent.on(() => {
 });
 ProjectDeletedEvent.on((event: ProjectDeletedEvent) => {
     const {projects} = $projects.get();
-    const updatedProjects = projects.filter((p) => getProjectKey(p) !== event.getProjectName());
+    const updatedProjects = projects.filter((p) => getProjectId(p) !== event.getProjectName());
     $projects.setKey('projects', updatedProjects);
     updateActiveProject();
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
@@ -1,0 +1,104 @@
+import {computed, map} from 'nanostores';
+import {Project} from '../../../app/settings/data/project/Project';
+import {ProjectListRequest} from '../../../app/settings/resource/ProjectListRequest';
+import {ProjectUpdatedEvent} from '../../../app/settings/event/ProjectUpdatedEvent';
+import {ProjectCreatedEvent} from '../../../app/settings/event/ProjectCreatedEvent';
+import {ProjectDeletedEvent} from '../../../app/settings/event/ProjectDeletedEvent';
+
+type ProjectsStore = {
+    projects: Readonly<Project>[];
+    activeProjectId: string | undefined;
+};
+
+export const $projects = map<ProjectsStore>({
+    projects: [],
+    activeProjectId: undefined,
+});
+
+export function setActiveProject(project: Readonly<Project> | undefined): void {
+    const isProjectInStore = $projects.get().projects.some((p) => getProjectKey(p) === getProjectKey(project));
+    if (!isProjectInStore) throw new Error('Project not found in store');
+    $projects.setKey('activeProjectId', getProjectKey(project));
+}
+
+export const $activeProject = computed($projects, (store) => {
+    return store.projects.find((p) => getProjectKey(p) === store.activeProjectId);
+});
+
+export const $activeProjectName = computed($activeProject, (activeProject) => {
+    if (!activeProject) return '';
+
+    return `${activeProject.getDisplayName()} (${activeProject.getLanguage()})`;
+});
+
+export const $isInitialized = computed($projects, (store) => {
+    return store.activeProjectId === undefined || store.projects.length > 0;
+});
+
+//
+// * Utilities
+//
+export function getProjectKey(project: Readonly<Project> | undefined): string | undefined {
+    return project?.getName();
+}
+
+//
+// * Internal
+//
+let isLoading = false;
+let needsReload = false;
+async function loadProjects(): Promise<void> {
+    if (isLoading) {
+        needsReload = true;
+        return;
+    }
+
+    isLoading = true;
+
+    try {
+        const request = new ProjectListRequest(true);
+        const projects = await request.sendAndParse();
+
+        $projects.setKey('projects', projects);
+        updateActiveProject();
+    } catch (error) {
+        console.error(error);
+    } finally {
+        isLoading = false;
+    }
+
+    if (needsReload) {
+        needsReload = false;
+        await loadProjects();
+    }
+}
+
+function updateActiveProject(): void {
+    if ($activeProject.get()) return;
+
+    const {projects} = $projects.get();
+
+    if (projects.length === 1) {
+        setActiveProject(projects[0]);
+        return;
+    }
+}
+
+//
+// * Initialization
+//
+
+void loadProjects();
+
+ProjectUpdatedEvent.on(() => {
+    loadProjects();
+});
+ProjectCreatedEvent.on(() => {
+    loadProjects();
+});
+ProjectDeletedEvent.on((event: ProjectDeletedEvent) => {
+    const {projects} = $projects.get();
+    const updatedProjects = projects.filter((p) => getProjectKey(p) !== event.getProjectName());
+    $projects.setKey('projects', updatedProjects);
+    updateActiveProject();
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/sidebarWidgets.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/sidebarWidgets.store.ts
@@ -17,6 +17,8 @@ export const $sidebarWidgets = map<WidgetsStore>({
 });
 
 export function setActiveWidget(widget: Readonly<Widget> | undefined): void {
+    const existsInStore = $sidebarWidgets.get().widgets.some((p) => getWidgetKey(p) === getWidgetKey(widget));
+    if (!existsInStore) throw new Error('Widget not found in store');
     $sidebarWidgets.setKey('activeWidgetId', getWidgetKey(widget));
 }
 
@@ -42,7 +44,9 @@ export function isMainWidget(widget: Readonly<Widget>): boolean {
     return getWidgetKey(widget)?.endsWith('studio:main') ?? false;
 }
 
-// Internal
+//
+// * Internal
+//
 
 const WIDGET_INTERFACE = 'contentstudio.menuitem';
 let isLoading = false;
@@ -77,15 +81,10 @@ async function loadWidgets(): Promise<void> {
 }
 
 function updateActiveWidget(): void {
+    if ($activeWidget.get()) return;
+
     const url = window.location.href;
     const {widgets} = $sidebarWidgets.get();
-
-    const {activeWidgetId} = $sidebarWidgets.get();
-    const hasActiveWidget = widgets.some((w) => getWidgetKey(w) === activeWidgetId);
-
-    if (hasActiveWidget) {
-        return;
-    }
 
     const widgetMatchingUrl = widgets.find((w) => {
         const widgetKey = getWidgetKey(w);

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/sidebarWidgets.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/sidebarWidgets.store.ts
@@ -16,15 +16,15 @@ export const $sidebarWidgets = map<WidgetsStore>({
     activeWidgetId: undefined,
 });
 
-export function setActiveWidget(widget: Readonly<Widget> | undefined): void {
-    const existsInStore = $sidebarWidgets.get().widgets.some((p) => getWidgetKey(p) === getWidgetKey(widget));
-    if (!existsInStore) throw new Error('Widget not found in store');
-    $sidebarWidgets.setKey('activeWidgetId', getWidgetKey(widget));
-}
-
 export const $activeWidget = computed($sidebarWidgets, (store) => {
     return store.widgets.find((w) => getWidgetKey(w) === store.activeWidgetId);
 });
+
+export function setActiveWidget(widget: Readonly<Widget> | undefined): void {
+    const existsInStore = $sidebarWidgets.get().widgets.some((p) => getWidgetKey(p) === getWidgetKey(widget));
+    if (!existsInStore) return;
+    $sidebarWidgets.setKey('activeWidgetId', getWidgetKey(widget));
+}
 
 //
 // * Utilities
@@ -110,9 +110,11 @@ function sortWidgets(widgets: Readonly<Widget>[]): Readonly<Widget>[] {
     const settingsWidget = widgets.find((w) => w.getWidgetDescriptorKey().toString().endsWith(SETTINGS_APP_ENDING));
     const defaultWidgets = widgets.filter((w) => {
         const widgetKey = getWidgetKey(w);
-        return !widgetKey.endsWith(MAIN_APP_ENDING) &&
+        return (
+            !widgetKey.endsWith(MAIN_APP_ENDING) &&
             !widgetKey.endsWith(ARCHIVE_APP_ENDING) &&
-            !widgetKey.endsWith(SETTINGS_APP_ENDING);
+            !widgetKey.endsWith(SETTINGS_APP_ENDING)
+        );
     });
     const sortedDefaultWidgets = defaultWidgets.sort((wa, wb) => {
         return wa.getWidgetDescriptorKey().toString().localeCompare(wb.getWidgetDescriptorKey().toString());
@@ -150,7 +152,7 @@ ApplicationEvent.on((event: ApplicationEvent) => {
     } else if (stoppedOrUninstalledEvent) {
         const {widgets} = $sidebarWidgets.get();
         const appKey = String(event.getApplicationKey());
-        const filteredWidgets = widgets.filter(w => getWidgetKey(w) !== appKey);
+        const filteredWidgets = widgets.filter((w) => getWidgetKey(w) !== appKey);
 
         $sidebarWidgets.setKey('widgets', filteredWidgets);
     }


### PR DESCRIPTION
## 1 - Some comments about the Acceptance criteria on #9285 

### 1.1 - No duplicate project loading requests across application

There are many places requesting projects directly (see `new ProjectListRequest`), and manipulating the active one via `ProjectContext`.

From my understanding it was out of the scope of this task to replace all `ProjectListRequest` and `ProjectContext` usage with the new projects store, but rather create the store and start using it in minimal context, and that's what I've done on `ProjectSelectionDialog`.

Note that I still left the `ProjectContext `manipulation there, with proper code comments to remember us to get rid of it once we fully migrate to use only the projects store.

### 1.2 - Project loading logic removed from ContentAppBar

I didn't touch `ContentAppBar` because we're not instantiating it anymore after the `AppBarElement` replacement of `ContentAppBar` (task #9279)

The only place still calling it is the `SettingsAppPanel` constructor, and I already added a comment there for future removal, but that depends on updating lib-admin-ui as well.

---

## 2 - Some extra comments and questions (reason for PR being draft)
a. Currently we only automatically set the active project if there's no project set as active and there's only one project loaded in the store. If none is active and there is more than one project, then we don't automayically set the active project! What should be the logic in this case?

b. I could've gone further and improved the `ProjectSelectionDialog` and `main.ts`, removing `ProjectListRequest` usage from both, and instead, getting projects from the store... I have two reasons for not doing that yet:
1) because I was unsure if that would be out of the scope
2) because there would be fricction with the `readonly` projects from the projects store (since most functions expect projects as `Project[]` not `Readonly<Project>[]`)

c. What should happen in case no project is selected?!