### PR TITLE
Enonic UI: Missing Dark theme metadata and CSS rules #9455

### DIFF
--- a/modules/app/src/main/resources/admin/tools/main/main.html
+++ b/modules/app/src/main/resources/admin/tools/main/main.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <meta name="viewport" content="width=device-width, user-scalable=no">
     <meta name="theme-color" content="#ffffff">
+    <meta name="color-scheme" content="light dark">
 
     <title>{{appName}} - Enonic XP Admin</title>
 
@@ -16,19 +17,22 @@
             const storedTheme = JSON.parse(stored)?.theme;
             const isDark = storedTheme === 'dark' || (storedTheme === 'system' && prefersDark) || (storedTheme === undefined && prefersDark);
             document.documentElement.classList.toggle('dark', isDark);
+            document.querySelector('meta[name="color-scheme"]').content = isDark ? 'dark' : 'light';
         } catch (e) {
             console.error('Error reading theme preference', e);
         }
     </script>
 
     <style>
-      :root {
-        color-scheme: light;
-      }
+        :root {
+            color-scheme: light;
+            background-color: #ffffff;
+        }
 
-      :root.dark {
-        color-scheme: dark;
-      }
+        :root.dark {
+            color-scheme: dark;
+            background-color: #242829;
+        }
     </style>
 
     <!-- favicons -->

--- a/modules/app/src/main/resources/admin/tools/main/main.html
+++ b/modules/app/src/main/resources/admin/tools/main/main.html
@@ -8,6 +8,29 @@
 
     <title>{{appName}} - Enonic XP Admin</title>
 
+    <!-- Set theme before styles are loaded to prevent flash of incorrect theme -->
+    <script>
+        try {
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const stored = localStorage.getItem('enonic:cs:app');
+            const storedTheme = JSON.parse(stored)?.theme;
+            const isDark = storedTheme === 'dark' || (storedTheme === 'system' && prefersDark) || (storedTheme === undefined && prefersDark);
+            document.documentElement.classList.toggle('dark', isDark);
+        } catch (e) {
+            console.error('Error reading theme preference', e);
+        }
+    </script>
+
+    <style>
+      :root {
+        color-scheme: light;
+      }
+
+      :root.dark {
+        color-scheme: dark;
+      }
+    </style>
+
     <!-- favicons -->
 
     <link rel="apple-touch-icon" href="{{assetsUri}}/icons/favicons/apple-touch-icon-60x60.png" sizes="60x60">

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/app.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/app.store.ts
@@ -65,11 +65,14 @@ function applyTheme(theme: Theme): void {
     if (typeof document === 'undefined') return;
 
     const resolvedTheme = resolveTheme(theme);
+    const isDark = resolvedTheme === 'dark';
 
-    if (resolvedTheme === 'dark') {
-        document.documentElement.classList.add('dark');
-    } else {
-        document.documentElement.classList.remove('dark');
+    document.documentElement.classList.toggle('dark', isDark);
+
+    // Update color-scheme meta tag to match the resolved theme
+    const colorSchemeMeta = document.querySelector('meta[name="color-scheme"]');
+    if (colorSchemeMeta) {
+        colorSchemeMeta.setAttribute('content', isDark ? 'dark' : 'light');
     }
 }
 


### PR DESCRIPTION
- Presetting .dark class on the root html tag if needed
- Setting root style in an inline block

This approach prevents flickering while waiting for style scripts loaded