### PR TITLE
Enonic UI: Fix content tree icons in Dark mode #9461

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/ContentIcon.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/ContentIcon.tsx
@@ -81,7 +81,7 @@ export const ContentIcon = ({
     if (canShowImage && src) {
         // 2x size for better quality
         return <Image
-            className={cn('w-6 h-6', isImageType ? 'object-cover' : 'object-contain', className)}
+            className={cn('w-6 h-6 dark:invert-100 dark:brightness-75 dark:contrast-125', isImageType ? 'object-cover' : 'object-contain', className)}
             alt={contentType}
             src={src}
             onError={() => setImageBroken(true)}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/grid/ContentTreeListRow.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/grid/ContentTreeListRow.tsx
@@ -24,7 +24,9 @@ const ContentTreeListRowSelectionControl = ({ data, className }: ContentTreeList
         return <span className={cn('w-3.5', className)}></span>;
     }
 
-    return <Checkbox className={'content-tree-row-checkbox'} tabindex={-1} key={data.id} id={'content-tree-' + data.id} checked={selectionMode === 'multiple' && isSelected} />
+    return <Checkbox
+        className='content-tree-row-checkbox relative z-0 after:absolute after:-inset-2 after:content-[""] after:rounded-sm after:pointer-events-auto after:-z-10'
+        tabindex={-1} key={data.id} id={'content-tree-' + data.id} checked={selectionMode === 'multiple' && isSelected}/>
 };
 
 export const ContentTreeListRow = ({item}: ContentTreeListRowProps): React.ReactElement => {


### PR DESCRIPTION
- For ContentIcon.tsx: 'dark:invert-100 dark:brightness-75 dark:contrast-125'
- Increased contact point for selection checkbox