### PR TITLE
Enonic UI: Disable Show excluded button #9483

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProjectSelectionDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProjectSelectionDialog.tsx
@@ -88,8 +88,8 @@ export const ProjectSelectionDialog = (): ReactElement => {
                                         <Listbox.Item
                                             key={project.getName()}
                                             value={project.getName()}
-                                            className="group flex self-stretch w-full min-w-full"
-                                            style={{paddingInlineStart: level * 20}}
+                                            className="group flex self-stretch w-full min-w-full px-2.5"
+                                            style={{paddingInlineStart: level * 20 + 10}}
                                             data-tone={project.getName() === activeProjectId ? 'inverse' : undefined}
                                         >
                                             <ProjectItem

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialog.tsx
@@ -1,7 +1,7 @@
 import {Button, cn, Dialog, Separator, Toggle} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
 import {Calendar} from 'lucide-react';
-import {useId, useState, type ReactElement} from 'react';
+import {useEffect, useId, useState, type ReactElement} from 'react';
 import {useI18n} from '../../../hooks/useI18n';
 import {$config} from '../../../store/config.store';
 import {$dependantPublishItems, $isPublishChecking, $isPublishReady, $isPublishSelectionSynced, $mainPublishItems, $publishCheckErrors, $publishDialog, $totalPublishableItems, applyDraftPublishDialogSelection, cancelDraftPublishDialogSelection, excludeInProgressPublishItems, excludeInvalidPublishItems, excludeNotPublishablePublishItems, markAllAsReadyInProgressPublishItems, publishItems, resetPublishDialogContext, setPublishDialogDependantItemSelected, setPublishDialogItemSelected, setPublishDialogItemWithChildrenSelected} from '../../../store/dialogs/publishDialog.store';
@@ -31,10 +31,17 @@ export const PublishDialog = (): ReactElement => {
     const visibleDependantItems = showExcluded
         ? dependantItems
         : dependantItems.filter(item => !item.excludedByDefault);
+    const hasAnyExcludedDependantItems = dependantItems.some(item => item.excludedByDefault);
     const hasVisibleDependantItems = visibleDependantItems.length > 0;
     const showExcludedLabel = useI18n('dialog.publish.excluded.show');
     const hideExcludedLabel = useI18n('dialog.publish.excluded.hide');
     const toggleExcludedLabel = showExcluded ? hideExcludedLabel : showExcludedLabel;
+
+    useEffect(() => {
+        if (!hasAnyExcludedDependantItems) {
+            setShowExcluded(false);
+        }
+    }, [hasAnyExcludedDependantItems]);
 
     const title = useI18n('dialog.publish');
     const separatorLabel = useI18n('dialog.publish.dependants');
@@ -105,7 +112,7 @@ export const PublishDialog = (): ReactElement => {
                         <div className={cn("flex flex-col gap-y-7.5", !hasDependantItems && 'hidden')}>
                             <div className="flex items-center gap-2.5 -my-2.5 pr-1">
                                 <Separator className="text-sm flex-1" label={separatorLabel} />
-                                <Toggle size="sm" label={toggleExcludedLabel} pressed={showExcluded} onPressedChange={setShowExcluded} />
+                                <Toggle size="sm" label={toggleExcludedLabel} pressed={showExcluded} onPressedChange={setShowExcluded} disabled={!hasAnyExcludedDependantItems} />
                             </div>
                             <ul className='flex flex-col gap-y-2.5'>
                                 {visibleDependantItems.map(({id, content, included, required}) => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/ProjectIcon.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/ProjectIcon.tsx
@@ -23,7 +23,7 @@ export const ProjectIcon = ({
 }: ProjectIconProps): ReactElement => {
     const url = hasIcon ? resolveProjectIconUrl(projectName) : null;
     if (url) {
-        return <img src={url} alt={projectName} draggable={false} className="ml-2.5 size-8 rounded-full bg-center object-cover"/>;
+        return <img src={url} alt={projectName} draggable={false} className={cn('size-8 rounded-full bg-center object-cover', className)} />;
     }
 
     if (!language) {
@@ -31,7 +31,7 @@ export const ProjectIcon = ({
             return (
                 <Layers
                     className={cn(
-                        'ml-2.5 size-8 flex items-center justify-center',
+                        'size-8 flex items-center justify-center',
                         className
                     )}
                 />
@@ -39,7 +39,7 @@ export const ProjectIcon = ({
         }
         return (
             <DefaultProjectIcon
-                className={cn('ml-2.5 size-8 flex items-center justify-center', className)}
+                className={cn('size-8 flex items-center justify-center', className)}
             />
         );
     }
@@ -52,7 +52,7 @@ export const ProjectIcon = ({
     const initials = lang.slice(0, 2);
 
     return (
-        <div className={cn('ml-2.5 relative size-8', className)} aria-hidden="true">
+        <div className={cn('relative size-8', className)} aria-hidden="true">
             <div className="absolute inset-0 flex items-center justify-center rounded-full border-1 border-bdr-subtle text-xs font-semibold lowercase text-subtle">
                 {initials}
             </div>


### PR DESCRIPTION
- Disabled and reset "Show excluded" button in Publish dialog, if nothing to show or hide. 
- Removed `ProjectIcon` margin, compensating it in `ProjectItem` directly, so it'll still look as intended in Project selection dialog.
Fixed that `<img>` `ProjectIcon` does not receive classes from outside the component, which led incorrect positioning of such icon in Sidebar.