### PR TITLE
Enonic UI: Version History basic functionality #9558

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/ContentVersion.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentVersion.ts
@@ -1,3 +1,5 @@
+import {ContentVersionAction} from './ContentVersionAction';
+import {ContentVersionActionJson} from './resource/json/ContentVersionActionJson';
 import {ContentVersionJson} from './resource/json/ContentVersionJson';
 import {ContentVersionPublishInfo} from './ContentVersionPublishInfo';
 import {Cloneable} from '@enonic/lib-admin-ui/Cloneable';
@@ -35,6 +37,8 @@ export class ContentVersion
 
     private readonly path: string;
 
+    private readonly actions: ContentVersionAction[];
+
     constructor(builder: ContentVersionBuilder) {
         this.modifier = builder.modifier;
         this.displayName = builder.displayName;
@@ -49,6 +53,7 @@ export class ContentVersion
         this.workflowInfo = builder.workflowInfo;
         this.permissionsChanged = !!builder.permissionsChanged;
         this.path = builder.path;
+        this.actions = builder.actions || [];
 
         if (this.publishInfo && this.publishInfo.getPublishedFrom()) {
             if (ContentVersion.equalDates(this.publishInfo.getPublishedFrom(), this.publishInfo.getTimestamp(), 500)) {
@@ -153,6 +158,10 @@ export class ContentVersion
         return this.path;
     }
 
+    getActions(): ContentVersionAction[] {
+        return this.actions.slice();
+    }
+
     newBuilder(): ContentVersionBuilder {
         return new ContentVersionBuilder(this);
     }
@@ -189,6 +198,8 @@ export class ContentVersionBuilder {
 
     permissionsChanged: boolean;
 
+    actions: ContentVersionAction[];
+
     constructor(source?: ContentVersion) {
         if (source) {
             this.modifier = source.getModifier();
@@ -221,6 +232,7 @@ export class ContentVersionBuilder {
         this.workflowInfo = Workflow.fromJson(contentVersionJson.workflow);
         this.permissionsChanged = contentVersionJson.permissionsChanged || false;
         this.path = contentVersionJson.path;
+        this.actions = contentVersionJson.actions?.map(ContentVersionAction.fromJson) ?? [];
 
         return this;
     }

--- a/modules/lib/src/main/resources/assets/js/app/ContentVersionAction.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentVersionAction.ts
@@ -1,0 +1,77 @@
+import {PrincipalKey} from '@enonic/lib-admin-ui/security/PrincipalKey';
+import {ContentVersionActionJson} from './resource/json/ContentVersionActionJson';
+
+export class ContentVersionAction {
+
+    private readonly operation: string;
+    private readonly fields: string[];
+    private readonly user: PrincipalKey;
+    private readonly opTime: Date;
+
+    constructor(builder: ContentVersionActionBuilder) {
+        this.operation = builder.operation;
+        this.fields = builder.fields;
+        this.user = builder.user;
+        this.opTime = builder.opTime;
+    }
+
+    getOperation(): string {
+        return this.operation;
+    }
+
+    getFields(): string[] {
+        return this.fields.slice();
+    }
+
+    getUser(): PrincipalKey {
+        return this.user;
+    }
+
+    getOpTime(): Date {
+        return this.opTime;
+    }
+
+    static fromJson(json: ContentVersionActionJson): ContentVersionAction {
+        return new ContentVersionActionBuilder().fromJson(json).build();
+    }
+}
+
+export class ContentVersionActionBuilder {
+    operation: string;
+    fields: string[];
+    user: PrincipalKey;
+    opTime: Date;
+
+    setOperation(operation: string): ContentVersionActionBuilder {
+        this.operation = operation;
+        return this;
+    }
+
+    setFields(fields: string[]): ContentVersionActionBuilder {
+        this.fields = fields;
+        return this;
+    }
+
+    setUser(user: PrincipalKey): ContentVersionActionBuilder {
+        this.user = user;
+        return this;
+    }
+
+    setOpTime(opTime: Date): ContentVersionActionBuilder {
+        this.opTime = opTime;
+        return this;
+    }
+
+    fromJson(json: ContentVersionActionJson): ContentVersionActionBuilder {
+        this.operation = json.operation;
+        this.fields = json.fields;
+        this.user = json.user ? PrincipalKey.fromString(json.user) : null;
+        this.opTime = json.opTime ? new Date(Date.parse(json.opTime)) : null;
+        return this;
+    }
+
+    build(): ContentVersionAction {
+        return new ContentVersionAction(this);
+    }
+}
+

--- a/modules/lib/src/main/resources/assets/js/app/resource/json/ContentVersionActionJson.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/json/ContentVersionActionJson.ts
@@ -1,0 +1,7 @@
+
+export interface ContentVersionActionJson {
+    operation: string;
+    fields: string[];
+    user: string;
+    opTime: string;
+}

--- a/modules/lib/src/main/resources/assets/js/app/resource/json/ContentVersionJson.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/json/ContentVersionJson.ts
@@ -1,7 +1,7 @@
+import {ContentVersionActionJson} from './ContentVersionActionJson';
 import {ContentVersionPublishInfoJson} from './ContentVersionPublishInfoJson';
 import {WorkflowJson} from '@enonic/lib-admin-ui/content/json/WorkflowJson';
 import {ChildOrderJson} from './ChildOrderJson';
-import {PermissionsJson} from '../../access/PermissionsJson';
 
 export interface ContentVersionJson {
 
@@ -28,4 +28,6 @@ export interface ContentVersionJson {
     permissionsChanged: boolean;
 
     path: string;
+
+    actions: ContentVersionActionJson[];
 }

--- a/modules/lib/src/main/resources/assets/js/app/view/context/ContextView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/ContextView.ts
@@ -9,6 +9,10 @@ import {AppHelper} from '@enonic/lib-admin-ui/util/AppHelper';
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {History, Link, List} from 'lucide-react';
 import Q from 'q';
+import {setActiveWidgetId} from '../../../v6/features/store/contextWidgets.store';
+import {APP_NAME} from '../../../v6/features/utils/cms/app/app';
+import {VERSIONS_WIDGET_KEY} from '../../../v6/features/utils/widget/versions/versions';
+import {VersionsWidgetElement} from '../../../v6/features/views/context/widget/versions/VersionsWidget';
 import {DetailsWidgetElement} from '../../../v6/features/views/context/widget/details';
 import {DependenciesWidgetElement} from '../../../v6/features/views/context/widget/dependencies';
 import {CompareStatus} from '../../content/CompareStatus';
@@ -24,7 +28,6 @@ import {PageNavigationHandler} from '../../wizard/PageNavigationHandler';
 import {PageNavigationMediator} from '../../wizard/PageNavigationMediator';
 import {ReloadActiveWidgetEvent} from './ReloadActiveWidgetEvent';
 import {PageEditorWidgetItemView} from './widget/pageeditor/PageEditorWidgetItemView';
-import {VersionHistoryView} from './widget/version/VersionHistoryView';
 import {InternalWidgetType, WidgetView} from './WidgetView';
 import {cn} from '@enonic/ui';
 import WidgetsSelectorElement from '../../../v6/features/views/context/widget/WidgetsSelector';
@@ -169,7 +172,7 @@ export class ContextView
     }
 
     private initWidgetsSelectionRow() {
-        this.widgetsSelectionRow = new WidgetsSelectorElement({}); 
+        this.widgetsSelectionRow = new WidgetsSelectorElement({});
         this.appendChild(this.widgetsSelectionRow);
         this.widgetsSelectionRow.updateState(this.activeWidget);
     }
@@ -279,6 +282,8 @@ export class ContextView
         this.activeWidget = widgetView;
         this.activeWidget.addClass('active');
 
+        setActiveWidgetId(this.activeWidget.getWidgetKey());
+
         this.toggleClass('default-widget', this.defaultWidgetView.isActive());
         this.toggleClass('internal', widgetView.isInternal());
 
@@ -302,6 +307,7 @@ export class ContextView
             this.activeWidget.removeClass('active');
         }
         this.activeWidget = null;
+        setActiveWidgetId(undefined);
     }
 
     activateDefaultWidget() {
@@ -357,6 +363,7 @@ export class ContextView
 
     private initCommonWidgetViews() {
         this.propertiesWidgetView = WidgetView.create()
+            .setWidget(Widget.create().setWidgetDescriptorKey(`${APP_NAME}:details`).build())
             .setName(i18n('field.contextPanel.details'))
             .setDescription(i18n('field.contextPanel.details.description'))
             .setWidgetClass('properties-widget')
@@ -390,6 +397,7 @@ export class ContextView
         this.pageEditorWidgetItemView.appendContextWindow(this.contextWindow);
 
         const pageEditorWidgetView = WidgetView.create()
+            .setWidget(Widget.create().setWidgetDescriptorKey(`${APP_NAME}:page`).build())
             .setName(i18n('field.contextPanel.pageEditor'))
             .setDescription(i18n('field.contextPanel.pageEditor.description'))
             .setWidgetClass('page-editor-widget')
@@ -410,6 +418,7 @@ export class ContextView
 
     protected createVersionsWidgetView(): WidgetView {
         return WidgetView.create()
+            .setWidget(Widget.create().setWidgetDescriptorKey(VERSIONS_WIDGET_KEY).build())
             .setName(i18n('field.contextPanel.versionHistory'))
             .setDescription(i18n('field.contextPanel.versionHistory.description'))
             .setWidgetClass('versions-widget')
@@ -417,11 +426,14 @@ export class ContextView
             .setIcon(History)
             .setType(InternalWidgetType.HISTORY)
             .setContextView(this)
-            .addWidgetItemView(new VersionHistoryView()).build();
+            .addWidgetItemView(new VersionsWidgetElement())
+            // .addWidgetItemView(new VersionHistoryView())
+            .build();
     }
 
     protected createDependenciesWidgetView(): WidgetView {
         return WidgetView.create()
+            .setWidget(Widget.create().setWidgetDescriptorKey(`${APP_NAME}:dependencies`).build())
             .setName(i18n('field.contextPanel.dependencies'))
             .setDescription(i18n('field.contextPanel.dependencies.description'))
             .setWidgetClass('dependency-widget')

--- a/modules/lib/src/main/resources/assets/js/app/view/context/WidgetView.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/WidgetView.ts
@@ -186,19 +186,19 @@ export class WidgetView
     }
 
     getWidgetKey(): string {
-        return this.widget ? this.widget.getWidgetDescriptorKey().getApplicationKey().getName() : null;
+        return this.widget ? this.widget.getWidgetDescriptorKey().toString() : null;
     }
 
     getWidgetIconUrl(): string {
-        return this.widget ? this.widget.getFullIconUrl() : null;
+        return this.widget?.getIconUrl() ? this.widget.getFullIconUrl() : null;
     }
 
     isInternal(): boolean {
-        return this.widget == null;
+        return this.widget == null || !this.widget.getUrl();
     }
 
     isExternal(): boolean {
-        return this.widget != null;
+        return !this.isInternal();
     }
 
     slideOut() {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/context/contextContent.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/context/contextContent.store.ts
@@ -1,4 +1,5 @@
 import {computed} from 'nanostores';
+import {EditContentEvent} from '../../../../app/event/EditContentEvent';
 import {$contentTreeItems} from '../contentTreeData.store';
 import {$contentTreeActiveItem, $contentTreeSelection} from '../contentTreeSelectionStore';
 
@@ -18,3 +19,11 @@ export const $contextContent = computed(
         return null;
     }
 );
+
+export const openContextContentForEdit = (): void => {
+    if (!$contextContent.get()) {
+        return;
+    }
+
+    new EditContentEvent([$contextContent.get()]).fire();
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/context/versionStore.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/context/versionStore.ts
@@ -1,0 +1,106 @@
+import {atom, computed} from 'nanostores';
+import {ContentVersion} from '../../../../app/ContentVersion';
+import {ContentOperation, VersionPublishStatus} from '../../utils/widget/versions/versions';
+
+
+export const $versions = atom<ContentVersion[]>([]);
+
+export const $versionsByDate = computed($versions, (versions) => {
+    const versionsByDate: Record<string, ContentVersion[]> = {};
+
+    versions.forEach((version) => {
+        const dateKey = version.getTimestamp().toDateString();
+
+        if (!versionsByDate[dateKey]) {
+            versionsByDate[dateKey] = [];
+        }
+
+        versionsByDate[dateKey].push(version);
+    });
+
+    return versionsByDate;
+});
+
+export const $activeVersionId = computed($versions, (versions) => {
+    return versions[0]?.getId();
+});
+
+export const $latestPublishedVersion = computed($versions, (versions) => {
+    return versions.find((version) => version.getActions().some(a => a.getOperation() === ContentOperation.PUBLISH.toString()));
+});
+
+export const $selectedVersions = atom<ReadonlySet<string>>(new Set());
+
+export const $selectionModeOn = computed($selectedVersions, (selected) => {
+    return selected.size > 0;
+})
+
+export const $expandedVersion = atom<string | undefined>(undefined)
+
+export const setExpandedVersion = (versionId: string | undefined): void => {
+    $expandedVersion.set(versionId);
+}
+
+export const setVersions = (versions: ContentVersion[]): void => {
+    $versions.set(versions);
+}
+
+export const clearVersions = (): void => {
+    $versions.set([]);
+}
+
+export const appendVersions = (versions: ContentVersion[]): void => {
+    $versions.set([...$versions.get(), ...versions]);
+}
+
+export const selectVersion = (versionId: string): void => {
+    if (!isVersionSelected(versionId)) {
+        const arr = Array.from($selectedVersions.get());
+        if (arr.length > 1) {
+            arr.shift();
+        }
+        arr.push(versionId);
+        $selectedVersions.set(new Set(arr));
+    }
+}
+
+export const deselectVersion = (versionId: string): void => {
+    if (isVersionSelected(versionId)) {
+        const newSelection = new Set($selectedVersions.get());
+        newSelection.delete(versionId);
+        $selectedVersions.set(newSelection);
+    }
+}
+
+export const isVersionSelected = (versionId: string): boolean => {
+    return $selectedVersions.get().has(versionId);
+}
+
+export const toggleVersionSelection = (versionId: string): void => {
+    if (isVersionSelected(versionId)) {
+        deselectVersion(versionId);
+    } else {
+        selectVersion(versionId);
+    }
+}
+
+export const resetVersionsSelection = (): void => {
+    $selectedVersions.set(new Set());
+}
+
+export const getVersionPublishStatus = (version: ContentVersion): VersionPublishStatus => {
+    const publishAction = version.getActions().find(action => action.getOperation() === ContentOperation.PUBLISH.toString());
+
+    if (publishAction) {
+        const hasUnpublishAction = version.getActions().find(action => action.getOperation() === ContentOperation.UNPUBLISH.toString());
+
+        if (hasUnpublishAction) {
+            return 'was_online';
+        }
+
+        const wasPublishedAgain = version.getId() !== $latestPublishedVersion.get()?.getId();
+        return wasPublishedAgain ? 'was_online' : 'online';
+    }
+
+    return 'offline';
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/contextWidgets.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/contextWidgets.store.ts
@@ -7,3 +7,9 @@ export const $isContextOpen = atom<boolean>(false);
 export function setContextOpen(isOpen: boolean): void {
     $isContextOpen.set(isOpen);
 }
+
+export const $activeWidgetId = atom<string | undefined>(undefined);
+
+export function setActiveWidgetId(widgetId: string | undefined): void {
+    $activeWidgetId.set(widgetId);
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/app/app.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/app/app.ts
@@ -1,0 +1,4 @@
+import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
+
+
+export const APP_NAME = CONFIG.get('appId');

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/widget/versions/versions.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/widget/versions/versions.ts
@@ -1,0 +1,59 @@
+import {i18n} from '@enonic/lib-admin-ui/util/Messages';
+import {ContentVersion} from '../../../../../app/ContentVersion';
+import {APP_NAME} from '../../cms/app/app';
+
+export enum ContentOperation {
+    CREATE = 'content.create',
+    DUPLICATE = 'content.duplicate',
+    IMPORT = 'content.import',
+    UPDATE = 'content.update',
+    PERMISSIONS = 'content.permissions',
+    MOVE = 'content.move',
+    SORT = 'content.sort',
+    PATCH = 'content.patch',
+    ARCHIVE = 'content.archive',
+    RESTORE = 'content.restore',
+    PUBLISH = 'content.publish',
+    UNPUBLISH = 'content.unpublish',
+}
+
+export enum ContentField {
+    displayName = 'displayName',
+    data = 'data',
+    x = 'x',
+    page = 'page',
+    owner = 'owner',
+    language = 'language',
+    publish = 'publish',
+    workflow = 'workflow',
+    variantOf = 'variantOf',
+    attachments = 'attachments',
+    name = 'name',
+    parentPath = 'parentPath',
+}
+
+export type VersionPublishStatus = 'online' | 'offline' | 'was_online';
+
+export const VERSIONS_WIDGET_KEY = `${APP_NAME}:versions`;
+
+export const getVersionUser = (version: ContentVersion): string => {
+    const key = version.getActions()[0]?.getUser();
+
+    return key?.toString() ?? version.getModifierDisplayName();
+}
+
+export const getOperationLabel = (version: ContentVersion): string => {
+    const action = version.getActions()[0]; // Working with the first action only for now
+
+    // PRE CS6 versions do not have actions, CS6 unpublished versions may not have actions
+    if (!action) {
+        return i18n('status.edited');
+    }
+
+    if (action.getOperation() === ContentOperation.CREATE.toString()) {
+        return i18n('status.created');
+    }
+
+    // Edited until 'Show all activities' mode is implemented
+    return i18n('status.edited');
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/widget/versions/versionsCache.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/widget/versions/versionsCache.ts
@@ -1,0 +1,74 @@
+import {ContentId} from '../../../../../app/content/ContentId';
+import {ContentVersion} from '../../../../../app/ContentVersion';
+
+// TODO: Implement cache invalidation strategy (Server-side events, TTL, etc.)
+
+type CachedVersionsEntry = {
+    versions: ContentVersion[];
+    totalHits: number;
+};
+
+const versionsCache = new Map<string, CachedVersionsEntry>();
+
+export type ContentVersionsLoadResult = {
+    versions: ContentVersion[];
+    hasMore: boolean;
+};
+
+export const getCachedVersions = (
+    contentId: ContentId,
+    from: number,
+    size: number,
+): ContentVersionsLoadResult | undefined => {
+    const cached = versionsCache.get(contentId.toString());
+
+    if (!cached || from >= cached.versions.length) {
+        return undefined;
+    }
+
+    const versions = cached.versions.slice(from, from + size);
+    const hasMore = (from + versions.length) < cached.totalHits;
+
+    return {
+        versions,
+        hasMore,
+    };
+};
+
+export const cacheVersions = (
+    contentId: ContentId,
+    from: number,
+    versions: ContentVersion[],
+    totalHits: number,
+): void => {
+    const cacheKey = contentId.toString();
+    const cached = versionsCache.get(cacheKey);
+
+    if (!cached) {
+        versionsCache.set(cacheKey, {
+            versions: versions.slice(),
+            totalHits,
+        });
+        return;
+    }
+
+    const mergedVersions = cached.versions.slice();
+
+    versions.forEach((version, index) => {
+        mergedVersions[from + index] = version;
+    });
+
+    versionsCache.set(cacheKey, {
+        versions: mergedVersions,
+        totalHits,
+    });
+};
+
+export const clearVersionsCache = (contentId?: ContentId): void => {
+    if (contentId) {
+        versionsCache.delete(contentId.toString());
+        return;
+    }
+
+    versionsCache.clear();
+};

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/widget/versions/versionsLoader.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/widget/versions/versionsLoader.ts
@@ -1,0 +1,31 @@
+import {ContentId} from '../../../../../app/content/ContentId';
+import {GetContentVersionsRequest} from '../../../../../app/resource/GetContentVersionsRequest';
+import {cacheVersions, getCachedVersions} from './versionsCache';
+import type {ContentVersionsLoadResult} from './versionsCache';
+
+const BATCH_SIZE = 10;
+
+export const loadContentVersions = async (contentId: ContentId, from: number = 0): Promise<ContentVersionsLoadResult> => {
+    const cached = getCachedVersions(contentId, from, BATCH_SIZE);
+
+    if (cached) {
+        return cached;
+    }
+
+    const response = await new GetContentVersionsRequest(contentId)
+        .setFrom(from)
+        .setSize(BATCH_SIZE) // 10 to display fetching process clearly
+        .sendAndParse();
+
+    const metadata = response.getMetadata();
+    const versions = response.getContentVersions();
+
+    cacheVersions(contentId, from, versions, metadata.totalHits);
+
+    return {
+        versions,
+        hasMore: (from + metadata.hits) < metadata.totalHits,
+    };
+};
+
+export type {ContentVersionsLoadResult} from './versionsCache';

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionSelectionToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionSelectionToolbar.tsx
@@ -1,0 +1,24 @@
+import {Button} from '@enonic/ui';
+import {useStore} from '@nanostores/preact';
+import {useCallback} from 'react';
+import {useI18n} from '../../../../hooks/useI18n';
+import {$selectedVersions, resetVersionsSelection} from '../../../../store/context/versionStore';
+
+const COMPONENT_NAME = 'VersionSelectionToolbar';
+
+export const VersionSelectionToolbar = (): React.ReactElement => {
+    const selection = useStore($selectedVersions);
+    const showChangesButtonLabel = useI18n('text.versions.showChanges');
+    const cancelButtonLabel = useI18n('action.cancel');
+
+    const cancelHandler = useCallback(() => {
+        resetVersionsSelection();
+    }, []);
+
+    return (
+        <div className='flex justify-center items-center gap-2.5 sticky top-0 bg-surface-neutral/85 py-3 z-1' data-component={COMPONENT_NAME}>
+            <Button label={showChangesButtonLabel} variant='filled' disabled={selection.size !== 2} />
+            <Button label={cancelButtonLabel} variant='outline' onClick={cancelHandler} />
+        </div>
+    )
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionsList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionsList.tsx
@@ -1,0 +1,132 @@
+import {useStore} from '@nanostores/preact';
+import {ReactElement, useCallback, useEffect, useRef, useState} from 'react';
+import {useI18n} from '../../../../hooks/useI18n';
+import {$contextContent} from '../../../../store/context/contextContent.store';
+import {
+    $selectedVersions,
+    $versionsByDate,
+    appendVersions,
+    resetVersionsSelection,
+    setExpandedVersion,
+    setVersions
+} from '../../../../store/context/versionStore';
+import {loadContentVersions} from '../../../../utils/widget/versions/versionsLoader';
+import {VersionsListItem} from './VersionsListItem';
+import {VersionSelectionToolbar} from './VersionSelectionToolbar';
+
+const COMPONENT_NAME = 'VersionsList';
+
+export const VersionsList = (): ReactElement => {
+    const versionsByDate = useStore($versionsByDate);
+    const selection = useStore($selectedVersions);
+    const content = useStore($contextContent);
+
+    const loadingLabel = useI18n('widget.versions.loading');
+
+    const [moreToLoad, setMoreToLoad] = useState(true);
+    const [offset, setOffset] = useState(0);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+    const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+    // Initial load when content changes
+    useEffect(() => {
+        if (!content) {
+            setVersions([]);
+            resetVersionsSelection();
+            setMoreToLoad(false);
+            setOffset(0);
+            setExpandedVersion(undefined);
+            return;
+        }
+
+        loadContentVersions(content.getContentId(), 0)
+            .then((result) => {
+                setVersions(result.versions);
+                resetVersionsSelection();
+                setMoreToLoad(result.hasMore);
+                setOffset(result.versions.length);
+                setExpandedVersion(undefined);
+            })
+            .catch(() => {
+                // TODO: handle error
+            });
+
+    }, [content]);
+
+    const loadMore = useCallback(async () => {
+        if (!content || !moreToLoad || isLoadingMore) return;
+
+        setIsLoadingMore(true);
+
+        try {
+            const result = await loadContentVersions(content.getContentId(), offset);
+            appendVersions(result.versions);
+            setMoreToLoad(result.hasMore);
+            setOffset((x) => x + result.versions.length);
+        } catch (err) {
+            // TODO: handle error
+        } finally {
+            setIsLoadingMore(false);
+        }
+    }, [content, offset, moreToLoad, isLoadingMore]);
+
+    useEffect(() => {
+        if (!moreToLoad || isLoadingMore) return;
+
+        const node = loadMoreRef.current;
+        if (!node) return;
+
+        const observer = new IntersectionObserver((entries) => {
+            if (entries[0].isIntersecting) {
+                loadMore();
+            }
+        }, {
+            root: null,
+            rootMargin: '200px',
+            threshold: 0.1
+        });
+
+        observer.observe(node);
+
+        return () => {
+            observer.disconnect();
+        };
+    }, [moreToLoad, isLoadingMore, loadMore]);
+
+    if (Object.keys(versionsByDate).length === 0) {
+        return (
+            <div className='text-center text-subtle'>
+                {useI18n('widget.versions.noVersions')}
+            </div>
+        );
+    }
+
+    return (
+        <div className='flex flex-col gap-7.5' data-component={COMPONENT_NAME}>
+            {selection.size > 0 && <VersionSelectionToolbar />}
+
+            {Object.entries(versionsByDate).map(([date, versions]) => (
+                <div key={date} className='flex flex-col gap-3 w-full'>
+                    <div className='text-base font-semibold'>{date}</div>
+
+                    <div className='flex flex-col gap-1.25'>
+                        {versions.map((version) => (
+                            <VersionsListItem key={version.getId()} version={version} />
+                        ))}
+                    </div>
+                </div>
+            ))}
+
+            {isLoadingMore && (
+                <div className='flex items-center justify-center text-sm text-grey-600'>
+                    {loadingLabel}
+                </div>
+            )}
+
+            {moreToLoad && !isLoadingMore && (
+                <div ref={loadMoreRef} className='h-10 w-full opacity-0' />
+            )}
+        </div>
+    );
+};

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionsListItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionsListItem.tsx
@@ -1,0 +1,118 @@
+import {DateHelper} from '@enonic/lib-admin-ui/util/DateHelper';
+import {Button, Checkbox, cn, IconButton} from '@enonic/ui';
+import {useStore} from '@nanostores/preact';
+import {PenLine, X} from 'lucide-react';
+import {TargetedMouseEvent} from 'preact';
+import {ComponentPropsWithoutRef} from 'preact/compat';
+import {useCallback, useMemo, useRef} from 'react';
+import {ContentVersion} from '../../../../../../app/ContentVersion';
+import {useI18n} from '../../../../hooks/useI18n';
+import {openContextContentForEdit} from '../../../../store/context/contextContent.store';
+import {
+    $activeVersionId,
+    $expandedVersion,
+    $selectedVersions,
+    $selectionModeOn,
+    isVersionSelected, setExpandedVersion,
+    toggleVersionSelection
+} from '../../../../store/context/versionStore';
+import {getOperationLabel, getVersionUser} from '../../../../utils/widget/versions/versions';
+import {VersionsListItemPublishStatus} from './VersionsListItemPublishStatus';
+
+export type VersionItemProps = {
+    version: ContentVersion;
+} & ComponentPropsWithoutRef<'div'>;
+
+export const COMPONENT_NAME = 'VersionsListItem';
+
+export const VersionsListItem = ({version, className, ...props}: VersionItemProps): React.ReactElement => {
+    const expanded = useStore($expandedVersion);
+    const selectedVersions = useStore($selectedVersions);
+    const isSelectionModeOn = useStore($selectionModeOn);
+    const activeVersionId = useStore($activeVersionId);
+
+    const checkBoxDivRef = useRef<HTMLDivElement>(null);
+
+    const isSelected = useMemo(() => {
+        return isVersionSelected(version.getId());
+    }, [version, selectedVersions]);
+    const toggleSelection = useCallback(() => {
+        toggleVersionSelection(version.getId());
+    }, [version]);
+    const isExpanded = useMemo(() => {
+        return expanded === version.getId();
+    }, [version, expanded]);
+    const toggleExpand = useCallback((e: TargetedMouseEvent<HTMLDivElement>) => {
+        if (e.target instanceof Node && checkBoxDivRef?.current?.contains(e.target)) { // Workaround until UI Checkbox is fixed
+            return;
+        }
+
+        setExpandedVersion(isExpanded ? undefined : version.getId());
+    }, [version, isExpanded]);
+    const handleRestoreClick = useCallback((e: TargetedMouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        // restoreVersion(version.getId());
+    }, [version]);
+
+    return (
+        <div key={version.getId()}
+             data-component={COMPONENT_NAME}
+             className={cn(
+                 'p-2.5 flex flex-col gap-5 hover:bg-surface-neutral-hover cursor-pointer',
+                 isExpanded && 'shadow-sm shadow-btn-tertiary-hover',
+                 className)}
+             onClick={toggleExpand}
+             {...props}>
+            <div className='w-full flex gap-2'>
+                <div className='flex flex-col justify-start grow'>
+                    <div className='flex gap-1'>
+                                                <span className='shrink-0 text-sm'>{DateHelper.getFormattedTimeFromDate(
+                                                    version.getTimestamp())}</span>
+                        <span className='text-bdr-soft text-sm'>|</span>
+                        <span className='text-sm'>{getOperationLabel(version)}</span>
+                    </div>
+                    <div className='text-xs'>{useI18n('field.version.by', getVersionUser(version))}</div>
+                </div>
+                <VersionsListItemPublishStatus version={version} />
+                {
+                    activeVersionId === version.getId() && (
+                                        <IconButton icon={PenLine} size={'sm'} onClick={openContextContentForEdit} className='shrink-0 w-4 bg-transparent'/>
+                                    )
+                }
+                {
+                    isSelectionModeOn && !isExpanded && (
+                                          <div ref={checkBoxDivRef} className='flex items-center'>
+                                              <Checkbox
+                                                  checked={isSelected}
+                                                  onCheckedChange={toggleSelection}
+                                              />
+                                          </div>
+                                      )
+                }
+
+            </div>
+            {
+                isExpanded && (
+                               <div className='w-full flex flex-col gap-5'>
+                                   <div className='flex'>
+                                       <Button
+                                           label={useI18n('field.version.revert')}
+                                           size='sm'
+                                           variant='solid'
+                                           onClick={handleRestoreClick}
+                                       />
+                                       <div ref={checkBoxDivRef} className={'flex grow items-center justify-end'}>
+                                           <Checkbox
+                                               className='text-sm'
+                                               label={useI18n('field.version.compare')}
+                                               checked={isSelected}
+                                               onCheckedChange={toggleSelection}
+                                               align='right'/>
+                                       </div>
+
+                                   </div>
+                               </div>
+                           )}
+        </div>
+    );
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionsListItemPublishStatus.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionsListItemPublishStatus.tsx
@@ -1,0 +1,30 @@
+import {IconButton} from '@enonic/ui';
+import {Globe, PenLine} from 'lucide-react';
+import {useMemo} from 'react';
+import {ContentVersion} from '../../../../../../app/ContentVersion';
+import {useI18n} from '../../../../hooks/useI18n';
+import {getVersionPublishStatus} from '../../../../store/context/versionStore';
+
+export type VersionsListItemPublishStatusProps = {
+    version: ContentVersion;
+}
+
+export const VersionsListItemPublishStatus = ({version}: VersionsListItemPublishStatusProps): React.ReactElement => {
+    const publishStatus = useMemo(() => getVersionPublishStatus(version), [version]);
+
+    if (publishStatus === 'online') {
+        return (
+            <div className='text-sm flex items-center text-success'>
+                {useI18n('status.online')}
+            </div>
+        );
+    }
+
+    if (publishStatus === 'was_online') {
+        return (
+            <IconButton icon={Globe} size={'sm'} className='shrink-0 w-4 bg-transparent'/>
+        );
+    }
+
+    return null;
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionsWidget.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionsWidget.tsx
@@ -1,0 +1,53 @@
+import {useStore} from '@nanostores/preact';
+import Q from 'q';
+import {ReactElement, useMemo} from 'react';
+import {ContentSummaryAndCompareStatus} from '../../../../../../app/content/ContentSummaryAndCompareStatus';
+import {WidgetItemViewInterface} from '../../../../../../app/view/context/WidgetItemView';
+import {LegacyElement} from '../../../../shared/LegacyElement';
+import {$activeWidgetId, $isContextOpen} from '../../../../store/contextWidgets.store';
+import {VERSIONS_WIDGET_KEY} from '../../../../utils/widget/versions/versions';
+import {VersionsList} from './VersionsList';
+
+
+const VERSIONS_WIDGET_NAME = 'VersionsWidget';
+
+export const VersionsWidget = (): ReactElement => {
+    const isContextOpen = useStore($isContextOpen);
+    const activeWidget = useStore($activeWidgetId);
+    const isActiveWidget = useMemo(() => activeWidget === VERSIONS_WIDGET_KEY, [activeWidget]);
+
+    return (isContextOpen && isActiveWidget &&
+        <div data-component={VERSIONS_WIDGET_NAME} className='flex flex-col gap-7.5 overflow-y-visible'>
+            <VersionsList />
+        </div>
+    )
+}
+
+
+export class VersionsWidgetElement
+    extends LegacyElement<typeof VersionsWidget>
+    implements WidgetItemViewInterface {
+    constructor() {
+        super({}, VersionsWidget);
+    }
+
+    public layout(): Q.Promise<void> {
+        return Q();
+    }
+
+    public setContentAndUpdateView(item: ContentSummaryAndCompareStatus): Q.Promise<null | void> {
+        return Q();
+    }
+
+    public fetchWidgetContents(url: string, contentId: string): Q.Promise<void> {
+        return Q();
+    }
+
+    public hide(): void {
+        return;
+    }
+
+    public show(): void {
+        return;
+    }
+}

--- a/modules/lib/src/main/resources/i18n/phrases.properties
+++ b/modules/lib/src/main/resources/i18n/phrases.properties
@@ -232,6 +232,7 @@ field.version.id=Version Id
 field.version.current=This version is current
 field.version.revert=Restore
 field.version.compare=Compare
+field.version.by=By {0}
 field.version.makeCurrent=Create a new version from this one
 field.menu=Menu
 field.settings=Settings
@@ -415,6 +416,8 @@ widget.archive.description=Archived content items
 widget.publishReport.displayName=Publishing report
 widget.publishReport.description=Compare published versions
 widget.versions.compare=Compare versions
+widget.versions.loading=Loading...
+widget.versions.noVersions=No versions to display
 #
 # Live view widgets
 #


### PR DESCRIPTION
- Basic styling according to Figma design
- Lazy load
- Basic versions statuses handling (no complicated statuses calculations)
- Caching versions
- Internal widgets (details/versions/dependencies) updated to have an actual widget object with ID, not only WidgetView object
- Added active widget id into the context for versions to react accordingly