### PR TITLE
Enonic UI: Edit settings #9614

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/EditPropertiesDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/EditPropertiesDialog.tsx
@@ -1,0 +1,132 @@
+import {Button, Dialog} from '@enonic/ui';
+import {useStore} from '@nanostores/preact';
+import {type ReactElement} from 'react';
+import {useI18n} from '../../hooks/useI18n';
+import {LanguageSelector} from '../selectors/LanguageSelector';
+import {OwnerSelector} from '../selectors/OwnerSelector';
+import {
+    $editPropertiesDialog,
+    $editPropertiesDialogOwnerOptions,
+    applyEditPropertiesDialog,
+    closeEditPropertiesDialog,
+    searchEditPropertiesOwners,
+    setEditPropertiesDialogLanguageSelection,
+    setEditPropertiesDialogOwnerSelection,
+} from '../../store/dialogs/editPropertiesDialog.store';
+
+const EDIT_PROPERTIES_DIALOG_NAME = 'EditPropertiesDialog';
+
+export const EditPropertiesDialog = (): ReactElement => {
+    const {
+        open,
+        content,
+        languageSelection,
+        ownerSelection,
+        localeOptions,
+        saving,
+    } = useStore($editPropertiesDialog, {
+        keys: [
+            'open',
+            'content',
+            'languageSelection',
+            'ownerSelection',
+            'localeOptions',
+            'saving',
+        ],
+    });
+    const ownerOptionsWithSelection = useStore($editPropertiesDialogOwnerOptions);
+
+    const title = useI18n('widget.properties.edit.settings.text');
+    const applyLabel = useI18n('action.apply');
+    const cancelLabel = useI18n('action.cancel');
+    const languageLabel = useI18n('field.lang');
+    const ownerLabel = useI18n('field.owner');
+    const searchPlaceholder = useI18n('field.search.placeholder');
+
+    const contentSummary = content?.getContentSummary();
+    const path = contentSummary?.getPath()?.toString();
+
+    const handleOpenChange = (next: boolean): void => {
+        if (!next && saving) {
+            return;
+        }
+        if (!next) {
+            closeEditPropertiesDialog();
+        }
+    };
+
+    const handleCancel = (): void => {
+        if (!saving) {
+            closeEditPropertiesDialog();
+        }
+    };
+
+    const handleApply = (): void => {
+        void applyEditPropertiesDialog();
+    };
+
+    const initialLanguage = contentSummary?.getLanguage() ?? '';
+    const initialOwner = contentSummary?.getOwner()?.toString() ?? '';
+    const selectedLanguage = languageSelection[0] ?? '';
+    const selectedOwner = ownerSelection[0] ?? '';
+    const hasChanges = !!contentSummary && (selectedLanguage !== initialLanguage || selectedOwner !== initialOwner);
+    const canApply = hasChanges && !saving;
+
+    return (
+        <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+            <Dialog.Portal>
+                <Dialog.Overlay/>
+                <Dialog.Content
+                    className='overflow-visible sm:h-fit md:min-w-184 md:max-w-180 md:max-h-[85vh] lg:max-w-220 gap-7.5'
+                    data-component={EDIT_PROPERTIES_DIALOG_NAME}
+                >
+                    <Dialog.DefaultHeader
+                        title={title}
+                        description={path}
+                    />
+                    <Dialog.Body className='flex flex-col gap-7.5 overflow-visible'>
+                        <LanguageSelector
+                            label={languageLabel}
+                            options={localeOptions}
+                            selection={languageSelection}
+                            onSelectionChange={setEditPropertiesDialogLanguageSelection}
+                            placeholder={searchPlaceholder}
+                            searchPlaceholder={searchPlaceholder}
+                            disabled={saving}
+                        />
+                        <OwnerSelector
+                            label={ownerLabel}
+                            options={ownerOptionsWithSelection}
+                            selection={ownerSelection}
+                            onSelectionChange={setEditPropertiesDialogOwnerSelection}
+                            placeholder={searchPlaceholder}
+                            searchPlaceholder={searchPlaceholder}
+                            disabled={saving}
+                            onSearchChange={(value) => {
+                                void searchEditPropertiesOwners(value);
+                            }}
+                        />
+                    </Dialog.Body>
+                    <Dialog.Footer className='justify-between'>
+                        <Button
+                            variant='outline'
+                            size='lg'
+                            label={cancelLabel}
+                            onClick={handleCancel}
+                            disabled={saving}
+                        />
+                        <Button
+                            variant='solid'
+                            size='lg'
+                            label={applyLabel}
+                            onClick={handleApply}
+                            disabled={!canApply}
+                        />
+                    </Dialog.Footer>
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+};
+
+EditPropertiesDialog.displayName = EDIT_PROPERTIES_DIALOG_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/LanguageSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/LanguageSelector.tsx
@@ -1,0 +1,145 @@
+import {Combobox, Listbox, cn} from '@enonic/ui';
+import {useEffect, useMemo, useState, type ReactElement} from 'react';
+import {buildKey} from '../../utils/format/keys';
+
+export type LanguageSelectorOption = {
+    id: string;
+    label: string;
+    disabled?: boolean;
+};
+
+export type LanguageSelectorProps = {
+    label: string;
+    options: LanguageSelectorOption[];
+    selection: readonly string[];
+    onSelectionChange: (selection: readonly string[]) => void;
+    disabled?: boolean;
+    placeholder?: string;
+    searchPlaceholder?: string;
+    emptyLabel?: string;
+    className?: string;
+};
+
+const LANGUAGE_SELECTOR_NAME = 'LanguageSelector';
+
+const toOptionKey = (value: string): string => buildKey(value);
+
+const matchesQuery = (option: LanguageSelectorOption, normalizedQuery: string): boolean => {
+    if (!normalizedQuery) {
+        return true;
+    }
+
+    return option.label.toLowerCase().includes(normalizedQuery);
+};
+
+export const LanguageSelector = ({
+    label,
+    options,
+    selection,
+    onSelectionChange,
+    disabled = false,
+    placeholder,
+    searchPlaceholder,
+    emptyLabel,
+    className,
+}: LanguageSelectorProps): ReactElement => {
+    const [open, setOpen] = useState(false);
+    const [inputValue, setInputValue] = useState('');
+
+    const selectedIds = selection ?? [];
+    const safeSelection = useMemo(() => selectedIds.map(toOptionKey), [selectedIds]);
+
+    const optionMap = useMemo(() => new Map(options.map(option => [option.id, option])), [options]);
+    const optionKeyMap = useMemo(() => {
+        return new Map(options.map(option => [toOptionKey(option.id), option.id]));
+    }, [options]);
+    const selectionDisplay = useMemo(() => {
+        const selectedId = selectedIds[0];
+        return selectedId ? optionMap.get(selectedId)?.label ?? selectedId : '';
+    }, [selectedIds, optionMap]);
+
+    useEffect(() => {
+        if (!open) {
+            setInputValue(selectionDisplay);
+        }
+    }, [open, selectionDisplay]);
+
+    const visibleOptions = useMemo(() => {
+        if (!open) {
+            return options;
+        }
+
+        const normalizedQuery = inputValue.trim().toLowerCase();
+        return options.filter(option => matchesQuery(option, normalizedQuery));
+    }, [open, options, inputValue]);
+
+    const handleOpenChange = (next: boolean): void => {
+        setOpen(next);
+        if (next && !open) {
+            setInputValue('');
+        }
+    };
+
+    const handleSelectionChange = (next: readonly string[]): void => {
+        const decodedSelection = next.map((value) => optionKeyMap.get(value) ?? value);
+        const selectedIds = decodedSelection.slice(0, 1);
+        const selectedId = selectedIds[0];
+        const nextDisplay = selectedId ? optionMap.get(selectedId)?.label ?? selectedId : '';
+
+        setInputValue(nextDisplay);
+        onSelectionChange(selectedIds);
+    };
+
+    return (
+        <div
+            data-component={LANGUAGE_SELECTOR_NAME}
+            className={cn('flex flex-col gap-2.5', className)}>
+            <span className='text-md font-semibold text-subtle'>{label}</span>
+            <Combobox.Root
+                open={open}
+                onOpenChange={handleOpenChange}
+                value={inputValue}
+                onChange={setInputValue}
+                selectionMode='single'
+                selection={safeSelection}
+                onSelectionChange={handleSelectionChange}
+                disabled={disabled}
+            >
+                <Combobox.Content className='relative'>
+                    <Combobox.Control>
+                        <Combobox.Search>
+                            <Combobox.SearchIcon />
+                            <Combobox.Input
+                                placeholder={searchPlaceholder ?? placeholder}
+                                aria-label={label}
+                            />
+                            <Combobox.Toggle />
+                        </Combobox.Search>
+                    </Combobox.Control>
+
+                    <Combobox.Popup>
+                        <Listbox.Content className='max-h-64 rounded-sm' label={label}>
+                            {visibleOptions.length === 0 && emptyLabel ? (
+                                <div className='px-4.5 py-2 text-sm text-subtle'>{emptyLabel}</div>
+                            ) : (
+                                visibleOptions.map(option => (
+                                    <Listbox.Item
+                                        key={option.id}
+                                        value={toOptionKey(option.id)}
+                                        disabled={option.disabled}
+                                    >
+                                        <span className='text-sm font-medium group-data-[tone=inverse]:text-alt'>
+                                            {option.label}
+                                        </span>
+                                    </Listbox.Item>
+                                ))
+                            )}
+                        </Listbox.Content>
+                    </Combobox.Popup>
+                </Combobox.Content>
+            </Combobox.Root>
+        </div>
+    );
+};
+
+LanguageSelector.displayName = LANGUAGE_SELECTOR_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/OwnerSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/OwnerSelector.tsx
@@ -1,0 +1,206 @@
+import {Combobox, Listbox, cn, Avatar} from '@enonic/ui';
+import {useEffect, useMemo, useState, type ReactElement} from 'react';
+import {createDebounce} from '../../utils/timing/createDebounce';
+import {buildKey} from '../../utils/format/keys';
+import {getInitials} from '../../utils/format/initials';
+
+export type OwnerSelectorOption = {
+    id: string;
+    label: string;
+    description?: string;
+    disabled?: boolean;
+};
+
+export type OwnerSelectorProps = {
+    label: string;
+    options: OwnerSelectorOption[];
+    selection: readonly string[];
+    onSelectionChange: (selection: readonly string[]) => void;
+    disabled?: boolean;
+    placeholder?: string;
+    searchPlaceholder?: string;
+    emptyLabel?: string;
+    filterOptions?: boolean;
+    onSearchChange?: (value: string) => void;
+    debounceMs?: number;
+    className?: string;
+};
+
+const OWNER_SELECTOR_NAME = 'OwnerSelector';
+
+const DEFAULT_DEBOUNCE_MS = 200;
+const NO_ACTIVE_OPTION = '__no-active__';
+
+const toOptionKey = (value: string): string => buildKey(value);
+
+const matchesQuery = (option: OwnerSelectorOption, normalizedQuery: string): boolean => {
+    if (!normalizedQuery) {
+        return true;
+    }
+
+    return option.label.toLowerCase().includes(normalizedQuery) ||
+           option.description?.toLowerCase().includes(normalizedQuery) === true;
+};
+
+export const OwnerSelector = ({
+    label,
+    options,
+    selection,
+    onSelectionChange,
+    disabled = false,
+    placeholder,
+    searchPlaceholder,
+    emptyLabel,
+    filterOptions,
+    onSearchChange,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    className,
+}: OwnerSelectorProps): ReactElement => {
+    const [open, setOpen] = useState(false);
+    const [inputValue, setInputValue] = useState('');
+    const [activeItem, setActiveItem] = useState<string>(NO_ACTIVE_OPTION);
+
+    const selectedIds = selection ?? [];
+    const safeSelection = useMemo(() => selectedIds.map(toOptionKey), [selectedIds]);
+
+    const optionMap = useMemo(() => new Map(options.map(option => [option.id, option])), [options]);
+    const optionKeyMap = useMemo(() => {
+        return new Map(options.map(option => [toOptionKey(option.id), option.id]));
+    }, [options]);
+    const selectionDisplay = useMemo(() => {
+        const selectedId = selectedIds[0];
+        return selectedId ? optionMap.get(selectedId)?.label ?? selectedId : '';
+    }, [selectedIds, optionMap]);
+
+    useEffect(() => {
+        if (!open) {
+            setInputValue(selectionDisplay);
+        }
+    }, [open, selectionDisplay]);
+
+    const shouldFilter = filterOptions ?? !onSearchChange;
+
+    const visibleOptions = useMemo(() => {
+        if (!open || !shouldFilter) {
+            return options;
+        }
+
+        const normalizedQuery = inputValue.trim().toLowerCase();
+        return options.filter(option => matchesQuery(option, normalizedQuery));
+    }, [open, shouldFilter, options, inputValue]);
+
+    const debouncedSearch = useMemo(() => {
+        if (!onSearchChange) {
+            return undefined;
+        }
+
+        return createDebounce(onSearchChange, debounceMs);
+    }, [onSearchChange, debounceMs]);
+
+    useEffect(() => {
+        if (!open || !onSearchChange) {
+            return;
+        }
+
+        if (debouncedSearch) {
+            debouncedSearch(inputValue);
+            return;
+        }
+
+        onSearchChange(inputValue);
+    }, [open, onSearchChange, debouncedSearch, inputValue]);
+
+    useEffect(() => {
+        if (open) {
+            return;
+        }
+        debouncedSearch?.cancel?.();
+    }, [open, debouncedSearch]);
+
+    const handleOpenChange = (next: boolean): void => {
+        setOpen(next);
+        if (next && !open) {
+            setInputValue('');
+            setActiveItem(NO_ACTIVE_OPTION);
+        }
+    };
+
+    const handleActiveChange = (next: string | null): void => {
+        setActiveItem(next ?? NO_ACTIVE_OPTION);
+    };
+
+    const handleSelectionChange = (next: readonly string[]): void => {
+        const decodedSelection = next.map((value) => optionKeyMap.get(value) ?? value);
+        const selectedIds = decodedSelection.slice(0, 1);
+        const selectedId = selectedIds[0];
+        const nextDisplay = selectedId ? optionMap.get(selectedId)?.label ?? selectedId : '';
+
+        setInputValue(nextDisplay);
+        onSelectionChange(selectedIds);
+    };
+
+    return (
+        <div
+            data-component={OWNER_SELECTOR_NAME}
+            className={cn('flex flex-col gap-2.5', className)}>
+            <span className='text-md font-semibold text-subtle'>{label}</span>
+            <Combobox.Root
+                open={open}
+                onOpenChange={handleOpenChange}
+                value={inputValue}
+                onChange={setInputValue}
+                active={activeItem}
+                setActive={handleActiveChange}
+                selectionMode='single'
+                selection={safeSelection}
+                onSelectionChange={handleSelectionChange}
+                disabled={disabled}
+            >
+                <Combobox.Content className='relative'>
+                    <Combobox.Control>
+                        <Combobox.Search>
+                            <Combobox.SearchIcon />
+                            <Combobox.Input
+                                placeholder={searchPlaceholder ?? placeholder}
+                                aria-label={label}
+                            />
+                            <Combobox.Toggle />
+                        </Combobox.Search>
+                    </Combobox.Control>
+
+                    <Combobox.Popup>
+                        <Listbox.Content className='max-h-64 overflow-y-auto rounded-sm' label={label}>
+                            {visibleOptions.length === 0 && emptyLabel ? (
+                                <div className='px-4.5 py-2 text-sm text-subtle'>{emptyLabel}</div>
+                            ) : (
+                                visibleOptions.map(option => (
+                                    <Listbox.Item
+                                        key={option.id}
+                                        value={toOptionKey(option.id)}
+                                        disabled={option.disabled}
+                                    >
+                                        <Avatar size='md' className='mr-2.5'>
+                                            <Avatar.Fallback>{getInitials(option.label)}</Avatar.Fallback>
+                                        </Avatar>
+                                        <div className='flex w-full flex-col gap-0.5'>
+                                            <span className='text-sm font-medium group-data-[tone=inverse]:text-alt'>
+                                                {option.label}
+                                            </span>
+                                            {option.description && (
+                                                <span className='text-xs text-subtle group-data-[tone=inverse]:text-alt'>
+                                                    {option.description}
+                                                </span>
+                                            )}
+                                        </div>
+                                    </Listbox.Item>
+                                ))
+                            )}
+                        </Listbox.Content>
+                    </Combobox.Popup>
+                </Combobox.Content>
+            </Combobox.Root>
+        </div>
+    );
+};
+
+OwnerSelector.displayName = OWNER_SELECTOR_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/editPropertiesDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/editPropertiesDialog.store.ts
@@ -1,0 +1,246 @@
+import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
+import {showFeedback} from '@enonic/lib-admin-ui/notify/MessageBus';
+import type {Principal} from '@enonic/lib-admin-ui/security/Principal';
+import {PrincipalKey} from '@enonic/lib-admin-ui/security/PrincipalKey';
+import {PrincipalType} from '@enonic/lib-admin-ui/security/PrincipalType';
+import {i18n} from '@enonic/lib-admin-ui/util/Messages';
+import {computed, map} from 'nanostores';
+import type {ContentSummaryAndCompareStatus} from '../../../../app/content/ContentSummaryAndCompareStatus';
+import {ContentLanguageUpdatedEvent} from '../../../../app/event/ContentLanguageUpdatedEvent';
+import {LocaleViewer} from '../../../../app/locale/LocaleViewer';
+import {GetContentByIdRequest} from '../../../../app/resource/GetContentByIdRequest';
+import {GetLocalesRequest} from '../../../../app/resource/GetLocalesRequest';
+import {UpdateContentMetadataRequest} from '../../../../app/resource/UpdateContentMetadataRequest';
+import {CSPrincipalLoader} from '../../../../app/security/CSPrincipalLoader';
+import {GetPrincipalsByKeysRequest} from '../../../../app/security/GetPrincipalsByKeysRequest';
+import type {LanguageSelectorOption} from '../../shared/selectors/LanguageSelector';
+import type {OwnerSelectorOption} from '../../shared/selectors/OwnerSelector';
+
+//
+// * Store state
+//
+
+type EditPropertiesDialogStore = {
+    open: boolean;
+    content?: ContentSummaryAndCompareStatus;
+    localeOptions: LanguageSelectorOption[];
+    ownerOptions: OwnerSelectorOption[];
+    selectedOwnerOption?: OwnerSelectorOption;
+    languageSelection: readonly string[];
+    ownerSelection: readonly string[];
+    saving: boolean;
+};
+
+const initialState: EditPropertiesDialogStore = {
+    open: false,
+    content: undefined,
+    localeOptions: [],
+    ownerOptions: [],
+    selectedOwnerOption: undefined,
+    languageSelection: [],
+    ownerSelection: [],
+    saving: false,
+};
+
+export const $editPropertiesDialog = map<EditPropertiesDialogStore>(structuredClone(initialState));
+
+//
+// * Derived state
+//
+
+export const $editPropertiesDialogOwnerOptions = computed(
+    $editPropertiesDialog,
+    ({ownerOptions, selectedOwnerOption}) => {
+        if (!selectedOwnerOption) {
+            return ownerOptions;
+        }
+
+        const hasSelected = ownerOptions.some(option => option.id === selectedOwnerOption.id);
+        return hasSelected ? ownerOptions : [selectedOwnerOption, ...ownerOptions];
+    },
+);
+
+//
+// * Internal state
+//
+
+const principalLoader = new CSPrincipalLoader();
+principalLoader.setAllowedTypes([PrincipalType.USER]);
+
+let ownerSearchToken = 0;
+let instanceId = 0;
+
+//
+// * Helpers
+//
+
+const toOwnerOption = (principal: Principal): OwnerSelectorOption => ({
+    id: principal.getKey().toString(),
+    label: principal.getDisplayName(),
+    description: principal.getKey().toPath(),
+});
+
+const resetEditPropertiesDialog = (): void => {
+    instanceId += 1;
+    ownerSearchToken += 1;
+    $editPropertiesDialog.set(structuredClone(initialState));
+};
+
+//
+// * Public API
+//
+
+export const openEditPropertiesDialog = (content: ContentSummaryAndCompareStatus): void => {
+    const contentSummary = content?.getContentSummary();
+    if (!contentSummary) {
+        return;
+    }
+
+    instanceId += 1;
+    ownerSearchToken += 1;
+
+    const language = contentSummary.getLanguage();
+    const ownerKey = contentSummary.getOwner()?.toString();
+
+    $editPropertiesDialog.set({
+        ...structuredClone(initialState),
+        open: true,
+        content,
+        languageSelection: language ? [language] : [],
+        ownerSelection: ownerKey ? [ownerKey] : [],
+    });
+
+    void loadEditPropertiesLocales(instanceId);
+    void loadEditPropertiesOwnerOption(contentSummary.getOwner(), instanceId);
+};
+
+export const closeEditPropertiesDialog = (): void => {
+    const {saving} = $editPropertiesDialog.get();
+    if (saving) {
+        return;
+    }
+    resetEditPropertiesDialog();
+};
+
+export const setEditPropertiesDialogLanguageSelection = (selection: readonly string[]): void => {
+    $editPropertiesDialog.setKey('languageSelection', selection);
+};
+
+export const setEditPropertiesDialogOwnerSelection = (selection: readonly string[]): void => {
+    const state = $editPropertiesDialog.get();
+    const nextId = selection[0];
+
+    let selectedOwnerOption = state.selectedOwnerOption;
+    if (!nextId) {
+        selectedOwnerOption = undefined;
+    } else if (selectedOwnerOption?.id !== nextId) {
+        selectedOwnerOption = state.ownerOptions.find(option => option.id === nextId);
+    }
+
+    $editPropertiesDialog.set({
+        ...state,
+        ownerSelection: selection,
+        selectedOwnerOption,
+    });
+};
+
+export const searchEditPropertiesOwners = async (value: string): Promise<void> => {
+    const requestId = ownerSearchToken + 1;
+    ownerSearchToken = requestId;
+    try {
+        const principals = await principalLoader.search(value);
+        if (ownerSearchToken !== requestId) {
+            return;
+        }
+        $editPropertiesDialog.setKey('ownerOptions', principals.map(toOwnerOption));
+    } catch (error) {
+        console.error(error);
+    }
+};
+
+export const applyEditPropertiesDialog = async (): Promise<void> => {
+    const state = $editPropertiesDialog.get();
+    const contentSummary = state.content?.getContentSummary();
+
+    if (!contentSummary || state.saving) {
+        return;
+    }
+
+    $editPropertiesDialog.setKey('saving', true);
+
+    try {
+        const contentItem = await new GetContentByIdRequest(contentSummary.getContentId()).sendAndParse();
+        const request = UpdateContentMetadataRequest.create(contentItem);
+
+        if (state.languageSelection[0]) {
+            request.setLanguage(state.languageSelection[0]);
+        }
+        if (state.ownerSelection[0]) {
+            request.setOwner(PrincipalKey.fromString(state.ownerSelection[0]));
+        } else {
+            request.setOwner(undefined);
+        }
+
+        const updatedContent = await request.sendAndParse();
+        showFeedback(i18n('notify.properties.settings.updated', updatedContent.getName().toString()));
+
+        if (updatedContent.getLanguage() && updatedContent.getLanguage() !== contentSummary.getLanguage()) {
+            new ContentLanguageUpdatedEvent(updatedContent.getLanguage()).fire();
+        }
+
+        resetEditPropertiesDialog();
+    } catch (error) {
+        DefaultErrorHandler.handle(error);
+        $editPropertiesDialog.setKey('saving', false);
+    }
+};
+
+//
+// * Internal loaders
+//
+
+const loadEditPropertiesLocales = async (currentInstance: number): Promise<void> => {
+    const {open, localeOptions} = $editPropertiesDialog.get();
+    if (!open || localeOptions.length > 0) {
+        return;
+    }
+
+    try {
+        const locales = await new GetLocalesRequest().sendAndParse();
+        if (instanceId !== currentInstance) {
+            return;
+        }
+        $editPropertiesDialog.setKey(
+            'localeOptions',
+            locales.map((locale) => ({
+                id: locale.getId(),
+                label: LocaleViewer.makeDisplayName(locale),
+            })),
+        );
+    } catch (error) {
+        console.error(error);
+    }
+};
+
+const loadEditPropertiesOwnerOption = async (
+    ownerKey: PrincipalKey | undefined,
+    currentInstance: number,
+): Promise<void> => {
+    if (!ownerKey) {
+        $editPropertiesDialog.setKey('selectedOwnerOption', undefined);
+        return;
+    }
+
+    try {
+        const principals = await new GetPrincipalsByKeysRequest([ownerKey]).sendAndParse();
+        if (instanceId !== currentInstance) {
+            return;
+        }
+        const principal = principals[0];
+        if (principal) {
+            $editPropertiesDialog.setKey('selectedOwnerOption', toOwnerOption(principal));
+        }
+    } catch (error) {
+        console.error(error);
+    }
+};

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/details/DetailsWidgetInfoSection.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/details/DetailsWidgetInfoSection.tsx
@@ -1,61 +1,84 @@
-import {NotifyManager} from '@enonic/lib-admin-ui/notify/NotifyManager';
-import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {Button, IconButton, Separator, Tooltip} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
 import {Copy} from 'lucide-react';
-import {ReactElement, useEffect, useState} from 'react';
-import {Content} from '../../../../../../app/content/Content';
-import {ContentLanguageUpdatedEvent} from '../../../../../../app/event/ContentLanguageUpdatedEvent';
+import {ReactElement, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {BasePropertiesWidgetItemViewHelper} from '../../../../../../app/view/context/widget/details/BasePropertiesWidgetItemViewHelper';
-import {EditPropertiesDialog} from '../../../../../../app/view/context/widget/details/EditPropertiesDialog';
 import {PropertiesWidgetItemViewValue} from '../../../../../../app/view/context/widget/details/PropertiesWidgetItemViewValue';
 import {PropertiesWizardStepFormType} from '../../../../../../app/view/context/widget/details/PropertiesWizardStepFormFactory';
 import {useI18n} from '../../../../hooks/useI18n';
 import {$contextContent} from '../../../../store/context/contextContent.store';
+import {closeEditPropertiesDialog, openEditPropertiesDialog} from '../../../../store/dialogs/editPropertiesDialog.store';
+import {EditPropertiesDialog} from '../../../../shared/dialogs/EditPropertiesDialog';
 
 type ContentProps = Map<string, PropertiesWidgetItemViewValue>;
-
-const helper = new BasePropertiesWidgetItemViewHelper();
-
-function copyToClipboard(text: string): void {
-    navigator?.clipboard?.writeText(text);
-}
 
 const DETAILS_WIDGET_INFO_SECTION_NAME = 'DetailsWidgetInfoSection';
 
 export const DetailsWidgetInfoSection = (): ReactElement => {
+    const helper = useMemo(() => new BasePropertiesWidgetItemViewHelper(), []);
+    const copyToClipboard = useCallback((text: string): void => {
+        void navigator?.clipboard?.writeText(text);
+    }, []);
     const content = useStore($contextContent);
     const [props, setProps] = useState<ContentProps>(new Map());
-    const [dialog, setDialog] = useState<EditPropertiesDialog>();
+    const [canEditSettings, setCanEditSettings] = useState(false);
 
     const titleText = useI18n('field.contextPanel.details.sections.info');
     const editSettingsLabel = useI18n('field.contextPanel.details.sections.info.editSettings');
     const copyTooltip = useI18n('field.contextPanel.details.sections.info.copy');
+    const contentId = content?.getContentId()?.toString();
+
+    const prevContentId = useRef<string | undefined>(undefined);
 
     useEffect(() => {
-        if (!content) return;
+        if (!content) {
+            setProps(new Map());
+            setCanEditSettings(false);
+            closeEditPropertiesDialog();
+            prevContentId.current = undefined;
+            return;
+        }
+
+        if (prevContentId.current && prevContentId.current !== contentId) {
+            closeEditPropertiesDialog();
+        }
+        prevContentId.current = contentId;
 
         helper.setItem(content);
-        helper.generateProps().then(setProps);
-        helper.getAllowedForms([PropertiesWizardStepFormType.SETTINGS]).then((allowedForms) => {
-            const dialog = new EditPropertiesDialog({
-                title: i18n('widget.properties.edit.settings.text'),
-                updatedHandler: (updatedContent: Content) => {
-                    NotifyManager.get().showFeedback(
-                        i18n('notify.properties.settings.updated', updatedContent.getName())
-                    );
-
-                    if (updatedContent.getLanguage() && updatedContent.getLanguage() !== content.getLanguage()) {
-                        new ContentLanguageUpdatedEvent(updatedContent.getLanguage()).fire();
-                    }
-                },
-            })
-                .setItem(content.getContentSummary())
-                .setFormsAllowed(allowedForms);
-
-            setDialog(dialog);
+        void helper.generateProps().then(setProps);
+        void helper.getAllowedForms([PropertiesWizardStepFormType.SETTINGS]).then((allowedForms) => {
+            setCanEditSettings(allowedForms.length > 0);
         });
-    }, [content]);
+    }, [content, contentId, helper]);
+
+    const renderPropertyRow = useCallback((key: string, value: PropertiesWidgetItemViewValue): ReactElement => {
+        const isId = key === 'Id';
+        const title = value.getTitle() ?? '';
+        const displayName = value.getDisplayName();
+
+        return (
+            <div key={key} className="contents">
+                <dt className="text-xs text-subtle">{key}</dt>
+                <dd className="flex items-center justify-between gap-2 overflow-hidden">
+                    <span className="text-xs truncate" title={title}>
+                        {displayName}
+                    </span>
+                    {isId && (
+                        <Tooltip value={copyTooltip} side="left">
+                            <IconButton
+                                className="size-4 shrink-0"
+                                size="sm"
+                                icon={Copy}
+                                iconSize={14}
+                                aria-label={copyTooltip}
+                                onClick={() => copyToClipboard(displayName)}
+                            />
+                        </Tooltip>
+                    )}
+                </dd>
+            </div>
+        );
+    }, [copyTooltip]);
 
     if (!content) return null;
 
@@ -64,34 +87,7 @@ export const DetailsWidgetInfoSection = (): ReactElement => {
             <Separator label={titleText} />
 
             <dl className="grid grid-cols-[max-content_1fr] items-center gap-x-7.5 gap-y-2.5">
-                {Array.from(props.entries()).map(([key, value]) => {
-                    const isId = key === 'Id';
-                    const title = value.getTitle() ?? '';
-                    const displayName = value.getDisplayName();
-
-                    return (
-                        <div key={key} className="contents">
-                            <dt className="text-xs text-subtle">{key}</dt>
-                            <dd className="flex items-center justify-between gap-2 overflow-hidden">
-                                <span className="text-xs truncate" title={title}>
-                                    {displayName}
-                                </span>
-                                {isId && (
-                                    <Tooltip value={copyTooltip} side="left">
-                                        <IconButton
-                                            className="size-4 shrink-0"
-                                            size="sm"
-                                            icon={Copy}
-                                            iconSize={14}
-                                            aria-label={copyTooltip}
-                                            onClick={() => copyToClipboard(displayName)}
-                                        />
-                                    </Tooltip>
-                                )}
-                            </dd>
-                        </div>
-                    );
-                })}
+                {Array.from(props.entries()).map(([key, value]) => renderPropertyRow(key, value))}
             </dl>
 
             <Button
@@ -99,8 +95,15 @@ export const DetailsWidgetInfoSection = (): ReactElement => {
                 size="sm"
                 variant="outline"
                 label={editSettingsLabel}
-                onClick={() => dialog?.open()}
+                onClick={() => {
+                    if (content) {
+                        openEditPropertiesDialog(content);
+                    }
+                }}
+                disabled={!canEditSettings}
             />
+
+            <EditPropertiesDialog/>
         </section>
     );
 };


### PR DESCRIPTION
Add edit settings dialog with language and owner selectors.
Components for ui, store for handling logic.
<img width="904" height="473" alt="image" src="https://github.com/user-attachments/assets/da204998-3624-4eb1-be53-092962e8c173" />
