### PR TITLE
Enonic UI: Match design for filter panel dependencies #9679

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -69,7 +69,7 @@ export class ContentBrowseFilterPanel<T extends ContentSummaryAndCompareStatus =
             exportOptions: this.getExportOptions(),
         });
 
-        this.appendChild(this.dependenciesSection);
+        super.appendChild(this.dependenciesSection);
         this.appendChild(this.filterComponent);
 
         this.handleEvents();

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/layout/filter/BrowseDependencies.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/layout/filter/BrowseDependencies.tsx
@@ -4,8 +4,8 @@ import {LegacyElement} from '../../../../shared/LegacyElement';
 import {ContentId} from '../../../../../../app/content/ContentId';
 import {useI18n} from '../../../../hooks/useI18n';
 import {ContentIcon} from '../../../../shared/icons/ContentIcon';
-import {IconButton} from '@enonic/ui';
 import {X} from 'lucide-react';
+import {IconButton} from '@enonic/ui';
 
 type BrowseDependenciesProps = {
     item?: ContentSummary;
@@ -27,17 +27,17 @@ const BrowseDependencies = ({
     if (!item) return null;
 
     return (
-        <div data-component={BROWSE_DEPENDENCIES_SECTION_NAME} className="mb-7.5">
+        <div data-component={BROWSE_DEPENDENCIES_SECTION_NAME} className="bg-surface-primary p-5 mb-2.5 space-y-2">
             <h4 className="font-semibold">{label}</h4>
-            <div className="flex items-center justify-between gap-2 mt-2">
-                <div className="flex items-center gap-2 overflow-hidden">
+            <div className="flex items-center justify-between gap-2.5 py-1.5 pl-4 pr-2 rounded-md bg-surface-neutral">
+                <div className="flex items-center gap-3 overflow-hidden">
                     <ContentIcon contentType={String(item.getType())} url={item.getIconUrl()} />
                     <div className="flex flex-col overflow-hidden">
                         <span className="block truncate">{item.getDisplayName()}</span>
                         <span className="text-xs text-subtle truncate">{item.getPath().toString()}</span>
                     </div>
                 </div>
-                <IconButton icon={X} onClick={onCancelClick} className="shrink-0" />
+                <IconButton variant="text" icon={X} onClick={onCancelClick} size="lg" className="shrink-0 size-7 rounded-md" />
             </div>
         </div>
     );

--- a/modules/lib/src/main/resources/assets/styles/browse/content-browse-filter-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/browse/content-browse-filter-panel.less
@@ -1,9 +1,13 @@
 .content-browse-filter-panel {
-  padding: 12px 20px;
+  padding: 0px;
   outline: none;
 
   input:focus, button:focus {
     outline: none;
+  }
+
+  .elements-container {
+    padding: 20px;
   }
 
   .search-container {


### PR DESCRIPTION
Preferrer `button` + `icon` instead of of `IconButton` in this case, because `IconButton` hover styling was not resulting in a good UI for this specific component.