### PR TITLE
Enonic UI: Infinite request retry on lost connection #9844

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.test.ts
@@ -1,8 +1,53 @@
-import {describe, it, expect, beforeEach} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {PublishStatus} from '../../../app/publish/PublishStatus';
 import type {ContentSummaryAndCompareStatus} from '../../../app/content/ContentSummaryAndCompareStatus';
 import {clearContentCache, getContent, hasContent, setContent, getMissingIds} from '../store/content.store';
-import {resetTree} from '../store/tree-list.store';
+import {addTreeNodes, resetTree, setTreeRootIds, $treeState} from '../store/tree-list.store';
+import {addFilterNodes, resetFilterTree, setFilterRootIds, $filterTreeState} from '../store/filter-tree.store';
+import {
+    clearChildrenIdsRetryCooldown,
+    clearFilterChildrenIdsRetryCooldown,
+    clearVisibleContentDataRetryCooldown,
+    clearVisibleFilterContentDataRetryCooldown,
+    deactivateFilter,
+    fetchChildrenIdsOnly,
+    fetchFilterChildrenIdsOnly,
+    fetchVisibleContentData,
+    fetchVisibleFilterContentData,
+    fetchRootChildrenIdsOnly,
+    isChildrenIdsLoadFailed,
+    isFilterChildrenIdsLoadFailed,
+    isVisibleContentDataLoadFailed,
+    isVisibleFilterContentDataLoadFailed,
+    resetChildrenIdsRetryState,
+    resetFilterChildrenIdsRetryState,
+    resetVisibleContentDataRetryState,
+    resetVisibleFilterContentDataRetryState,
+} from './content-fetcher';
+
+const {mockFetchAndCompareStatus, mockFetchChildrenIds} = vi.hoisted(() => ({
+    mockFetchAndCompareStatus: vi.fn(),
+    mockFetchChildrenIds: vi.fn(),
+}));
+
+vi.mock('../../../app/resource/ContentSummaryAndCompareStatusFetcher', () => ({
+    ContentSummaryAndCompareStatusFetcher: class {
+        fetchAndCompareStatus = mockFetchAndCompareStatus;
+        fetchChildren = vi.fn();
+        fetchChildrenIds = mockFetchChildrenIds;
+        createRootChildOrder = vi.fn(() => ({}));
+        updateReadonlyAndCompareStatus = vi.fn((items) => Promise.resolve(items));
+    },
+}));
+
+vi.mock('../utils/cms/content/workflow', () => ({
+    calcWorkflowStateStatus: vi.fn(() => null),
+}));
+
+vi.mock('../utils/cms/content/prettify', () => ({
+    resolveDisplayName: vi.fn((content) => content?.getDisplayName?.() ?? ''),
+    resolveSubName: vi.fn((content) => content?.getName?.() ?? ''),
+}));
 
 /**
  * Integration tests for content-fetcher store interactions.
@@ -19,20 +64,35 @@ import {resetTree} from '../store/tree-list.store';
 function createMockContent(id: string, displayName?: string): ContentSummaryAndCompareStatus {
     return {
         getId: () => id,
+        getName: () => displayName ?? `Name ${id}`,
         getDisplayName: () => displayName ?? `Content ${id}`,
         getType: () => ({toString: () => 'base:folder'}) as unknown,
         getPublishStatus: () => PublishStatus.ONLINE,
         hasChildren: () => false,
         getContentSummary: () => ({
             getIconUrl: () => null,
+            getName: () => displayName ?? `Name ${id}`,
+            getDisplayName: () => displayName ?? `Content ${id}`,
         }),
-    } as ContentSummaryAndCompareStatus;
+    } as unknown as ContentSummaryAndCompareStatus;
 }
 
 describe('content-fetcher store integration', () => {
     beforeEach(() => {
         resetTree();
+        resetFilterTree();
         clearContentCache();
+        mockFetchAndCompareStatus.mockReset();
+        mockFetchChildrenIds.mockReset();
+        resetVisibleContentDataRetryState();
+        resetVisibleFilterContentDataRetryState();
+        resetChildrenIdsRetryState();
+        resetFilterChildrenIdsRetryState();
+        vi.useRealTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
     });
 
     describe('cache-first logic', () => {
@@ -130,6 +190,274 @@ describe('content-fetcher store integration', () => {
             const missing = getMissingIds(['1', '2', '3', '4']);
 
             expect(missing).toEqual(['1', '3', '4']);
+        });
+    });
+
+    describe('visible content retry cooldown', () => {
+        it('throttles immediate retries after main tree fetch failure', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addTreeNodes([{id: 'main-offline-1', data: null, parentId: null, hasChildren: false}]);
+            setTreeRootIds(['main-offline-1']);
+
+            mockFetchAndCompareStatus.mockRejectedValue(new Error('offline'));
+
+            await fetchVisibleContentData(['main-offline-1']);
+            await fetchVisibleContentData(['main-offline-1']);
+
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(1);
+
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.999Z'));
+            await fetchVisibleContentData(['main-offline-1']);
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(1);
+
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await fetchVisibleContentData(['main-offline-1']);
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(2);
+        });
+
+        it('throttles immediate retries after filter tree fetch failure', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addFilterNodes([{id: 'filter-offline-1', data: null, parentId: null, hasChildren: false}]);
+            setFilterRootIds(['filter-offline-1']);
+
+            mockFetchAndCompareStatus.mockRejectedValue(new Error('offline'));
+
+            await fetchVisibleFilterContentData(['filter-offline-1']);
+            await fetchVisibleFilterContentData(['filter-offline-1']);
+
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(1);
+
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await fetchVisibleFilterContentData(['filter-offline-1']);
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(2);
+        });
+
+        it('allows 3 attempts and marks main node as failed after third failure', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addTreeNodes([{id: 'main-failed-3x', data: null, parentId: null, hasChildren: false}]);
+            setTreeRootIds(['main-failed-3x']);
+            mockFetchAndCompareStatus.mockRejectedValue(new Error('offline'));
+
+            await fetchVisibleContentData(['main-failed-3x']); // attempt 1
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await fetchVisibleContentData(['main-failed-3x']); // attempt 2
+            vi.setSystemTime(new Date('2026-02-14T00:00:02.002Z'));
+            await fetchVisibleContentData(['main-failed-3x']); // attempt 3
+
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(3);
+            expect(isVisibleContentDataLoadFailed('main-failed-3x')).toBe(true);
+
+            vi.setSystemTime(new Date('2026-02-14T00:00:03.003Z'));
+            await fetchVisibleContentData(['main-failed-3x']);
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(3);
+        });
+
+        it('allows 3 attempts and marks filter node as failed after third failure', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addFilterNodes([{id: 'filter-failed-3x', data: null, parentId: null, hasChildren: false}]);
+            setFilterRootIds(['filter-failed-3x']);
+            mockFetchAndCompareStatus.mockRejectedValue(new Error('offline'));
+
+            await fetchVisibleFilterContentData(['filter-failed-3x']); // attempt 1
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await fetchVisibleFilterContentData(['filter-failed-3x']); // attempt 2
+            vi.setSystemTime(new Date('2026-02-14T00:00:02.002Z'));
+            await fetchVisibleFilterContentData(['filter-failed-3x']); // attempt 3
+
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(3);
+            expect(isVisibleFilterContentDataLoadFailed('filter-failed-3x')).toBe(true);
+        });
+
+        it('retry reset allows a new 3-attempt cycle', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addTreeNodes([{id: 'main-retry-cycle', data: null, parentId: null, hasChildren: false}]);
+            setTreeRootIds(['main-retry-cycle']);
+            mockFetchAndCompareStatus.mockRejectedValue(new Error('offline'));
+
+            await fetchVisibleContentData(['main-retry-cycle']);
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await fetchVisibleContentData(['main-retry-cycle']);
+            vi.setSystemTime(new Date('2026-02-14T00:00:02.002Z'));
+            await fetchVisibleContentData(['main-retry-cycle']);
+            expect(isVisibleContentDataLoadFailed('main-retry-cycle')).toBe(true);
+
+            clearVisibleContentDataRetryCooldown(['main-retry-cycle']);
+            expect(isVisibleContentDataLoadFailed('main-retry-cycle')).toBe(false);
+
+            await fetchVisibleContentData(['main-retry-cycle']);
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(4);
+        });
+
+        it('filter retry reset allows immediate re-attempt', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addFilterNodes([{id: 'filter-retry-cycle', data: null, parentId: null, hasChildren: false}]);
+            setFilterRootIds(['filter-retry-cycle']);
+            mockFetchAndCompareStatus.mockRejectedValue(new Error('offline'));
+
+            await fetchVisibleFilterContentData(['filter-retry-cycle']);
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await fetchVisibleFilterContentData(['filter-retry-cycle']);
+            vi.setSystemTime(new Date('2026-02-14T00:00:02.002Z'));
+            await fetchVisibleFilterContentData(['filter-retry-cycle']);
+            expect(isVisibleFilterContentDataLoadFailed('filter-retry-cycle')).toBe(true);
+
+            clearVisibleFilterContentDataRetryCooldown(['filter-retry-cycle']);
+            expect(isVisibleFilterContentDataLoadFailed('filter-retry-cycle')).toBe(false);
+
+            await fetchVisibleFilterContentData(['filter-retry-cycle']);
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(4);
+        });
+
+        it('adds cooldown only for unresolved IDs on partial response', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addTreeNodes([
+                {id: 'partial-a', data: null, parentId: null, hasChildren: false},
+                {id: 'partial-b', data: null, parentId: null, hasChildren: false},
+            ]);
+            setTreeRootIds(['partial-a', 'partial-b']);
+
+            mockFetchAndCompareStatus.mockImplementation((contentIds: {toString: () => string}[]) => {
+                const ids = contentIds.map((id) => id.toString());
+                if (ids.includes('partial-a') && ids.includes('partial-b')) {
+                    return Promise.resolve([createMockContent('partial-a')]);
+                }
+                return Promise.resolve([createMockContent('partial-b')]);
+            });
+
+            await fetchVisibleContentData(['partial-a', 'partial-b']);
+            expect($treeState.get().nodes.get('partial-a')?.data).not.toBeNull();
+            expect($treeState.get().nodes.get('partial-b')?.data).toBeNull();
+
+            await fetchVisibleContentData(['partial-a', 'partial-b']);
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(1);
+
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await fetchVisibleContentData(['partial-a', 'partial-b']);
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(2);
+            expect($treeState.get().nodes.get('partial-b')?.data).not.toBeNull();
+        });
+
+        it('does not request resolved IDs again in filter tree after success', async () => {
+            addFilterNodes([{id: 'filter-success-1', data: null, parentId: null, hasChildren: false}]);
+            setFilterRootIds(['filter-success-1']);
+            mockFetchAndCompareStatus.mockResolvedValue([createMockContent('filter-success-1')]);
+
+            await fetchVisibleFilterContentData(['filter-success-1']);
+            expect($filterTreeState.get().nodes.get('filter-success-1')?.data).not.toBeNull();
+
+            await fetchVisibleFilterContentData(['filter-success-1']);
+            expect(mockFetchAndCompareStatus).toHaveBeenCalledTimes(1);
+        });
+
+        it('clears main retry-failure state on root reload', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addTreeNodes([{id: 'main-reset-on-root-load', data: null, parentId: null, hasChildren: false}]);
+            setTreeRootIds(['main-reset-on-root-load']);
+            mockFetchAndCompareStatus.mockRejectedValue(new Error('offline'));
+
+            await fetchVisibleContentData(['main-reset-on-root-load']);
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await fetchVisibleContentData(['main-reset-on-root-load']);
+            vi.setSystemTime(new Date('2026-02-14T00:00:02.002Z'));
+            await fetchVisibleContentData(['main-reset-on-root-load']);
+            expect(isVisibleContentDataLoadFailed('main-reset-on-root-load')).toBe(true);
+
+            mockFetchChildrenIds.mockResolvedValue([{toString: () => 'new-root-id'}]);
+            await fetchRootChildrenIdsOnly();
+
+            expect(isVisibleContentDataLoadFailed('main-reset-on-root-load')).toBe(false);
+        });
+
+        it('clears filter retry-failure state when filter mode deactivates', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addFilterNodes([{id: 'filter-reset-on-deactivate', data: null, parentId: null, hasChildren: false}]);
+            setFilterRootIds(['filter-reset-on-deactivate']);
+            mockFetchAndCompareStatus.mockRejectedValue(new Error('offline'));
+
+            await fetchVisibleFilterContentData(['filter-reset-on-deactivate']);
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await fetchVisibleFilterContentData(['filter-reset-on-deactivate']);
+            vi.setSystemTime(new Date('2026-02-14T00:00:02.002Z'));
+            await fetchVisibleFilterContentData(['filter-reset-on-deactivate']);
+            expect(isVisibleFilterContentDataLoadFailed('filter-reset-on-deactivate')).toBe(true);
+
+            deactivateFilter();
+
+            expect(isVisibleFilterContentDataLoadFailed('filter-reset-on-deactivate')).toBe(false);
+        });
+    });
+
+    describe('children IDs retry cooldown', () => {
+        it('allows 3 non-root attempts and marks main parent as failed after third failure', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addTreeNodes([{id: 'parent-main-3x', data: null, parentId: null, hasChildren: true}]);
+            setTreeRootIds(['parent-main-3x']);
+            mockFetchChildrenIds.mockRejectedValue(new Error('offline'));
+
+            await expect(fetchChildrenIdsOnly('parent-main-3x')).rejects.toThrow('offline');
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await expect(fetchChildrenIdsOnly('parent-main-3x')).rejects.toThrow('offline');
+            vi.setSystemTime(new Date('2026-02-14T00:00:02.002Z'));
+            await expect(fetchChildrenIdsOnly('parent-main-3x')).rejects.toThrow('offline');
+
+            expect(mockFetchChildrenIds).toHaveBeenCalledTimes(3);
+            expect(isChildrenIdsLoadFailed('parent-main-3x')).toBe(true);
+
+            vi.setSystemTime(new Date('2026-02-14T00:00:03.003Z'));
+            await expect(fetchChildrenIdsOnly('parent-main-3x')).resolves.toEqual([]);
+            expect(mockFetchChildrenIds).toHaveBeenCalledTimes(3);
+
+            clearChildrenIdsRetryCooldown('parent-main-3x');
+            mockFetchChildrenIds.mockResolvedValue([{toString: () => 'child-main-ok'}]);
+            await expect(fetchChildrenIdsOnly('parent-main-3x')).resolves.toEqual(['child-main-ok']);
+            expect(isChildrenIdsLoadFailed('parent-main-3x')).toBe(false);
+        });
+
+        it('allows 3 non-root attempts and marks filter parent as failed after third failure', async () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-02-14T00:00:00.000Z'));
+
+            addFilterNodes([{id: 'parent-filter-3x', data: null, parentId: null, hasChildren: true}]);
+            setFilterRootIds(['parent-filter-3x']);
+            mockFetchChildrenIds.mockRejectedValue(new Error('offline'));
+
+            await expect(fetchFilterChildrenIdsOnly('parent-filter-3x')).rejects.toThrow('offline');
+            vi.setSystemTime(new Date('2026-02-14T00:00:01.001Z'));
+            await expect(fetchFilterChildrenIdsOnly('parent-filter-3x')).rejects.toThrow('offline');
+            vi.setSystemTime(new Date('2026-02-14T00:00:02.002Z'));
+            await expect(fetchFilterChildrenIdsOnly('parent-filter-3x')).rejects.toThrow('offline');
+
+            expect(mockFetchChildrenIds).toHaveBeenCalledTimes(3);
+            expect(isFilterChildrenIdsLoadFailed('parent-filter-3x')).toBe(true);
+
+            vi.setSystemTime(new Date('2026-02-14T00:00:03.003Z'));
+            await expect(fetchFilterChildrenIdsOnly('parent-filter-3x')).resolves.toEqual([]);
+            expect(mockFetchChildrenIds).toHaveBeenCalledTimes(3);
+
+            clearFilterChildrenIdsRetryCooldown('parent-filter-3x');
+            mockFetchChildrenIds.mockResolvedValue([{toString: () => 'child-filter-ok'}]);
+            await expect(fetchFilterChildrenIdsOnly('parent-filter-3x')).resolves.toEqual(['child-filter-ok']);
+            expect(isFilterChildrenIdsLoadFailed('parent-filter-3x')).toBe(false);
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.ts
@@ -370,11 +370,25 @@ export async function fetchChildrenIdsOnly(
     parentId: string | null,
     childOrder?: ChildOrder
 ): Promise<string[]> {
+    const state = $treeState.get();
+
+    if (parentId === null) {
+        resetVisibleContentDataRetryState();
+        resetChildrenIdsRetryState();
+    } else {
+        const parent = state.nodes.get(parentId);
+        if (!parent || !parent.hasChildren || parent.childIds.length > 0) return [];
+    }
+
+    if (state.loadingIds.has(toParentRetryKey(parentId))) return [];
+    if (!isParentRetryReady(childrenIdsRetryState, parentId, Date.now())) return [];
+
     setNodeLoading(parentId, true);
 
     try {
         const parentContentId = parentId ? new ContentId(parentId) : undefined;
         const ids = await fetcher.fetchChildrenIds(parentContentId, childOrder);
+        clearChildrenIdsRetryCooldown(parentId);
 
         // Convert ContentId[] to string[]
         const idStrings = ids.map((id) => id.toString());
@@ -399,6 +413,9 @@ export async function fetchChildrenIdsOnly(
         }
 
         return idStrings;
+    } catch (error) {
+        markParentRetryFailure(childrenIdsRetryState, failedChildrenParentIds, parentId, Date.now());
+        throw error;
     } finally {
         setNodeLoading(parentId, false);
     }
@@ -414,6 +431,224 @@ export async function fetchRootChildrenIdsOnly(): Promise<string[]> {
 
 // Batch size for loading content data in viewport loading
 const DATA_BATCH_SIZE = 20;
+const VISIBLE_DATA_RETRY_DELAY_MS = 1_000;
+const MAX_VISIBLE_DATA_ATTEMPTS = 3;
+const ROOT_PARENT_RETRY_KEY = '__root__';
+
+/**
+ * Tracks retry cooldown per content ID after visible data fetch failures.
+ * Prevents tight retry loops (e.g. when browser is offline).
+ */
+type BatchLoadState = {
+    attempts: number;
+    retryAt: number;
+    ids: string[];
+};
+
+const visibleDataBatchState = new Map<string, BatchLoadState>();
+const visibleFilterDataBatchState = new Map<string, BatchLoadState>();
+const visibleDataFailedIds = new Set<string>();
+const visibleFilterDataFailedIds = new Set<string>();
+const childrenIdsRetryState = new Map<string, {attempts: number; retryAt: number}>();
+const filterChildrenIdsRetryState = new Map<string, {attempts: number; retryAt: number}>();
+const failedChildrenParentIds = new Set<string>();
+const failedFilterChildrenParentIds = new Set<string>();
+
+/**
+ * Normalizes parent retry key. Root-level parent is stored as __root__.
+ */
+function toParentRetryKey(parentId: string | null): string {
+    return parentId ?? ROOT_PARENT_RETRY_KEY;
+}
+
+/**
+ * Returns true when a parent can be retried now.
+ * Stops retries after MAX_VISIBLE_DATA_ATTEMPTS.
+ */
+function isParentRetryReady(
+    stateByParentKey: Map<string, {attempts: number; retryAt: number}>,
+    parentId: string | null,
+    now: number
+): boolean {
+    const state = stateByParentKey.get(toParentRetryKey(parentId));
+    if (!state) return true;
+    if (state.attempts >= MAX_VISIBLE_DATA_ATTEMPTS) return false;
+    return state.retryAt <= now;
+}
+
+/**
+ * Records parent-level failure with cooldown and attempt counter.
+ */
+function markParentRetryFailure(
+    stateByParentKey: Map<string, {attempts: number; retryAt: number}>,
+    failedParentIds: Set<string>,
+    parentId: string | null,
+    now = Date.now()
+): void {
+    const key = toParentRetryKey(parentId);
+    const previousState = stateByParentKey.get(key);
+    const attempts = (previousState?.attempts ?? 0) + 1;
+
+    stateByParentKey.set(key, {
+        attempts,
+        retryAt: now + VISIBLE_DATA_RETRY_DELAY_MS,
+    });
+
+    if (attempts >= MAX_VISIBLE_DATA_ATTEMPTS) {
+        failedParentIds.add(key);
+    }
+}
+
+/**
+ * Clears parent-level retry and failed marker after successful or manual retry.
+ */
+function clearParentRetryFailure(
+    stateByParentKey: Map<string, {attempts: number; retryAt: number}>,
+    failedParentIds: Set<string>,
+    parentId: string | null
+): void {
+    const key = toParentRetryKey(parentId);
+    stateByParentKey.delete(key);
+    failedParentIds.delete(key);
+}
+
+/**
+ * Clears all parent retry state, e.g. when mode resets.
+ */
+function resetParentRetryState(
+    stateByParentKey: Map<string, {attempts: number; retryAt: number}>,
+    failedParentIds: Set<string>
+): void {
+    stateByParentKey.clear();
+    failedParentIds.clear();
+}
+
+/**
+ * Clears all data-batch retry state and failed IDs.
+ */
+function resetBatchFailureState(stateByBatchKey: Map<string, BatchLoadState>, failedIds: Set<string>): void {
+    stateByBatchKey.clear();
+    failedIds.clear();
+}
+
+/**
+ * Creates stable key for retry state of one data fetch batch.
+ */
+function toBatchKey(ids: string[]): string {
+    return ids.join(',');
+}
+
+/**
+ * Returns true when a data batch can be retried now.
+ * Stops retries after MAX_VISIBLE_DATA_ATTEMPTS.
+ */
+function isBatchReady(stateByBatchKey: Map<string, BatchLoadState>, ids: string[], now: number): boolean {
+    const state = stateByBatchKey.get(toBatchKey(ids));
+    if (!state) return true;
+    if (state.attempts >= MAX_VISIBLE_DATA_ATTEMPTS) return false;
+    return state.retryAt <= now;
+}
+
+/**
+ * Records batch-level failure with cooldown and attempt counter.
+ * When max attempts is reached, all IDs in this batch become failed IDs.
+ */
+function markBatchFailure(
+    stateByBatchKey: Map<string, BatchLoadState>,
+    failedIds: Set<string>,
+    ids: string[],
+    now = Date.now()
+): void {
+    if (ids.length === 0) return;
+
+    const key = toBatchKey(ids);
+    const previousState = stateByBatchKey.get(key);
+    const attempts = (previousState?.attempts ?? 0) + 1;
+
+    stateByBatchKey.set(key, {
+        attempts,
+        retryAt: now + VISIBLE_DATA_RETRY_DELAY_MS,
+        ids,
+    });
+
+    if (attempts >= MAX_VISIBLE_DATA_ATTEMPTS) {
+        ids.forEach((id) => failedIds.add(id));
+    }
+}
+
+/**
+ * Clears failed IDs and related retry entries that intersect with IDs.
+ *
+ * The key part is intersection-based cleanup:
+ * if the caller retries subset A, we also remove stale retry entries whose
+ * stored batch contains any ID from A. This keeps retry state consistent
+ * even when UI grouping and fetch batching boundaries differ.
+ */
+function clearBatchFailure(
+    stateByBatchKey: Map<string, BatchLoadState>,
+    failedIds: Set<string>,
+    ids: string[]
+): void {
+    if (ids.length === 0) return;
+
+    ids.forEach((id) => failedIds.delete(id));
+
+    // Clear any batch state that intersects with provided IDs
+    const idSet = new Set(ids);
+    for (const [key, state] of stateByBatchKey.entries()) {
+        if (state.ids.some((id) => idSet.has(id))) {
+            stateByBatchKey.delete(key);
+        }
+    }
+}
+
+export function isVisibleContentDataLoadFailed(id: string): boolean {
+    return visibleDataFailedIds.has(id);
+}
+
+export function isVisibleFilterContentDataLoadFailed(id: string): boolean {
+    return visibleFilterDataFailedIds.has(id);
+}
+
+export function clearVisibleContentDataRetryCooldown(ids: string[]): void {
+    clearBatchFailure(visibleDataBatchState, visibleDataFailedIds, ids);
+}
+
+export function clearVisibleFilterContentDataRetryCooldown(ids: string[]): void {
+    clearBatchFailure(visibleFilterDataBatchState, visibleFilterDataFailedIds, ids);
+}
+
+export function isChildrenIdsLoadFailed(parentId: string | null): boolean {
+    return failedChildrenParentIds.has(toParentRetryKey(parentId));
+}
+
+export function isFilterChildrenIdsLoadFailed(parentId: string | null): boolean {
+    return failedFilterChildrenParentIds.has(toParentRetryKey(parentId));
+}
+
+export function clearChildrenIdsRetryCooldown(parentId: string | null): void {
+    clearParentRetryFailure(childrenIdsRetryState, failedChildrenParentIds, parentId);
+}
+
+export function clearFilterChildrenIdsRetryCooldown(parentId: string | null): void {
+    clearParentRetryFailure(filterChildrenIdsRetryState, failedFilterChildrenParentIds, parentId);
+}
+
+export function resetChildrenIdsRetryState(): void {
+    resetParentRetryState(childrenIdsRetryState, failedChildrenParentIds);
+}
+
+export function resetFilterChildrenIdsRetryState(): void {
+    resetParentRetryState(filterChildrenIdsRetryState, failedFilterChildrenParentIds);
+}
+
+export function resetVisibleContentDataRetryState(): void {
+    resetBatchFailureState(visibleDataBatchState, visibleDataFailedIds);
+}
+
+export function resetVisibleFilterContentDataRetryState(): void {
+    resetBatchFailureState(visibleFilterDataBatchState, visibleFilterDataFailedIds);
+}
 
 /**
  * Fetches content data for IDs that are missing from tree nodes.
@@ -434,7 +669,12 @@ export async function fetchVisibleContentData(ids: string[]): Promise<void> {
     // - Node is not already loading
     const idsNeedingUpdate = ids.filter((id) => {
         const node = state.nodes.get(id);
-        return node && node.data === null && !state.loadingDataIds.has(id);
+        return (
+            node &&
+            node.data === null &&
+            !state.loadingDataIds.has(id) &&
+            !visibleDataFailedIds.has(id)
+        );
     });
 
     if (idsNeedingUpdate.length === 0) return;
@@ -446,6 +686,7 @@ export async function fetchVisibleContentData(ids: string[]): Promise<void> {
     // Update tree nodes with cached content immediately (no fetch needed)
     if (cachedContents.length > 0) {
         updateTreeNodesWithData(cachedContents);
+        clearBatchFailure(visibleDataBatchState, visibleDataFailedIds, cachedContents.map((c) => c.getId()));
     }
 
     // Filter to IDs not in cache
@@ -460,14 +701,28 @@ export async function fetchVisibleContentData(ids: string[]): Promise<void> {
         // Fetch in batches to avoid overwhelming the server
         for (let i = 0; i < uncachedIds.length; i += DATA_BATCH_SIZE) {
             const batch = uncachedIds.slice(i, i + DATA_BATCH_SIZE);
+            if (!isBatchReady(visibleDataBatchState, batch, Date.now())) continue;
             const contentIds = batch.map((id) => new ContentId(id));
-            const contents = await fetcher.fetchAndCompareStatus(contentIds);
+            try {
+                const contents = await fetcher.fetchAndCompareStatus(contentIds);
+                const fetchedIds = new Set(contents.map((content) => content.getId()));
+                const unresolvedIds = batch.filter((id) => !fetchedIds.has(id));
 
-            // Update content cache
-            setContents(contents);
+                // Update content cache
+                setContents(contents);
 
-            // Update tree node data
-            updateTreeNodesWithData(contents);
+                // Update tree node data
+                updateTreeNodesWithData(contents);
+                clearBatchFailure(visibleDataBatchState, visibleDataFailedIds, [...fetchedIds]);
+
+                // Retry unresolved IDs with backoff up to max attempts
+                if (unresolvedIds.length > 0) {
+                    markBatchFailure(visibleDataBatchState, visibleDataFailedIds, unresolvedIds, Date.now());
+                }
+            } catch {
+                // Isolate failure to this batch and continue with others
+                markBatchFailure(visibleDataBatchState, visibleDataFailedIds, batch, Date.now());
+            }
         }
     } finally {
         setNodesLoadingData(uncachedIds, false);
@@ -525,6 +780,8 @@ export async function activateFilter(query: ContentQuery): Promise<void> {
     // Set filter state
     setFilterActiveState(true);
     filterQuery = query;
+    resetVisibleFilterContentDataRetryState();
+    resetFilterChildrenIdsRetryState();
     // Reset filter tree
     resetFilterTree();
     // Set loading state
@@ -556,6 +813,8 @@ export function deactivateFilter(): void {
     // Increment to invalidate any pending filter requests
     filterRequestId++;
     filterQuery = null;
+    resetVisibleFilterContentDataRetryState();
+    resetFilterChildrenIdsRetryState();
     deactivateFilterState();
 }
 
@@ -654,7 +913,12 @@ export async function fetchVisibleFilterContentData(ids: string[]): Promise<void
     // - Node is not already loading
     const idsNeedingUpdate = ids.filter((id) => {
         const node = state.nodes.get(id);
-        return node && node.data === null && !state.loadingDataIds.has(id);
+        return (
+            node &&
+            node.data === null &&
+            !state.loadingDataIds.has(id) &&
+            !visibleFilterDataFailedIds.has(id)
+        );
     });
 
     if (idsNeedingUpdate.length === 0) return;
@@ -672,6 +936,7 @@ export async function fetchVisibleFilterContentData(ids: string[]): Promise<void
         }));
 
         addFilterNodes(updates);
+        clearBatchFailure(visibleFilterDataBatchState, visibleFilterDataFailedIds, cachedContents.map((c) => c.getId()));
     }
 
     // Filter to IDs not in cache
@@ -686,20 +951,34 @@ export async function fetchVisibleFilterContentData(ids: string[]): Promise<void
         // Fetch in batches
         for (let i = 0; i < uncachedIds.length; i += DATA_BATCH_SIZE) {
             const batch = uncachedIds.slice(i, i + DATA_BATCH_SIZE);
+            if (!isBatchReady(visibleFilterDataBatchState, batch, Date.now())) continue;
             const contentIds = batch.map((id) => new ContentId(id));
-            const contents = await fetcher.fetchAndCompareStatus(contentIds);
+            try {
+                const contents = await fetcher.fetchAndCompareStatus(contentIds);
+                const fetchedIds = new Set(contents.map((content) => content.getId()));
+                const unresolvedIds = batch.filter((id) => !fetchedIds.has(id));
 
-            // Update content cache
-            setContents(contents);
+                // Update content cache
+                setContents(contents);
 
-            // Update filter tree node data
-            const updates: CreateNodeOptions<ContentTreeNodeData>[] = contents.map((content) => ({
-                id: content.getId(),
-                data: toTreeNodeData(content),
-                hasChildren: content.hasChildren(),
-            }));
+                // Update filter tree node data
+                const updates: CreateNodeOptions<ContentTreeNodeData>[] = contents.map((content) => ({
+                    id: content.getId(),
+                    data: toTreeNodeData(content),
+                    hasChildren: content.hasChildren(),
+                }));
 
-            addFilterNodes(updates);
+                addFilterNodes(updates);
+                clearBatchFailure(visibleFilterDataBatchState, visibleFilterDataFailedIds, [...fetchedIds]);
+
+                // Retry unresolved IDs with backoff up to max attempts
+                if (unresolvedIds.length > 0) {
+                    markBatchFailure(visibleFilterDataBatchState, visibleFilterDataFailedIds, unresolvedIds, Date.now());
+                }
+            } catch {
+                // Isolate failure to this batch and continue with others
+                markBatchFailure(visibleFilterDataBatchState, visibleFilterDataFailedIds, batch, Date.now());
+            }
         }
     } finally {
         setFilterNodesLoadingData(uncachedIds, false);
@@ -722,11 +1001,19 @@ export async function fetchFilterChildrenIdsOnly(
     parentId: string,
     childOrder?: ChildOrder
 ): Promise<string[]> {
+    const state = $filterTreeState.get();
+    const parent = state.nodes.get(parentId);
+
+    if (!parent || !parent.hasChildren || parent.childIds.length > 0) return [];
+    if (state.loadingIds.has(parentId)) return [];
+    if (!isParentRetryReady(filterChildrenIdsRetryState, parentId, Date.now())) return [];
+
     setFilterNodeLoading(parentId, true);
 
     try {
         const parentContentId = new ContentId(parentId);
         const ids = await fetcher.fetchChildrenIds(parentContentId, childOrder);
+        clearFilterChildrenIdsRetryCooldown(parentId);
 
         // Convert ContentId[] to string[]
         const idStrings = ids.map((id) => id.toString());
@@ -746,6 +1033,9 @@ export async function fetchFilterChildrenIdsOnly(
         setFilterNodeTotalChildren(parentId, idStrings.length);
 
         return idStrings;
+    } catch (error) {
+        markParentRetryFailure(filterChildrenIdsRetryState, failedFilterChildrenParentIds, parentId, Date.now());
+        throw error;
     } finally {
         setFilterNodeLoading(parentId, false);
     }

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/grid/ContentTreeList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/grid/ContentTreeList.tsx
@@ -1,24 +1,32 @@
-import {cn, VirtualizedTreeList} from '@enonic/ui';
+import {Button, cn, VirtualizedTreeList} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
-import {Loader2, LoaderCircle} from 'lucide-react';
-import {useCallback, useEffect, useMemo, useRef} from 'react';
+import {AlertCircle, LoaderCircle} from 'lucide-react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import type {ListRange, VirtuosoHandle} from 'react-virtuoso';
 import {Virtuoso} from 'react-virtuoso';
 import {EditContentEvent} from '../../../../../app/event/EditContentEvent';
 import {
+    clearChildrenIdsRetryCooldown,
+    clearFilterChildrenIdsRetryCooldown,
+    clearVisibleContentDataRetryCooldown,
+    clearVisibleFilterContentDataRetryCooldown,
     fetchChildrenIdsOnly,
     fetchFilterChildrenIdsOnly,
     fetchMoreFilteredResults,
     fetchRootChildrenIdsOnly,
     fetchVisibleContentData,
     fetchVisibleFilterContentData,
+    isChildrenIdsLoadFailed,
+    isFilterChildrenIdsLoadFailed,
+    isVisibleContentDataLoadFailed,
+    isVisibleFilterContentDataLoadFailed,
 } from '../../../api/content-fetcher';
+import {useI18n} from '../../../hooks/useI18n';
 import type {FlatNode} from '../../../lib/tree-store';
-import {virtuosoComponents} from '../../../shared/lists';
 import {ItemLabel} from '../../../shared/ItemLabel';
+import {virtuosoComponents} from '../../../shared/lists';
 import {ProgressBar} from '../../../shared/primitives/ProgressBar';
 import {$activeFlatNodes, $isFilterActive} from '../../../store/active-tree.store';
-import {$activeProject} from '../../../store/projects.store';
 import {$activeId, $selection, clearSelection, setActive, setSelection} from '../../../store/contentTreeSelection.store';
 import {
     $filterLoadingState,
@@ -27,6 +35,7 @@ import {
     filterNodeNeedsChildrenLoad,
     filterRootHasMoreChildren,
 } from '../../../store/filter-tree.store';
+import {$activeProject} from '../../../store/projects.store';
 import {$treeState, collapseNode, expandNode, nodeNeedsChildrenLoad} from '../../../store/tree-list.store';
 import {useDebouncedCallback} from '../../../utils/hooks/useDebouncedCallback';
 import type {ContentData} from './ContentData';
@@ -34,12 +43,15 @@ import {ContentTreeContextMenu, type ContentTreeContextMenuProps} from './Conten
 import {ContentTreeListItem} from './ContentTreeListItem';
 import {ContentTreeListSkeletonRow} from './ContentTreeListSkeletonRow';
 import type {ContentUploadData} from './ContentUploadData';
+import {
+    buildVisibleTreeItems,
+    type ContentFlatNode,
+    type ErrorPlaceholderNode,
+} from './content-tree-list-visible-items';
 
 //
 // * Types
 //
-
-type ContentFlatNode = FlatNode<ContentData | ContentUploadData>;
 
 //
 // * Type checking helpers
@@ -85,6 +97,34 @@ const ContentTreeListUploadRow = ({item}: ContentTreeListUploadRowProps): React.
 
 ContentTreeListUploadRow.displayName = 'ContentTreeListUploadRow';
 
+type ContentTreeListErrorRowProps = {
+    level: number;
+    label: string;
+    retryLabel: string;
+    loading: boolean;
+    onRetry: () => void;
+};
+
+const ContentTreeListErrorRow = ({level, label, retryLabel, loading, onRetry}: ContentTreeListErrorRowProps): React.ReactElement => {
+    return (
+        <VirtualizedTreeList.Row active={false} selected={false}>
+            <VirtualizedTreeList.RowLeft>
+                <span className="w-3.5" />
+                <VirtualizedTreeList.RowLevelSpacer level={level} />
+                <AlertCircle size={20} className="shrink-0 text-danger" />
+            </VirtualizedTreeList.RowLeft>
+            <VirtualizedTreeList.RowContent>
+                <div className="flex items-center justify-between gap-2.5">
+                    <span className="text-sm text-danger truncate">{label}</span>
+                    <Button size="sm" variant="outline" label={retryLabel} disabled={loading} onClick={onRetry} />
+                </div>
+            </VirtualizedTreeList.RowContent>
+        </VirtualizedTreeList.Row>
+    );
+};
+
+ContentTreeListErrorRow.displayName = 'ContentTreeListErrorRow';
+
 //
 // * Constants
 //
@@ -100,6 +140,8 @@ const FAST_SCROLL_VELOCITY = 0.5;
 
 /** Debounce delay for viewport data loading (ms) */
 const VIEWPORT_LOAD_DEBOUNCE = 100;
+const RETRY_BATCH_SIZE = 20;
+const ERROR_ROW_PREFIX = '__error_batch__';
 
 //
 // * Main Component
@@ -113,11 +155,84 @@ const CONTENT_TREE_LIST_NAME = 'ContentTreeList';
 
 export const ContentTreeList = ({contextMenuActions = {}}: ContentTreeListProps): React.ReactElement => {
     const virtuosoRef = useRef<VirtuosoHandle>(null);
+    const visibleDataLoadInFlightRef = useRef(false);
+    const [isVisibleDataLoadInFlight, setIsVisibleDataLoadInFlight] = useState(false);
     const flatNodes = useStore($activeFlatNodes);
     const selection = useStore($selection);
     const activeId = useStore($activeId);
     const isFilterActive = useStore($isFilterActive);
     const activeProject = useStore($activeProject);
+    const loadFailedLabel = useI18n('field.tree.loadFailed');
+    const retryLabel = useI18n('action.retry');
+
+    const failedNodeIds = useMemo(
+        () =>
+            flatNodes
+                .filter((node) => {
+                    if (node.nodeType !== 'node' || node.data !== null) return false;
+                    return isFilterActive
+                        ? isVisibleFilterContentDataLoadFailed(node.id)
+                        : isVisibleContentDataLoadFailed(node.id);
+                })
+                .map((node) => node.id),
+        [flatNodes, isFilterActive]
+    );
+
+    const failedNodeIdSet = useMemo(() => new Set(failedNodeIds), [failedNodeIds]);
+    const hasPendingPlaceholders = useMemo(
+        () => flatNodes.some((node) => node.nodeType === 'node' && node.data === null && !failedNodeIdSet.has(node.id)),
+        [flatNodes, failedNodeIdSet]
+    );
+    const pendingChildLoadParentIds = useMemo(() => {
+        const parentIds = new Set<string>();
+
+        for (const node of flatNodes) {
+            if (node.nodeType !== 'loading' || node.parentId === null) continue;
+            if (isFilterActive) {
+                if (isFilterChildrenIdsLoadFailed(node.parentId) || !filterNodeNeedsChildrenLoad(node.parentId)) continue;
+            } else {
+                if (isChildrenIdsLoadFailed(node.parentId) || !nodeNeedsChildrenLoad(node.parentId)) continue;
+            }
+            parentIds.add(node.parentId);
+        }
+
+        return [...parentIds];
+    }, [flatNodes, isFilterActive]);
+
+    const {visibleItems, rawIndexById} = useMemo(
+        () =>
+            buildVisibleTreeItems({
+                rawItems: flatNodes,
+                isFailedPlaceholder: (item) =>
+                    item.nodeType === 'node' &&
+                    item.data === null &&
+                    (isFilterActive ? isVisibleFilterContentDataLoadFailed(item.id) : isVisibleContentDataLoadFailed(item.id)),
+                errorRowPrefix: ERROR_ROW_PREFIX,
+            }),
+        [flatNodes, isFilterActive]
+    );
+    const visibleItemsRef = useRef<ContentFlatNode[]>(visibleItems);
+    visibleItemsRef.current = visibleItems;
+
+    const setVisibleDataLoadInFlight = useCallback((value: boolean) => {
+        visibleDataLoadInFlightRef.current = value;
+        setIsVisibleDataLoadInFlight((current) => (current === value ? current : value));
+    }, []);
+
+    const retryFailedNodes = useCallback((failedIds: string[]) => {
+        if (failedIds.length === 0 || visibleDataLoadInFlightRef.current) return;
+        const retryIds = failedIds.slice(0, RETRY_BATCH_SIZE);
+
+        setVisibleDataLoadInFlight(true);
+
+        const reloadPromise = isFilterActive
+            ? (clearVisibleFilterContentDataRetryCooldown(retryIds), fetchVisibleFilterContentData(retryIds))
+            : (clearVisibleContentDataRetryCooldown(retryIds), fetchVisibleContentData(retryIds));
+
+        void reloadPromise.finally(() => {
+            setVisibleDataLoadInFlight(false);
+        });
+    }, [isFilterActive, setVisibleDataLoadInFlight]);
 
     // Track visible range for viewport-based loading
     const visibleRangeRef = useRef<ListRange>({startIndex: 0, endIndex: 20});
@@ -134,32 +249,65 @@ export const ContentTreeList = ({contextMenuActions = {}}: ContentTreeListProps)
     // Load visible content data (debounced to avoid excessive API calls during scroll)
     // NOTE: Reads directly from stores to avoid stale closure values
     const loadVisibleContentData = useDebouncedCallback(() => {
+        if (visibleDataLoadInFlightRef.current) return;
+
         const {startIndex, endIndex} = visibleRangeRef.current;
         const buffer = bufferSizeRef.current;
 
-        // Read current state directly from stores (avoids stale closure)
-        const currentFlatNodes = $activeFlatNodes.get();
+        // Read current state directly from stores/refs (avoids stale closure)
+        const currentVisibleItems = visibleItemsRef.current;
         const currentIsFilterActive = $isFilterActive.get();
-
         // Add buffer zone around viewport
         const start = Math.max(0, startIndex - buffer);
-        const end = Math.min(currentFlatNodes.length, endIndex + buffer);
+        const end = Math.min(currentVisibleItems.length, endIndex + buffer);
 
         // Find nodes that need data (have ID but no content loaded)
-        const idsNeedingData = currentFlatNodes
+        const idsNeedingData = currentVisibleItems
             .slice(start, end)
             .filter((node) => node.nodeType === 'node' && node.data === null)
             .map((node) => node.id);
 
         if (idsNeedingData.length > 0) {
+            setVisibleDataLoadInFlight(true);
+
             // Use filter-specific fetch when in filter mode
-            if (currentIsFilterActive) {
-                fetchVisibleFilterContentData(idsNeedingData);
-            } else {
-                fetchVisibleContentData(idsNeedingData);
-            }
+            const loadPromise = currentIsFilterActive
+                ? fetchVisibleFilterContentData(idsNeedingData)
+                : fetchVisibleContentData(idsNeedingData);
+
+            void loadPromise.finally(() => {
+                setVisibleDataLoadInFlight(false);
+            });
         }
     }, VIEWPORT_LOAD_DEBOUNCE);
+
+    // Keep retry attempts progressing even without scroll events.
+    useEffect(() => {
+        if (!hasPendingPlaceholders) return;
+
+        const retryTimer = setInterval(() => {
+            loadVisibleContentData();
+        }, 1000);
+
+        return () => clearInterval(retryTimer);
+    }, [hasPendingPlaceholders, loadVisibleContentData]);
+
+    // Keep retry attempts progressing for loading non-root children IDs.
+    useEffect(() => {
+        if (pendingChildLoadParentIds.length === 0) return;
+
+        const retryTimer = setInterval(() => {
+            for (const parentId of pendingChildLoadParentIds) {
+                if (isFilterActive) {
+                    void fetchFilterChildrenIdsOnly(parentId).catch(() => undefined);
+                } else {
+                    void fetchChildrenIdsOnly(parentId).catch(() => undefined);
+                }
+            }
+        }, 1000);
+
+        return () => clearInterval(retryTimer);
+    }, [pendingChildLoadParentIds, isFilterActive]);
 
     // Load root IDs on mount and when project changes (lazy loading: IDs first, data on demand)
     // Filter mode loads via activateFilter(), not here
@@ -169,7 +317,7 @@ export const ContentTreeList = ({contextMenuActions = {}}: ContentTreeListProps)
             // Only load if main tree is empty (caching)
             const mainTreeState = $treeState.get();
             if (mainTreeState.rootIds.length === 0) {
-                fetchRootChildrenIdsOnly();
+                void fetchRootChildrenIdsOnly().catch(() => undefined);
             }
         }
     }, [isFilterActive, activeProject]);
@@ -187,13 +335,13 @@ export const ContentTreeList = ({contextMenuActions = {}}: ContentTreeListProps)
                 // Expand in filter tree
                 expandFilterNode(id);
                 if (filterNodeNeedsChildrenLoad(id)) {
-                    fetchFilterChildrenIdsOnly(id);
+                    void fetchFilterChildrenIdsOnly(id).catch(() => undefined);
                 }
             } else {
                 // Expand in main tree
                 expandNode(id);
                 if (nodeNeedsChildrenLoad(id)) {
-                    fetchChildrenIdsOnly(id);
+                    void fetchChildrenIdsOnly(id).catch(() => undefined);
                 }
             }
         },
@@ -301,9 +449,10 @@ export const ContentTreeList = ({contextMenuActions = {}}: ContentTreeListProps)
             // Check loading state to prevent duplicate fetches
             const isFilterLoading = $filterLoadingState.get() === 'loading';
             if ($isFilterActive.get() && filterRootHasMoreChildren() && !isFilterLoading) {
-                const currentFlatNodes = $activeFlatNodes.get();
-                const loadMoreIndex = currentFlatNodes.findIndex((n) => n.id === '__filter_load_more__');
+                const currentVisibleItems = visibleItemsRef.current;
+                const loadMoreIndex = currentVisibleItems.findIndex((n) => n.id === '__filter_load_more__');
                 if (loadMoreIndex >= 0 && loadMoreIndex <= range.endIndex) {
+                    const currentFlatNodes = $activeFlatNodes.get();
                     const currentCount = currentFlatNodes.filter((n) => n.nodeType === 'node').length;
                     fetchMoreFilteredResults(currentCount);
                 }
@@ -329,13 +478,13 @@ export const ContentTreeList = ({contextMenuActions = {}}: ContentTreeListProps)
             aria-label='Content browser'
             className='w-full flex-1 min-h-0'
         >
-            {({items, getItemProps, containerProps}) => {
+            {({getItemProps, containerProps}) => {
                 const {className: containerClassName, ...restContainerProps} = containerProps;
                 return (
                     <ContentTreeContextMenu actions={contextMenuActions}>
                         <Virtuoso<ContentFlatNode>
                             ref={virtuosoRef}
-                            data={items as ContentFlatNode[]}
+                            data={visibleItems}
                             className={cn('h-full px-5 py-2.5 bg-surface-neutral', containerClassName)}
                             components={virtuosoComponents}
                             rangeChanged={handleRangeChange}
@@ -343,16 +492,56 @@ export const ContentTreeList = ({contextMenuActions = {}}: ContentTreeListProps)
                             itemContent={(index, node) => {
                                 const {id, level, isExpanded, hasChildren, nodeType, data} = node;
 
+                                if (id.startsWith(ERROR_ROW_PREFIX)) {
+                                    const failedIds = (node as ErrorPlaceholderNode).failedIds;
+                                    const isRetrying = failedIds.some((failedId) =>
+                                        flatNodes.some((n) => n.id === failedId && n.isLoadingData)
+                                    );
+
+                                    return (
+                                        <ContentTreeListErrorRow
+                                            level={level}
+                                            label={loadFailedLabel}
+                                            retryLabel={retryLabel}
+                                            loading={isRetrying || isVisibleDataLoadInFlight}
+                                            onRetry={() => retryFailedNodes(failedIds)}
+                                        />
+                                    );
+                                }
+
                                 if (hasProgressData(data)) {
                                     return <ContentTreeListUploadRow item={node as FlatNode<ContentUploadData>} />;
                                 }
 
                                 if (nodeType === 'loading') {
-                                    return (
-                                        <VirtualizedTreeList.RowLoading level={level} className="min-h-12">
-                                            <Loader2 className="ml-13.5 size-6 animate-spin text-subtle" />
-                                        </VirtualizedTreeList.RowLoading>
-                                    );
+                                    const parentId = node.parentId;
+                                    const isParentLoadFailed = parentId !== null &&
+                                        (isFilterActive
+                                            ? isFilterChildrenIdsLoadFailed(parentId)
+                                            : isChildrenIdsLoadFailed(parentId));
+
+                                    if (isParentLoadFailed && parentId !== null) {
+                                        const isRetrying = flatNodes.some((n) => n.id === parentId && n.isLoading);
+                                        return (
+                                            <ContentTreeListErrorRow
+                                                level={level}
+                                                label={loadFailedLabel}
+                                                retryLabel={retryLabel}
+                                                loading={isRetrying}
+                                                onRetry={() => {
+                                                    if (isFilterActive) {
+                                                        clearFilterChildrenIdsRetryCooldown(parentId);
+                                                        void fetchFilterChildrenIdsOnly(parentId).catch(() => undefined);
+                                                    } else {
+                                                        clearChildrenIdsRetryCooldown(parentId);
+                                                        void fetchChildrenIdsOnly(parentId).catch(() => undefined);
+                                                    }
+                                                }}
+                                            />
+                                        );
+                                    }
+
+                                    return <ContentTreeListSkeletonRow level={level} />;
                                 }
 
                                 if (nodeType === 'node' && data === null) {
@@ -360,7 +549,8 @@ export const ContentTreeList = ({contextMenuActions = {}}: ContentTreeListProps)
                                 }
 
                                 if (hasDisplayNameData(data)) {
-                                    const itemProps = getItemProps(index, node);
+                                    const originalIndex = rawIndexById.get(id) ?? index;
+                                    const itemProps = getItemProps(originalIndex, node);
                                     const isSelected = selection.has(id);
                                     const isActive = activeId === id;
                                     // Active item with no selection should look like selected

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/grid/content-tree-list-visible-items.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/grid/content-tree-list-visible-items.test.ts
@@ -1,0 +1,99 @@
+import {describe, expect, it} from 'vitest';
+import type {ContentFlatNode} from './content-tree-list-visible-items';
+import {buildVisibleTreeItems} from './content-tree-list-visible-items';
+
+function createNode(id: string, level: number, data: unknown): ContentFlatNode {
+    return {
+        id,
+        data,
+        level,
+        isExpanded: false,
+        isLoading: false,
+        isLoadingData: false,
+        hasChildren: false,
+        parentId: null,
+        nodeType: 'node',
+    } as ContentFlatNode;
+}
+
+function createLoadingNode(id: string, level: number): ContentFlatNode {
+    return {
+        id,
+        data: null,
+        level,
+        isExpanded: false,
+        isLoading: true,
+        isLoadingData: false,
+        hasChildren: false,
+        parentId: null,
+        nodeType: 'loading',
+    } as ContentFlatNode;
+}
+
+describe('buildVisibleTreeItems', () => {
+    it('groups failed placeholders into a single error row and keeps non-failed placeholders visible', () => {
+        const rawItems = [
+            createNode('failed-a', 0, null),
+            createNode('pending-b', 0, null),
+            createNode('resolved-c', 0, {displayName: 'C'}),
+            createNode('pending-d', 0, null),
+        ];
+
+        const {visibleItems} = buildVisibleTreeItems({
+            rawItems,
+            isFailedPlaceholder: (item) => item.id === 'failed-a',
+            errorRowPrefix: '__error_batch__',
+        });
+
+        expect(visibleItems.map((item) => item.id)).toEqual([
+            '__error_batch__failed-a__1',
+            'pending-b',
+            'resolved-c',
+            'pending-d',
+        ]);
+    });
+
+    it('keeps non-node loading rows and preserves raw index mapping', () => {
+        const rawItems = [
+            createNode('failed-a', 0, null),
+            createLoadingNode('__filter_load_more__', 0),
+            createNode('resolved-b', 0, {displayName: 'B'}),
+        ];
+
+        const {visibleItems, rawIndexById} = buildVisibleTreeItems({
+            rawItems,
+            isFailedPlaceholder: (item) => item.id === 'failed-a',
+            errorRowPrefix: '__error_batch__',
+        });
+
+        expect(visibleItems.map((item) => item.id)).toEqual([
+            '__error_batch__failed-a__1',
+            '__filter_load_more__',
+            'resolved-b',
+        ]);
+        expect(rawIndexById.get('resolved-b')).toBe(2);
+    });
+
+    it('flushes nested failed placeholder rows and keeps sibling placeholders visible', () => {
+        const rawItems = [
+            createNode('root-a', 0, {displayName: 'Root A'}),
+            createNode('child-failed-a', 1, null),
+            createNode('child-pending-a', 1, null),
+            createNode('root-b', 0, {displayName: 'Root B'}),
+        ];
+
+        const {visibleItems} = buildVisibleTreeItems({
+            rawItems,
+            isFailedPlaceholder: (item) => item.id === 'child-failed-a',
+            errorRowPrefix: '__error_batch__',
+        });
+
+        expect(visibleItems.map((item) => item.id)).toEqual([
+            'root-a',
+            '__error_batch__child-failed-a__1',
+            'child-pending-a',
+            'root-b',
+        ]);
+        expect(visibleItems[1].level).toBe(1);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/grid/content-tree-list-visible-items.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/grid/content-tree-list-visible-items.ts
@@ -1,0 +1,71 @@
+import type {FlatNode} from '../../../lib/tree-store';
+import type {ContentData} from './ContentData';
+import type {ContentUploadData} from './ContentUploadData';
+
+export type ContentFlatNode = FlatNode<ContentData | ContentUploadData>;
+export type ErrorPlaceholderNode = ContentFlatNode & {failedIds: string[]};
+
+type BuildVisibleTreeItemsParams = {
+    rawItems: ContentFlatNode[];
+    isFailedPlaceholder: (item: ContentFlatNode) => boolean;
+    errorRowPrefix: string;
+};
+
+type BuildVisibleTreeItemsResult = {
+    visibleItems: ContentFlatNode[];
+    rawIndexById: Map<string, number>;
+};
+
+export function buildVisibleTreeItems({
+    rawItems,
+    isFailedPlaceholder,
+    errorRowPrefix,
+}: BuildVisibleTreeItemsParams): BuildVisibleTreeItemsResult {
+    const rawIndexById = new Map<string, number>(rawItems.map((item, idx) => [item.id, idx]));
+    const visibleItems: ContentFlatNode[] = [];
+    let pendingFailedIds: string[] = [];
+    let pendingFailedLevel = 0;
+
+    /**
+     * Collapses contiguous failed placeholders into one synthetic row.
+     *
+     * Note: This is a render optimization only. Non-failed placeholders are
+     * preserved in visible items so viewport loading can still request them.
+     */
+    const flushFailedChunk = () => {
+        if (pendingFailedIds.length === 0) return;
+
+        const errorId = `${errorRowPrefix}${pendingFailedIds[0]}__${pendingFailedIds.length}`;
+        visibleItems.push({
+            id: errorId,
+            data: null,
+            level: pendingFailedLevel,
+            isExpanded: false,
+            isLoading: false,
+            isLoadingData: false,
+            hasChildren: false,
+            parentId: null,
+            nodeType: 'loading',
+            failedIds: pendingFailedIds,
+        } as ErrorPlaceholderNode);
+
+        pendingFailedIds = [];
+    };
+
+    rawItems.forEach((item) => {
+        if (isFailedPlaceholder(item)) {
+            if (pendingFailedIds.length === 0) {
+                pendingFailedLevel = item.level;
+            }
+            pendingFailedIds.push(item.id);
+            return;
+        }
+
+        flushFailedChunk();
+        visibleItems.push(item);
+    });
+
+    flushFailedChunk();
+
+    return {visibleItems, rawIndexById};
+}

--- a/modules/lib/src/main/resources/i18n/phrases.properties
+++ b/modules/lib/src/main/resources/i18n/phrases.properties
@@ -63,6 +63,7 @@ action.remove=Remove
 action.translate=Localize
 action.open=Open
 action.reset=Reset
+action.retry=Retry
 action.removeFromList=Remove from list
 
 action.fold=Fold
@@ -324,6 +325,7 @@ field.treeListToolbar.deselectAll=Reset selection ({0})
 field.treeListToolbar.selected=Selected
 field.treeListToolbar.showSelected=Selected only
 field.treeListToolbar.showAll=Show all
+field.tree.loadFailed=Could not load item(s)
 field.ok=Ok
 #
 #   Status


### PR DESCRIPTION
Stabilized retry batching and preserve pending placeholders:
- use failure-time timestamps for retry cooldowns in content and children fetch flows (3 attempts for a failed fetch, 1000ms cooldown)
- align filter "load more" visibility checks with rendered (visible) item indexes
- keep non-failed placeholders visible so pending nodes continue loading
- keep failed placeholders grouped only for UI error-row rendering
- add focused docs/comments for retry state helpers and batch-intersection cleanup
- update visible-items tests to cover grouped failures without hiding pending siblings