### PR TITLE
Enonic UI: Incorrect behavior when publishing items #9807

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/api/publish.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/api/publish.ts
@@ -11,8 +11,19 @@ import {getCmsApiUrl} from '../utils/url/cms';
 //
 
 export type PublishContentParams = {
+    /**
+     * Root IDs selected in the publish dialog (main list only).
+     * Dependants are resolved and included server-side.
+     */
     ids: ContentId[];
+    /**
+     * IDs explicitly excluded from the resolved dependant list.
+     */
     excludedIds?: ContentId[];
+    /**
+     * Root IDs whose descendants should be excluded.
+     * This is typically all selected roots until "include children" is enabled per item.
+     */
     excludeChildrenIds?: ContentId[];
     message?: string;
     schedule?: {
@@ -22,8 +33,17 @@ export type PublishContentParams = {
 };
 
 export type ResolvePublishParams = {
+    /**
+     * Root IDs selected in the publish dialog (main list only).
+     */
     ids: ContentId[];
+    /**
+     * IDs explicitly excluded from the resolved dependant list.
+     */
     excludedIds?: ContentId[];
+    /**
+     * Root IDs whose descendants should be excluded.
+     */
     excludeChildrenIds?: ContentId[];
 };
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueDialogDetailsContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueDialogDetailsContent.tsx
@@ -166,7 +166,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
         itemsUpdating,
         itemsLoading,
         items,
-        excludedChildrenIds,
+        excludeChildrenIds,
         dependants,
         excludedDependantIds,
         requiredDependantIds,
@@ -186,7 +186,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
             'itemsUpdating',
             'itemsLoading',
             'items',
-            'excludedChildrenIds',
+            'excludeChildrenIds',
             'dependants',
             'excludedDependantIds',
             'requiredDependantIds',
@@ -323,11 +323,11 @@ export const IssueDialogDetailsContent = (): ReactElement => {
             : undefined;
         void syncPublishDialogContext({
             items,
-            excludedChildrenIds,
+            excludeChildrenIds,
             excludedDependantIds,
             schedule,
         });
-    }, [excludedChildrenIds, excludedDependantIds, issueData, issuePublishFrom, issuePublishTo, items, syncPublishDialogContext]);
+    }, [excludeChildrenIds, excludedDependantIds, issueData, issuePublishFrom, issuePublishTo, items, syncPublishDialogContext]);
 
     const assigneeIds = useMemo(
         () => issueData?.getApprovers().map(approver => approver.toString()) ?? [],
@@ -341,9 +341,9 @@ export const IssueDialogDetailsContent = (): ReactElement => {
         () => selectedItemIds.map(id => id.toString()),
         [selectedItemIds],
     );
-    const excludedChildrenSet = useMemo(
-        () => new Set(excludedChildrenIds.map(id => id.toString())),
-        [excludedChildrenIds],
+    const excludeChildrenSet = useMemo(
+        () => new Set(excludeChildrenIds.map(id => id.toString())),
+        [excludeChildrenIds],
     );
     const excludedDependantSet = useMemo(
         () => new Set(excludedDependantIds.map(id => id.toString())),
@@ -552,7 +552,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
             if (schedule) {
                 void syncPublishDialogContext({
                     items,
-                    excludedChildrenIds,
+                    excludeChildrenIds,
                     excludedDependantIds,
                     schedule,
                 });
@@ -766,7 +766,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
                                             disabled={isItemsDisabled || itemsLoading}
                                             renderRow={(item) => {
                                                 const id = item.getContentId();
-                                                const includeChildren = !excludedChildrenSet.has(id.toString());
+                                                const includeChildren = !excludeChildrenSet.has(id.toString());
                                                 const hasUnpublishedChildrenForItem = itemsWithUnpublishedChildren
                                                     ? itemsWithUnpublishedChildren.has(id.toString())
                                                     : true;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/new-issue/NewIssueDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/new-issue/NewIssueDialogContent.tsx
@@ -1,4 +1,4 @@
-import {Button, Dialog, GridList, Input, Checkbox, TextArea} from '@enonic/ui';
+import {Button, Checkbox, Dialog, GridList, Input, TextArea} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
 import {CornerDownRight} from 'lucide-react';
 import {useCallback, useMemo, type ReactElement} from 'react';
@@ -6,23 +6,23 @@ import {useCallback, useMemo, type ReactElement} from 'react';
 import {ContentId} from '../../../../../app/content/ContentId';
 import {IssueType} from '../../../../../app/issue/IssueType';
 import {useI18n} from '../../../hooks/useI18n';
-import {useItemsWithUnpublishedChildren} from '../../../utils/cms/content/useItemsWithUnpublishedChildren';
-import {ContentRow, SplitList} from '../../lists';
-import {useAssigneeSearch, useAssigneeSelection} from '../../selectors/assignee/hooks/useAssigneeSearch';
-import {AssigneeSelector} from '../../selectors/assignee/AssigneeSelector';
-import {ContentCombobox} from '../../selectors/content';
 import {
     $newIssueDialog,
     $newIssueDialogCreateCount,
     addNewIssueItemsByIds,
     removeNewIssueItemsByIds,
     setNewIssueAssignees,
-    setNewIssueDescription,
     setNewIssueDependantIncluded,
+    setNewIssueDescription,
     setNewIssueItemIncludeChildren,
     setNewIssueTitle,
     submitNewIssueDialog,
 } from '../../../store/dialogs/newIssueDialog.store';
+import {useItemsWithUnpublishedChildren} from '../../../utils/cms/content/useItemsWithUnpublishedChildren';
+import {ContentRow, SplitList} from '../../lists';
+import {AssigneeSelector} from '../../selectors/assignee/AssigneeSelector';
+import {useAssigneeSearch, useAssigneeSelection} from '../../selectors/assignee/hooks/useAssigneeSearch';
+import {ContentCombobox} from '../../selectors/content';
 import {IssueIcon} from '../issue/IssueIcon';
 import {useIssuePublishTargetIds} from '../issue/hooks/useIssuePublishTargetIds';
 
@@ -34,7 +34,7 @@ export const NewIssueDialogContent = (): ReactElement => {
         description,
         assigneeIds,
         items,
-        excludedChildrenIds,
+        excludeChildrenIds,
         dependants,
         excludedDependantIds,
         requiredDependantIds,
@@ -46,7 +46,7 @@ export const NewIssueDialogContent = (): ReactElement => {
             'description',
             'assigneeIds',
             'items',
-            'excludedChildrenIds',
+            'excludeChildrenIds',
             'dependants',
             'excludedDependantIds',
             'requiredDependantIds',
@@ -69,9 +69,9 @@ export const NewIssueDialogContent = (): ReactElement => {
     const noResultsLabel = useI18n('dialog.search.result.noResults');
     const includeChildrenLabel = useI18n('field.content.includeChildren');
 
-    const excludedChildrenSet = useMemo(
-        () => new Set(excludedChildrenIds.map(id => id.toString())),
-        [excludedChildrenIds],
+    const excludeChildrenSet = useMemo(
+        () => new Set(excludeChildrenIds.map(id => id.toString())),
+        [excludeChildrenIds],
     );
     const excludedDependantSet = useMemo(
         () => new Set(excludedDependantIds.map(id => id.toString())),
@@ -95,8 +95,8 @@ export const NewIssueDialogContent = (): ReactElement => {
     const isItemsDisabled = submitting || loading;
 
     const createButtonLabel = createCount > 1
-                              ? `${createLabel} (${createCount})`
-                              : createLabel;
+        ? `${createLabel} (${createCount})`
+        : createLabel;
     const isCreateDisabled = submitting || loading || title.trim().length === 0;
 
     const selectedIds = useMemo(
@@ -137,10 +137,10 @@ export const NewIssueDialogContent = (): ReactElement => {
         >
             <Dialog.Header className='grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 px-5'>
                 <div className='flex min-w-0 items-center gap-2.5'>
-                    <IssueIcon type={IssueType.STANDARD}/>
+                    <IssueIcon type={IssueType.STANDARD} />
                     <Dialog.Title className='min-w-0 truncate text-2xl font-semibold'>{dialogTitle}</Dialog.Title>
                 </div>
-                <Dialog.DefaultClose className='self-start justify-self-end'/>
+                <Dialog.DefaultClose className='self-start justify-self-end' />
             </Dialog.Header>
             <Dialog.Body className='min-h-0 overflow-y-auto rounded-sm outline-none focus:ring-2 focus:ring-ring/10 focus:ring-inset'>
                 <div className='flex min-h-0 flex-col gap-7.5 px-5'>
@@ -191,10 +191,10 @@ export const NewIssueDialogContent = (): ReactElement => {
                                 disabled={isItemsDisabled}
                                 renderRow={(item) => {
                                     const id = item.getContentId();
-                                    const includeChildren = !excludedChildrenSet.has(id.toString());
+                                    const includeChildren = !excludeChildrenSet.has(id.toString());
                                     const hasUnpublishedChildrenForItem = itemsWithUnpublishedChildren
-                                                                          ? itemsWithUnpublishedChildren.has(id.toString())
-                                                                          : true;
+                                        ? itemsWithUnpublishedChildren.has(id.toString())
+                                        : true;
                                     const showChildrenCheckbox = hasUnpublishedChildrenForItem && item.hasChildren();
 
                                     return (
@@ -205,8 +205,8 @@ export const NewIssueDialogContent = (): ReactElement => {
                                                 id={`main-${item.getId()}`}
                                                 disabled={isItemsDisabled}
                                             >
-                                                <ContentRow.Label action="edit"/>
-                                                <ContentRow.Status variant="simple"/>
+                                                <ContentRow.Label action="edit" />
+                                                <ContentRow.Status variant="simple" />
                                                 <ContentRow.RemoveButton
                                                     onRemove={() => removeNewIssueItemsByIds([item.getContentId()])}
                                                     disabled={isItemsDisabled || items.length === 1}
@@ -221,7 +221,7 @@ export const NewIssueDialogContent = (): ReactElement => {
                                                     className="gap-3 px-2.5 -mt-1"
                                                 >
                                                     <GridList.Cell className="pl-2.5 flex items-center gap-2.5">
-                                                        <CornerDownRight className="size-4 shrink-0"/>
+                                                        <CornerDownRight className="size-4 shrink-0" />
                                                         <GridList.Action>
                                                             <Checkbox
                                                                 className="font-semibold"
@@ -266,8 +266,8 @@ export const NewIssueDialogContent = (): ReactElement => {
                                                     setNewIssueDependantIncluded(id, checked)
                                                 }
                                             />
-                                            <ContentRow.Label action="edit"/>
-                                            <ContentRow.Status variant="simple"/>
+                                            <ContentRow.Label action="edit" />
+                                            <ContentRow.Status variant="simple" />
                                         </ContentRow>
                                     );
                                 }}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishItemsList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishItemsList.tsx
@@ -51,7 +51,7 @@ export class PublishItemsListElement
 
     private $excludedIds: WritableAtom<ContentId[]>;
 
-    private $excludedChildrenIds: WritableAtom<ContentId[]>;
+    private $excludeChildrenIds: WritableAtom<ContentId[]>;
 
     constructor(props: ElementProps) {
         super({
@@ -65,25 +65,25 @@ export class PublishItemsListElement
             },
             onIncludeChildrenChange: (contentId: ContentId, enabled: boolean) => {
                 if (enabled) {
-                    this.$excludedChildrenIds.set(this.$excludedChildrenIds.get().filter(id => id !== contentId));
-                } else if (!this.$excludedChildrenIds.get().includes(contentId)) {
-                    this.$excludedChildrenIds.set([...this.$excludedChildrenIds.get(), contentId]);
+                    this.$excludeChildrenIds.set(this.$excludeChildrenIds.get().filter(id => id !== contentId));
+                } else if (!this.$excludeChildrenIds.get().includes(contentId)) {
+                    this.$excludeChildrenIds.set([...this.$excludeChildrenIds.get(), contentId]);
                 }
             },
         }, PublishItemsList);
 
         this.$excludedIds = atom([]);
-        this.$excludedChildrenIds = atom([]);
-        this.$excludedChildrenIds.set(props.includeChildren ? [] : props.items.map(item => item.getContentId()));
+        this.$excludeChildrenIds = atom([]);
+        this.$excludeChildrenIds.set(props.includeChildren ? [] : props.items.map(item => item.getContentId()));
     }
 
     setIncludeChildren(include: boolean): void {
         this.props.setKey('includeChildren', include);
-        this.$excludedChildrenIds.set(include ? [] : this.props.get().items.map(item => item.getContentId()));
+        this.$excludeChildrenIds.set(include ? [] : this.props.get().items.map(item => item.getContentId()));
     }
 
     setExcludedChildrenIds(ids: ContentId[]): void {
-        this.$excludedChildrenIds.set(ids);
+        this.$excludeChildrenIds.set(ids);
     }
 
     //
@@ -111,7 +111,7 @@ export class PublishItemsListElement
     }
 
     onChildrenListChanged(listener: (notAdded: boolean) => void) {
-        this.$excludedChildrenIds.listen((value, oldValue) => {
+        this.$excludeChildrenIds.listen((value, oldValue) => {
             const newIds = value.map(id => id.toString());
             const oldIds = oldValue.map(id => id.toString());
             const addedIds = newIds.filter(id => !oldIds.includes(id));
@@ -139,11 +139,11 @@ export class PublishItemsListElement
     }
 
     getIncludeChildrenIds(): ContentId[] {
-        return this.getItemsIds().filter(id => !this.$excludedChildrenIds.get().includes(id));
+        return this.getItemsIds().filter(id => !this.$excludeChildrenIds.get().includes(id));
     }
 
     getExcludeChildrenIds(): ContentId[] {
-        return this.$excludedChildrenIds.get();
+        return this.$excludeChildrenIds.get();
     }
 
     isVisible(): boolean {
@@ -152,7 +152,7 @@ export class PublishItemsListElement
 
     reset(): void {
         this.$excludedIds.set([]);
-        this.$excludedChildrenIds.set([]);
+        this.$excludeChildrenIds.set([]);
         this.props.setKey('items', []);
         this.props.setKey('readOnly', false);
     }

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/requestPublish/RequestPublishDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/requestPublish/RequestPublishDialogContent.tsx
@@ -38,7 +38,7 @@ export const RequestPublishDialogContent = (): ReactElement => {
         description,
         assigneeIds,
         items,
-        excludedChildrenIds,
+        excludeChildrenIds,
         dependants,
         excludedDependantIds,
         requiredDependantIds,
@@ -51,7 +51,7 @@ export const RequestPublishDialogContent = (): ReactElement => {
             'description',
             'assigneeIds',
             'items',
-            'excludedChildrenIds',
+            'excludeChildrenIds',
             'dependants',
             'excludedDependantIds',
             'requiredDependantIds',
@@ -76,9 +76,9 @@ export const RequestPublishDialogContent = (): ReactElement => {
     const noResultsLabel = useI18n('dialog.search.result.noResults');
     const includeChildrenLabel = useI18n('field.content.includeChildren');
 
-    const excludedChildrenSet = useMemo(
-        () => new Set(excludedChildrenIds.map(id => id.toString())),
-        [excludedChildrenIds],
+    const excludeChildrenSet = useMemo(
+        () => new Set(excludeChildrenIds.map(id => id.toString())),
+        [excludeChildrenIds],
     );
     const excludedDependantSet = useMemo(
         () => new Set(excludedDependantIds.map(id => id.toString())),
@@ -206,7 +206,7 @@ export const RequestPublishDialogContent = (): ReactElement => {
                                 disabled={isItemsDisabled}
                                 renderRow={(item) => {
                                     const id = item.getContentId();
-                                    const includeChildren = !excludedChildrenSet.has(id.toString());
+                                    const includeChildren = !excludeChildrenSet.has(id.toString());
                                     const hasUnpublishedChildrenForItem = itemsWithUnpublishedChildren
                                         ? itemsWithUnpublishedChildren.has(id.toString())
                                         : true;

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialogDetails.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialogDetails.store.ts
@@ -50,7 +50,7 @@ type IssueDialogDetailsStore = {
     itemsLoading: boolean;
     itemsError: boolean;
     items: ContentSummaryAndCompareStatus[];
-    excludedChildrenIds: ContentId[];
+    excludeChildrenIds: ContentId[];
     dependants: ContentSummaryAndCompareStatus[];
     excludedDependantIds: ContentId[];
     requiredDependantIds: ContentId[];
@@ -85,7 +85,7 @@ const initialState: IssueDialogDetailsStore = {
     itemsLoading: false,
     itemsError: false,
     items: [],
-    excludedChildrenIds: [],
+    excludeChildrenIds: [],
     dependants: [],
     excludedDependantIds: [],
     requiredDependantIds: [],
@@ -157,7 +157,7 @@ export const loadIssueDialogItems = async (
 
     const publishRequest = targetIssue.getPublishRequest();
     const itemIds = publishRequest?.getItemsIds() ?? [];
-    const excludedChildrenIds = publishRequest?.getExcludeChildrenIds() ?? [];
+    const excludeChildrenIds = publishRequest?.getExcludeChildrenIds() ?? [];
     const excludedDependantIds = publishRequest?.getExcludeIds() ?? [];
 
     if (itemIds.length === 0) {
@@ -166,7 +166,7 @@ export const loadIssueDialogItems = async (
             itemsLoading: false,
             itemsError: false,
             items: [],
-            excludedChildrenIds: [],
+            excludeChildrenIds: [],
             dependants: [],
             excludedDependantIds: [],
             requiredDependantIds: [],
@@ -190,7 +190,7 @@ export const loadIssueDialogItems = async (
         items: canReuseItems ? currentState.items : [],
         dependants: isSameIssue ? currentState.dependants : [],
         requiredDependantIds: isSameIssue ? currentState.requiredDependantIds : [],
-        excludedChildrenIds,
+        excludeChildrenIds,
         excludedDependantIds,
     });
 
@@ -204,7 +204,7 @@ export const loadIssueDialogItems = async (
 
         const result = await resolvePublishDependencies({
             ids: itemIds,
-            excludeChildrenIds: excludedChildrenIds,
+            excludeChildrenIds: excludeChildrenIds,
         });
         if (requestId !== dependenciesRequestId) {
             return;
@@ -229,7 +229,7 @@ export const loadIssueDialogItems = async (
         $issueDialogDetails.set({
             ...latestState,
             items: sortedItems,
-            excludedChildrenIds,
+            excludeChildrenIds,
             dependants: sortedDependants,
             requiredDependantIds,
             excludedDependantIds: nextExcludedDependantIds,

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/newIssueDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/newIssueDialog.store.ts
@@ -21,7 +21,7 @@ type NewIssueDialogStore = {
     description: string;
     assigneeIds: string[];
     items: ContentSummaryAndCompareStatus[];
-    excludedChildrenIds: ContentId[];
+    excludeChildrenIds: ContentId[];
     dependants: ContentSummaryAndCompareStatus[];
     excludedDependantIds: ContentId[];
     requiredDependantIds: ContentId[];
@@ -36,7 +36,7 @@ const initialState: NewIssueDialogStore = {
     description: '',
     assigneeIds: [],
     items: [],
-    excludedChildrenIds: [],
+    excludeChildrenIds: [],
     dependants: [],
     excludedDependantIds: [],
     requiredDependantIds: [],
@@ -111,7 +111,7 @@ export const setNewIssueItems = (items: ContentSummaryAndCompareStatus[]): void 
         $newIssueDialog.set(resetDependenciesState({
             ...$newIssueDialog.get(),
             items: [],
-            excludedChildrenIds: [],
+            excludeChildrenIds: [],
         }));
         return;
     }
@@ -119,7 +119,7 @@ export const setNewIssueItems = (items: ContentSummaryAndCompareStatus[]): void 
     $newIssueDialog.set({
         ...$newIssueDialog.get(),
         items: nextItems,
-        excludedChildrenIds: getItemIds(nextItems),
+        excludeChildrenIds: getItemIds(nextItems),
     });
 
     reloadDependenciesDebounced();
@@ -134,15 +134,15 @@ export const addNewIssueItems = (items: ContentSummaryAndCompareStatus[]): void 
     const existingIds = new Set(state.items.map(item => item.getContentId().toString()));
     const newItems = items.filter(item => !existingIds.has(item.getContentId().toString()));
     const nextItems = dedupeItems([...state.items, ...newItems]);
-    const nextExcludedChildrenIds = uniqueIds([
-        ...state.excludedChildrenIds,
+    const nextExcludeChildrenIds = uniqueIds([
+        ...state.excludeChildrenIds,
         ...newItems.map(item => item.getContentId()),
     ]);
 
     $newIssueDialog.set({
         ...state,
         items: nextItems,
-        excludedChildrenIds: nextExcludedChildrenIds,
+        excludeChildrenIds: nextExcludeChildrenIds,
     });
 
     reloadDependenciesDebounced();
@@ -173,14 +173,14 @@ export const removeNewIssueItemsByIds = (ids: ContentId[]): void => {
     const idsToRemove = new Set(ids.map(id => id.toString()));
     const state = $newIssueDialog.get();
     const nextItems = state.items.filter(item => !idsToRemove.has(item.getContentId().toString()));
-    const nextExcludedChildrenIds = state.excludedChildrenIds
+    const nextExcludeChildrenIds = state.excludeChildrenIds
         .filter(id => !idsToRemove.has(id.toString()));
 
     if (nextItems.length === 0) {
         $newIssueDialog.set(resetDependenciesState({
             ...state,
             items: [],
-            excludedChildrenIds: [],
+            excludeChildrenIds: [],
         }));
         return;
     }
@@ -188,7 +188,7 @@ export const removeNewIssueItemsByIds = (ids: ContentId[]): void => {
     $newIssueDialog.set({
         ...state,
         items: nextItems,
-        excludedChildrenIds: nextExcludedChildrenIds,
+        excludeChildrenIds: nextExcludeChildrenIds,
     });
 
     reloadDependenciesDebounced();
@@ -196,19 +196,19 @@ export const removeNewIssueItemsByIds = (ids: ContentId[]): void => {
 
 export const setNewIssueItemIncludeChildren = (id: ContentId, includeChildren: boolean): void => {
     const state = $newIssueDialog.get();
-    const alreadyExcluded = hasContentIdInIds(id, state.excludedChildrenIds);
+    const alreadyExcluded = hasContentIdInIds(id, state.excludeChildrenIds);
 
     if (includeChildren && alreadyExcluded) {
         $newIssueDialog.setKey(
-            'excludedChildrenIds',
-            state.excludedChildrenIds.filter(item => !item.equals(id)),
+            'excludeChildrenIds',
+            state.excludeChildrenIds.filter(item => !item.equals(id)),
         );
         reloadDependenciesDebounced();
         return;
     }
 
     if (!includeChildren && !alreadyExcluded) {
-        $newIssueDialog.setKey('excludedChildrenIds', [...state.excludedChildrenIds, id]);
+        $newIssueDialog.setKey('excludeChildrenIds', [...state.excludeChildrenIds, id]);
         reloadDependenciesDebounced();
     }
 };
@@ -247,7 +247,7 @@ export const submitNewIssueDialog = async (): Promise<void> => {
     const publishRequest = PublishRequest
         .create()
         .addExcludeIds(state.excludedDependantIds)
-        .addPublishRequestItems(buildItems(state.items, state.excludedChildrenIds))
+        .addPublishRequestItems(buildItems(state.items, state.excludeChildrenIds))
         .build();
 
     try {
@@ -293,7 +293,7 @@ const reloadNewIssueDependencies = async (): Promise<void> => {
     try {
         const result = await resolvePublishDependencies({
             ids: itemIds,
-            excludeChildrenIds: state.excludedChildrenIds,
+            excludeChildrenIds: state.excludeChildrenIds,
         });
 
         if (currentInstance !== instanceId) {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
@@ -284,13 +284,13 @@ export const setPublishDialogState = (state: Partial<Omit<PublishDialogStore, 'o
 
 export const syncPublishDialogContext = async ({
     items,
-    excludedChildrenIds = [],
+    excludeChildrenIds = [],
     excludedDependantIds = [],
     message,
     schedule,
 }: {
     items: ContentSummaryAndCompareStatus[];
-    excludedChildrenIds?: ContentId[];
+    excludeChildrenIds?: ContentId[];
     excludedDependantIds?: ContentId[];
     message?: string;
     schedule?: PublishSchedule;
@@ -310,7 +310,7 @@ export const syncPublishDialogContext = async ({
         failed: false,
         items,
         excludedItemsIds: [],
-        excludedItemsWithChildrenIds: [...excludedChildrenIds],
+        excludedItemsWithChildrenIds: [...excludeChildrenIds],
         excludedDependantItemsIds: [...excludedDependantIds],
         message,
         schedule,
@@ -318,7 +318,7 @@ export const syncPublishDialogContext = async ({
 
     $draftPublishDialogSelection.set({
         excludedItemsIds: [],
-        excludedItemsWithChildrenIds: [...excludedChildrenIds],
+        excludedItemsWithChildrenIds: [...excludeChildrenIds],
         excludedDependantItemsIds: [...excludedDependantIds],
     });
 
@@ -1023,11 +1023,37 @@ async function markIdsReady(ids: ContentId[]): Promise<ContentId[]> {
     }
 }
 
+type PublishRequestData = {
+    ids: ContentId[];
+    excludedIds: ContentId[];
+    excludeChildrenIds: ContentId[];
+};
+
+/**
+ * Build publish request data to match legacy publish semantics:
+ * - ids: included main items only
+ * - excludedIds: excluded dependant items only
+ * - excludeChildrenIds: included main items where descendants should be excluded
+ */
+function buildPublishRequestData(): PublishRequestData {
+    const {items, excludedItemsIds, excludedItemsWithChildrenIds, excludedDependantItemsIds} = $publishDialog.get();
+
+    const includedMainItems = items.filter(item => !hasContentIdInIds(item.getContentId(), excludedItemsIds));
+
+    const excludeChildrenIds = includedMainItems
+        .filter(item => !item.hasChildren() || hasContentIdInIds(item.getContentId(), excludedItemsWithChildrenIds))
+        .map(item => item.getContentId());
+
+    return {
+        ids: includedMainItems.map(item => item.getContentId()),
+        excludedIds: uniqueIds(excludedDependantItemsIds),
+        excludeChildrenIds: uniqueIds(excludeChildrenIds),
+    };
+}
+
 async function sendPublishRequest(): Promise<TaskId | undefined> {
-    const publishableIds = $publishableIds.get();
-    const {message, excludedItemsIds, excludedItemsWithChildrenIds, excludedDependantItemsIds, schedule} = $publishDialog.get();
-    const allExcludedItemsWithChildrenIds = uniqueIds([...excludedItemsWithChildrenIds, ...excludedItemsIds]);
-    const allExcludedItemsIds = uniqueIds([...excludedItemsIds, ...excludedDependantItemsIds]);
+    const {message, schedule} = $publishDialog.get();
+    const publishRequestData = buildPublishRequestData();
 
     const hasScheduleValues = schedule?.from || schedule?.to;
     const resolvedSchedule = hasScheduleValues
@@ -1039,9 +1065,9 @@ async function sendPublishRequest(): Promise<TaskId | undefined> {
 
     try {
         return await publishContent({
-            ids: publishableIds,
-            excludedIds: allExcludedItemsIds,
-            excludeChildrenIds: allExcludedItemsWithChildrenIds,
+            ids: publishRequestData.ids,
+            excludedIds: publishRequestData.excludedIds,
+            excludeChildrenIds: publishRequestData.excludeChildrenIds,
             message: message || undefined,
             schedule: resolvedSchedule,
         });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.ts
@@ -21,7 +21,7 @@ type RequestPublishDialogStore = {
     description: string;
     assigneeIds: string[];
     items: ContentSummaryAndCompareStatus[];
-    excludedChildrenIds: ContentId[];
+    excludeChildrenIds: ContentId[];
     dependants: ContentSummaryAndCompareStatus[];
     excludedDependantIds: ContentId[];
     requiredDependantIds: ContentId[];
@@ -45,7 +45,7 @@ const initialState: RequestPublishDialogStore = {
     description: '',
     assigneeIds: [],
     items: [],
-    excludedChildrenIds: [],
+    excludeChildrenIds: [],
     dependants: [],
     excludedDependantIds: [],
     requiredDependantIds: [],
@@ -191,18 +191,18 @@ export const setRequestPublishItems = (
         $requestPublishDialog.set(resetDependenciesState({
             ...$requestPublishDialog.get(),
             items: [],
-            excludedChildrenIds: [],
+            excludeChildrenIds: [],
         }));
         resetChecksState();
         return;
     }
 
-    const excludedChildrenIds = includeChildren ? [] : getItemIds(nextItems);
+    const excludeChildrenIds = includeChildren ? [] : getItemIds(nextItems);
 
     $requestPublishDialog.set({
         ...$requestPublishDialog.get(),
         items: nextItems,
-        excludedChildrenIds,
+        excludeChildrenIds,
     });
 
     reloadDependenciesDebounced();
@@ -210,25 +210,25 @@ export const setRequestPublishItems = (
 
 export const setRequestPublishItemIncludeChildren = (id: ContentId, includeChildren: boolean): void => {
     const state = $requestPublishDialog.get();
-    const alreadyExcluded = hasContentIdInIds(id, state.excludedChildrenIds);
+    const alreadyExcluded = hasContentIdInIds(id, state.excludeChildrenIds);
 
     if (includeChildren && alreadyExcluded) {
         $requestPublishDialog.setKey(
-            'excludedChildrenIds',
-            state.excludedChildrenIds.filter(item => !item.equals(id)),
+            'excludeChildrenIds',
+            state.excludeChildrenIds.filter(item => !item.equals(id)),
         );
         reloadDependenciesDebounced();
         return;
     }
 
     if (!includeChildren && !alreadyExcluded) {
-        $requestPublishDialog.setKey('excludedChildrenIds', [...state.excludedChildrenIds, id]);
+        $requestPublishDialog.setKey('excludeChildrenIds', [...state.excludeChildrenIds, id]);
         reloadDependenciesDebounced();
     }
 };
 
 export const removeRequestPublishItem = (id: ContentId): void => {
-    const {items, excludedChildrenIds} = $requestPublishDialog.get();
+    const {items, excludeChildrenIds} = $requestPublishDialog.get();
     const newItems = items.filter(item => !item.getContentId().equals(id));
 
     if (newItems.length === 0) {
@@ -239,7 +239,7 @@ export const removeRequestPublishItem = (id: ContentId): void => {
     $requestPublishDialog.set({
         ...$requestPublishDialog.get(),
         items: newItems,
-        excludedChildrenIds: excludedChildrenIds.filter(i => !i.equals(id)),
+        excludeChildrenIds: excludeChildrenIds.filter(i => !i.equals(id)),
     });
 
     reloadDependenciesDebounced();
@@ -374,7 +374,7 @@ export const submitRequestPublishDialog = async (): Promise<void> => {
     const publishRequest = PublishRequest
         .create()
         .addExcludeIds(state.excludedDependantIds)
-        .addPublishRequestItems(buildItems(state.items, state.excludedChildrenIds))
+        .addPublishRequestItems(buildItems(state.items, state.excludeChildrenIds))
         .build();
 
     try {
@@ -425,7 +425,7 @@ const reloadRequestPublishDependencies = async (): Promise<void> => {
     try {
         const result = await resolvePublishDependencies({
             ids: itemIds,
-            excludeChildrenIds: state.excludedChildrenIds,
+            excludeChildrenIds: state.excludeChildrenIds,
         });
 
         if (currentInstance !== instanceId) {

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/buildItems.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/buildItems.ts
@@ -15,13 +15,13 @@ export const dedupeItems = (items: ContentSummaryAndCompareStatus[]): ContentSum
 
 export const buildItems = (
     items: ContentSummaryAndCompareStatus[],
-    excludedChildrenIds: ContentId[],
+    excludeChildrenIds: ContentId[],
 ): PublishRequestItem[] => {
     return items.map(item =>
         PublishRequestItem
             .create()
             .setId(item.getContentId())
-            .setIncludeChildren(!hasContentIdInIds(item.getContentId(), excludedChildrenIds))
+            .setIncludeChildren(!hasContentIdInIds(item.getContentId(), excludeChildrenIds))
             .build()
     );
 };


### PR DESCRIPTION
The publish dialog request used incorrect payload semantics: ids was derived from publishableIds (mixing main items and dependants), excludedIds mixed main and dependant exclusions, and the children-exclusion naming obscured intent. This could send dependants as roots and represent removed main items in the wrong field.
Fixed by building request data from explicit dialog semantics: ids = included main items, excludedIds = excluded dependants, excludeChildrenIds = included main items whose descendants are excluded.

Closes #9807 and also fixes #9611