### PR TITLE
Enonic UI: Child in tree list not changing publish status #9866

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.test.ts
@@ -49,7 +49,11 @@ function createNodeData(id: string, displayName?: string): ContentTreeNodeData {
 }
 
 // Mock ContentSummaryAndCompareStatus for cache
-function createMockContent(id: string, displayName?: string): ContentSummaryAndCompareStatus {
+function createMockContent(
+    id: string,
+    displayName?: string,
+    publishStatus: PublishStatus | 'missing' = PublishStatus.ONLINE
+): ContentSummaryAndCompareStatus {
     const mockName = {
         isUnnamed: () => false,
         toString: () => id,
@@ -71,7 +75,7 @@ function createMockContent(id: string, displayName?: string): ContentSummaryAndC
         getId: () => id,
         getDisplayName: () => displayName ?? `Content ${id}`,
         getType: () => mockType,
-        getPublishStatus: () => PublishStatus.ONLINE,
+        getPublishStatus: () => (publishStatus === 'missing' ? undefined : publishStatus),
         hasChildren: () => false,
         hasContentSummary: () => true,
         hasUploadItem: () => false,
@@ -479,6 +483,19 @@ describe('tree-list.store', () => {
             expect(merged).toHaveLength(1);
             const data = merged[0].data;
             expect(data && 'item' in data ? data.item?.getDisplayName() : undefined).toBe('Cache Name');
+        });
+
+        it('uses cache publish status even when unpublished payload has no publish status', () => {
+            addTreeNodes([{id: '1', data: createNodeData('1', 'Tree Name')}]);
+            setTreeRootIds(['1']);
+            setContent(createMockContent('1', 'Cache Name', PublishStatus.ONLINE));
+
+            // Unpublish event payloads may carry compare status changes with publishStatus unset.
+            setContents([createMockContent('1', 'Cache Name', 'missing')]);
+
+            const merged = $mergedFlatNodes.get();
+            const data = merged[0].data;
+            expect(data && 'publishStatus' in data ? data.publishStatus : PublishStatus.ONLINE).toBeUndefined();
         });
 
         it('injects uploads at parent position', () => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/tree/utils.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/tree/utils.ts
@@ -44,7 +44,7 @@ export function convertToContentFlatNode(
             id: data.id,
             displayName: content ? resolveDisplayName(content) : data.displayName,
             name: data.name,
-            publishStatus: content?.getPublishStatus() ?? data.publishStatus,
+            publishStatus: content ? content.getPublishStatus() : data.publishStatus,
             workflowStatus: content ? calcWorkflowStateStatus(content.getContentSummary()) : data.workflowStatus,
             contentType: data.contentType,
             iconUrl: content?.getContentSummary()?.getIconUrl() ?? data.iconUrl,


### PR DESCRIPTION
Fixed stale publish status in tree merge by making convertToContentFlatNode() use cache publish status whenever cached content exists, instead of falling back to old node status via nullish coalescing. 
Updated merge behavior to prevent ONLINE status from being reused after unpublish events where payload publish status is missing. 
Added regression test in tree-list.store.test.ts covering cached child data with missing publish status in subsequent update payloads.