### PR TITLE
keys.ts: add ligature expansion to normalize() #9966

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/identifier.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/identifier.ts
@@ -1,3 +1,5 @@
+import {expandLigatures} from '../../format/ligatures';
+
 /**
  * Checks whether a string is a valid project identifier.
  * Allows lowercase alphanumeric characters and hyphens,
@@ -8,17 +10,6 @@ export function validateProjectIdentifier(value: string): boolean {
 
     return regExp.test(value) && !value.endsWith('-');
 }
-
-/**
- * Characters that do not decompose via NFD normalization and
- * need explicit Latin-ASCII expansion. Covers Nordic (æ, ø),
- * German (ß), and other common European ligatures.
- */
-const LIGATURES: Record<string, string> = {
-    æ: 'ae', œ: 'oe', ß: 'ss', ø: 'o', đ: 'd', ł: 'l', ŋ: 'ng', þ: 'th',
-};
-
-const LIGATURE_RE = new RegExp(`[${Object.keys(LIGATURES).join('')}]`, 'g');
 
 /**
  * Converts an arbitrary string into a valid project identifier.
@@ -33,9 +24,7 @@ const LIGATURE_RE = new RegExp(`[${Object.keys(LIGATURES).join('')}]`, 'g');
  * @param isUserInput - Preserve a trailing hyphen for live typing.
  */
 export function prettifyProjectIdentifier(value: string, isUserInput?: boolean): string {
-    const prettified = value
-        .toLowerCase()
-        .replace(LIGATURE_RE, (ch) => LIGATURES[ch])
+    const prettified = expandLigatures(value.toLowerCase())
         .normalize('NFD')
         .replace(/[\u0300-\u036f]/g, '')   // strip combining diacritical marks (é→e, ü→u)
         .replace(/[^a-z0-9]+/g, '-')       // replace non-alphanumeric runs with single hyphen

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/format/keys.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/format/keys.test.ts
@@ -1,0 +1,139 @@
+import {describe, expect, it} from 'vitest';
+import {buildKey, normalize} from './keys';
+
+describe('normalize', () => {
+    describe('basic transformations', () => {
+        it('should lowercase input', () => {
+            expect(normalize('Hello')).toBe('hello');
+        });
+
+        it('should replace spaces with underscores', () => {
+            expect(normalize('My Project Name')).toBe('my_project_name');
+        });
+
+        it('should replace hyphens with underscores', () => {
+            expect(normalize('test--key')).toBe('test_key');
+        });
+
+        it('should replace dots with underscores', () => {
+            expect(normalize('foo.bar')).toBe('foo_bar');
+        });
+
+        it('should replace slashes with underscores', () => {
+            expect(normalize('foo/bar/baz')).toBe('foo_bar_baz');
+        });
+
+        it('should replace backslashes with underscores', () => {
+            expect(normalize('foo\\bar')).toBe('foo_bar');
+        });
+
+        it('should replace colons with underscores', () => {
+            expect(normalize('foo:bar')).toBe('foo_bar');
+        });
+
+        it('should handle mixed separators', () => {
+            expect(normalize('foo.bar/baz')).toBe('foo_bar_baz');
+        });
+    });
+
+    describe('diacritics', () => {
+        it('should strip accented characters', () => {
+            expect(normalize('café')).toBe('cafe');
+        });
+
+        it('should strip umlauts', () => {
+            expect(normalize('Über')).toBe('uber');
+        });
+    });
+
+    describe('ligatures', () => {
+        it('should expand æ to ae', () => {
+            expect(normalize('æbler')).toBe('aebler');
+        });
+
+        it('should expand ø to o', () => {
+            expect(normalize('fjørd')).toBe('fjord');
+        });
+
+        it('should expand ß to ss', () => {
+            expect(normalize('straße')).toBe('strasse');
+        });
+
+        it('should expand œ to oe', () => {
+            expect(normalize('œuvre')).toBe('oeuvre');
+        });
+
+        it('should expand ł to l', () => {
+            expect(normalize('łódź')).toBe('lodz');
+        });
+
+        it('should expand đ to d', () => {
+            expect(normalize('đón')).toBe('don');
+        });
+    });
+
+    describe('non-alphanumeric removal', () => {
+        it('should remove special characters', () => {
+            expect(normalize('Hello@World!')).toBe('helloworld');
+        });
+
+        it('should remove parentheses', () => {
+            expect(normalize('foo(bar)')).toBe('foobar');
+        });
+    });
+
+    describe('underscore handling', () => {
+        it('should collapse multiple underscores', () => {
+            expect(normalize('a___b')).toBe('a_b');
+        });
+
+        it('should trim leading underscores', () => {
+            expect(normalize('__foo')).toBe('foo');
+        });
+
+        it('should trim trailing underscores', () => {
+            expect(normalize('foo__')).toBe('foo');
+        });
+
+        it('should collapse underscores from consecutive separators', () => {
+            expect(normalize('a - b')).toBe('a_b');
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should return empty string for empty input', () => {
+            expect(normalize('')).toBe('');
+        });
+
+        it('should return empty string for non-string input', () => {
+            expect(normalize(null as unknown as string)).toBe('');
+            expect(normalize(undefined as unknown as string)).toBe('');
+        });
+
+        it('should return empty string for all-special-character input', () => {
+            expect(normalize('!@#$%')).toBe('');
+        });
+
+        it('should handle single character', () => {
+            expect(normalize('A')).toBe('a');
+        });
+    });
+});
+
+describe('buildKey', () => {
+    it('should join normalized args with hyphens', () => {
+        expect(buildKey('Foo', 'Bar')).toBe('foo-bar');
+    });
+
+    it('should normalize each segment independently', () => {
+        expect(buildKey('My App', 'user.name')).toBe('my_app-user_name');
+    });
+
+    it('should handle single argument', () => {
+        expect(buildKey('Test')).toBe('test');
+    });
+
+    it('should handle three arguments', () => {
+        expect(buildKey('a', 'b', 'c')).toBe('a-b-c');
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/format/keys.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/format/keys.ts
@@ -1,8 +1,11 @@
+import {expandLigatures} from './ligatures';
+
 /**
  * Normalizes text for use as keys (e.g., localStorage keys, identifiers).
  *
  * Transformation rules:
  * - Converts to lowercase
+ * - Expands ligatures (æ→ae, ß→ss, etc.)
  * - Replaces whitespace, hyphens, dots, slashes with underscores
  * - Removes all non-alphanumeric characters except underscores
  * - Collapses multiple underscores into one
@@ -23,8 +26,7 @@ export function normalize(text: string): string {
         return '';
     }
 
-    return text
-        .toLowerCase()
+    return expandLigatures(text.toLowerCase())
         .normalize('NFD') // Decompose accented characters
         .replace(/[\u0300-\u036f]/g, '') // Remove diacritics
         .replace(/[\s\-./\\:]+/g, '_') // Replace separators with underscores

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/format/ligatures.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/format/ligatures.ts
@@ -1,0 +1,19 @@
+/**
+ * Characters that do not decompose via NFD normalization and
+ * need explicit Latin-ASCII expansion. Covers Nordic (æ, ø),
+ * German (ß), and other common European ligatures.
+ */
+const LIGATURES: Record<string, string> = {
+    æ: 'ae', œ: 'oe', ß: 'ss', ø: 'o', đ: 'd', ł: 'l', ŋ: 'ng', þ: 'th',
+};
+
+const LIGATURE_RE = new RegExp(`[${Object.keys(LIGATURES).join('')}]`, 'g');
+
+/**
+ * Expands ligature characters into their Latin-ASCII equivalents.
+ * Must be called **before** NFD normalization, since NFD does not
+ * decompose these characters.
+ */
+export function expandLigatures(value: string): string {
+    return value.replace(LIGATURE_RE, (ch) => LIGATURES[ch]);
+}


### PR DESCRIPTION
Extracted shared `expandLigatures()` helper from `identifier.ts` into a new `format/ligatures.ts` module. Added ligature expansion to `normalize()` in `keys.ts` before NFD normalization to fix ligatures (`æ`, `ø`, `ß`, `œ`, etc.) silently disappearing from key output. Added 30 tests for `keys.ts` covering the full normalization pipeline.

Closes #9966

<sub>*Drafted with AI assistance*</sub>