### PR TITLE
Site content baseUrl not cleared on save, triggers false unsaved changes #9980

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/UpdatePersistedContentWithStoreRoutine.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/UpdatePersistedContentWithStoreRoutine.ts
@@ -101,11 +101,7 @@ export class UpdatePersistedContentWithStoreRoutine
     }
 
     private syncPortalBaseUrlInSiteConfig(data: PropertyTree, baseUrl: string | null): void {
-        if (baseUrl == null) {
-            return;
-        }
-
-        if (StringHelper.isBlank(baseUrl)) {
+        if (baseUrl == null || StringHelper.isBlank(baseUrl)) {
             this.removePortalBaseUrlFromSiteConfig(data);
             return;
         }

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
@@ -1,6 +1,7 @@
 import {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
 import type {PropertyPath} from '@enonic/lib-admin-ui/data/PropertyPath';
 import {PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
+import {ValueTypes} from '@enonic/lib-admin-ui/data/ValueTypes';
 import {atom, computed, map} from 'nanostores';
 import type {Content} from '../../../app/content/Content';
 import type {ContentName} from '../../../app/content/ContentName';
@@ -274,8 +275,8 @@ function injectSiteBaseUrlBridge(data: PropertyTree | null, content: Content): P
 
     if (baseUrl != null && baseUrl.trim().length > 0) {
         data.setString(BASE_URL_INPUT_PROP, 0, baseUrl);
-    } else if (root.getPropertyArray(BASE_URL_INPUT_PROP)?.getSize() > 0) {
-        data.removeProperty(BASE_URL_INPUT_PROP, 0);
+    } else {
+        data.setProperty(BASE_URL_INPUT_PROP, 0, ValueTypes.STRING.newNullValue());
     }
 
     return data;

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentWizardTabs.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentWizardTabs.tsx
@@ -3,21 +3,23 @@ import {useStore} from '@nanostores/preact';
 import {type ReactElement} from 'react';
 import {useI18n} from '../../../hooks/useI18n';
 import {
+    $contentTypeDisplayName,
     $displayName,
     $hasPage,
     $isContentFormExpanded,
-    $contentTypeDisplayName,
     $mixinsTabs,
 } from '../../../store/wizardContent.store';
 import {CollapsedFormPanel} from './CollapsedFormPanel';
 import {ContentDataView} from './ContentDataView';
-import {PageView} from './PageView';
 import {MixinView} from './MixinView';
+import {PageView} from './PageView';
 import {ToggleFormButton} from './ToggleFormButton';
 
 type ContentWizardTabsProps = {
     tabListAction?: ReactElement;
 };
+
+const CONTENT_WIZARD_TABS_NAME = 'ContentWizardTabs';
 
 export const ContentWizardTabs = ({tabListAction}: ContentWizardTabsProps): ReactElement => {
     const isExpanded = useStore($isContentFormExpanded);
@@ -28,11 +30,11 @@ export const ContentWizardTabs = ({tabListAction}: ContentWizardTabsProps): Reac
     const pageTabLabel = useI18n('field.page');
 
     if (!isExpanded) {
-        return <CollapsedFormPanel displayName={displayName || contentTypeDisplayName} />;
+        return <CollapsedFormPanel data-component={CONTENT_WIZARD_TABS_NAME} displayName={displayName || contentTypeDisplayName} />;
     }
 
     return (
-        <Tab.Root defaultValue="content" className="flex flex-col gap-7.5">
+        <Tab.Root data-component={CONTENT_WIZARD_TABS_NAME} defaultValue="content" className="flex flex-col gap-7.5">
             <div className="flex items-center gap-2">
                 <Tab.List className="w-auto flex-1 min-w-0">
                     <Tab.DefaultTrigger value="content">{contentTypeDisplayName}</Tab.DefaultTrigger>
@@ -66,4 +68,4 @@ export const ContentWizardTabs = ({tabListAction}: ContentWizardTabsProps): Reac
     );
 };
 
-ContentWizardTabs.displayName = 'ContentWizardTabs';
+ContentWizardTabs.displayName = CONTENT_WIZARD_TABS_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
@@ -4,20 +4,23 @@ import {useI18n} from '../../../hooks/useI18n';
 import {EditableText} from '../../../shared/primitives/EditableText';
 import {$displayName, setDraftDisplayName} from '../../../store/wizardContent.store';
 
+const DISPLAY_NAME_INPUT_NAME = 'DisplayNameInput';
+
 export const DisplayNameInput = (): ReactElement => {
     const displayName = useStore($displayName);
     const placeholder = useI18n('field.displayName');
 
     return (
         <EditableText
+            data-component={DISPLAY_NAME_INPUT_NAME}
             size="xl"
             value={displayName}
             placeholder={placeholder}
             onValueChange={setDraftDisplayName}
             onCommit={setDraftDisplayName}
-            className='min-w-64 px-5 placeholder:text-subtle/50 border-l-bdr-subtle rounded-none '
+            className='min-w-64 px-5 placeholder:text-subtle/50 border-l-bdr-subtle rounded-xs'
         />
     );
 };
 
-DisplayNameInput.displayName = 'DisplayNameInput';
+DisplayNameInput.displayName = DISPLAY_NAME_INPUT_NAME;


### PR DESCRIPTION
Fixed clearing the `baseUrl` field in site content wizard — the old value was preserved because `syncPortalBaseUrlInSiteConfig` returned early when the bridge property was `null` instead of removing the stale value from `siteConfig[portal].config.baseUrl`.

Fixed false unsaved-changes state after save — `injectSiteBaseUrlBridge` was removing the bridge `PropertyArray` when `baseUrl` was empty, causing the FormRenderer to re-create it on the draft tree, bump `$wizardDataVersion`, and flip `$wizardHasChanges` to `true`.

Closes #9980

<sub>*Drafted with AI assistance*</sub>