### PR TITLE
Don't show border for a focused Display Name #10008

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
@@ -18,7 +18,7 @@ export const DisplayNameInput = (): ReactElement => {
             placeholder={placeholder}
             onValueChange={setDraftDisplayName}
             onCommit={setDraftDisplayName}
-            className='min-w-64 px-5 placeholder:text-subtle/50 border-l-bdr-subtle rounded-xs'
+            className='min-w-64 px-5 placeholder:text-subtle/50 border-l-bdr-subtle rounded-xs focus:border-transparent'
         />
     );
 };


### PR DESCRIPTION
Set border transparent on focus to keep placement and distances equal while removing "duplicate" line from border + ring.