### PR TITLE
Add Cache-Control header to HTML responses #10062

### DIFF
--- a/modules/app/src/main/resources/admin/extensions/settings/settings.js
+++ b/modules/app/src/main/resources/admin/extensions/settings/settings.js
@@ -16,6 +16,9 @@ function handleGet() {
     return {
         contentType: 'text/html',
         body: mustache.render(view, params),
+        headers: {
+            'Cache-Control': 'no-cache',
+        },
     };
 }
 

--- a/modules/app/src/main/resources/admin/tools/main/main.js
+++ b/modules/app/src/main/resources/admin/tools/main/main.js
@@ -16,6 +16,9 @@ exports.renderTemplate = function (params) {
     const response = {
         contentType: 'text/html',
         body: mustache.render(view, params),
+        headers: {
+            'Cache-Control': 'no-cache',
+        },
     };
 
     if (enableSecurityPolicy) {
@@ -26,9 +29,7 @@ exports.renderTemplate = function (params) {
         if (!securityPolicy) {
             securityPolicy = `default-src 'self'; connect-src 'self' ws: wss: ${baseMarketUrl}; script-src 'self' 'unsafe-inline'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:`;
         }
-        response.headers = {
-            'Content-Security-Policy': securityPolicy
-        };
+        response.headers['Content-Security-Policy'] = securityPolicy;
     }
 
     return response;


### PR DESCRIPTION
Add `Cache-Control: no-cache` header to HTML responses in main tool and settings extension controllers. This ensures browsers revalidate the HTML page on each load, picking up new fingerprinted asset URLs after redeployment without requiring a hard reload.

Closes #10062

<sub>*Drafted with AI assistance*</sub>
