### PR TITLE
Optimize lib-contentstudio processResources task #10066

### DIFF
--- a/modules/lib/build.gradle
+++ b/modules/lib/build.gradle
@@ -49,6 +49,10 @@ tasks.named( 'check' ).configure {
     dependsOn tasks.named( 'pnpmTest' )
 }
 
+tasks.named( 'processResources' ).configure {
+    exclude 'assets/js/**'
+}
+
 tasks.register( 'pnpmBuild', PnpmTask ) {
     dependsOn tasks.named( 'pnpmInstall' )
     description = 'Build JS and DTS'


### PR DESCRIPTION
Excluded TypeScript source files from resource copying — they are only used as input to pnpmBuild (which reads from source directly) and excluded from the jar. 
Reduced processResources from 2104 files (15MB) to 572 files (6MB).