### PR TITLE
Add dependabot groups for related npm packages #10076

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,24 @@ updates:
       - "/testing"
     ignore:
       - dependency-name: "@enonic/lib-admin-ui"
+    groups:
+      tailwindcss:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+      enonic-types:
+        patterns:
+          - "@enonic-types/*"
+      rspack:
+        patterns:
+          - "@rspack/*"
+      swc:
+        patterns:
+          - "@swc/*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Added `tailwindcss`, `enonic-types`, `swc`, and `vitest` dependency groups to the npm section of `dependabot.yml`. Without grouping, dependabot may bump e.g. `tailwindcss` without `@tailwindcss/vite`, or update some `@enonic-types/*` packages but not others, breaking the build.

Closes #10076

<sub>*Drafted with AI assistance*</sub>
