### PR TITLE
Fix jQuery UI error caused by disabled AMD support in Rspack #10083

### DIFF
--- a/modules/app/rspack.config.js
+++ b/modules/app/rspack.config.js
@@ -99,6 +99,7 @@ module.exports = {
             failOnError: true
         }),
     ],
+    amd: {},
     mode: isProd ? 'production' : 'development',
     devtool: isProd ? false : 'source-map',
     performance: {hints: false}


### PR DESCRIPTION
Enabled AMD module dependency analysis in Rspack config (`amd: {}`). Rspack disables this by default, unlike Webpack, which broke jQuery UI's AMD `define()` dependency chain — `plugin.js` was never loaded, causing `$.ui.plugin is undefined` at runtime.

Closes #10083

<sub>*Drafted with AI assistance*</sub>
