### PR TITLE
Form pipeline: validation integration #9928

### DIFF
--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -203,8 +203,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@enonic/ui':
-        specifier: ~0.47.1
-        version: 0.47.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.47.2
+        version: 0.47.2(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.59.0)
@@ -293,8 +293,8 @@ importers:
   .xp/dev/lib-contentstudio:
     dependencies:
       '@enonic/ui':
-        specifier: ~0.47.1
-        version: 0.47.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.47.2
+        version: 0.47.2(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@nanostores/preact':
         specifier: ^1.0.0
         version: 1.1.0(nanostores@0.11.4)(preact@10.29.0)
@@ -643,8 +643,8 @@ packages:
     resolution: {integrity: sha512-Wsyt6ViWI3Qje4aDujpOUpbSW59ei6AQvWM/ioiTKfYIAkpwcJDxsLlLrJ3PrJUflWScFkzPT2pWFGxJzYBtmg==}
     engines: {node: '>= 24.13.0'}
 
-  '@enonic/ui@0.47.1':
-    resolution: {integrity: sha512-Jh9gH30WvLsSoJJd6G5L55t8o5ygxFOOKMUnG/iuGXqPO5Dhyap07CPz3xHaiRxKkiv5ylfnsePf0/Wop2gEmQ==}
+  '@enonic/ui@0.47.2':
+    resolution: {integrity: sha512-O5OJDnF0Z89Cc8D4u71s9MGmoBgV6zquCOKeh2PrTJR4QxYzrVytkBo3GP6wOYy3ZfJo/wZYFjSCP/+MIM6+pw==}
     engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -5218,7 +5218,7 @@ snapshots:
       mousetrap: 1.6.5
       q: 1.5.1
 
-  '@enonic/ui@0.47.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+  '@enonic/ui@0.47.2(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       class-variance-authority: 0.7.1

--- a/modules/lib/package.json
+++ b/modules/lib/package.json
@@ -26,7 +26,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@enonic/ui": "~0.47.1",
+    "@enonic/ui": "~0.47.2",
     "@nanostores/preact": "^1.0.0",
     "ckeditor4-react": "4.3.0",
     "class-variance-authority": "^0.7.1",

--- a/modules/lib/pnpm-lock.yaml
+++ b/modules/lib/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@enonic/ui':
-        specifier: ~0.47.1
-        version: 0.47.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.47.2
+        version: 0.47.2(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@nanostores/preact':
         specifier: ^1.0.0
         version: 1.1.0(nanostores@0.11.4)(preact@10.29.0)
@@ -236,8 +236,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@enonic/ui':
-        specifier: ~0.47.1
-        version: 0.47.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.47.2
+        version: 0.47.2(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.59.0)
@@ -439,8 +439,8 @@ packages:
       typescript: ^5.8.3
       typescript-eslint: ^8.39.0
 
-  '@enonic/ui@0.47.1':
-    resolution: {integrity: sha512-Jh9gH30WvLsSoJJd6G5L55t8o5ygxFOOKMUnG/iuGXqPO5Dhyap07CPz3xHaiRxKkiv5ylfnsePf0/Wop2gEmQ==}
+  '@enonic/ui@0.47.2':
+    resolution: {integrity: sha512-O5OJDnF0Z89Cc8D4u71s9MGmoBgV6zquCOKeh2PrTJR4QxYzrVytkBo3GP6wOYy3ZfJo/wZYFjSCP/+MIM6+pw==}
     engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -4135,7 +4135,7 @@ snapshots:
       typescript: 5.9.3
       typescript-eslint: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
 
-  '@enonic/ui@0.47.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+  '@enonic/ui@0.47.2(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       class-variance-authority: 0.7.1

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -66,6 +66,7 @@ import {
     setMixinsDescriptors as setWizardMixinsDescriptors,
     setPersistedContent as setWizardPersistedContent,
 } from '../../v6/features/store/wizardContent.store';
+import {escalateVisibility, initializeValidation, setServerValidationErrors} from '../../v6/features/store/wizardValidation.store';
 import {setWizardToolbarIsPathAvailable} from '../../v6/features/store/wizardToolbar.store';
 import {type PreviewToolbarElement} from '../../v6/features/views/browse/layout/preview/PreviewToolbar';
 import {ContentWizardTabsToolbarElement} from '../../v6/features/views/wizard/content-wizard-tabs/ContentWizardTabsToolbarElement';
@@ -551,6 +552,7 @@ export class ContentWizardPanel
 
         const publishActionHandler = () => {
             if (this.hasUnsavedChanges()) {
+                escalateVisibility('all');
                 this.contentWizardStepForm.validate();
                 this.displayValidationErrors(!this.isValid());
             }
@@ -926,6 +928,7 @@ export class ContentWizardPanel
                 this.contentType ?? null,
                 [],
             );
+            initializeValidation(this.isNew());
         } else if (this.contentType) {
             setWizardContentType(this.contentType);
         }
@@ -2238,6 +2241,9 @@ export class ContentWizardPanel
         this.updateXDataStepForms(currentContent);
         // sets validation errors on form context
         this.initFormContext();
+
+        escalateVisibility('all');
+        setServerValidationErrors(this.getCurrentItem().getValidationErrors());
 
         if (!this.isRename) {
             this.resetWizard();

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
@@ -100,7 +100,7 @@ export const $wizardDraftData = atom<PropertyTree | null>(null);
 
 export const $wizardDataChangedPaths = map<Record<string, number>>({});
 
-const $wizardDataVersion = atom<number>(0);
+export const $wizardDataVersion = atom<number>(0);
 
 export const $wizardPersistedMixins = wizardTrackedState.mixins.persisted;
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.ts
@@ -1,0 +1,195 @@
+import type {ValidationError} from '@enonic/lib-admin-ui/ValidationError';
+import {ValidationErrorHelper} from '@enonic/lib-admin-ui/ValidationErrorHelper';
+import {type RawValueMap, type ValidationVisibility, validateForm} from '@enonic/lib-admin-ui/form2';
+import {atom} from 'nanostores';
+import type {PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
+import {
+    $contentType,
+    $enabledMixinsNames,
+    $mixinsDescriptors,
+    $wizardDataVersion,
+    $wizardDraftData,
+    $wizardDraftMixins,
+    onWizardContentReset,
+    setWizardFormValidation,
+} from './wizardContent.store';
+import {createDebounce} from '../utils/timing/createDebounce';
+
+//
+// * State
+//
+
+export const $validationVisibility = atom<ValidationVisibility>('none');
+
+const $serverErrors = atom<ValidationError[]>([]);
+
+const contentRawValueMap: RawValueMap = new Map();
+
+const mixinRawValueMaps = new Map<string, RawValueMap>();
+
+//
+// * Internal
+//
+
+const DEBOUNCE_DELAY = 150;
+
+function runValidation(): void {
+    const contentType = $contentType.get();
+    const draftData = $wizardDraftData.get();
+    const draftMixins = $wizardDraftMixins.get();
+    const descriptors = $mixinsDescriptors.get();
+    const enabledNames = $enabledMixinsNames.get();
+    const serverErrors = $serverErrors.get();
+
+    if (!contentType || !draftData) {
+        setWizardFormValidation(true);
+        return;
+    }
+
+    const contentResult = validateForm(contentType.getForm(), draftData.getRoot(), {
+        rawValues: contentRawValueMap,
+        serverErrors,
+    });
+
+    let allMixinsValid = true;
+
+    for (const name of enabledNames) {
+        const descriptor = descriptors.find((d) => d.getName() === name);
+        if (!descriptor || descriptor.getFormItems().length === 0) {
+            continue;
+        }
+
+        const mixin = draftMixins.find((m) => m.getName().toString() === name);
+        if (!mixin) {
+            continue;
+        }
+
+        const mixinResult = validateForm(descriptor.toForm(), mixin.getData().getRoot(), {
+            rawValues: getMixinRawValueMap(name),
+        });
+
+        if (!mixinResult.isValid) {
+            allMixinsValid = false;
+        }
+    }
+
+    setWizardFormValidation(contentResult.isValid && allMixinsValid);
+}
+
+const debouncedRunValidation = createDebounce(runValidation, DEBOUNCE_DELAY);
+
+//
+// * Subscriptions
+//
+
+type Unsubscribe = () => void;
+
+const subscriptions: Unsubscribe[] = [];
+
+let mixinTreeCleanups: Unsubscribe[] = [];
+
+function setupSubscriptions(): void {
+    subscriptions.push(
+        $wizardDataVersion.subscribe(() => {
+            debouncedRunValidation();
+        }),
+    );
+
+    subscriptions.push(
+        $contentType.subscribe(() => {
+            debouncedRunValidation();
+        }),
+    );
+
+    subscriptions.push(
+        $wizardDraftMixins.subscribe((mixins) => {
+            // Detach previous mixin tree listeners
+            for (const cleanup of mixinTreeCleanups) {
+                cleanup();
+            }
+            mixinTreeCleanups = [];
+
+            // Attach new listeners to each mixin's PropertyTree
+            for (const mixin of mixins) {
+                const tree: PropertyTree = mixin.getData();
+                const handler = () => {
+                    debouncedRunValidation();
+                };
+                tree.onChanged(handler);
+                mixinTreeCleanups.push(() => tree.unChanged(handler));
+            }
+
+            // Mixin list itself changed (add/remove) — trigger validation
+            debouncedRunValidation();
+        }),
+    );
+}
+
+//
+// * Exported functions
+//
+
+export function initializeValidation(isNew: boolean): void {
+    resetValidation();
+    $validationVisibility.set(isNew ? 'interactive' : 'all');
+    setupSubscriptions();
+    runValidation();
+}
+
+export function escalateVisibility(mode: ValidationVisibility): void {
+    const order: ValidationVisibility[] = ['none', 'interactive', 'all'];
+    const current = order.indexOf($validationVisibility.get());
+    const next = order.indexOf(mode);
+
+    if (next > current) {
+        $validationVisibility.set(mode);
+    }
+}
+
+export function setServerValidationErrors(errors: ValidationError[]): void {
+    const customErrors = errors.filter((e) => ValidationErrorHelper.isCustomError(e));
+    $serverErrors.set(customErrors);
+    runValidation();
+}
+
+export function getContentRawValueMap(): RawValueMap {
+    return contentRawValueMap;
+}
+
+export function getMixinRawValueMap(name: string): RawValueMap {
+    let map = mixinRawValueMaps.get(name);
+    if (!map) {
+        map = new Map();
+        mixinRawValueMaps.set(name, map);
+    }
+    return map;
+}
+
+export function flushValidation(): void {
+    debouncedRunValidation.flush();
+}
+
+export function resetValidation(): void {
+    debouncedRunValidation.cancel();
+
+    for (const cleanup of mixinTreeCleanups) {
+        cleanup();
+    }
+    mixinTreeCleanups = [];
+
+    for (const unsub of subscriptions) {
+        unsub();
+    }
+    subscriptions.length = 0;
+
+    $validationVisibility.set('none');
+    $serverErrors.set([]);
+    contentRawValueMap.clear();
+    mixinRawValueMaps.clear();
+}
+
+//
+// * Cleanup registration
+//
+
+onWizardContentReset(resetValidation);

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
@@ -1,9 +1,11 @@
 import {useStore} from '@nanostores/preact';
 import {type ReactElement, useMemo} from 'react';
+import {RawValueProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
 import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
 import {$contextContent} from '../../../store/context/contextContent.store';
 import {$activeProject} from '../../../store/projects.store';
 import {$contentType, $wizardDraftData} from '../../../store/wizardContent.store';
+import {$validationVisibility, getContentRawValueMap} from '../../../store/wizardValidation.store';
 import {FormRenderer} from '../../../shared/form';
 import {HtmlAreaProvider} from '../../../shared/form/input-types/html-area';
 import {DisplayNameInput} from './DisplayNameInput';
@@ -14,7 +16,10 @@ export const ContentForm = (): ReactElement | null => {
     const draftData = useStore($wizardDraftData);
     const contextContent = useStore($contextContent);
     const activeProject = useStore($activeProject);
+    const visibility = useStore($validationVisibility);
     const applicationKeys = useApplicationKeys();
+
+    const rawValueMap = useMemo(() => getContentRawValueMap(), []);
 
     const contentSummary = useMemo(
         () => contextContent?.getContentSummary(),
@@ -30,17 +35,21 @@ export const ContentForm = (): ReactElement | null => {
     return (
         <div className="flex flex-col gap-7.5">
             <DisplayNameInput />
-            <HtmlAreaProvider
-                contentSummary={contentSummary}
-                project={activeProject}
-                applicationKeys={applicationKeys}
-                assetsUri={assetsUri}
-            >
-                <FormRenderer
-                    form={contentType.getForm()}
-                    propertySet={draftData.getRoot()}
-                />
-            </HtmlAreaProvider>
+            <ValidationVisibilityProvider visibility={visibility}>
+                <RawValueProvider map={rawValueMap}>
+                    <HtmlAreaProvider
+                        contentSummary={contentSummary}
+                        project={activeProject}
+                        applicationKeys={applicationKeys}
+                        assetsUri={assetsUri}
+                    >
+                        <FormRenderer
+                            form={contentType.getForm()}
+                            propertySet={draftData.getRoot()}
+                        />
+                    </HtmlAreaProvider>
+                </RawValueProvider>
+            </ValidationVisibilityProvider>
         </div>
     );
 };

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/MixinView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/MixinView.tsx
@@ -1,9 +1,11 @@
 import {useStore} from '@nanostores/preact';
 import {type ReactElement, useMemo} from 'react';
+import {RawValueProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
 import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
 import {$contextContent} from '../../../store/context/contextContent.store';
 import {$activeProject} from '../../../store/projects.store';
 import {$mixinsDescriptors, $wizardDraftMixins} from '../../../store/wizardContent.store';
+import {$validationVisibility, getMixinRawValueMap} from '../../../store/wizardValidation.store';
 import {FormRenderer} from '../../../shared/form';
 import {HtmlAreaProvider} from '../../../shared/form/input-types/html-area';
 import {useApplicationKeys} from './useApplicationKeys';
@@ -18,7 +20,10 @@ export const MixinView = ({mixinName, displayName}: MixinViewProps): ReactElemen
     const draftMixins = useStore($wizardDraftMixins);
     const contextContent = useStore($contextContent);
     const activeProject = useStore($activeProject);
+    const visibility = useStore($validationVisibility);
     const applicationKeys = useApplicationKeys();
+
+    const rawValueMap = useMemo(() => getMixinRawValueMap(mixinName), [mixinName]);
 
     const contentSummary = useMemo(
         () => contextContent?.getContentSummary(),
@@ -44,17 +49,21 @@ export const MixinView = ({mixinName, displayName}: MixinViewProps): ReactElemen
     }
 
     return (
-        <HtmlAreaProvider
-            contentSummary={contentSummary}
-            project={activeProject}
-            applicationKeys={applicationKeys}
-            assetsUri={assetsUri}
-        >
-            <FormRenderer
-                form={form}
-                propertySet={mixinData.getRoot()}
-            />
-        </HtmlAreaProvider>
+        <ValidationVisibilityProvider visibility={visibility}>
+            <RawValueProvider map={rawValueMap}>
+                <HtmlAreaProvider
+                    contentSummary={contentSummary}
+                    project={activeProject}
+                    applicationKeys={applicationKeys}
+                    assetsUri={assetsUri}
+                >
+                    <FormRenderer
+                        form={form}
+                        propertySet={mixinData.getRoot()}
+                    />
+                </HtmlAreaProvider>
+            </RawValueProvider>
+        </ValidationVisibilityProvider>
     );
 };
 


### PR DESCRIPTION
Wire form2 validation pipeline into v6 wizard.

New `wizardValidation.store` runs debounced `validateForm()` on content and mixin form trees, writing results to `$wizardDataValidation` via `setWizardFormValidation()`. Content and mixin forms wrapped with `ValidationVisibilityProvider` and `RawValueProvider` so `InputField` receives visibility mode and raw value tracking. `ContentWizardPanel` bridges the lifecycle: initializes on load, escalates visibility on publish/save, injects server validation errors after save.

Requires https://github.com/enonic/lib-admin-ui/pull/4366

Closes #9928

<sub>*Drafted with AI assistance*</sub>
