### PR TITLE
DisplayNameInput: add validation error styling #10128

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/primitives/EditableText.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/primitives/EditableText.tsx
@@ -39,6 +39,7 @@ export type EditableTextProps = {
     onEditingChange?: (isEditing: boolean) => void;
     allowEmpty?: boolean;
     fullWidth?: boolean;
+    error?: boolean;
 } & VariantProps<typeof editableTextVariants>
     & Omit<ComponentPropsWithoutRef<'input'>, 'value' | 'onChange' | 'type' | 'size'>;
 
@@ -56,6 +57,7 @@ export const EditableText = forwardRef<HTMLInputElement, EditableTextProps>(({
     allowEmpty = true,
     size,
     fullWidth = false,
+    error,
     className,
     onFocus,
     onBlur,
@@ -198,6 +200,7 @@ export const EditableText = forwardRef<HTMLInputElement, EditableTextProps>(({
                 type="text"
                 value={draft}
                 placeholder={placeholder}
+                aria-invalid={error || undefined}
                 onChange={(e) => {
                     const nextValue = e.currentTarget.value;
                     setDraft(nextValue);
@@ -212,6 +215,7 @@ export const EditableText = forwardRef<HTMLInputElement, EditableTextProps>(({
                     fullWidth ? 'w-full' : 'min-w-6 max-w-full',
                     !isFocused && !fullWidth && 'truncate',
                     className,
+                    error && 'focus:ring-error',
                 )}
                 {...props}
             />

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
@@ -1,25 +1,51 @@
+import {cn} from '@enonic/ui';
+import {FieldError} from '@enonic/lib-admin-ui/form2/components/field-error';
 import {useStore} from '@nanostores/preact';
-import {type ReactElement} from 'react';
+import {useState, type ReactElement} from 'react';
 import {useI18n} from '../../../hooks/useI18n';
 import {EditableText} from '../../../shared/primitives/EditableText';
 import {$displayName, setDraftDisplayName} from '../../../store/wizardContent.store';
+import {$validationVisibility} from '../../../store/wizardValidation.store';
 
 const DISPLAY_NAME_INPUT_NAME = 'DisplayNameInput';
 
 export const DisplayNameInput = (): ReactElement => {
     const displayName = useStore($displayName);
+    const visibility = useStore($validationVisibility);
+    const [touched, setTouched] = useState(false);
+
     const placeholder = useI18n('field.displayName');
+    const errorMessage = useI18n('field.displayName.required');
+
+    const isInvalid = displayName.trim().length === 0;
+    const showError = isInvalid && (
+        visibility === 'all' || (visibility === 'interactive' && touched)
+    );
+
+    const handleEditingChange = (isEditing: boolean): void => {
+        if (!isEditing) {
+            setTouched(true);
+        }
+    };
 
     return (
-        <EditableText
-            data-component={DISPLAY_NAME_INPUT_NAME}
-            size="xl"
-            value={displayName}
-            placeholder={placeholder}
-            onValueChange={setDraftDisplayName}
-            onCommit={setDraftDisplayName}
-            className='min-w-64 px-5 placeholder:text-subtle/50 border-l-bdr-subtle rounded-xs focus:border-transparent'
-        />
+        <div>
+            <EditableText
+                data-component={DISPLAY_NAME_INPUT_NAME}
+                size="xl"
+                value={displayName}
+                placeholder={placeholder}
+                onValueChange={setDraftDisplayName}
+                onCommit={setDraftDisplayName}
+                onEditingChange={handleEditingChange}
+                error={showError}
+                className={cn(
+                    'min-w-64 px-5 placeholder:text-subtle/50 rounded-xs focus:border-transparent',
+                    showError ? 'border-l-error' : 'border-l-bdr-subtle',
+                )}
+            />
+            <FieldError className="mt-2" message={showError ? errorMessage : undefined} />
+        </div>
     );
 };
 

--- a/modules/lib/src/main/resources/i18n/phrases.properties
+++ b/modules/lib/src/main/resources/i18n/phrases.properties
@@ -326,6 +326,7 @@ field.content.showEntire=Show the entire content
 field.root=Project root
 field.path=Path
 field.displayName=Display Name
+field.displayName.required=Display Name is required
 field.baseUrl=Base URL
 field.baseUrl.help=Override the default base URL
 field.creator=Created by


### PR DESCRIPTION
Added validation error styling to `DisplayNameInput`. The component now subscribes to `$validationVisibility` and tracks touched state to show a `FieldError` message and error border when the display name is empty. Extended `EditableText` with an `error` prop for `aria-invalid` and error ring styling.

Closes #10128

<sub>*Drafted with AI assistance*</sub>
