### PR TITLE
SiteConfigurator: content selector fails with DescriptorKey error in application config dialog #10150

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormRenderContext.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormRenderContext.tsx
@@ -1,18 +1,21 @@
+import type {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
 import {type ReactElement, type ReactNode, createContext, useContext, useMemo} from 'react';
 
 type FormRenderContextValue = {
     enabled: boolean;
+    applicationKey?: ApplicationKey;
 };
 
 const FormRenderContext = createContext<FormRenderContextValue | undefined>(undefined);
 
 type FormRenderProviderProps = {
     enabled: boolean;
+    applicationKey?: ApplicationKey;
     children: ReactNode;
 };
 
-export const FormRenderProvider = ({enabled, children}: FormRenderProviderProps): ReactElement => {
-    const value = useMemo(() => ({enabled}), [enabled]);
+export const FormRenderProvider = ({enabled, applicationKey, children}: FormRenderProviderProps): ReactElement => {
+    const value = useMemo(() => ({enabled, applicationKey}), [enabled, applicationKey]);
 
     return (
         <FormRenderContext.Provider value={value}>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormRenderer.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormRenderer.tsx
@@ -1,3 +1,4 @@
+import type {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
 import type {Form} from '@enonic/lib-admin-ui/form/Form';
 import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
 import {type ReactElement} from 'react';
@@ -8,11 +9,12 @@ type FormRendererProps = {
     form: Form;
     propertySet: PropertySet;
     enabled?: boolean;
+    applicationKey?: ApplicationKey;
 };
 
-export const FormRenderer = ({form, propertySet, enabled = true}: FormRendererProps): ReactElement => {
+export const FormRenderer = ({form, propertySet, enabled = true, applicationKey}: FormRendererProps): ReactElement => {
     return (
-        <FormRenderProvider enabled={enabled}>
+        <FormRenderProvider enabled={enabled} applicationKey={applicationKey}>
             <div className="flex flex-col gap-7.5" data-component="FormRenderer">
                 {form.getFormItems().map(item => (
                     <FormItemRenderer key={item.getName()} formItem={item} propertySet={propertySet} />

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/content-selector/ContentSelectorInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/content-selector/ContentSelectorInput.tsx
@@ -3,6 +3,7 @@ import type {ReactElement} from 'react';
 import {useStore} from '@nanostores/preact';
 import {$activeProject} from '../../../../store/projects.store';
 import {useSelectorInput} from '../../../../hooks/useSelectorInput';
+import {useFormRender} from '../../FormRenderContext';
 import {ContentCombobox} from '../../../selectors/content';
 import {ContentRow} from '../../../selectors/shared/combobox/ContentRow';
 import {SelectorSelection, SelectorSelectionItem} from '../../../selectors/shared/selection';
@@ -15,6 +16,7 @@ import {ContentSelectorInputAddButton} from './ContentSelectorInputAddButton';
  */
 export const ContentSelectorInput = (props: SelfManagedComponentProps<ContentSelectorConfig>): ReactElement => {
     const activeProject = useStore($activeProject);
+    const {applicationKey} = useFormRender();
 
     const {
         contextContent: selectorContextContent,
@@ -46,6 +48,7 @@ export const ContentSelectorInput = (props: SelfManagedComponentProps<ContentSel
                     contentTypeNames={contentTypeNames}
                     allowedContentPaths={allowedContentPaths}
                     contextContent={selectorContextContent?.getContentSummary()}
+                    applicationKey={applicationKey}
                     listMode={listMode}
                     disabled={disabled}
                     rowRenderer={ContentRow}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-selector/ImageSelectorInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-selector/ImageSelectorInput.tsx
@@ -3,8 +3,10 @@ import type {ImageSelectorConfig} from './ImageSelectorConfig';
 import type {ReactElement} from 'react';
 import {ImageSelector} from '../../../selectors/image';
 import {useSelectorInput} from '../../../../hooks/useSelectorInput';
+import {useFormRender} from '../../FormRenderContext';
 
 export const ImageSelectorInput = (props: SelfManagedComponentProps<ImageSelectorConfig>): ReactElement => {
+    const {applicationKey} = useFormRender();
     const {contextContent, selectionMode, hasErrors, hideToggleIcon, listMode, selection, placeholder, emptyLabel, handleSelectionChange} =
         useSelectorInput(props);
 
@@ -22,6 +24,7 @@ export const ImageSelectorInput = (props: SelfManagedComponentProps<ImageSelecto
             hideToggleIcon={hideToggleIcon}
             allowedContentPaths={allowedContentPaths}
             contextContent={contextContent?.getContentSummary()}
+            applicationKey={applicationKey}
             listMode={listMode}
             disabled={disabled}
             closeOnBlur

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/media-selector/MediaSelectorInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/media-selector/MediaSelectorInput.tsx
@@ -3,8 +3,10 @@ import type {MediaSelectorConfig} from './MediaSelectorConfig';
 import type {ReactElement} from 'react';
 import {MediaSelector} from '../../../selectors/media';
 import {useSelectorInput} from '../../../../hooks/useSelectorInput';
+import {useFormRender} from '../../FormRenderContext';
 
 export const MediaSelectorInput = (props: SelfManagedComponentProps<MediaSelectorConfig>): ReactElement => {
+    const {applicationKey} = useFormRender();
     const {contextContent, selectionMode, hasErrors, hideToggleIcon, listMode, selection, placeholder, emptyLabel, handleSelectionChange} =
         useSelectorInput(props);
 
@@ -24,6 +26,7 @@ export const MediaSelectorInput = (props: SelfManagedComponentProps<MediaSelecto
             contentTypeNames={contentTypeNames}
             allowedContentPaths={allowedContentPaths}
             contextContent={contextContent?.getContentSummary()}
+            applicationKey={applicationKey}
             listMode={listMode}
             disabled={disabled}
             withUpload

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/site-configurator/SiteConfiguratorInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/site-configurator/SiteConfiguratorInput.tsx
@@ -1,6 +1,7 @@
 import {type Application} from '@enonic/lib-admin-ui/application/Application';
 import {ApplicationConfig} from '@enonic/lib-admin-ui/application/ApplicationConfig';
 import {ApplicationEvent} from '@enonic/lib-admin-ui/application/ApplicationEvent';
+import {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
 import {AuthHelper} from '@enonic/lib-admin-ui/auth/AuthHelper';
 import {type PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
 import {PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
@@ -364,6 +365,11 @@ const SiteConfiguratorDialog = ({
     onConfirmDiscard,
     onDirtyChange,
 }: SiteConfiguratorDialogProps): ReactElement | null => {
+    const applicationKey = useMemo(
+        () => editing ? ApplicationKey.fromString(editing.appKey) : undefined,
+        [editing?.appKey],
+    );
+
     if (!editing) return null;
 
     return (
@@ -396,6 +402,7 @@ const SiteConfiguratorDialog = ({
                                 form={form}
                                 propertySet={editing.editingSet}
                                 enabled={!disabled}
+                                applicationKey={applicationKey}
                             />
                         </Dialog.Body>
 


### PR DESCRIPTION
Extended `FormRenderContext` with optional `applicationKey` so selector input types inside application config forms (SiteConfigurator) can pass it to `ContentSelectorQueryRequest`. Without it, the server cannot resolve relative content type names and fails with a 500 DescriptorKey error.

- Added `applicationKey` to `FormRenderContext` and `FormRenderer`
- `ContentSelectorInput`, `MediaSelectorInput`, `ImageSelectorInput` read it from context and pass to their selectors
- `SiteConfiguratorDialog` creates `ApplicationKey` from `editing.appKey` and passes to `FormRenderer`

Closes #10150

<sub>*Drafted with AI assistance*</sub>
