### PR TITLE
Implement ItemSetView and OptionSetView in v6 form pipeline #10154

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ settings.local.json
 
 # Workflow
 .worktrees/
+docs/superpowers/

--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -288,7 +288,7 @@ importers:
         version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)
       vitest:
         specifier: ~4.1.0
-        version: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
+        version: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
 
   .xp/dev/lib-contentstudio:
     dependencies:
@@ -429,8 +429,8 @@ importers:
         specifier: ^15.15.0
         version: 15.15.0
       happy-dom:
-        specifier: ^20.0.10
-        version: 20.8.4
+        specifier: ^20.8.8
+        version: 20.8.9
       jquery:
         specifier: ^3.7.1
         version: 3.7.1
@@ -454,7 +454,7 @@ importers:
         version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)
       vitest:
         specifier: ^4.0.11
-        version: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
+        version: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
 
 packages:
 
@@ -3140,8 +3140,8 @@ packages:
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
-  happy-dom@20.8.4:
-    resolution: {integrity: sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ==}
+  happy-dom@20.8.9:
+    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
     engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
@@ -6270,7 +6270,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
+      vitest: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -7666,7 +7666,7 @@ snapshots:
 
   handle-thing@2.0.1: {}
 
-  happy-dom@20.8.4:
+  happy-dom@20.8.9:
     dependencies:
       '@types/node': 25.5.0
       '@types/whatwg-mimetype': 3.0.2
@@ -9193,7 +9193,7 @@ snapshots:
       lightningcss: 1.31.1
       terser: 5.46.1
 
-  vitest@4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)):
+  vitest@4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
@@ -9218,7 +9218,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
       '@vitest/ui': 4.1.0(vitest@4.1.0)
-      happy-dom: 20.8.4
+      happy-dom: 20.8.9
     transitivePeerDependencies:
       - msw
 

--- a/modules/lib/pnpm-lock.yaml
+++ b/modules/lib/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^15.15.0
         version: 15.15.0
       happy-dom:
-        specifier: ^20.0.10
-        version: 20.8.4
+        specifier: ^20.8.8
+        version: 20.8.9
       jquery:
         specifier: ^3.7.1
         version: 3.7.1
@@ -170,7 +170,7 @@ importers:
         version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)
       vitest:
         specifier: ^4.0.11
-        version: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
+        version: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
 
   .xp/dev/lib-admin-ui:
     dependencies:
@@ -306,7 +306,7 @@ importers:
         version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)
       vitest:
         specifier: ~4.1.0
-        version: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
+        version: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
 
 packages:
 
@@ -2922,8 +2922,8 @@ packages:
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
-  happy-dom@20.8.4:
-    resolution: {integrity: sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ==}
+  happy-dom@20.8.9:
+    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
     engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
@@ -5971,7 +5971,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
+      vitest: 4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -7346,7 +7346,7 @@ snapshots:
 
   handle-thing@2.0.1: {}
 
-  happy-dom@20.8.4:
+  happy-dom@20.8.9:
     dependencies:
       '@types/node': 25.5.0
       '@types/whatwg-mimetype': 3.0.2
@@ -8847,7 +8847,7 @@ snapshots:
       lightningcss: 1.31.1
       terser: 5.46.1
 
-  vitest@4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)):
+  vitest@4.1.0(@types/node@25.5.0)(@vitest/ui@4.1.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.31.1)(terser@5.46.1))
@@ -8872,7 +8872,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
       '@vitest/ui': 4.1.0(vitest@4.1.0)
-      happy-dom: 20.8.4
+      happy-dom: 20.8.9
     transitivePeerDependencies:
       - msw
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormItemRenderer.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormItemRenderer.tsx
@@ -22,8 +22,6 @@ const FORM_ITEM_RENDERER_NAME = 'FormItemRenderer';
 export const FormItemRenderer = ({formItem, propertySet}: FormItemRendererProps): ReactElement => {
     const {enabled} = useFormRender();
 
-    // TODO: Move to lib-admin-ui
-
     if (instanceOf(formItem, Input)) {
         return <InputField input={formItem} propertySet={propertySet} enabled={enabled} />;
     }
@@ -31,10 +29,10 @@ export const FormItemRenderer = ({formItem, propertySet}: FormItemRendererProps)
         return <FieldSetView fieldSet={formItem} propertySet={propertySet} />;
     }
     if (instanceOf(formItem, FormItemSet)) {
-        return <ItemSetView name={formItem.getName()} />;
+        return <ItemSetView itemSet={formItem} propertySet={propertySet} />;
     }
     if (instanceOf(formItem, FormOptionSet)) {
-        return <OptionSetView name={formItem.getName()} />;
+        return <OptionSetView optionSet={formItem} propertySet={propertySet} />;
     }
     return (
         <div data-component={FORM_ITEM_RENDERER_NAME} className="rounded border border-dashed border-bdr-subtle px-3 py-2 text-xs text-subtle">

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/ItemSetView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/ItemSetView.tsx
@@ -1,13 +1,120 @@
-import {type ReactElement} from 'react';
+import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
+import type {FormItemSet} from '@enonic/lib-admin-ui/form/set/itemset/FormItemSet';
+import {useI18n, usePropertySetArray, useSetOccurrenceManager, useValidationVisibility} from '@enonic/lib-admin-ui/form2';
+import {SortableList} from '@enonic/lib-admin-ui/form2/components/sortable-list';
+import {type ReactElement, useCallback, useMemo, useState} from 'react';
+import {FormItemRenderer} from './FormItemRenderer';
+import {useFormRender} from './FormRenderContext';
+import {SetAddButton, SetHeader, SetOccurrenceView, useSetPropertyArray} from './set-occurrence';
 
 type ItemSetViewProps = {
-    name: string;
+    itemSet: FormItemSet;
+    propertySet: PropertySet;
 };
 
-export const ItemSetView = ({name}: ItemSetViewProps): ReactElement => (
-    <div className="rounded border border-dashed border-bdr-subtle px-3 py-2 text-xs text-subtle">
-        FormItemSet: {name} — not yet supported
-    </div>
-);
+export const ItemSetView = ({itemSet, propertySet}: ItemSetViewProps): ReactElement => {
+    const name = itemSet.getName();
+    const label = itemSet.getLabel();
+    const occurrences = itemSet.getOccurrences();
+    const formItems = useMemo(() => itemSet.getFormItems(), [itemSet]);
+    const t = useI18n();
+    const {enabled} = useFormRender();
+    const visibility = useValidationVisibility();
+    const [interacted, setInteracted] = useState(false);
+
+    const propertyArray = useSetPropertyArray(name, propertySet, occurrences);
+    const {propertySets} = usePropertySetArray(propertyArray);
+    const {state, remove, move} = useSetOccurrenceManager(occurrences, propertySets);
+
+    const showErrors = visibility === 'all' || (visibility === 'interactive' && interacted);
+
+    const occurrenceError = useMemo(() => {
+        if (!showErrors) return undefined;
+        const min = occurrences.getMinimum();
+        const max = occurrences.getMaximum();
+
+        if (state.isMinimumBreached) {
+            return min === 1 ? t('field.value.required') : t('field.occurrence.breaks.min', min);
+        }
+        if (state.isMaximumBreached) {
+            return max === 1 ? t('field.occurrence.breaks.max.one') : t('field.occurrence.breaks.max.many', max);
+        }
+        return undefined;
+    }, [showErrors, state.isMinimumBreached, state.isMaximumBreached, occurrences, t]);
+
+    // Skip add() — it only pushes an ID without a PropertySet, so the subsequent
+    // syncPropertySets() generates a second ID on reconciliation, causing a key
+    // change and remount. Guard with state.canAdd and let addSet() + sync handle IDs.
+    const handleAdd = useCallback(() => {
+        setInteracted(true);
+        if (!state.canAdd) return;
+        propertyArray.addSet();
+    }, [state.canAdd, propertyArray]);
+
+    const handleRemove = useCallback((index: number) => {
+        setInteracted(true);
+        if (remove(index)) {
+            propertyArray.remove(index);
+        }
+    }, [remove, propertyArray]);
+
+    const handleMove = useCallback((fromIndex: number, toIndex: number) => {
+        if (move(fromIndex, toIndex)) {
+            propertyArray.move(fromIndex, toIndex);
+        }
+    }, [move, propertyArray]);
+
+    const isMultiple = occurrences.multiple();
+    const showAddButton = enabled && state.canAdd && isMultiple;
+
+    return (
+        <div className="flex flex-col gap-3" data-component="ItemSetView">
+            <SetHeader label={label} occurrences={occurrences} occurrenceError={occurrenceError} />
+            {state.count > 0 && isMultiple && (
+                <SortableList
+                    items={propertySets}
+                    keyExtractor={(_: PropertySet, i: number) => state.ids[i]}
+                    onMove={handleMove}
+                    enabled={enabled && state.count > 1}
+                    dragLabel={t('field.occurrence.action.reorder')}
+                    className="flex flex-col gap-2.5"
+                    renderItem={({item, index}) => (
+                        <SetOccurrenceView
+                            index={index}
+                            canRemove={enabled && state.canRemove}
+                            onRemove={handleRemove}
+                        >
+                            {formItems.map(formItem => (
+                                <FormItemRenderer
+                                    key={formItem.getName()}
+                                    formItem={formItem}
+                                    propertySet={item}
+                                />
+                            ))}
+                        </SetOccurrenceView>
+                    )}
+                />
+            )}
+            {state.count > 0 && !isMultiple && (
+                <div className="flex flex-col gap-2.5">
+                    {propertySets.map((ps, index) => (
+                        <div key={state.ids[index]} className="flex flex-col gap-7.5 border-l border-bdr-soft pl-5">
+                            {formItems.map(formItem => (
+                                <FormItemRenderer
+                                    key={formItem.getName()}
+                                    formItem={formItem}
+                                    propertySet={ps}
+                                />
+                            ))}
+                        </div>
+                    ))}
+                </div>
+            )}
+            {showAddButton && (
+                <SetAddButton label={t('action.add')} onClick={handleAdd} disabled={!state.canAdd} />
+            )}
+        </div>
+    );
+};
 
 ItemSetView.displayName = 'ItemSetView';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/ItemSetView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/ItemSetView.tsx
@@ -65,7 +65,7 @@ export const ItemSetView = ({itemSet, propertySet}: ItemSetViewProps): ReactElem
     }, [move, propertyArray]);
 
     const isMultiple = occurrences.multiple();
-    const showAddButton = enabled && state.canAdd && isMultiple;
+    const showAddButton = enabled && state.canAdd;
 
     return (
         <div className="flex flex-col gap-3" data-component="ItemSetView">

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/OptionSetView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/OptionSetView.tsx
@@ -1,13 +1,120 @@
-import {type ReactElement} from 'react';
+import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
+import type {FormOptionSet} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSet';
+import {useI18n, usePropertySetArray, useSetOccurrenceManager, useValidationVisibility} from '@enonic/lib-admin-ui/form2';
+import {SortableList} from '@enonic/lib-admin-ui/form2/components/sortable-list';
+import {type ReactElement, useCallback, useMemo, useState} from 'react';
+import {OptionSetOccurrenceView} from './option-set';
+import {useFormRender} from './FormRenderContext';
+import {SetAddButton, SetHeader, SetOccurrenceView, useSetPropertyArray} from './set-occurrence';
 
 type OptionSetViewProps = {
-    name: string;
+    optionSet: FormOptionSet;
+    propertySet: PropertySet;
 };
 
-export const OptionSetView = ({name}: OptionSetViewProps): ReactElement => (
-    <div className="rounded border border-dashed border-bdr-subtle px-3 py-2 text-xs text-subtle">
-        FormOptionSet: {name} — not yet supported
-    </div>
-);
+export const OptionSetView = ({optionSet, propertySet}: OptionSetViewProps): ReactElement => {
+    const name = optionSet.getName();
+    const label = optionSet.getLabel();
+    const occurrences = optionSet.getOccurrences();
+    const t = useI18n();
+    const {enabled} = useFormRender();
+    const visibility = useValidationVisibility();
+    const [interacted, setInteracted] = useState(false);
+
+    const propertyArray = useSetPropertyArray(name, propertySet, occurrences);
+    const {propertySets} = usePropertySetArray(propertyArray);
+    const {state, remove, move} = useSetOccurrenceManager(occurrences, propertySets);
+
+    const showErrors = visibility === 'all' || (visibility === 'interactive' && interacted);
+
+    const occurrenceError = useMemo(() => {
+        if (!showErrors) return undefined;
+        const min = occurrences.getMinimum();
+        const max = occurrences.getMaximum();
+
+        if (state.isMinimumBreached) {
+            return min === 1 ? t('field.value.required') : t('field.occurrence.breaks.min', min);
+        }
+        if (state.isMaximumBreached) {
+            return max === 1 ? t('field.occurrence.breaks.max.one') : t('field.occurrence.breaks.max.many', max);
+        }
+        return undefined;
+    }, [showErrors, state.isMinimumBreached, state.isMaximumBreached, occurrences, t]);
+
+    // Skip add() — it only pushes an ID without a PropertySet, so the subsequent
+    // syncPropertySets() generates a second ID on reconciliation, causing a key
+    // change and remount. Guard with state.canAdd and let addSet() + sync handle IDs.
+    const handleAdd = useCallback(() => {
+        setInteracted(true);
+        if (!state.canAdd) return;
+        propertyArray.addSet();
+    }, [state.canAdd, propertyArray]);
+
+    const handleRemove = useCallback((index: number) => {
+        setInteracted(true);
+        if (remove(index)) {
+            propertyArray.remove(index);
+        }
+    }, [remove, propertyArray]);
+
+    const handleMove = useCallback((fromIndex: number, toIndex: number) => {
+        if (move(fromIndex, toIndex)) {
+            propertyArray.move(fromIndex, toIndex);
+        }
+    }, [move, propertyArray]);
+
+    const isMultiple = occurrences.multiple();
+    const showAddButton = enabled && state.canAdd && isMultiple;
+
+    // Single-occurrence OptionSet (most common case: 0:1 or 1:1)
+    if (!isMultiple) {
+        return (
+            <div className="flex flex-col gap-3" data-component="OptionSetView">
+                <SetHeader label={label} occurrences={occurrences} occurrenceError={occurrenceError} />
+                {propertySets.map((ps, index) => (
+                    <OptionSetOccurrenceView
+                        key={state.ids[index]}
+                        optionSet={optionSet}
+                        occurrencePropertySet={ps}
+                        enabled={enabled}
+                    />
+                ))}
+            </div>
+        );
+    }
+
+    // Multi-occurrence OptionSet (rare but supported)
+    return (
+        <div className="flex flex-col gap-3" data-component="OptionSetView">
+            <SetHeader label={label} occurrences={occurrences} occurrenceError={occurrenceError} />
+            {state.count > 0 && (
+                <SortableList
+                    items={propertySets}
+                    keyExtractor={(_: PropertySet, i: number) => state.ids[i]}
+                    onMove={handleMove}
+                    enabled={enabled && state.count > 1}
+                    dragLabel={t('field.occurrence.action.reorder')}
+                    className="flex flex-col gap-2.5"
+                    renderItem={({item, index}) => (
+                        <SetOccurrenceView
+                            index={index}
+                            canRemove={enabled && state.canRemove}
+                            onRemove={handleRemove}
+                        >
+                            <OptionSetOccurrenceView
+                                optionSet={optionSet}
+                                occurrencePropertySet={item}
+                                enabled={enabled}
+                            />
+                        </SetOccurrenceView>
+                    )}
+                />
+            )}
+            {showAddButton && (
+                <SetAddButton label={t('action.add')} onClick={handleAdd} disabled={!state.canAdd} />
+            )}
+        </div>
+    );
+};
 
 OptionSetView.displayName = 'OptionSetView';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/OptionSetView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/OptionSetView.tsx
@@ -64,7 +64,7 @@ export const OptionSetView = ({optionSet, propertySet}: OptionSetViewProps): Rea
     }, [move, propertyArray]);
 
     const isMultiple = occurrences.multiple();
-    const showAddButton = enabled && state.canAdd && isMultiple;
+    const showAddButton = enabled && state.canAdd;
 
     // Single-occurrence OptionSet (most common case: 0:1 or 1:1)
     if (!isMultiple) {
@@ -79,6 +79,9 @@ export const OptionSetView = ({optionSet, propertySet}: OptionSetViewProps): Rea
                         enabled={enabled}
                     />
                 ))}
+                {showAddButton && (
+                    <SetAddButton label={t('action.add')} onClick={handleAdd} disabled={!state.canAdd} />
+                )}
             </div>
         );
     }

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/OptionSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/OptionSelector.tsx
@@ -1,6 +1,6 @@
-import {Checkbox, RadioGroup} from '@enonic/ui';
 import type {FormOptionSet} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSet';
 import type {FormOptionSetOption} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSetOption';
+import {Checkbox, RadioGroup} from '@enonic/ui';
 import {type ReactElement, useCallback, useMemo} from 'react';
 
 type OptionSelectorProps = {
@@ -18,7 +18,6 @@ export const OptionSelector = ({
     selectedNames,
     isSelected,
     onSelect,
-    onDeselect,
     onToggle,
     enabled,
 }: OptionSelectorProps): ReactElement => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/OptionSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/OptionSelector.tsx
@@ -1,0 +1,78 @@
+import {Checkbox, RadioGroup} from '@enonic/ui';
+import type {FormOptionSet} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSet';
+import type {FormOptionSetOption} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSetOption';
+import {type ReactElement, useCallback, useMemo} from 'react';
+
+type OptionSelectorProps = {
+    optionSet: FormOptionSet;
+    selectedNames: string[];
+    isSelected: (name: string) => boolean;
+    onSelect: (name: string) => void;
+    onDeselect: (name: string) => void;
+    onToggle: (name: string) => void;
+    enabled: boolean;
+};
+
+export const OptionSelector = ({
+    optionSet,
+    selectedNames,
+    isSelected,
+    onSelect,
+    onDeselect,
+    onToggle,
+    enabled,
+}: OptionSelectorProps): ReactElement => {
+    const isRadio = optionSet.isRadioSelection();
+    const options: FormOptionSetOption[] = useMemo(() => optionSet.getOptions(), [optionSet]);
+    const multiselection = optionSet.getMultiselection();
+    const isAtMax = !isRadio && multiselection.getMaximum() > 0
+        && selectedNames.length >= multiselection.getMaximum();
+
+    const handleRadioChange = useCallback(
+        (value: string) => {
+            onSelect(value);
+        },
+        [onSelect],
+    );
+
+    if (isRadio) {
+        return (
+            <RadioGroup
+                name={optionSet.getName()}
+                value={selectedNames[0] ?? ''}
+                onValueChange={handleRadioChange}
+            >
+                {options.map(option => (
+                    <RadioGroup.Item
+                        key={option.getName()}
+                        value={option.getName()}
+                        disabled={!enabled}
+                    >
+                        <RadioGroup.Indicator />
+                        <span>{option.getLabel() || option.getName()}</span>
+                    </RadioGroup.Item>
+                ))}
+            </RadioGroup>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-2" data-component="OptionSelector">
+            {options.map(option => {
+                const name = option.getName();
+                const checked = isSelected(name);
+                return (
+                    <Checkbox
+                        key={name}
+                        checked={checked}
+                        onCheckedChange={() => onToggle(name)}
+                        disabled={!enabled || (isAtMax && !checked)}
+                        label={option.getLabel() || name}
+                    />
+                );
+            })}
+        </div>
+    );
+};
+
+OptionSelector.displayName = 'OptionSelector';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/OptionSetOccurrenceView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/OptionSetOccurrenceView.tsx
@@ -1,0 +1,113 @@
+import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
+import type {FormOptionSet} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSet';
+import {FieldError, useI18n, useValidationVisibility} from '@enonic/lib-admin-ui/form2';
+import {type ReactElement, useCallback, useMemo, useState} from 'react';
+import {FormItemRenderer} from '../FormItemRenderer';
+import {OptionSelector} from './OptionSelector';
+import {useOptionSetSelection} from './useOptionSetSelection';
+
+type OptionSetOccurrenceViewProps = {
+    optionSet: FormOptionSet;
+    occurrencePropertySet: PropertySet;
+    enabled: boolean;
+};
+
+export const OptionSetOccurrenceView = ({
+    optionSet,
+    occurrencePropertySet,
+    enabled,
+}: OptionSetOccurrenceViewProps): ReactElement => {
+    const t = useI18n();
+    const visibility = useValidationVisibility();
+    const [interacted, setInteracted] = useState(false);
+    const multiselection = optionSet.getMultiselection();
+
+    const {selectedNames, isSelected, select, deselect, toggle} = useOptionSetSelection(
+        optionSet,
+        occurrencePropertySet,
+    );
+
+    const showErrors = visibility === 'all' || (visibility === 'interactive' && interacted);
+
+    const multiselectionError = useMemo(() => {
+        if (!showErrors) return undefined;
+        const count = selectedNames.length;
+        const min = multiselection.getMinimum();
+        const max = multiselection.getMaximum();
+
+        if (multiselection.minimumBreached(count)) {
+            return min === 1
+                ? t('field.optionset.breaks.min.one')
+                : t('field.optionset.breaks.min.many', min);
+        }
+        if (multiselection.maximumBreached(count)) {
+            return max === 1
+                ? t('field.optionset.breaks.max.one')
+                : t('field.optionset.breaks.max.many', max);
+        }
+        return undefined;
+    }, [showErrors, selectedNames, multiselection, t]);
+
+    const handleSelect = useCallback((name: string) => {
+        setInteracted(true);
+        select(name);
+    }, [select]);
+
+    const handleDeselect = useCallback((name: string) => {
+        setInteracted(true);
+        deselect(name);
+    }, [deselect]);
+
+    const handleToggle = useCallback((name: string) => {
+        setInteracted(true);
+        toggle(name);
+    }, [toggle]);
+
+    // Render nested form items for selected options
+    const selectedOptions = useMemo(() => {
+        return optionSet.getOptions().filter(o => selectedNames.includes(o.getName()));
+    }, [optionSet, selectedNames]);
+
+    return (
+        <div className="flex flex-col gap-4" data-component="OptionSetOccurrenceView">
+            <OptionSelector
+                optionSet={optionSet}
+                selectedNames={selectedNames}
+                isSelected={isSelected}
+                onSelect={handleSelect}
+                onDeselect={handleDeselect}
+                onToggle={handleToggle}
+                enabled={enabled}
+            />
+            {multiselectionError != null && <FieldError message={multiselectionError} />}
+            {selectedOptions.map(option => {
+                const optionName = option.getName();
+                const formItems = option.getFormItems();
+                if (formItems.length === 0) return null;
+
+                const optionDataSet = occurrencePropertySet
+                    .getPropertyArray(optionName)
+                    ?.getSet(0);
+
+                if (optionDataSet == null) return null;
+
+                return (
+                    <div
+                        key={optionName}
+                        className="flex flex-col gap-7.5 border-l border-bdr-soft pl-5"
+                    >
+                        {formItems.map(formItem => (
+                            <FormItemRenderer
+                                key={formItem.getName()}
+                                formItem={formItem}
+                                propertySet={optionDataSet}
+                            />
+                        ))}
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
+
+OptionSetOccurrenceView.displayName = 'OptionSetOccurrenceView';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/index.ts
@@ -1,0 +1,3 @@
+export {OptionSelector} from './OptionSelector';
+export {OptionSetOccurrenceView} from './OptionSetOccurrenceView';
+export {useOptionSetSelection} from './useOptionSetSelection';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/useOptionSetSelection.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/useOptionSetSelection.ts
@@ -1,0 +1,135 @@
+import {PropertyArray} from '@enonic/lib-admin-ui/data/PropertyArray';
+import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
+import {Value} from '@enonic/lib-admin-ui/data/Value';
+import {ValueTypes} from '@enonic/lib-admin-ui/data/ValueTypes';
+import type {FormOptionSet} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSet';
+import {usePropertyArray} from '@enonic/lib-admin-ui/form2';
+import {useCallback, useMemo} from 'react';
+
+const SELECTED_NAME = '_selected';
+
+type UseOptionSetSelectionResult = {
+    selectedNames: string[];
+    isSelected: (name: string) => boolean;
+    select: (name: string) => void;
+    deselect: (name: string) => void;
+    toggle: (name: string) => void;
+};
+
+export function useOptionSetSelection(
+    optionSet: FormOptionSet,
+    occurrencePropertySet: PropertySet,
+): UseOptionSetSelectionResult {
+    const isRadio = optionSet.isRadioSelection();
+    const schemaOptionNames = useMemo(
+        () => optionSet.getOptions().map(o => o.getName()),
+        [optionSet],
+    );
+
+    const selectedArray = useMemo(() => {
+        let array = occurrencePropertySet.getPropertyArray(SELECTED_NAME);
+
+        if (array == null) {
+            array = PropertyArray.create()
+                .setName(SELECTED_NAME)
+                .setType(ValueTypes.STRING)
+                .setParent(occurrencePropertySet)
+                .build();
+            occurrencePropertySet.addPropertyArray(array);
+        }
+
+        return array;
+    }, [occurrencePropertySet]);
+
+    const {values} = usePropertyArray(selectedArray);
+
+    const selectedNames = useMemo(() => {
+        return values
+            .map(v => v.getString())
+            .filter((n): n is string => n != null && schemaOptionNames.includes(n));
+    }, [values, schemaOptionNames]);
+
+    const isSelected = useCallback(
+        (name: string) => selectedNames.includes(name),
+        [selectedNames],
+    );
+
+    const ensureOptionPropertySet = useCallback(
+        (name: string) => {
+            let optionArray = occurrencePropertySet.getPropertyArray(name);
+            if (optionArray == null) {
+                optionArray = PropertyArray.create()
+                    .setName(name)
+                    .setType(ValueTypes.DATA)
+                    .setParent(occurrencePropertySet)
+                    .build();
+                occurrencePropertySet.addPropertyArray(optionArray);
+            }
+            if (optionArray.getSize() === 0) {
+                optionArray.addSet();
+            }
+        },
+        [occurrencePropertySet],
+    );
+
+    const select = useCallback(
+        (name: string) => {
+            ensureOptionPropertySet(name);
+
+            if (isRadio) {
+                // Radio: replace single selection
+                const value = new Value(name, ValueTypes.STRING);
+                const existing = selectedArray.get(0);
+                if (existing != null) {
+                    existing.setValue(value);
+                } else {
+                    selectedArray.add(value);
+                }
+            } else {
+                // Multi: add and sort
+                const alreadySelected = selectedNames.includes(name);
+                if (!alreadySelected) {
+                    selectedArray.add(new Value(name, ValueTypes.STRING));
+                    // Sort alphabetically by rebuilding array
+                    const allNames = [...selectedNames, name].sort();
+                    // Remove all and re-add sorted
+                    while (selectedArray.getSize() > 0) {
+                        selectedArray.remove(selectedArray.getSize() - 1);
+                    }
+                    for (const n of allNames) {
+                        selectedArray.add(new Value(n, ValueTypes.STRING));
+                    }
+                }
+            }
+        },
+        [isRadio, selectedArray, selectedNames, ensureOptionPropertySet],
+    );
+
+    const deselect = useCallback(
+        (name: string) => {
+            // Find index in the raw array, not filtered selectedNames —
+            // stale option names in _selected would shift filtered indices.
+            const size = selectedArray.getSize();
+            for (let i = 0; i < size; i++) {
+                if (selectedArray.get(i)?.getValue().getString() === name) {
+                    selectedArray.remove(i);
+                    break;
+                }
+            }
+        },
+        [selectedArray],
+    );
+
+    const toggle = useCallback(
+        (name: string) => {
+            if (selectedNames.includes(name)) {
+                deselect(name);
+            } else {
+                select(name);
+            }
+        },
+        [selectedNames, select, deselect],
+    );
+
+    return {selectedNames, isSelected, select, deselect, toggle};
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/useOptionSetSelection.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/option-set/useOptionSetSelection.ts
@@ -89,7 +89,6 @@ export function useOptionSetSelection(
                 // Multi: add and sort
                 const alreadySelected = selectedNames.includes(name);
                 if (!alreadySelected) {
-                    selectedArray.add(new Value(name, ValueTypes.STRING));
                     // Sort alphabetically by rebuilding array
                     const allNames = [...selectedNames, name].sort();
                     // Remove all and re-add sorted

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/SetAddButton.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/SetAddButton.tsx
@@ -1,0 +1,23 @@
+import {Button} from '@enonic/ui';
+import {Plus} from 'lucide-react';
+import {type ReactElement} from 'react';
+
+type SetAddButtonProps = {
+    label: string;
+    onClick: () => void;
+    disabled?: boolean;
+};
+
+export const SetAddButton = ({label, onClick, disabled}: SetAddButtonProps): ReactElement => (
+    <div className="flex justify-end">
+        <Button
+            variant="outline"
+            label={label}
+            endIcon={Plus}
+            onClick={onClick}
+            disabled={disabled}
+        />
+    </div>
+);
+
+SetAddButton.displayName = 'SetAddButton';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/SetHeader.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/SetHeader.tsx
@@ -1,0 +1,25 @@
+import type {Occurrences} from '@enonic/lib-admin-ui/form/Occurrences';
+import {FieldError} from '@enonic/lib-admin-ui/form2';
+import {type ReactElement} from 'react';
+
+type SetHeaderProps = {
+    label: string;
+    occurrences: Occurrences;
+    occurrenceError?: string;
+};
+
+export const SetHeader = ({label, occurrences, occurrenceError}: SetHeaderProps): ReactElement => {
+    const isRequired = occurrences.getMinimum() > 0;
+
+    return (
+        <div className="flex flex-col gap-1" data-component="SetHeader">
+            <div className="flex items-baseline gap-1">
+                <span className="text-base font-semibold">{label}</span>
+                {isRequired && <span className="text-destructive text-sm">*</span>}
+            </div>
+            {occurrenceError != null && <FieldError message={occurrenceError} />}
+        </div>
+    );
+};
+
+SetHeader.displayName = 'SetHeader';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/SetOccurrenceView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/SetOccurrenceView.tsx
@@ -1,6 +1,7 @@
-import {IconButton} from '@enonic/ui';
+import {cn, IconButton} from '@enonic/ui';
 import {ChevronRight, X} from 'lucide-react';
 import {type ReactElement, type ReactNode, useCallback, useState} from 'react';
+import {useI18n} from '../../../hooks/useI18n';
 
 type SetOccurrenceViewProps = {
     label?: string;
@@ -27,6 +28,8 @@ export const SetOccurrenceView = ({
         onRemove(index);
     }, [onRemove, index]);
 
+    const removeLabel = useI18n('action.remove')
+
     return (
         <div className="rounded border border-bdr-soft" data-component="SetOccurrenceView">
             <button
@@ -37,7 +40,7 @@ export const SetOccurrenceView = ({
             >
                 <ChevronRight
                     size={16}
-                    className={`shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
+                    className={cn('shrink-0 transition-transform', expanded && 'rotate-90')}
                 />
                 <span className="flex-1 truncate text-sm font-medium">
                     {label || `#${index + 1}`}
@@ -47,7 +50,7 @@ export const SetOccurrenceView = ({
                         variant="text"
                         icon={X}
                         size="sm"
-                        aria-label="Remove"
+                        aria-label={removeLabel}
                         onClick={(e) => {
                             e.stopPropagation();
                             handleRemove();

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/SetOccurrenceView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/SetOccurrenceView.tsx
@@ -1,0 +1,67 @@
+import {IconButton} from '@enonic/ui';
+import {ChevronRight, X} from 'lucide-react';
+import {type ReactElement, type ReactNode, useCallback, useState} from 'react';
+
+type SetOccurrenceViewProps = {
+    label?: string;
+    index: number;
+    canRemove: boolean;
+    onRemove: (index: number) => void;
+    children: ReactNode;
+};
+
+export const SetOccurrenceView = ({
+    label,
+    index,
+    canRemove,
+    onRemove,
+    children,
+}: SetOccurrenceViewProps): ReactElement => {
+    const [expanded, setExpanded] = useState(true);
+
+    const handleToggle = useCallback(() => {
+        setExpanded(prev => !prev);
+    }, []);
+
+    const handleRemove = useCallback(() => {
+        onRemove(index);
+    }, [onRemove, index]);
+
+    return (
+        <div className="rounded border border-bdr-soft" data-component="SetOccurrenceView">
+            <button
+                type="button"
+                className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-surface-hover"
+                aria-expanded={expanded}
+                onClick={handleToggle}
+            >
+                <ChevronRight
+                    size={16}
+                    className={`shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
+                />
+                <span className="flex-1 truncate text-sm font-medium">
+                    {label || `#${index + 1}`}
+                </span>
+                {canRemove && (
+                    <IconButton
+                        variant="text"
+                        icon={X}
+                        size="sm"
+                        aria-label="Remove"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            handleRemove();
+                        }}
+                    />
+                )}
+            </button>
+            {expanded && (
+                <div className="flex flex-col gap-7.5 border-t border-bdr-soft px-4 py-4">
+                    {children}
+                </div>
+            )}
+        </div>
+    );
+};
+
+SetOccurrenceView.displayName = 'SetOccurrenceView';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/index.ts
@@ -1,0 +1,4 @@
+export {SetAddButton} from './SetAddButton';
+export {SetHeader} from './SetHeader';
+export {SetOccurrenceView} from './SetOccurrenceView';
+export {useSetPropertyArray} from './useSetPropertyArray';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/useSetPropertyArray.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/set-occurrence/useSetPropertyArray.ts
@@ -1,0 +1,37 @@
+import {PropertyArray} from '@enonic/lib-admin-ui/data/PropertyArray';
+import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
+import {ValueTypes} from '@enonic/lib-admin-ui/data/ValueTypes';
+import type {Occurrences} from '@enonic/lib-admin-ui/form/Occurrences';
+import {useEffect, useMemo} from 'react';
+
+export function useSetPropertyArray(
+    name: string,
+    propertySet: PropertySet,
+    occurrences: Occurrences,
+): PropertyArray {
+    const propertyArray = useMemo(() => {
+        let array = propertySet.getPropertyArray(name);
+
+        if (array == null) {
+            array = PropertyArray.create()
+                .setName(name)
+                .setType(ValueTypes.DATA)
+                .setParent(propertySet)
+                .build();
+            propertySet.addPropertyArray(array);
+        }
+
+        return array;
+    }, [name, propertySet, occurrences]);
+
+    // Seed in effect to avoid side effects during render (addSet fires tree events).
+    // Matches InputField's pattern where OccurrenceManager seeds in useEffect.
+    useEffect(() => {
+        const min = occurrences.getMinimum();
+        while (propertyArray.getSize() < min) {
+            propertyArray.addSet();
+        }
+    }, [propertyArray, occurrences]);
+
+    return propertyArray;
+}


### PR DESCRIPTION
Replaced placeholder `ItemSetView` and `OptionSetView` with full implementations using form2 hooks (`usePropertySetArray`, `useSetOccurrenceManager`). Added shared set-occurrence components (`SetHeader`, `SetAddButton`, `SetOccurrenceView`, `useSetPropertyArray`). Implemented `useOptionSetSelection` for `_selected` PropertyArray management and `OptionSelector` with RadioGroup/Checkbox rendering. Updated `FormItemRenderer` to pass full form item props to set views.

Requires #https://github.com/enonic/lib-admin-ui/pull/4382

Closes #10154

<sub>*Drafted with AI assistance*</sub>