### PR TITLE
Publish Request dialog is not updated after server-side changes #10110

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/dialog.store.test.utils.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/dialog.store.test.utils.ts
@@ -1,0 +1,88 @@
+import {vi} from 'vitest';
+import {ContentId} from '../../../../app/content/ContentId';
+import type {ContentSummaryAndCompareStatus} from '../../../../app/content/ContentSummaryAndCompareStatus';
+import type {ContentServerChangeItem} from '../../../../app/event/ContentServerChangeItem';
+
+type ResolveResultOptions = {
+    dependants?: ContentId[];
+    required?: ContentId[];
+    invalid?: ContentId[];
+    inProgress?: ContentId[];
+    notPublishable?: ContentId[];
+};
+
+type MockContentOptions = {
+    displayName?: string;
+    path?: string;
+    hasChildren?: boolean;
+    isOnline?: boolean;
+};
+
+export function createMockContent(
+    id: string,
+    {
+        displayName = `Content ${id}`,
+        path,
+        hasChildren = false,
+        isOnline = false,
+    }: MockContentOptions = {},
+): ContentSummaryAndCompareStatus {
+    const contentId = new ContentId(id);
+
+    return {
+        getId: () => id,
+        getContentId: () => contentId,
+        getDisplayName: () => displayName,
+        getPath: () => path ? {toString: () => path} : undefined,
+        hasChildren: () => hasChildren,
+        isOnline: () => isOnline,
+    } as ContentSummaryAndCompareStatus;
+}
+
+export function createMockChangeItem(id: string): ContentServerChangeItem {
+    return {
+        getContentId: () => ({
+            toString: () => id,
+        }),
+    } as unknown as ContentServerChangeItem;
+}
+
+export function createResolveResult({
+    dependants = [],
+    required = [],
+    invalid = [],
+    inProgress = [],
+    notPublishable = [],
+}: ResolveResultOptions) {
+    return {
+        getDependants: () => dependants,
+        getRequired: () => required,
+        getInvalid: () => invalid,
+        getInProgress: () => inProgress,
+        getNotPublishable: () => notPublishable,
+    };
+}
+
+export function createDeferredPromise<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+        resolve = promiseResolve;
+        reject = promiseReject;
+    });
+
+    return {promise, resolve, reject};
+}
+
+export async function flushPromises(turns = 5): Promise<void> {
+    for (let i = 0; i < turns; i += 1) {
+        await Promise.resolve();
+    }
+}
+
+export async function flushDebouncedReload(delayMs: number, turns = 5): Promise<void> {
+    await flushPromises(turns);
+    await vi.advanceTimersByTimeAsync(delayMs);
+    await flushPromises(turns);
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.test.ts
@@ -1,14 +1,29 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {ContentId} from '../../../../app/content/ContentId';
-import type {ContentSummaryAndCompareStatus} from '../../../../app/content/ContentSummaryAndCompareStatus';
-import {emitContentUpdated} from '../socket.store';
 import {
+    emitContentArchived,
+    emitContentCreated,
+    emitContentDeleted,
+    emitContentPublished,
+    emitContentRenamed,
+    emitContentUpdated,
+} from '../socket.store';
+import {
+    $dependantPublishItems,
     $isPublishReady,
     $publishCheckErrors,
     $publishDialog,
+    $publishDialogPending,
     openPublishDialog,
     resetPublishDialogContext,
 } from './publishDialog.store';
+import {
+    createMockChangeItem,
+    createMockContent,
+    createResolveResult,
+    flushDebouncedReload as flushDelayedReload,
+    flushPromises,
+} from './dialog.store.test.utils';
 
 const {
     mockFetchContentSummariesWithStatus,
@@ -50,49 +65,24 @@ vi.mock('../../services/task.service', () => ({
     trackTask: mockTrackTask,
 }));
 
-function createMockContent(id: string, displayName = `Content ${id}`): ContentSummaryAndCompareStatus {
-    const contentId = new ContentId(id);
-
-    return {
-        getId: () => id,
-        getContentId: () => contentId,
-        getDisplayName: () => displayName,
-        hasChildren: () => false,
-        isOnline: () => false,
-    } as ContentSummaryAndCompareStatus;
-}
-
-function createResolveResult({
-    dependants = [],
-    required = [],
-    invalid = [],
-    inProgress = [],
-    notPublishable = [],
-}: {
-    dependants?: ContentId[];
-    required?: ContentId[];
-    invalid?: ContentId[];
-    inProgress?: ContentId[];
-    notPublishable?: ContentId[];
-}) {
-    return {
-        getDependants: () => dependants,
-        getRequired: () => required,
-        getInvalid: () => invalid,
-        getInProgress: () => inProgress,
-        getNotPublishable: () => notPublishable,
-    };
-}
-
 async function flushInitialReload(): Promise<void> {
-    for (let i = 0; i < 10; i += 1) {
-        await Promise.resolve();
-    }
+    await flushPromises(10);
 }
 
 async function flushDebouncedReload(): Promise<void> {
-    await vi.advanceTimersByTimeAsync(150);
+    await flushDelayedReload(150);
 }
+
+const publishRemovalEventCases = [
+    {
+        name: 'deleted',
+        emit: (ids: string[]) => emitContentDeleted(ids.map(createMockChangeItem)),
+    },
+    {
+        name: 'archived',
+        emit: (ids: string[]) => emitContentArchived(ids.map(createMockChangeItem)),
+    },
+] as const;
 
 describe('publishDialog.store', () => {
     beforeEach(() => {
@@ -114,8 +104,8 @@ describe('publishDialog.store', () => {
 
     it('reloads publish checks when a tracked main item is updated externally', async () => {
         const itemId = new ContentId('item-1');
-        const original = createMockContent('item-1', 'Original name');
-        const updated = createMockContent('item-1', 'Updated name');
+        const original = createMockContent('item-1', {displayName: 'Original name'});
+        const updated = createMockContent('item-1', {displayName: 'Updated name'});
 
         mockResolvePublishDependencies
             .mockResolvedValueOnce(createResolveResult({inProgress: [itemId]}))
@@ -138,5 +128,133 @@ describe('publishDialog.store', () => {
         expect($publishCheckErrors.get().inProgress.count).toBe(0);
         expect($isPublishReady.get()).toBe(true);
         expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(4);
+    });
+
+    it('patches renamed tracked items without forcing a dependency reload', async () => {
+        const dependantId = new ContentId('dep-1');
+        const mainOriginal = createMockContent('item-1', {displayName: 'Original main'});
+        const mainRenamed = createMockContent('item-1', {displayName: 'Renamed main'});
+        const dependantOriginal = createMockContent('dep-1', {displayName: 'Original dependant'});
+        const dependantRenamed = createMockContent('dep-1', {displayName: 'Renamed dependant'});
+
+        mockResolvePublishDependencies.mockImplementation(() => {
+            return createResolveResult({dependants: [dependantId]});
+        });
+        mockFetchContentSummariesWithStatus.mockImplementation((ids: ContentId[]) => {
+            return ids.some(id => id.equals(dependantId)) ? [dependantOriginal] : [];
+        });
+
+        openPublishDialog([mainOriginal]);
+        await flushInitialReload();
+
+        expect($dependantPublishItems.get()[0].content.getDisplayName()).toBe('Original dependant');
+
+        emitContentRenamed([mainRenamed, dependantRenamed], []);
+
+        expect($publishDialog.get().items[0].getDisplayName()).toBe('Renamed main');
+        expect($dependantPublishItems.get()[0].content.getDisplayName()).toBe('Renamed dependant');
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+    });
+
+    it('refreshes main items when created content is below a selected main item path', async () => {
+        const parent = createMockContent('item-1', {displayName: 'Parent', path: '/parent'});
+        const updatedParent = createMockContent('item-1', {displayName: 'Parent', path: '/parent', hasChildren: true});
+        const unrelated = createMockContent('item-2', {displayName: 'Elsewhere', path: '/other/child'});
+        const child = createMockContent('item-3', {displayName: 'Child', path: '/parent/child'});
+
+        mockFetchContentSummariesWithStatus.mockImplementation((ids: ContentId[]) => {
+            return ids.some(id => id.toString() === 'item-1') ? [updatedParent] : [];
+        });
+
+        openPublishDialog([parent]);
+        await flushInitialReload();
+
+        emitContentCreated([unrelated]);
+        await flushDebouncedReload();
+
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+        expect($publishDialog.get().items[0].hasChildren()).toBe(false);
+
+        emitContentCreated([child]);
+        await flushDebouncedReload();
+
+        expect($publishDialog.get().items[0].hasChildren()).toBe(true);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(4);
+    });
+
+    it.each(publishRemovalEventCases)(
+        'removes a non-last main item and reloads on $name events',
+        async ({emit}) => {
+            const first = createMockContent('item-1', {displayName: 'First'});
+            const second = createMockContent('item-2', {displayName: 'Second'});
+
+            openPublishDialog([first, second]);
+            await flushInitialReload();
+
+            emit(['item-1']);
+            await flushDebouncedReload();
+
+            expect($publishDialog.get().open).toBe(true);
+            expect($publishDialog.get().items.map(item => item.getId())).toEqual(['item-2']);
+            expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(4);
+        },
+    );
+
+    it('reloads when only some main items are published', async () => {
+        const first = createMockContent('item-1', {displayName: 'First'});
+        const second = createMockContent('item-2', {displayName: 'Second'});
+
+        openPublishDialog([first, second]);
+        await flushInitialReload();
+
+        emitContentPublished([first]);
+        await flushDebouncedReload();
+
+        expect($publishDialog.get().open).toBe(true);
+        expect($publishDialog.get().items.map(item => item.getId())).toEqual(['item-1', 'item-2']);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(4);
+    });
+
+    it.each([
+        ...publishRemovalEventCases,
+        {
+            name: 'published',
+            emit: (ids: string[]) => emitContentPublished(ids.map(id => createMockContent(id))),
+        },
+    ])(
+        'closes the dialog when the last main item is affected by $name events',
+        async ({emit}) => {
+            const item = createMockContent('item-1', {displayName: 'Item'});
+
+            openPublishDialog([item]);
+            await flushInitialReload();
+
+            emit(['item-1']);
+            await flushDebouncedReload();
+
+            expect($publishDialog.get().open).toBe(false);
+            expect($publishDialog.get().items).toEqual([]);
+            expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+        },
+    );
+
+    it('ignores published events while submitting', async () => {
+        const item = createMockContent('item-1', {displayName: 'Item'});
+
+        openPublishDialog([item]);
+        await flushInitialReload();
+
+        $publishDialogPending.set({
+            ...$publishDialogPending.get(),
+            submitting: true,
+        });
+
+        emitContentPublished([item]);
+        await flushDebouncedReload();
+
+        expect($publishDialog.get().open).toBe(true);
+        expect($publishDialog.get().items.map(currentItem => currentItem.getId())).toEqual(['item-1']);
+        expect($publishDialogPending.get().submitting).toBe(true);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.test.ts
@@ -1,0 +1,142 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {ContentId} from '../../../../app/content/ContentId';
+import type {ContentSummaryAndCompareStatus} from '../../../../app/content/ContentSummaryAndCompareStatus';
+import {emitContentUpdated} from '../socket.store';
+import {
+    $isPublishReady,
+    $publishCheckErrors,
+    $publishDialog,
+    openPublishDialog,
+    resetPublishDialogContext,
+} from './publishDialog.store';
+
+const {
+    mockFetchContentSummariesWithStatus,
+    mockHasUnpublishedChildren,
+    mockFindIdsByParents,
+    mockMarkAsReady,
+    mockPublishContent,
+    mockResolvePublishDependencies,
+    mockCleanupTask,
+    mockTrackTask,
+} = vi.hoisted(() => ({
+    mockFetchContentSummariesWithStatus: vi.fn(),
+    mockHasUnpublishedChildren: vi.fn(),
+    mockFindIdsByParents: vi.fn(),
+    mockMarkAsReady: vi.fn(),
+    mockPublishContent: vi.fn(),
+    mockResolvePublishDependencies: vi.fn(),
+    mockCleanupTask: vi.fn(),
+    mockTrackTask: vi.fn(),
+}));
+
+vi.mock('../../api/content', () => ({
+    fetchContentSummariesWithStatus: mockFetchContentSummariesWithStatus,
+}));
+
+vi.mock('../../api/hasUnpublishedChildren', () => ({
+    hasUnpublishedChildren: mockHasUnpublishedChildren,
+}));
+
+vi.mock('../../api/publish', () => ({
+    findIdsByParents: mockFindIdsByParents,
+    markAsReady: mockMarkAsReady,
+    publishContent: mockPublishContent,
+    resolvePublishDependencies: mockResolvePublishDependencies,
+}));
+
+vi.mock('../../services/task.service', () => ({
+    cleanupTask: mockCleanupTask,
+    trackTask: mockTrackTask,
+}));
+
+function createMockContent(id: string, displayName = `Content ${id}`): ContentSummaryAndCompareStatus {
+    const contentId = new ContentId(id);
+
+    return {
+        getId: () => id,
+        getContentId: () => contentId,
+        getDisplayName: () => displayName,
+        hasChildren: () => false,
+        isOnline: () => false,
+    } as ContentSummaryAndCompareStatus;
+}
+
+function createResolveResult({
+    dependants = [],
+    required = [],
+    invalid = [],
+    inProgress = [],
+    notPublishable = [],
+}: {
+    dependants?: ContentId[];
+    required?: ContentId[];
+    invalid?: ContentId[];
+    inProgress?: ContentId[];
+    notPublishable?: ContentId[];
+}) {
+    return {
+        getDependants: () => dependants,
+        getRequired: () => required,
+        getInvalid: () => invalid,
+        getInProgress: () => inProgress,
+        getNotPublishable: () => notPublishable,
+    };
+}
+
+async function flushInitialReload(): Promise<void> {
+    for (let i = 0; i < 10; i += 1) {
+        await Promise.resolve();
+    }
+}
+
+async function flushDebouncedReload(): Promise<void> {
+    await vi.advanceTimersByTimeAsync(150);
+}
+
+describe('publishDialog.store', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        resetPublishDialogContext();
+        mockFetchContentSummariesWithStatus.mockReset().mockResolvedValue([]);
+        mockHasUnpublishedChildren.mockReset().mockResolvedValue(new Map());
+        mockFindIdsByParents.mockReset().mockResolvedValue([]);
+        mockMarkAsReady.mockReset();
+        mockPublishContent.mockReset();
+        mockResolvePublishDependencies.mockReset().mockResolvedValue(createResolveResult({}));
+    });
+
+    afterEach(() => {
+        resetPublishDialogContext();
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+    });
+
+    it('reloads publish checks when a tracked main item is updated externally', async () => {
+        const itemId = new ContentId('item-1');
+        const original = createMockContent('item-1', 'Original name');
+        const updated = createMockContent('item-1', 'Updated name');
+
+        mockResolvePublishDependencies
+            .mockResolvedValueOnce(createResolveResult({inProgress: [itemId]}))
+            .mockResolvedValueOnce(createResolveResult({inProgress: [itemId]}))
+            .mockResolvedValueOnce(createResolveResult({}))
+            .mockResolvedValueOnce(createResolveResult({}));
+
+        openPublishDialog([original]);
+        await flushInitialReload();
+
+        expect($publishCheckErrors.get().inProgress.count).toBe(1);
+        expect($isPublishReady.get()).toBe(false);
+
+        emitContentUpdated([updated]);
+
+        expect($publishDialog.get().items[0].getDisplayName()).toBe('Updated name');
+
+        await flushDebouncedReload();
+
+        expect($publishCheckErrors.get().inProgress.count).toBe(0);
+        expect($isPublishReady.get()).toBe(true);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(4);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
@@ -9,8 +9,11 @@ import {hasUnpublishedChildren} from '../../api/hasUnpublishedChildren';
 import {findIdsByParents, markAsReady, publishContent, resolvePublishDependencies as resolvePublishDeps} from '../../api/publish';
 import {cleanupTask, trackTask} from '../../services/task.service';
 import {hasContentById, hasContentIdInIds, isIdsEqual, uniqueIds} from '../../utils/cms/content/ids';
+import {patchItemsById} from '../../utils/cms/content/patchItemsById';
+import {findContentIdsWithCreatedDescendants} from '../../utils/cms/content/paths';
+import {createGuardedSocketHandler} from '../../utils/store/createGuardedSocketHandler';
 import {createDebounce} from '../../utils/timing/createDebounce';
-import {$contentArchived, $contentCreated, $contentDeleted, $contentPublished, $contentUpdated} from '../socket.store';
+import {$contentArchived, $contentCreated, $contentDeleted, $contentPublished, $contentRenamed, $contentUpdated} from '../socket.store';
 import type {TaskResultState} from '../task.store';
 
 //
@@ -721,6 +724,12 @@ const isDialogActive = (): boolean => {
     return open && items.length > 0;
 };
 
+const onPublishSocketEvent = createGuardedSocketHandler(isDialogActive);
+const onIdlePublishSocketEvent = createGuardedSocketHandler(() => {
+    const {submitting} = $publishDialogPending.get();
+    return !submitting && isDialogActive();
+});
+
 /** Remove items by IDs from both main items and dependant items */
 const removeItemsByIds = (idsToRemove: Set<string>): {removedMain: boolean; removedDependant: boolean} => {
     const {items} = $publishDialog.get();
@@ -742,17 +751,62 @@ const removeItemsByIds = (idsToRemove: Set<string>): {removedMain: boolean; remo
     return {removedMain, removedDependant};
 };
 
-/** Patch items with updated data, keeping items not in the update */
-const patchItemsWithUpdates = (updates: ContentSummaryAndCompareStatus[]): boolean => {
+const handleRemovedPublishItems = (idsToRemove: Set<string>): void => {
+    const {removedMain, removedDependant} = removeItemsByIds(idsToRemove);
+
+    if ($publishDialog.get().items.length === 0) {
+        resetPublishDialogContext();
+        return;
+    }
+
+    if (removedMain || removedDependant) {
+        reloadPublishDialogDataDebounced();
+    }
+};
+
+const patchTrackedPublishItems = (
+    updates: ContentSummaryAndCompareStatus[],
+): {updatedMain: boolean; updatedDependants: boolean} => {
+    if (updates.length === 0) {
+        return {updatedMain: false, updatedDependants: false};
+    }
+
     const {items} = $publishDialog.get();
-    const updateMap = new Map(updates.map(u => [u.getId(), u]));
+    const dependantItems = $publishDialogDependants.get();
+    const patchedItems = patchItemsById(items, updates);
+    const patchedDependants = patchItemsById(dependantItems, updates);
+    const updatedMain = patchedItems.changed;
+    const updatedDependants = patchedDependants.changed;
 
-    const hasUpdates = items.some(item => updateMap.has(item.getId()));
-    if (!hasUpdates) return false;
+    if (updatedMain) {
+        $publishDialog.setKey('items', patchedItems.items);
+    }
 
-    const patchedItems = items.map(item => updateMap.get(item.getId()) ?? item);
-    $publishDialog.setKey('items', patchedItems);
-    return true;
+    if (updatedDependants) {
+        $publishDialogDependants.set(patchedDependants.items);
+    }
+
+    return {updatedMain, updatedDependants};
+};
+
+const refreshPublishDialogMainItems = async (ids: ContentId[]): Promise<void> => {
+    if (ids.length === 0) {
+        return;
+    }
+
+    try {
+        const updatedItems = await fetchContentSummariesWithStatus(ids);
+        if (updatedItems.length > 0) {
+            const {items} = $publishDialog.get();
+            const patchedItems = patchItemsById(items, updatedItems);
+
+            if (patchedItems.changed) {
+                $publishDialog.setKey('items', patchedItems.items);
+            }
+        }
+    } catch (error) {
+        console.error(error);
+    }
 };
 
 //
@@ -794,85 +848,46 @@ $publishDialog.subscribe((state, oldState) => {
 //
 
 // Handle content created: reload dependencies as new content might be a child or dependency
-$contentCreated.subscribe((event) => {
-    if (!event || !isDialogActive()) return;
+$contentCreated.subscribe(onPublishSocketEvent((event) => {
+    const mainItemIds = findContentIdsWithCreatedDescendants($publishDialog.get().items, event.data);
+    if (mainItemIds.length === 0) return;
 
-    // New content could be a child of items with "include children" or a new dependency
-    reloadPublishDialogDataDebounced();
-});
+    void refreshPublishDialogMainItems(mainItemIds).finally(() => {
+        reloadPublishDialogDataDebounced();
+    });
+}));
 
 // Handle content updates: patch visible items and reload checks if tracked content changed
-$contentUpdated.subscribe((event) => {
-    if (!event || !isDialogActive()) return;
-
-    const dependantItems = $publishDialogDependants.get();
-    const updatedIds = new Set(event.data.map(item => item.getId()));
-
-    // Patch main items immutably
-    const hasUpdatedMainItems = patchItemsWithUpdates(event.data);
+$contentUpdated.subscribe(onPublishSocketEvent((event) => {
+    const {updatedMain, updatedDependants} = patchTrackedPublishItems(event.data);
 
     // Reload when tracked items change so SelectionStatusBar stays in sync.
-    const hasUpdatedDependants = dependantItems.some(item => updatedIds.has(item.getId()));
-    if (hasUpdatedMainItems || hasUpdatedDependants) {
+    if (updatedMain || updatedDependants) {
         reloadPublishDialogDataDebounced();
     }
-});
+}));
+
+// Handle content renames: patch tracked rows without forcing dependency resolution
+$contentRenamed.subscribe(onPublishSocketEvent((event) => {
+    patchTrackedPublishItems(event.data.items);
+}));
 
 // Handle content deletion: remove from lists, close if no items left, reload if needed
-$contentDeleted.subscribe((event) => {
-    if (!event || !isDialogActive()) return;
-
-    const deletedIds = new Set(event.data.map(item => item.getContentId().toString()));
-    const {removedMain, removedDependant} = removeItemsByIds(deletedIds);
-
-    // Close dialog if all main items were deleted
-    const {items} = $publishDialog.get();
-    if (items.length === 0) {
-        resetPublishDialogContext();
-        return;
-    }
-
-    // Reload dependencies if any items were removed
-    if (removedMain || removedDependant) {
-        reloadPublishDialogDataDebounced();
-    }
-});
+$contentDeleted.subscribe(onPublishSocketEvent((event) => {
+    handleRemovedPublishItems(new Set(event.data.map(item => item.getContentId().toString())));
+}));
 
 // Handle content archived: same as delete
-$contentArchived.subscribe((event) => {
-    if (!event || !isDialogActive()) return;
-
-    const archivedIds = new Set(event.data.map(item => item.getContentId().toString()));
-    const {removedMain, removedDependant} = removeItemsByIds(archivedIds);
-
-    // Close dialog if all main items were archived
-    const {items} = $publishDialog.get();
-    if (items.length === 0) {
-        resetPublishDialogContext();
-        return;
-    }
-
-    // Reload dependencies if any items were removed
-    if (removedMain || removedDependant) {
-        reloadPublishDialogDataDebounced();
-    }
-});
+$contentArchived.subscribe(onPublishSocketEvent((event) => {
+    handleRemovedPublishItems(new Set(event.data.map(item => item.getContentId().toString())));
+}));
 
 //
 // * Completion Handling
 //
 
 // Handle content published: close dialog if all main items were published
-$contentPublished.subscribe((event) => {
-    if (!event) return;
-
-    // Skip if dialog is submitting - task service handles completion
-    const {submitting} = $publishDialogPending.get();
-    if (submitting) return;
-
-    // Handle dialog-open state updates
-    if (!isDialogActive()) return;
-
+$contentPublished.subscribe(onIdlePublishSocketEvent((event) => {
     const {items} = $publishDialog.get();
     const publishedIds = new Set(event.data.map(item => item.getId()));
 
@@ -885,7 +900,7 @@ $contentPublished.subscribe((event) => {
 
     // Otherwise reload to update status
     reloadPublishDialogDataDebounced();
-});
+}));
 
 // TODO: Use AbortController to cancel the request if the instanceId changes
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
@@ -801,7 +801,7 @@ $contentCreated.subscribe((event) => {
     reloadPublishDialogDataDebounced();
 });
 
-// Handle content updates: patch main items, reload if dependants affected
+// Handle content updates: patch visible items and reload checks if tracked content changed
 $contentUpdated.subscribe((event) => {
     if (!event || !isDialogActive()) return;
 
@@ -809,11 +809,11 @@ $contentUpdated.subscribe((event) => {
     const updatedIds = new Set(event.data.map(item => item.getId()));
 
     // Patch main items immutably
-    patchItemsWithUpdates(event.data);
+    const hasUpdatedMainItems = patchItemsWithUpdates(event.data);
 
-    // Reload when dependants change - dependency graph might have changed
+    // Reload when tracked items change so SelectionStatusBar stays in sync.
     const hasUpdatedDependants = dependantItems.some(item => updatedIds.has(item.getId()));
-    if (hasUpdatedDependants) {
+    if (hasUpdatedMainItems || hasUpdatedDependants) {
         reloadPublishDialogDataDebounced();
     }
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.test.ts
@@ -1,0 +1,144 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {ContentId} from '../../../../app/content/ContentId';
+import type {ContentSummaryAndCompareStatus} from '../../../../app/content/ContentSummaryAndCompareStatus';
+import {emitContentRenamed, emitContentUpdated} from '../socket.store';
+import {
+    $isRequestPublishReady,
+    $requestPublishDialog,
+    $requestPublishDialogErrors,
+    openRequestPublishDialog,
+    resetRequestPublishDialogContext,
+} from './requestPublishDialog.store';
+
+const {
+    mockFetchContentSummariesWithStatus,
+    mockMarkAsReady,
+    mockResolvePublishDependencies,
+    mockShowError,
+    mockShowFeedback,
+    mockShowSuccess,
+    mockShowWarning,
+} = vi.hoisted(() => ({
+    mockFetchContentSummariesWithStatus: vi.fn(),
+    mockMarkAsReady: vi.fn(),
+    mockResolvePublishDependencies: vi.fn(),
+    mockShowError: vi.fn(),
+    mockShowFeedback: vi.fn(),
+    mockShowSuccess: vi.fn(),
+    mockShowWarning: vi.fn(),
+}));
+
+vi.mock('../../api/content', () => ({
+    fetchContentSummariesWithStatus: mockFetchContentSummariesWithStatus,
+}));
+
+vi.mock('../../api/publish', () => ({
+    markAsReady: mockMarkAsReady,
+    resolvePublishDependencies: mockResolvePublishDependencies,
+}));
+
+vi.mock('@enonic/lib-admin-ui/notify/MessageBus', () => ({
+    showError: mockShowError,
+    showFeedback: mockShowFeedback,
+    showSuccess: mockShowSuccess,
+    showWarning: mockShowWarning,
+}));
+
+vi.mock('@enonic/lib-admin-ui/util/Messages', () => ({
+    i18n: (key: string) => key,
+}));
+
+function createMockContent(id: string, displayName = `Content ${id}`): ContentSummaryAndCompareStatus {
+    const contentId = new ContentId(id);
+
+    return {
+        getId: () => id,
+        getContentId: () => contentId,
+        getDisplayName: () => displayName,
+    } as ContentSummaryAndCompareStatus;
+}
+
+function createResolveResult({
+    dependants = [],
+    required = [],
+    invalid = [],
+    inProgress = [],
+    notPublishable = [],
+}: {
+    dependants?: ContentId[];
+    required?: ContentId[];
+    invalid?: ContentId[];
+    inProgress?: ContentId[];
+    notPublishable?: ContentId[];
+}) {
+    return {
+        getDependants: () => dependants,
+        getRequired: () => required,
+        getInvalid: () => invalid,
+        getInProgress: () => inProgress,
+        getNotPublishable: () => notPublishable,
+    };
+}
+
+async function flushRequestPublishReload(): Promise<void> {
+    await vi.advanceTimersByTimeAsync(200);
+}
+
+describe('requestPublishDialog.store', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        resetRequestPublishDialogContext();
+        mockFetchContentSummariesWithStatus.mockReset().mockResolvedValue([]);
+        mockMarkAsReady.mockReset();
+        mockResolvePublishDependencies.mockReset().mockResolvedValue(createResolveResult({}));
+        mockShowError.mockReset();
+        mockShowFeedback.mockReset();
+        mockShowSuccess.mockReset();
+        mockShowWarning.mockReset();
+    });
+
+    afterEach(() => {
+        resetRequestPublishDialogContext();
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+    });
+
+    it('patches updated main items and refreshes ready-state checks after external updates', async () => {
+        const itemId = new ContentId('item-1');
+        const original = createMockContent('item-1', 'Original name');
+        const updated = createMockContent('item-1', 'Updated name');
+
+        mockResolvePublishDependencies
+            .mockResolvedValueOnce(createResolveResult({inProgress: [itemId]}))
+            .mockResolvedValueOnce(createResolveResult({}));
+
+        openRequestPublishDialog([original]);
+        await flushRequestPublishReload();
+
+        expect($requestPublishDialogErrors.get().inProgress.count).toBe(1);
+        expect($isRequestPublishReady.get()).toBe(false);
+
+        emitContentUpdated([updated]);
+
+        expect($requestPublishDialog.get().items[0].getDisplayName()).toBe('Updated name');
+
+        await flushRequestPublishReload();
+
+        expect($requestPublishDialogErrors.get().inProgress.count).toBe(0);
+        expect($isRequestPublishReady.get()).toBe(true);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+    });
+
+    it('patches renamed items without forcing a dependency reload', async () => {
+        const original = createMockContent('item-1', 'Original name');
+        const renamed = createMockContent('item-1', 'Renamed item');
+
+        openRequestPublishDialog([original]);
+        await flushRequestPublishReload();
+
+        emitContentRenamed([renamed], []);
+
+        expect($requestPublishDialog.get().items[0].getDisplayName()).toBe('Renamed item');
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(1);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.test.ts
@@ -1,16 +1,31 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {ContentId} from '../../../../app/content/ContentId';
-import type {ContentSummaryAndCompareStatus} from '../../../../app/content/ContentSummaryAndCompareStatus';
-import {emitContentRenamed, emitContentUpdated} from '../socket.store';
+import {
+    emitContentArchived,
+    emitContentCreated,
+    emitContentDeleted,
+    emitContentPublished,
+    emitContentRenamed,
+    emitContentUpdated,
+} from '../socket.store';
 import {
     $isRequestPublishReady,
     $requestPublishDialog,
     $requestPublishDialogErrors,
     openRequestPublishDialog,
     resetRequestPublishDialogContext,
+    submitRequestPublishDialog,
 } from './requestPublishDialog.store';
+import {
+    createDeferredPromise,
+    createMockChangeItem,
+    createMockContent,
+    createResolveResult,
+    flushDebouncedReload,
+} from './dialog.store.test.utils';
 
 const {
+    mockCreateIssueSendAndParse,
     mockFetchContentSummariesWithStatus,
     mockMarkAsReady,
     mockResolvePublishDependencies,
@@ -19,6 +34,7 @@ const {
     mockShowSuccess,
     mockShowWarning,
 } = vi.hoisted(() => ({
+    mockCreateIssueSendAndParse: vi.fn(),
     mockFetchContentSummariesWithStatus: vi.fn(),
     mockMarkAsReady: vi.fn(),
     mockResolvePublishDependencies: vi.fn(),
@@ -37,6 +53,34 @@ vi.mock('../../api/publish', () => ({
     resolvePublishDependencies: mockResolvePublishDependencies,
 }));
 
+vi.mock('../../../../app/issue/resource/CreateIssueRequest', () => ({
+    CreateIssueRequest: class {
+        setApprovers(): this {
+            return this;
+        }
+
+        setPublishRequest(): this {
+            return this;
+        }
+
+        setTitle(): this {
+            return this;
+        }
+
+        setDescription(): this {
+            return this;
+        }
+
+        setType(): this {
+            return this;
+        }
+
+        sendAndParse(): Promise<never> {
+            return mockCreateIssueSendAndParse();
+        }
+    },
+}));
+
 vi.mock('@enonic/lib-admin-ui/notify/MessageBus', () => ({
     showError: mockShowError,
     showFeedback: mockShowFeedback,
@@ -48,40 +92,23 @@ vi.mock('@enonic/lib-admin-ui/util/Messages', () => ({
     i18n: (key: string) => key,
 }));
 
-function createMockContent(id: string, displayName = `Content ${id}`): ContentSummaryAndCompareStatus {
-    const contentId = new ContentId(id);
-
-    return {
-        getId: () => id,
-        getContentId: () => contentId,
-        getDisplayName: () => displayName,
-    } as ContentSummaryAndCompareStatus;
-}
-
-function createResolveResult({
-    dependants = [],
-    required = [],
-    invalid = [],
-    inProgress = [],
-    notPublishable = [],
-}: {
-    dependants?: ContentId[];
-    required?: ContentId[];
-    invalid?: ContentId[];
-    inProgress?: ContentId[];
-    notPublishable?: ContentId[];
-}) {
-    return {
-        getDependants: () => dependants,
-        getRequired: () => required,
-        getInvalid: () => invalid,
-        getInProgress: () => inProgress,
-        getNotPublishable: () => notPublishable,
-    };
-}
+const requestPublishMainItemEventCases = [
+    {
+        name: 'deleted',
+        emit: (ids: string[]) => emitContentDeleted(ids.map(createMockChangeItem)),
+    },
+    {
+        name: 'archived',
+        emit: (ids: string[]) => emitContentArchived(ids.map(createMockChangeItem)),
+    },
+    {
+        name: 'published',
+        emit: (ids: string[]) => emitContentPublished(ids.map(id => createMockContent(id))),
+    },
+] as const;
 
 async function flushRequestPublishReload(): Promise<void> {
-    await vi.advanceTimersByTimeAsync(200);
+    await flushDebouncedReload(200);
 }
 
 describe('requestPublishDialog.store', () => {
@@ -89,6 +116,7 @@ describe('requestPublishDialog.store', () => {
         vi.useFakeTimers();
         resetRequestPublishDialogContext();
         mockFetchContentSummariesWithStatus.mockReset().mockResolvedValue([]);
+        mockCreateIssueSendAndParse.mockReset();
         mockMarkAsReady.mockReset();
         mockResolvePublishDependencies.mockReset().mockResolvedValue(createResolveResult({}));
         mockShowError.mockReset();
@@ -105,8 +133,8 @@ describe('requestPublishDialog.store', () => {
 
     it('patches updated main items and refreshes ready-state checks after external updates', async () => {
         const itemId = new ContentId('item-1');
-        const original = createMockContent('item-1', 'Original name');
-        const updated = createMockContent('item-1', 'Updated name');
+        const original = createMockContent('item-1', {displayName: 'Original name'});
+        const updated = createMockContent('item-1', {displayName: 'Updated name'});
 
         mockResolvePublishDependencies
             .mockResolvedValueOnce(createResolveResult({inProgress: [itemId]}))
@@ -130,8 +158,8 @@ describe('requestPublishDialog.store', () => {
     });
 
     it('patches renamed items without forcing a dependency reload', async () => {
-        const original = createMockContent('item-1', 'Original name');
-        const renamed = createMockContent('item-1', 'Renamed item');
+        const original = createMockContent('item-1', {displayName: 'Original name'});
+        const renamed = createMockContent('item-1', {displayName: 'Renamed item'});
 
         openRequestPublishDialog([original]);
         await flushRequestPublishReload();
@@ -140,5 +168,150 @@ describe('requestPublishDialog.store', () => {
 
         expect($requestPublishDialog.get().items[0].getDisplayName()).toBe('Renamed item');
         expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes main items when created content is below a selected item path', async () => {
+        const parent = createMockContent('item-1', {displayName: 'Parent', path: '/parent'});
+        const updatedParent = createMockContent('item-1', {displayName: 'Parent', path: '/parent', hasChildren: true});
+        const unrelated = createMockContent('item-2', {displayName: 'Elsewhere', path: '/other/child'});
+        const child = createMockContent('item-3', {displayName: 'Child', path: '/parent/child'});
+
+        mockFetchContentSummariesWithStatus.mockImplementation((ids: ContentId[]) => {
+            return ids.some(id => id.toString() === 'item-1') ? [updatedParent] : [];
+        });
+
+        openRequestPublishDialog([parent]);
+        await flushRequestPublishReload();
+
+        emitContentCreated([unrelated]);
+        await flushRequestPublishReload();
+
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(1);
+        expect($requestPublishDialog.get().items[0].hasChildren()).toBe(false);
+
+        emitContentCreated([child]);
+        await flushRequestPublishReload();
+
+        expect($requestPublishDialog.get().items[0].hasChildren()).toBe(true);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+    });
+
+    it.each(requestPublishMainItemEventCases)(
+        'removes a non-last main item and reloads on $name events',
+        async ({emit}) => {
+            const first = createMockContent('item-1', {displayName: 'First'});
+            const second = createMockContent('item-2', {displayName: 'Second'});
+
+            openRequestPublishDialog([first, second]);
+            await flushRequestPublishReload();
+
+            emit(['item-1']);
+            await flushRequestPublishReload();
+
+            expect($requestPublishDialog.get().open).toBe(true);
+            expect($requestPublishDialog.get().items.map(item => item.getId())).toEqual(['item-2']);
+            expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+        },
+    );
+
+    it.each(requestPublishMainItemEventCases)(
+        'closes the dialog when the last main item is removed by $name events',
+        async ({emit}) => {
+            const item = createMockContent('item-1', {displayName: 'Item'});
+
+            openRequestPublishDialog([item]);
+            await flushRequestPublishReload();
+
+            emit(['item-1']);
+            await flushRequestPublishReload();
+
+            expect($requestPublishDialog.get().open).toBe(false);
+            expect($requestPublishDialog.get().items).toEqual([]);
+            expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(1);
+        },
+    );
+
+    it('defers socket events during submit and reconciles them after a failed request', async () => {
+        const item = createMockContent('item-1', {displayName: 'Item'});
+        const submitRequestDeferred = createDeferredPromise<never>();
+
+        openRequestPublishDialog([item]);
+        await flushRequestPublishReload();
+
+        mockCreateIssueSendAndParse.mockReturnValueOnce(submitRequestDeferred.promise);
+
+        $requestPublishDialog.set({
+            ...$requestPublishDialog.get(),
+            title: 'Publish request',
+            description: 'Keep this draft state intact',
+            assigneeIds: ['user:system:editor'],
+        });
+
+        const submitPromise = submitRequestPublishDialog();
+        await Promise.resolve();
+
+        emitContentPublished([item]);
+
+        expect($requestPublishDialog.get().open).toBe(true);
+        expect($requestPublishDialog.get().items.map(currentItem => currentItem.getId())).toEqual(['item-1']);
+        expect($requestPublishDialog.get().title).toBe('Publish request');
+        expect($requestPublishDialog.get().description).toBe('Keep this draft state intact');
+        expect($requestPublishDialog.get().assigneeIds).toEqual(['user:system:editor']);
+        expect($requestPublishDialog.get().submitting).toBe(true);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(1);
+
+        submitRequestDeferred.reject(new Error('Request failed'));
+        await submitPromise;
+
+        expect($requestPublishDialog.get().open).toBe(false);
+        expect($requestPublishDialog.get().items).toEqual([]);
+        expect($requestPublishDialog.get().title).toBe('');
+        expect($requestPublishDialog.get().description).toBe('');
+        expect($requestPublishDialog.get().assigneeIds).toEqual([]);
+        expect($requestPublishDialog.get().submitting).toBe(false);
+        expect(mockShowError).toHaveBeenCalledWith('Request failed');
+    });
+
+    it('reconciles queued non-removal events after a failed request', async () => {
+        const item = createMockContent('item-1', {displayName: 'Original item'});
+        const updatedItem = createMockContent('item-1', {displayName: 'Updated item'});
+        const submitRequestDeferred = createDeferredPromise<never>();
+
+        mockFetchContentSummariesWithStatus.mockImplementation((ids: ContentId[]) => {
+            return ids.some(id => id.toString() === 'item-1') ? [updatedItem] : [];
+        });
+
+        openRequestPublishDialog([item]);
+        await flushRequestPublishReload();
+
+        mockCreateIssueSendAndParse.mockReturnValueOnce(submitRequestDeferred.promise);
+
+        $requestPublishDialog.set({
+            ...$requestPublishDialog.get(),
+            title: 'Publish request',
+            description: 'Keep this draft state intact',
+            assigneeIds: ['user:system:editor'],
+        });
+
+        const submitPromise = submitRequestPublishDialog();
+        await Promise.resolve();
+
+        emitContentUpdated([updatedItem]);
+
+        expect($requestPublishDialog.get().items[0].getDisplayName()).toBe('Original item');
+        expect($requestPublishDialog.get().submitting).toBe(true);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(1);
+
+        submitRequestDeferred.reject(new Error('Request failed'));
+        await submitPromise;
+
+        expect($requestPublishDialog.get().open).toBe(true);
+        expect($requestPublishDialog.get().items[0].getDisplayName()).toBe('Updated item');
+        expect($requestPublishDialog.get().title).toBe('Publish request');
+        expect($requestPublishDialog.get().description).toBe('Keep this draft state intact');
+        expect($requestPublishDialog.get().assigneeIds).toEqual(['user:system:editor']);
+        expect($requestPublishDialog.get().submitting).toBe(false);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+        expect(mockShowError).toHaveBeenCalledWith('Request failed');
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.ts
@@ -12,6 +12,14 @@ import {markAsReady, resolvePublishDependencies} from '../../api/publish';
 import {buildItems, dedupeItems, getItemIds} from '../../utils/cms/content/buildItems';
 import {hasContentIdInIds, uniqueIds} from '../../utils/cms/content/ids';
 import {createDebounce} from '../../utils/timing/createDebounce';
+import {
+    $contentArchived,
+    $contentCreated,
+    $contentDeleted,
+    $contentPublished,
+    $contentRenamed,
+    $contentUpdated,
+} from '../socket.store';
 
 const DEPENDENCY_RELOAD_DELAY_MS = 150;
 
@@ -132,6 +140,68 @@ const patchItemsWithUpdates = (
     updates.forEach(item => updateMap.set(item.getId(), item));
 
     return items.map(item => updateMap.get(item.getId()) ?? item);
+};
+
+const isRequestPublishDialogActive = (): boolean => {
+    const {open, items} = $requestPublishDialog.get();
+    return open && items.length > 0;
+};
+
+const patchTrackedRequestPublishItems = (
+    updates: ContentSummaryAndCompareStatus[],
+): {updatedMain: boolean; updatedDependants: boolean} => {
+    if (updates.length === 0) {
+        return {updatedMain: false, updatedDependants: false};
+    }
+
+    const updateIds = new Set(updates.map(item => item.getId()));
+    const state = $requestPublishDialog.get();
+    const updatedMain = state.items.some(item => updateIds.has(item.getId()));
+    const updatedDependants = state.dependants.some(item => updateIds.has(item.getId()));
+
+    if (!updatedMain && !updatedDependants) {
+        return {updatedMain, updatedDependants};
+    }
+
+    $requestPublishDialog.set({
+        ...state,
+        items: updatedMain ? patchItemsWithUpdates(state.items, updates) : state.items,
+        dependants: updatedDependants ? patchItemsWithUpdates(state.dependants, updates) : state.dependants,
+    });
+
+    return {updatedMain, updatedDependants};
+};
+
+const removeTrackedRequestPublishItems = (
+    idsToRemove: Set<string>,
+): {removedMain: boolean; removedDependants: boolean} => {
+    const state = $requestPublishDialog.get();
+    const items = state.items.filter(item => !idsToRemove.has(item.getContentId().toString()));
+    const dependants = state.dependants.filter(item => !idsToRemove.has(item.getContentId().toString()));
+    const excludeChildrenIds = state.excludeChildrenIds.filter(id => !idsToRemove.has(id.toString()));
+    const excludedDependantIds = state.excludedDependantIds.filter(id => !idsToRemove.has(id.toString()));
+    const requiredDependantIds = state.requiredDependantIds.filter(id => !idsToRemove.has(id.toString()));
+
+    const removedMain = items.length !== state.items.length;
+    const removedDependants = dependants.length !== state.dependants.length;
+    const exclusionsChanged = excludeChildrenIds.length !== state.excludeChildrenIds.length ||
+        excludedDependantIds.length !== state.excludedDependantIds.length ||
+        requiredDependantIds.length !== state.requiredDependantIds.length;
+
+    if (!removedMain && !removedDependants && !exclusionsChanged) {
+        return {removedMain, removedDependants};
+    }
+
+    $requestPublishDialog.set({
+        ...state,
+        items,
+        dependants,
+        excludeChildrenIds,
+        excludedDependantIds,
+        requiredDependantIds,
+    });
+
+    return {removedMain, removedDependants};
 };
 
 const resetDependenciesState = (state: RequestPublishDialogStore): RequestPublishDialogStore => {
@@ -506,3 +576,88 @@ const markIdsReady = async (ids: ContentId[]): Promise<ContentId[]> => {
         return [];
     }
 };
+
+$contentCreated.subscribe((event) => {
+    if (!event || !isRequestPublishDialogActive()) {
+        return;
+    }
+
+    reloadDependenciesDebounced();
+});
+
+$contentUpdated.subscribe((event) => {
+    if (!event || !isRequestPublishDialogActive()) {
+        return;
+    }
+
+    const {updatedMain, updatedDependants} = patchTrackedRequestPublishItems(event.data);
+
+    if (updatedMain || updatedDependants) {
+        reloadDependenciesDebounced();
+    }
+});
+
+$contentRenamed.subscribe((event) => {
+    if (!event || !isRequestPublishDialogActive()) {
+        return;
+    }
+
+    patchTrackedRequestPublishItems(event.data.items);
+});
+
+$contentDeleted.subscribe((event) => {
+    if (!event || !isRequestPublishDialogActive()) {
+        return;
+    }
+
+    const {removedMain, removedDependants} = removeTrackedRequestPublishItems(
+        new Set(event.data.map(item => item.getContentId().toString())),
+    );
+
+    if ($requestPublishDialog.get().items.length === 0) {
+        resetRequestPublishDialogContext();
+        return;
+    }
+
+    if (removedMain || removedDependants) {
+        reloadDependenciesDebounced();
+    }
+});
+
+$contentArchived.subscribe((event) => {
+    if (!event || !isRequestPublishDialogActive()) {
+        return;
+    }
+
+    const {removedMain, removedDependants} = removeTrackedRequestPublishItems(
+        new Set(event.data.map(item => item.getContentId().toString())),
+    );
+
+    if ($requestPublishDialog.get().items.length === 0) {
+        resetRequestPublishDialogContext();
+        return;
+    }
+
+    if (removedMain || removedDependants) {
+        reloadDependenciesDebounced();
+    }
+});
+
+$contentPublished.subscribe((event) => {
+    if (!event || !isRequestPublishDialogActive()) {
+        return;
+    }
+
+    const {removedMain, removedDependants} = removeTrackedRequestPublishItems(
+        new Set(event.data.map(item => item.getContentId().toString())),
+    );
+
+    if ($requestPublishDialog.get().items.length === 0) {
+        resetRequestPublishDialogContext();
+        return;
+    }
+
+    if (removedMain || removedDependants) {
+        reloadDependenciesDebounced();
+    }
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.ts
@@ -11,6 +11,9 @@ import {fetchContentSummariesWithStatus} from '../../api/content';
 import {markAsReady, resolvePublishDependencies} from '../../api/publish';
 import {buildItems, dedupeItems, getItemIds} from '../../utils/cms/content/buildItems';
 import {hasContentIdInIds, uniqueIds} from '../../utils/cms/content/ids';
+import {patchItemsById} from '../../utils/cms/content/patchItemsById';
+import {findContentIdsWithCreatedDescendants} from '../../utils/cms/content/paths';
+import {createGuardedSocketHandler} from '../../utils/store/createGuardedSocketHandler';
 import {createDebounce} from '../../utils/timing/createDebounce';
 import {
     $contentArchived,
@@ -123,28 +126,61 @@ export const $isRequestPublishReady = computed(
 );
 
 let instanceId = 0;
+let hasQueuedRequestPublishSocketChanges = false;
+const queuedRequestPublishRemovedIds = new Set<string>();
 
 const reloadDependenciesDebounced = createDebounce(() => {
     void reloadRequestPublishDependencies();
 }, DEPENDENCY_RELOAD_DELAY_MS);
 
-const patchItemsWithUpdates = (
-    items: ContentSummaryAndCompareStatus[],
-    updates: ContentSummaryAndCompareStatus[],
-): ContentSummaryAndCompareStatus[] => {
-    if (updates.length === 0) {
-        return items;
-    }
-
-    const updateMap = new Map<string, ContentSummaryAndCompareStatus>();
-    updates.forEach(item => updateMap.set(item.getId(), item));
-
-    return items.map(item => updateMap.get(item.getId()) ?? item);
+const hasOpenRequestPublishDialog = (): boolean => {
+    const {open, items} = $requestPublishDialog.get();
+    return open && items.length > 0;
 };
 
 const isRequestPublishDialogActive = (): boolean => {
-    const {open, items} = $requestPublishDialog.get();
-    return open && items.length > 0;
+    const {submitting} = $requestPublishDialog.get();
+    return hasOpenRequestPublishDialog() && !submitting;
+};
+
+const onActiveRequestPublishSocketEvent = createGuardedSocketHandler(isRequestPublishDialogActive);
+
+const clearQueuedRequestPublishSocketChanges = (): void => {
+    hasQueuedRequestPublishSocketChanges = false;
+    queuedRequestPublishRemovedIds.clear();
+};
+
+const queueRequestPublishSocketChanges = (removedIds?: Iterable<string>): void => {
+    hasQueuedRequestPublishSocketChanges = true;
+
+    if (!removedIds) {
+        return;
+    }
+
+    for (const id of removedIds) {
+        queuedRequestPublishRemovedIds.add(id);
+    }
+};
+
+const onRequestPublishSocketEvent = <T>(
+    handler: (event: T) => void,
+    getRemovedIds?: (event: T) => Iterable<string>,
+): ((event: T | null | undefined) => void) => {
+    const activeHandler = onActiveRequestPublishSocketEvent(handler);
+
+    return (event) => {
+        if (event == null) {
+            return;
+        }
+
+        const {submitting} = $requestPublishDialog.get();
+        if (submitting && hasOpenRequestPublishDialog()) {
+            queueRequestPublishSocketChanges(getRemovedIds?.(event));
+            return;
+        }
+
+        activeHandler(event);
+    };
 };
 
 const patchTrackedRequestPublishItems = (
@@ -154,10 +190,11 @@ const patchTrackedRequestPublishItems = (
         return {updatedMain: false, updatedDependants: false};
     }
 
-    const updateIds = new Set(updates.map(item => item.getId()));
     const state = $requestPublishDialog.get();
-    const updatedMain = state.items.some(item => updateIds.has(item.getId()));
-    const updatedDependants = state.dependants.some(item => updateIds.has(item.getId()));
+    const patchedItems = patchItemsById(state.items, updates);
+    const patchedDependants = patchItemsById(state.dependants, updates);
+    const updatedMain = patchedItems.changed;
+    const updatedDependants = patchedDependants.changed;
 
     if (!updatedMain && !updatedDependants) {
         return {updatedMain, updatedDependants};
@@ -165,11 +202,62 @@ const patchTrackedRequestPublishItems = (
 
     $requestPublishDialog.set({
         ...state,
-        items: updatedMain ? patchItemsWithUpdates(state.items, updates) : state.items,
-        dependants: updatedDependants ? patchItemsWithUpdates(state.dependants, updates) : state.dependants,
+        items: patchedItems.items,
+        dependants: patchedDependants.items,
     });
 
     return {updatedMain, updatedDependants};
+};
+
+const refreshRequestPublishMainItems = async (ids: ContentId[]): Promise<void> => {
+    if (ids.length === 0) {
+        return;
+    }
+
+    try {
+        const updatedItems = await fetchContentSummariesWithStatus(ids);
+        if (updatedItems.length > 0) {
+            patchTrackedRequestPublishItems(updatedItems);
+        }
+    } catch (error) {
+        console.error(error);
+    }
+};
+
+const syncQueuedRequestPublishSocketChanges = async (): Promise<void> => {
+    if (!hasQueuedRequestPublishSocketChanges) {
+        return;
+    }
+
+    const removedIds = new Set(queuedRequestPublishRemovedIds);
+    clearQueuedRequestPublishSocketChanges();
+
+    if (!hasOpenRequestPublishDialog()) {
+        return;
+    }
+
+    if (removedIds.size > 0) {
+        removeTrackedRequestPublishItems(removedIds);
+
+        if ($requestPublishDialog.get().items.length === 0) {
+            resetRequestPublishDialogContext();
+            return;
+        }
+    }
+
+    const itemIds = getItemIds($requestPublishDialog.get().items);
+    if (itemIds.length > 0) {
+        try {
+            const updatedItems = await fetchContentSummariesWithStatus(itemIds);
+            if (updatedItems.length > 0) {
+                patchTrackedRequestPublishItems(updatedItems);
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+
+    await reloadRequestPublishDependencies();
 };
 
 const removeTrackedRequestPublishItems = (
@@ -204,6 +292,23 @@ const removeTrackedRequestPublishItems = (
     return {removedMain, removedDependants};
 };
 
+const getRemovedRequestPublishIds = (items: {getContentId: () => {toString: () => string}}[]): Set<string> => {
+    return new Set(items.map(item => item.getContentId().toString()));
+};
+
+const handleRemovedRequestPublishItems = (idsToRemove: Set<string>): void => {
+    const {removedMain, removedDependants} = removeTrackedRequestPublishItems(idsToRemove);
+
+    if ($requestPublishDialog.get().items.length === 0) {
+        resetRequestPublishDialogContext();
+        return;
+    }
+
+    if (removedMain || removedDependants) {
+        reloadDependenciesDebounced();
+    }
+};
+
 const resetDependenciesState = (state: RequestPublishDialogStore): RequestPublishDialogStore => {
     return {
         ...state,
@@ -222,6 +327,7 @@ const resetChecksState = (): void => {
 export const resetRequestPublishDialogContext = (): void => {
     instanceId += 1;
     reloadDependenciesDebounced.cancel();
+    clearQueuedRequestPublishSocketChanges();
     $requestPublishDialog.set(structuredClone(initialState));
     resetChecksState();
 };
@@ -417,12 +523,7 @@ export const markAllAsReadyInProgressRequestPublishItems = async (): Promise<voi
     try {
         const updatedItems = await fetchContentSummariesWithStatus(ids);
         if (updatedItems.length > 0) {
-            const state = $requestPublishDialog.get();
-            $requestPublishDialog.set({
-                ...state,
-                items: patchItemsWithUpdates(state.items, updatedItems),
-                dependants: patchItemsWithUpdates(state.dependants, updatedItems),
-            });
+            patchTrackedRequestPublishItems(updatedItems);
         }
     } catch (error) {
         console.error(error);
@@ -467,6 +568,10 @@ export const submitRequestPublishDialog = async (): Promise<void> => {
         showError(error?.message ?? String(error));
     } finally {
         $requestPublishDialog.setKey('submitting', false);
+
+        if (hasOpenRequestPublishDialog()) {
+            await syncQueuedRequestPublishSocketChanges();
+        }
     }
 };
 
@@ -577,87 +682,37 @@ const markIdsReady = async (ids: ContentId[]): Promise<ContentId[]> => {
     }
 };
 
-$contentCreated.subscribe((event) => {
-    if (!event || !isRequestPublishDialogActive()) {
+$contentCreated.subscribe(onRequestPublishSocketEvent((event) => {
+    const mainItemIds = findContentIdsWithCreatedDescendants($requestPublishDialog.get().items, event.data);
+    if (mainItemIds.length === 0) {
         return;
     }
 
-    reloadDependenciesDebounced();
-});
+    void refreshRequestPublishMainItems(mainItemIds).finally(() => {
+        reloadDependenciesDebounced();
+    });
+}));
 
-$contentUpdated.subscribe((event) => {
-    if (!event || !isRequestPublishDialogActive()) {
-        return;
-    }
-
+$contentUpdated.subscribe(onRequestPublishSocketEvent((event) => {
     const {updatedMain, updatedDependants} = patchTrackedRequestPublishItems(event.data);
 
     if (updatedMain || updatedDependants) {
         reloadDependenciesDebounced();
     }
-});
+}));
 
-$contentRenamed.subscribe((event) => {
-    if (!event || !isRequestPublishDialogActive()) {
-        return;
-    }
-
+$contentRenamed.subscribe(onRequestPublishSocketEvent((event) => {
     patchTrackedRequestPublishItems(event.data.items);
-});
+}));
 
-$contentDeleted.subscribe((event) => {
-    if (!event || !isRequestPublishDialogActive()) {
-        return;
-    }
+$contentDeleted.subscribe(onRequestPublishSocketEvent((event) => {
+    handleRemovedRequestPublishItems(getRemovedRequestPublishIds(event.data));
+}, (event) => event.data.map(item => item.getContentId().toString())));
 
-    const {removedMain, removedDependants} = removeTrackedRequestPublishItems(
-        new Set(event.data.map(item => item.getContentId().toString())),
-    );
+$contentArchived.subscribe(onRequestPublishSocketEvent((event) => {
+    handleRemovedRequestPublishItems(getRemovedRequestPublishIds(event.data));
+}, (event) => event.data.map(item => item.getContentId().toString())));
 
-    if ($requestPublishDialog.get().items.length === 0) {
-        resetRequestPublishDialogContext();
-        return;
-    }
-
-    if (removedMain || removedDependants) {
-        reloadDependenciesDebounced();
-    }
-});
-
-$contentArchived.subscribe((event) => {
-    if (!event || !isRequestPublishDialogActive()) {
-        return;
-    }
-
-    const {removedMain, removedDependants} = removeTrackedRequestPublishItems(
-        new Set(event.data.map(item => item.getContentId().toString())),
-    );
-
-    if ($requestPublishDialog.get().items.length === 0) {
-        resetRequestPublishDialogContext();
-        return;
-    }
-
-    if (removedMain || removedDependants) {
-        reloadDependenciesDebounced();
-    }
-});
-
-$contentPublished.subscribe((event) => {
-    if (!event || !isRequestPublishDialogActive()) {
-        return;
-    }
-
-    const {removedMain, removedDependants} = removeTrackedRequestPublishItems(
-        new Set(event.data.map(item => item.getContentId().toString())),
-    );
-
-    if ($requestPublishDialog.get().items.length === 0) {
-        resetRequestPublishDialogContext();
-        return;
-    }
-
-    if (removedMain || removedDependants) {
-        reloadDependenciesDebounced();
-    }
-});
+$contentPublished.subscribe(onRequestPublishSocketEvent((event) => {
+    handleRemovedRequestPublishItems(getRemovedRequestPublishIds(event.data));
+}, (event) => event.data.map(item => item.getContentId().toString())));

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/patchItemsById.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/patchItemsById.ts
@@ -1,0 +1,30 @@
+type IdAwareItem = {
+    getId: () => string;
+};
+
+export function patchItemsById<T extends IdAwareItem>(
+    items: T[],
+    updates: readonly T[],
+): {items: T[]; changed: boolean} {
+    if (items.length === 0 || updates.length === 0) {
+        return {items, changed: false};
+    }
+
+    const updateMap = new Map(updates.map(item => [item.getId(), item]));
+    let changed = false;
+
+    const patchedItems = items.map(item => {
+        const updatedItem = updateMap.get(item.getId());
+        if (updatedItem) {
+            changed = true;
+            return updatedItem;
+        }
+
+        return item;
+    });
+
+    return {
+        items: changed ? patchedItems : items,
+        changed,
+    };
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/paths.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/paths.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from 'vitest';
+import {ContentId} from '../../../../../app/content/ContentId';
+import {
+    findContentIdsWithCreatedDescendants,
+    isDescendantContentPath,
+    type PathAwareContent,
+    type PathLikeContent,
+} from './paths';
+
+function createPathItem(path?: string): PathLikeContent {
+    return {
+        getPath: () => path ? {toString: () => path} : undefined,
+    };
+}
+
+function createPathAwareItem(id: string, path?: string): PathAwareContent {
+    const contentId = new ContentId(id);
+
+    return {
+        getContentId: () => contentId,
+        getPath: () => path ? {toString: () => path} : undefined,
+    };
+}
+
+describe('content paths utils', () => {
+    it('matches only descendant paths', () => {
+        expect(isDescendantContentPath('/site/parent', '/site/parent/child')).toBe(true);
+        expect(isDescendantContentPath('/site/parent', '/site/parent')).toBe(false);
+        expect(isDescendantContentPath('/site/parent', '/site/parent-2/child')).toBe(false);
+    });
+
+    it('returns parent ids with created descendants', () => {
+        const parentItems = [
+            createPathAwareItem('1', '/site/parent'),
+            createPathAwareItem('2', '/site/other'),
+        ];
+        const createdItems = [
+            createPathItem('/site/parent/child'),
+            createPathItem('/outside/item'),
+        ];
+
+        expect(findContentIdsWithCreatedDescendants(parentItems, createdItems).map(id => id.toString())).toEqual(['1']);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/paths.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/paths.ts
@@ -1,0 +1,52 @@
+import type {ContentId} from '../../../../../app/content/ContentId';
+
+type ContentPathValue = {
+    toString: () => string;
+} | null | undefined;
+
+export type PathLikeContent = {
+    getPath?: () => ContentPathValue;
+};
+
+export type PathAwareContent = PathLikeContent & {
+    getContentId: () => ContentId;
+};
+
+function getContentPath(item: PathLikeContent): string | undefined {
+    return item.getPath?.()?.toString();
+}
+
+export function isDescendantContentPath(parentPath: string | undefined, childPath: string | undefined): boolean {
+    if (!parentPath || !childPath || parentPath === childPath) {
+        return false;
+    }
+
+    const parentPrefix = parentPath === '/' ? '/' : `${parentPath}/`;
+    return childPath.startsWith(parentPrefix);
+}
+
+export function findContentIdsWithCreatedDescendants(
+    parentItems: readonly PathAwareContent[],
+    createdItems: readonly PathLikeContent[],
+): ContentId[] {
+    if (parentItems.length === 0 || createdItems.length === 0) {
+        return [];
+    }
+
+    const matchedIds = new Map<string, ContentId>();
+
+    parentItems.forEach(parentItem => {
+        const parentPath = getContentPath(parentItem);
+        if (!parentPath) {
+            return;
+        }
+
+        const hasMatchingChild = createdItems.some(item => isDescendantContentPath(parentPath, getContentPath(item)));
+        if (hasMatchingChild) {
+            const id = parentItem.getContentId();
+            matchedIds.set(id.toString(), id);
+        }
+    });
+
+    return Array.from(matchedIds.values());
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/store/createGuardedSocketHandler.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/store/createGuardedSocketHandler.test.ts
@@ -1,0 +1,33 @@
+import {describe, expect, it, vi} from 'vitest';
+import {createGuardedSocketHandler} from './createGuardedSocketHandler';
+
+describe('createGuardedSocketHandler', () => {
+    it('runs the handler when the event is defined and active', () => {
+        const handler = vi.fn();
+        const guardedHandler = createGuardedSocketHandler(() => true)(handler);
+        const event = {data: ['item-1']};
+
+        guardedHandler(event);
+
+        expect(handler).toHaveBeenCalledWith(event);
+    });
+
+    it('skips the handler when the event is nullish', () => {
+        const handler = vi.fn();
+        const guardedHandler = createGuardedSocketHandler(() => true)(handler);
+
+        guardedHandler(undefined);
+        guardedHandler(null);
+
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('skips the handler when inactive', () => {
+        const handler = vi.fn();
+        const guardedHandler = createGuardedSocketHandler(() => false)(handler);
+
+        guardedHandler({data: ['item-1']});
+
+        expect(handler).not.toHaveBeenCalled();
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/store/createGuardedSocketHandler.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/store/createGuardedSocketHandler.ts
@@ -1,0 +1,10 @@
+export const createGuardedSocketHandler =
+    (isActive: () => boolean) =>
+        <T>(handler: (event: T) => void) =>
+            (event: T | null | undefined): void => {
+                if (event == null || !isActive()) {
+                    return;
+                }
+
+                handler(event);
+            };


### PR DESCRIPTION
Refresh items in request publishing dialog on server events to avoid stale items. Update selection status bar when items are updated from elsewhere as well.