### PR TITLE
Content Wizard allows to save invalid values #10163

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -52,6 +52,7 @@ import {openRenameContentDialog} from '../../v6/features/store/dialogs/renameCon
 import {
     $displayName,
     $isContentFormExpanded,
+    $isFormValid,
     $wizardContentState,
     $wizardDraftName,
     $wizardHasChanges,
@@ -66,8 +67,8 @@ import {
     setMixinsDescriptors as setWizardMixinsDescriptors,
     setPersistedContent as setWizardPersistedContent,
 } from '../../v6/features/store/wizardContent.store';
-import {escalateVisibility, initializeValidation, setServerValidationErrors} from '../../v6/features/store/wizardValidation.store';
 import {setWizardToolbarIsPathAvailable} from '../../v6/features/store/wizardToolbar.store';
+import {escalateVisibility, initializeValidation, setServerValidationErrors} from '../../v6/features/store/wizardValidation.store';
 import {type PreviewToolbarElement} from '../../v6/features/views/browse/layout/preview/PreviewToolbar';
 import {ContentWizardTabsToolbarElement} from '../../v6/features/views/wizard/content-wizard-tabs/ContentWizardTabsToolbarElement';
 import {Permission} from '../access/Permission';
@@ -291,6 +292,9 @@ export class ContentWizardPanel
     private contentFormExpandedUnsubscribe?: () => void;
 
     private contentStateUnsubscribe?: () => void;
+
+    private formValidUnsubscribe?: () => void;
+
 
     constructor(params: ContentWizardPanelParams, cls?: string) {
         super(params);
@@ -865,14 +869,15 @@ export class ContentWizardPanel
                 this.contentFormExpandedUnsubscribe = undefined;
                 this.contentStateUnsubscribe?.();
                 this.contentStateUnsubscribe = undefined;
+                this.formValidUnsubscribe?.();
+                this.formValidUnsubscribe = undefined;
                 resetWizardContent();
             });
 
             const thumbnailUploader: ThumbnailUploaderEl = this.getFormIcon();
 
             this.onValidityChanged((event: ValidityChangedEvent) => {
-                const isThisValid: boolean = this.isValid();
-                this.isContentFormValid = isThisValid;
+                this.isContentFormValid = this.isValid() && $isFormValid.get();
 
                 if (!this.getPersistedItem()) {
                     return;
@@ -880,11 +885,24 @@ export class ContentWizardPanel
 
                 this.wizardActions
                     .setContentCanBePublished(this.checkContentCanBePublished())
-                    .setIsValid(isThisValid)
+                    .setIsValid(this.isContentFormValid)
                     .refreshState();
                 if (!this.isNew()) {
-                    this.displayValidationErrors(!(isThisValid && event.isValid()));
+                    this.displayValidationErrors(!(this.isContentFormValid && event.isValid()));
                 }
+            });
+
+            this.formValidUnsubscribe = $isFormValid.subscribe((isValid, previous) => {
+                if (previous === undefined) return;
+
+                const isThisValid = this.isValid();
+                this.isContentFormValid = isThisValid && isValid;
+                this.wizardActions
+                    .setFormValid(isValid)
+                    .setContentCanBePublished(this.checkContentCanBePublished())
+                    .setIsValid(this.isContentFormValid)
+                    .refreshState();
+                this.notifyDataChanged();
             });
 
             thumbnailUploader.setEnabled(this.contentType ? !this.contentType?.isImage() : false);
@@ -932,6 +950,8 @@ export class ContentWizardPanel
         } else if (this.contentType) {
             setWizardContentType(this.contentType);
         }
+
+        initializeValidation(this.isNew());
 
         if (!this.wizardHasChangesUnsubscribe) {
             this.wizardHasChangesUnsubscribe = $wizardHasChanges.subscribe((hasChanges, previousHasChanges) => {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/action/ContentWizardActions.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/action/ContentWizardActions.ts
@@ -1,7 +1,3 @@
-import {type AccessControlList} from '../../access/AccessControlList';
-import {type Content} from '../../content/Content';
-import {type ContentSummaryAndCompareStatus} from '../../content/ContentSummaryAndCompareStatus';
-import {Permission} from '../../access/Permission';
 import {CloseAction} from '@enonic/lib-admin-ui/app/wizard/CloseAction';
 import {WizardActions} from '@enonic/lib-admin-ui/app/wizard/WizardActions';
 import {type ManagedActionExecutor} from '@enonic/lib-admin-ui/managedaction/ManagedActionExecutor';
@@ -12,11 +8,15 @@ import {type ActionsMap, type ActionsState, ActionsStateManager} from '@enonic/l
 import {AppHelper} from '@enonic/lib-admin-ui/util/AppHelper';
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import Q from 'q';
+import {type AccessControlList} from '../../access/AccessControlList';
+import {Permission} from '../../access/Permission';
+import {type Content} from '../../content/Content';
+import {type ContentSummaryAndCompareStatus} from '../../content/ContentSummaryAndCompareStatus';
 import {GetContentByPathRequest} from '../../resource/GetContentByPathRequest';
 import {GetContentPermissionsByIdRequest} from '../../resource/GetContentPermissionsByIdRequest';
 import {GetContentRootPermissionsRequest} from '../../resource/GetContentRootPermissionsRequest';
-import {type ContentWizardPanel} from '../ContentWizardPanel';
 import {AccessControlHelper} from '../AccessControlHelper';
+import {type ContentWizardPanel} from '../ContentWizardPanel';
 import {ArchiveContentAction} from './ArchiveContentAction';
 import {ContentSaveAction} from './ContentSaveAction';
 import {CreateIssueAction} from './CreateIssueAction';
@@ -68,6 +68,8 @@ export class ContentWizardActions
     private userCanModify: boolean = true;
 
     private isContentValid: boolean = false;
+
+    private isFormValid: boolean = true;
 
     private hasPublishRequest: boolean = false;
 
@@ -213,6 +215,7 @@ export class ContentWizardActions
 
     private doCheckSaveActionStateHandler(): void {
         let isEnabled: boolean = this.wizardPanel.hasUnsavedChanges() &&
+                                 this.isFormValid &&
                                  (this.isUnnamedContent() || this.wizardPanel.isHeaderValidForSaving());
 
         if (this.persistedContent) {
@@ -374,6 +377,11 @@ export class ContentWizardActions
         return this;
     }
 
+    setFormValid(value: boolean): ContentWizardActions {
+        this.isFormValid = value;
+        return this;
+    }
+
     setContentCanBeMarkedAsReady(value: boolean): ContentWizardActions {
         this.contentCanBeMarkedAsReady = value;
         return this;
@@ -396,7 +404,7 @@ export class ContentWizardActions
         const canBePublished: boolean = this.canBePublished();
         const canBeUnpublished: boolean = this.content.isPublished() && this.userCanPublish;
         const canBeMarkedAsReady: boolean = this.contentCanBeMarkedAsReady && this.userCanModify;
-        const canBeRequestedPublish: boolean = this.isContentValid && !this.content.isOnline();
+        const canBeRequestedPublish: boolean = this.isContentValid && this.isFormValid && !this.content.isOnline();
         const isInheritedItem: boolean = this.wizardPanel.isContentExistsInParentProject() && this.content.hasOriginProject();
         const canBeReset: boolean = isInheritedItem && !this.content.isFullyInherited();
         const canBeLocalized: boolean = isInheritedItem && this.content.isDataInherited();

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
@@ -5,6 +5,7 @@ import {ValueTypes} from '@enonic/lib-admin-ui/data/ValueTypes';
 import {atom, batched, computed, map} from 'nanostores';
 import type {Content} from '../../../app/content/Content';
 import type {ContentName} from '../../../app/content/ContentName';
+import type {ContentState} from '../../../app/content/ContentState';
 import {ContentUnnamed} from '../../../app/content/ContentUnnamed';
 import {Mixin} from '../../../app/content/Mixin';
 import type {MixinDescriptor} from '../../../app/content/MixinDescriptor';
@@ -13,7 +14,6 @@ import {WorkflowState} from '../../../app/content/WorkflowState';
 import type {ContentType} from '../../../app/inputtype/schema/ContentType';
 import type {Page} from '../../../app/page/Page';
 import {ContentDiffHelper} from '../../../app/util/ContentDiffHelper';
-import type {ContentState} from '../../../app/content/ContentState';
 import {
     addStringOccurrence,
     removeStringOccurrence,
@@ -123,6 +123,10 @@ export const $mixinsDescriptors = atom<MixinDescriptor[]>([]);
 export const $wizardDataValidation = map<FormDataValidation>({});
 
 export const $isContentFormExpanded = atom<boolean>(true);
+
+export const $isFormValid = computed($wizardDataValidation, (validation): boolean => {
+    return !Object.values(validation).some(msgs => Array.isArray(msgs) && msgs.length > 0);
+});
 
 //
 // * Derived


### PR DESCRIPTION
Added `$isFormValid` computed store that derives validity from `$wizardDataValidation`, and wired it into `ContentWizardPanel` and `ContentWizardActions` so Save and Publish Request are disabled when form inputs have validation errors (e.g. value exceeds configured max).

Closes #10163

<sub>*Drafted with AI assistance*</sub>
