### PR TITLE
ContentSelectorInput sends null applicationKey when allowedContentPaths uses ${site} #10194

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
@@ -26,6 +26,11 @@ export const ContentForm = (): ReactElement | null => {
         [contextContent],
     );
 
+    const applicationKey = useMemo(
+        () => contentType?.getContentTypeName().getApplicationKey(),
+        [contentType],
+    );
+
     const assetsUri = CONFIG.getString('assetsUri');
 
     if (!contentType || !draftData) {
@@ -46,6 +51,7 @@ export const ContentForm = (): ReactElement | null => {
                         <FormRenderer
                             form={contentType.getForm()}
                             propertySet={draftData.getRoot()}
+                            applicationKey={applicationKey}
                         />
                     </HtmlAreaProvider>
                 </RawValueProvider>

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/MixinView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/MixinView.tsx
@@ -44,6 +44,11 @@ export const MixinView = ({mixinName, displayName}: MixinViewProps): ReactElemen
 
     const form = useMemo(() => descriptor?.toForm(), [descriptor]);
 
+    const applicationKey = useMemo(
+        () => descriptor?.getMixinName().getApplicationKey(),
+        [descriptor],
+    );
+
     if (!form || form.getFormItems().length === 0 || !mixinData) {
         return <p className="text-subtle">{displayName} configuration</p>;
     }
@@ -60,6 +65,7 @@ export const MixinView = ({mixinName, displayName}: MixinViewProps): ReactElemen
                     <FormRenderer
                         form={form}
                         propertySet={mixinData.getRoot()}
+                        applicationKey={applicationKey}
                     />
                 </HtmlAreaProvider>
             </RawValueProvider>


### PR DESCRIPTION
Pass `applicationKey` to `FormRenderer` in `ContentForm` and `MixinView`, derived from the content type and mixin descriptor names respectively. This ensures `ContentSelectorInput` includes the key in selector query requests, fixing a 500 error when `allowedContentPaths` uses the `${site}` placeholder.

Closes #10194

<sub>*Drafted with AI assistance*</sub>
