### PR TITLE
Incorrect styling of item required for publishing in the Publishing Wizard #10220

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialogMainContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialogMainContent.tsx
@@ -171,7 +171,7 @@ export const PublishDialogMainContent = ({
                                         key={item.id}
                                         content={item.content}
                                         id={item.id}
-                                        disabled={item.required || loading}
+                                        disabled={loading}
                                     >
                                         <ContentRow.Label action="edit" />
                                         <ContentRow.Status variant="diff" />
@@ -184,7 +184,7 @@ export const PublishDialogMainContent = ({
                                     {showChildrenCheckbox && (
                                         <GridList.Row
                                             id={`${item.id}-children`}
-                                            disabled={item.required || loading || !item.included}
+                                            disabled={loading || !item.included}
                                             className="gap-3 px-2.5 -mt-1"
                                         >
                                             <GridList.Cell className="pl-2.5 flex items-center gap-2.5">
@@ -226,11 +226,12 @@ export const PublishDialogMainContent = ({
                                 key={item.id}
                                 content={item.content}
                                 id={item.id}
-                                disabled={item.required || loading}
+                                disabled={loading}
                             >
                                 <ContentRow.Checkbox
                                     checked={item.included}
                                     onCheckedChange={(checked) => setPublishDialogDependantItemSelected(item.content.getContentId(), checked)}
+                                    disabled={item.required || loading}
                                 />
                                 <ContentRow.Label action="edit" />
                                 <ContentRow.Status variant="diff" />

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/status/DiffStatusBadge.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/status/DiffStatusBadge.tsx
@@ -3,8 +3,7 @@ import {CompareStatus, CompareStatusChecker} from '../../../../app/content/Compa
 import {PublishStatus} from '../../../../app/publish/PublishStatus';
 import {useI18n} from '../../hooks/useI18n';
 import type {ContentState} from '../../../../app/content/ContentState';
-import {createCompareStatusKey, createPublishStatusKey, createContentStateKey} from '../../utils/cms/content/status';
-import {StatusIcon} from '../icons/StatusIcon';
+import {createCompareStatusKey, createPublishStatusKey} from '../../utils/cms/content/status';
 
 type Props = {
     publishStatus: PublishStatus;
@@ -16,16 +15,19 @@ type Props = {
 
 const DIFF_STATUS_BADGE_NAME = 'DiffStatusBadge';
 
-export const DiffStatusBadge = ({publishStatus, compareStatus, contentState, wasPublished, className}: Props) => {
+export const DiffStatusBadge = ({
+    publishStatus,
+    compareStatus,
+    contentState,
+    wasPublished,
+    className,
+}: Props) => {
     const isOnline = publishStatus === PublishStatus.ONLINE;
-    const isModified = compareStatus === CompareStatus.NEWER;
     const isMovedAndModified = CompareStatusChecker.isMovedAndModified(compareStatus, contentState);
     const hasDiff = compareStatus !== CompareStatus.EQUAL;
-    const hideContentState = isOnline && contentState === 'ready' && !isModified && !isMovedAndModified;
 
     const publishStatusLabel = useI18n(createPublishStatusKey(publishStatus));
     const modifiedLabel = useI18n('status.modified');
-    const contentStateLabel = useI18n(createContentStateKey(contentState));
     const compareStatusLabel = useI18n(createCompareStatusKey(compareStatus, wasPublished));
     const compareStatusLabels = isMovedAndModified ? `${modifiedLabel}, ${compareStatusLabel}` : compareStatusLabel;
 
@@ -36,12 +38,6 @@ export const DiffStatusBadge = ({publishStatus, compareStatus, contentState, was
             </span>
             {hasDiff && (
                 <span className='text-subtle group-data-[tone=inverse]:text-alt italic capitalize border-l-1 border-bdr-subtle pl-2'>{compareStatusLabels}</span>
-            )}
-            {contentState && !hideContentState && (
-                <span className="inline-flex items-center gap-x-1 overflow-hidden border-l-1 border-bdr-subtle pl-2 text-nowrap">
-                    <StatusIcon status={contentState} aria-label={contentStateLabel} className="shrink-0" />
-                    <span className="text-nowrap truncate">{contentStateLabel}</span>
-                </span>
             )}
         </span>
     );

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/details/DetailsWidgetContentSection.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/details/DetailsWidgetContentSection.tsx
@@ -1,10 +1,15 @@
 import {useStore} from '@nanostores/preact';
-import {ReactElement} from 'react';
-import {ContentSummaryAndCompareStatus} from 'src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatus';
+import {type ReactElement} from 'react';
+import {CompareStatus, CompareStatusChecker} from '../../../../../../app/content/CompareStatus';
+import type {ContentState} from '../../../../../../app/content/ContentState';
+import {PublishStatus} from '../../../../../../app/publish/PublishStatus';
+import {type ContentSummaryAndCompareStatus} from 'src/main/resources/assets/js/app/content/ContentSummaryAndCompareStatus';
 import {useI18n} from '../../../../hooks/useI18n';
 import {ContentIcon} from '../../../../shared/icons/ContentIcon';
+import {StatusIcon} from '../../../../shared/icons/StatusIcon';
 import {DiffStatusBadge} from '../../../../shared/status/DiffStatusBadge';
 import {$contextContent} from '../../../../store/context/contextContent.store';
+import {createContentStateKey} from '../../../../utils/cms/content/status';
 import {calcContentState} from '../../../../utils/cms/content/workflow';
 
 function createDisplayName(content: ContentSummaryAndCompareStatus): string {
@@ -15,20 +20,46 @@ function createDisplayName(content: ContentSummaryAndCompareStatus): string {
     return content.getUploadItem()?.getName() ?? '';
 }
 
+function getVisibleContentState(
+    publishStatus: PublishStatus,
+    compareStatus: CompareStatus,
+    contentState: ContentState | null,
+): ContentState | null {
+    if (!contentState) {
+        return null;
+    }
+
+    const isModified = compareStatus === CompareStatus.NEWER;
+    const isMovedAndModified = CompareStatusChecker.isMovedAndModified(compareStatus, contentState);
+    const shouldHideReadyState = publishStatus === PublishStatus.ONLINE
+        && contentState === 'ready'
+        && !isModified
+        && !isMovedAndModified;
+
+    return shouldHideReadyState ? null : contentState;
+}
+
 const DETAILS_WIDGET_CONTENT_SECTION_NAME = 'DetailsWidgetContentSection';
 
 export const DetailsWidgetContentSection = (): ReactElement => {
     const content = useStore($contextContent);
 
+    const contentSummary = content?.getContentSummary();
+    const publishStatus = content?.getPublishStatus();
+    const compareStatus = content?.getCompareStatus();
+    const contentState = contentSummary ? calcContentState(contentSummary) : null;
+    const visibleContentState = publishStatus != null && compareStatus != null
+        ? getVisibleContentState(publishStatus, compareStatus, contentState)
+        : null;
+
     const iconLabel = useI18n('field.contextPanel.details.sections.content.icon');
     const statusLabel = useI18n('field.contextPanel.details.sections.content.status');
     const displayNameLabel = useI18n('field.contextPanel.details.sections.content.displayName');
     const pathLabel = useI18n('field.contextPanel.details.sections.content.path');
+    const contentStateLabel = useI18n(visibleContentState ? createContentStateKey(visibleContentState) : '');
 
     if (!content) return null;
 
-    const contentSummary = content.getContentSummary();
-    const contentState = calcContentState(contentSummary);
     const displayName = createDisplayName(content);
 
     return (
@@ -45,10 +76,16 @@ export const DetailsWidgetContentSection = (): ReactElement => {
                     <dt className="text-xs text-subtle">{statusLabel}</dt>
                     <dd className="flex gap-2 items-center">
                         <DiffStatusBadge
-                            publishStatus={content.getPublishStatus()}
-                            compareStatus={content.getCompareStatus()}
+                            publishStatus={publishStatus}
+                            compareStatus={compareStatus}
                             contentState={contentState}
                             wasPublished={!!contentSummary.getPublishFirstTime()} />
+                        {visibleContentState && (
+                            <span className="inline-flex items-center gap-x-1 overflow-hidden border-l-1 border-bdr-subtle pl-2 text-nowrap">
+                                <StatusIcon status={visibleContentState} aria-label={contentStateLabel} className="shrink-0" />
+                                <span className="text-nowrap truncate">{contentStateLabel}</span>
+                            </span>
+                        )}
                     </dd>
                 </div>
 


### PR DESCRIPTION
When an item is required for publishing, it's only the checkbox that should be disabled, not the entire line. Gate ready for publishing to details panel