### PR TITLE
Auto-switch to Inspect tab on component selection #10238

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/hooks/usePageEditorTabs.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/hooks/usePageEditorTabs.ts
@@ -11,9 +11,11 @@ export function usePageEditorTabs(
 ): UsePageEditorTabsResult {
     const [activeTab, setActiveTab] = useState<string>('inspect');
 
-    // Auto-select Insert tab when not inspecting and insert is available
+    // Auto-switch tabs based on inspection state
     useEffect(() => {
-        if (!isInspecting && isInsertTabAvailable) {
+        if (isInspecting) {
+            setActiveTab('inspect');
+        } else if (isInsertTabAvailable) {
             setActiveTab('insert');
         }
     }, [isInspecting, isInsertTabAvailable]);


### PR DESCRIPTION
Made `usePageEditorTabs` switch bidirectionally: selecting a component now auto-switches to the Inspect tab, while deselecting still switches to Insert.

Closes #10238

<sub>*Drafted with AI assistance*</sub>
