### PR TITLE
AdminSiteHandler: resolve nearest site if missing #10265

### DIFF
--- a/modules/app/src/main/java/com/enonic/app/contentstudio/site/AdminSiteHandler.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/site/AdminSiteHandler.java
@@ -136,7 +136,12 @@ public class AdminSiteHandler
             final Content content =
                 contentById != null ? contentById : callAsContentAdmin( repositoryId, branch, () -> this.getContentByPath( contentPath ) );
 
-            if ( content != null && !content.getPath().isRoot() )
+            if ( content == null )
+            {
+                portalRequest.setSite(
+                    callAsContentAdmin( repositoryId, branch, () -> this.contentService.findNearestSiteByPath( contentPath ) ) );
+            }
+            else if ( !content.getPath().isRoot() )
             {
                 portalRequest.setContent( content );
                 portalRequest.setContentPath( content.getPath() );
@@ -157,7 +162,12 @@ public class AdminSiteHandler
                 portalRequest.setSite( content.isSite()
                                            ? (Site) content
                                            : callAsContentAdmin( repositoryId, branch,
-                                                                 () -> this.contentService.findNearestSiteByPath( contentPath ) ) );
+                                                                 () -> this.contentService.findNearestSiteByPath( content.getPath() ) ) );
+            }
+            else
+            {
+                portalRequest.setSite(
+                    callAsContentAdmin( repositoryId, branch, () -> this.contentService.findNearestSiteByPath( contentPath ) ) );
             }
         }
 


### PR DESCRIPTION
Falls back to `ContentService.findNearestSiteByPath(contentPath)` in `AdminSiteHandler` when the content lookup returns null, mirroring XP's `SiteHandler`. Applied in both edit and preview/inline/admin branches so site mappings can handle virtual URLs in admin preview the same way they do in live mode. The root-content case (content resolved to root) is preserved as-is.

Closes #10265

<sub>*Drafted with AI assistance*</sub>