### PR TITLE
ContextWindow: cross-iframe drag and drop #10191 

### DIFF
--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -178,8 +178,8 @@ importers:
         specifier: ^1.11.20
         version: 1.11.20
       dompurify:
-        specifier: ~3.3.3
-        version: 3.3.3
+        specifier: ~3.4.0
+        version: 3.4.0
       fine-uploader:
         specifier: ^5.16.2
         version: 5.16.2
@@ -308,8 +308,8 @@ importers:
   .xp/dev/lib-contentstudio:
     dependencies:
       '@enonic/ui':
-        specifier: ~0.47.6
-        version: 0.47.6(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.47.12
+        version: 0.47.12(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@nanostores/preact':
         specifier: ^1.0.0
         version: 1.1.0(nanostores@0.11.4)(preact@10.29.0)
@@ -380,6 +380,9 @@ importers:
       '@enonic/lib-admin-ui':
         specifier: workspace:*
         version: link:../lib-admin-ui
+      '@enonic/page-editor':
+        specifier: ^0.0.6
+        version: 0.0.6
       '@radix-ui/react-slot':
         specifier: ^1.2.0
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
@@ -647,6 +650,30 @@ packages:
   '@enonic/page-editor@0.0.6':
     resolution: {integrity: sha512-Z56Dq8ZUpF6aH2IhAHrHkpiJURHQVT1h0gkyYOs50eNoiK3SV5Z1tI0mc9CJlIIpjCT8pWLWRhqq0jg07ssC2Q==}
     engines: {node: '>= 24.13.0'}
+
+  '@enonic/ui@0.47.12':
+    resolution: {integrity: sha512-j/WEIP5KFeKCwEaWtFFxTKt1/pzT3DQH7bqUNBWn+xpZFu5Zl3Q5Xt6C34F8qtJqEndRsLSY4b50R9H5mCjC2A==}
+    engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
+    peerDependencies:
+      '@radix-ui/react-slot': ^1.2.0
+      focus-trap-react: ^11.0.0
+      lucide-react: '>=0.500.0'
+      preact: '>=10.0.0'
+      react: ^19.0.0
+      react-dom: ^19.0.0
+      react-virtuoso: ^4.0.0
+      tw-animate-css: ^1.0.0
+    peerDependenciesMeta:
+      preact:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      react-virtuoso:
+        optional: true
+      tw-animate-css:
+        optional: true
 
   '@enonic/ui@0.47.6':
     resolution: {integrity: sha512-RhIh/Rfb5RS3iIt1TkJpvX8MAcb+bExTq8HlfPlWvJmimsVVdyftAkX2uGTAihhZDQIiaGUFcbIWKa1fRQmq1A==}
@@ -2982,6 +3009,9 @@ packages:
 
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -5565,7 +5595,7 @@ snapshots:
 
   '@enonic/page-editor@0.0.6':
     dependencies:
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       jquery: 3.7.1
       jquery-simulate: 1.0.2
       jquery-ui: 1.14.2
@@ -5574,7 +5604,7 @@ snapshots:
       nanostores: 1.2.0
       q: 1.5.1
 
-  '@enonic/ui@0.47.6(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+  '@enonic/ui@0.47.12(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       class-variance-authority: 0.7.1
@@ -7901,6 +7931,10 @@ snapshots:
       domelementtype: 2.3.0
 
   dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/modules/app/pnpm-workspace.yaml
+++ b/modules/app/pnpm-workspace.yaml
@@ -3,28 +3,28 @@ packages:
   - .xp/dev/*
 
 ignoredBuiltDependencies:
-  - '@swc/core'
-  - '@tailwindcss/oxide'
+  - "@swc/core"
+  - "@tailwindcss/oxide"
   - esbuild
   - less
 
 minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:
-  - '@enonic/ui'
-  - '@enonic/page-editor'
+  - "@enonic/ui"
+  - "@enonic/page-editor"
 
 overrides:
-  brace-expansion@<1.1.13: '>=1.1.13'
-  brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3'
-  brace-expansion@>=4.0.0 <5.0.5: '>=5.0.5'
-  file-type@>=13.0.0 <21.3.1: '>=21.3.1'
-  file-type@>=20.0.0 <=21.3.1: '>=21.3.2'
-  flatted@<=3.4.1: '>=3.4.2'
-  node-forge@<1.4.0: '>=1.4.0'
-  node-forge@<=1.3.3: '>=1.4.0'
-  path-to-regexp@<0.1.13: '>=0.1.13'
-  picomatch@<2.3.2: '>=2.3.2'
-  picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
-  vite@>=7.0.0 <=7.3.1: '>=7.3.2'
-  vite@>=7.1.0 <=7.3.1: '>=7.3.2'
+  brace-expansion@<1.1.13: ">=1.1.13"
+  brace-expansion@>=2.0.0 <2.0.3: ">=2.0.3"
+  brace-expansion@>=4.0.0 <5.0.5: ">=5.0.5"
+  file-type@>=13.0.0 <21.3.1: ">=21.3.1"
+  file-type@>=20.0.0 <=21.3.1: ">=21.3.2"
+  flatted@<=3.4.1: ">=3.4.2"
+  node-forge@<1.4.0: ">=1.4.0"
+  node-forge@<=1.3.3: ">=1.4.0"
+  path-to-regexp@<0.1.13: ">=0.1.13"
+  picomatch@<2.3.2: ">=2.3.2"
+  picomatch@>=4.0.0 <4.0.4: ">=4.0.4"
+  vite@>=7.0.0 <=7.3.1: ">=7.3.2"
+  vite@>=7.1.0 <=7.3.1: ">=7.3.2"

--- a/modules/app/src/main/resources/assets/js/page-editor.ts
+++ b/modules/app/src/main/resources/assets/js/page-editor.ts
@@ -1,13 +1,15 @@
-import {PageEditor, EditorEvents, EditorEvent, type ItemView} from '@enonic/page-editor';
+import {EditorEvent, EditorEvents, PageEditor, type ItemView} from '@enonic/page-editor';
 import '@enonic/page-editor/styles.css';
 import {EditorEventHandler} from './EditorEventHandler';
 
 PageEditor.init(true);
-// console.info('Page editor started in edit mode.');
 
 const eventHandler = new EditorEventHandler();
 
-PageEditor.on(EditorEvents.ComponentLoadRequest, (event: EditorEvent<{ view: ItemView, isExisting: boolean }>) => {
-    const {view, isExisting} = event.getData();
-    eventHandler.loadComponentView(view, isExisting);
-});
+PageEditor.on(
+    EditorEvents.ComponentLoadRequest,
+    (event: EditorEvent<{ view: ItemView; isExisting: boolean }>) => {
+        const {view, isExisting} = event.getData();
+        eventHandler.loadComponentView(view, isExisting);
+    },
+);

--- a/modules/lib/package.json
+++ b/modules/lib/package.json
@@ -26,7 +26,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@enonic/ui": "~0.47.6",
+    "@enonic/ui": "~0.47.12",
     "@nanostores/preact": "^1.0.0",
     "ckeditor4-react": "4.3.0",
     "class-variance-authority": "^0.7.1",
@@ -55,6 +55,7 @@
     "focus-trap-react": "^11.0.0"
   },
   "devDependencies": {
+    "@enonic/page-editor": "^0.0.6",
     "@enonic/eslint-config": "^2.1.0",
     "@enonic/lib-admin-ui": "workspace:*",
     "@radix-ui/react-slot": "^1.2.0",

--- a/modules/lib/pnpm-lock.yaml
+++ b/modules/lib/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   .:
     dependencies:
       '@enonic/ui':
-        specifier: ~0.47.6
-        version: 0.47.6(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.47.12
+        version: 0.47.12(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@nanostores/preact':
         specifier: ^1.0.0
         version: 1.1.0(nanostores@0.11.4)(preact@10.29.0)
@@ -93,6 +93,9 @@ importers:
       '@enonic/lib-admin-ui':
         specifier: workspace:*
         version: link:.xp/dev/lib-admin-ui
+      '@enonic/page-editor':
+        specifier: ^0.0.6
+        version: 0.0.6
       '@radix-ui/react-slot':
         specifier: ^1.2.0
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
@@ -190,8 +193,8 @@ importers:
         specifier: ^1.11.20
         version: 1.11.20
       dompurify:
-        specifier: ~3.3.3
-        version: 3.3.3
+        specifier: ~3.4.0
+        version: 3.4.0
       fine-uploader:
         specifier: ^5.16.2
         version: 5.16.2
@@ -453,6 +456,34 @@ packages:
       '@typescript-eslint/parser': ^8.39.0
       typescript: ^5.8.3
       typescript-eslint: ^8.39.0
+
+  '@enonic/page-editor@0.0.6':
+    resolution: {integrity: sha512-Z56Dq8ZUpF6aH2IhAHrHkpiJURHQVT1h0gkyYOs50eNoiK3SV5Z1tI0mc9CJlIIpjCT8pWLWRhqq0jg07ssC2Q==}
+    engines: {node: '>= 24.13.0'}
+
+  '@enonic/ui@0.47.12':
+    resolution: {integrity: sha512-j/WEIP5KFeKCwEaWtFFxTKt1/pzT3DQH7bqUNBWn+xpZFu5Zl3Q5Xt6C34F8qtJqEndRsLSY4b50R9H5mCjC2A==}
+    engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
+    peerDependencies:
+      '@radix-ui/react-slot': ^1.2.0
+      focus-trap-react: ^11.0.0
+      lucide-react: '>=0.500.0'
+      preact: '>=10.0.0'
+      react: ^19.0.0
+      react-dom: ^19.0.0
+      react-virtuoso: ^4.0.0
+      tw-animate-css: ^1.0.0
+    peerDependenciesMeta:
+      preact:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      react-virtuoso:
+        optional: true
+      tw-animate-css:
+        optional: true
 
   '@enonic/ui@0.47.6':
     resolution: {integrity: sha512-RhIh/Rfb5RS3iIt1TkJpvX8MAcb+bExTq8HlfPlWvJmimsVVdyftAkX2uGTAihhZDQIiaGUFcbIWKa1fRQmq1A==}
@@ -2753,6 +2784,9 @@ packages:
 
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -5239,7 +5273,18 @@ snapshots:
       typescript: 5.9.3
       typescript-eslint: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
 
-  '@enonic/ui@0.47.6(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+  '@enonic/page-editor@0.0.6':
+    dependencies:
+      dompurify: 3.4.0
+      jquery: 3.7.1
+      jquery-simulate: 1.0.2
+      jquery-ui: 1.14.2
+      mousetrap: 1.6.5
+      nanoid: 5.1.7
+      nanostores: 1.2.0
+      q: 1.5.1
+
+  '@enonic/ui@0.47.12(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       class-variance-authority: 0.7.1
@@ -7507,6 +7552,10 @@ snapshots:
       domelementtype: 2.3.0
 
   dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/modules/lib/pnpm-workspace.yaml
+++ b/modules/lib/pnpm-workspace.yaml
@@ -3,8 +3,8 @@ packages:
   - .xp/dev/*
 
 ignoredBuiltDependencies:
-  - '@swc/core'
-  - '@tailwindcss/oxide'
+  - "@swc/core"
+  - "@tailwindcss/oxide"
   - edgedriver
   - esbuild
   - geckodriver
@@ -13,16 +13,16 @@ ignoredBuiltDependencies:
 minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:
-  - '@enonic/ui'
+  - "@enonic/ui"
 
 overrides:
-  brace-expansion@<1.1.13: '>=1.1.13'
-  brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3'
-  brace-expansion@>=4.0.0 <5.0.5: '>=5.0.5'
-  file-type@>=13.0.0 <21.3.1: '>=21.3.1'
-  file-type@>=20.0.0 <=21.3.1: '>=21.3.2'
-  flatted@<=3.4.1: '>=3.4.2'
-  path-to-regexp@<0.1.13: '>=0.1.13'
-  picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
-  vite@>=7.0.0 <=7.3.1: '>=7.3.2'
-  vite@>=7.1.0 <=7.3.1: '>=7.3.2'
+  brace-expansion@<1.1.13: ">=1.1.13"
+  brace-expansion@>=2.0.0 <2.0.3: ">=2.0.3"
+  brace-expansion@>=4.0.0 <5.0.5: ">=5.0.5"
+  file-type@>=13.0.0 <21.3.1: ">=21.3.1"
+  file-type@>=20.0.0 <=21.3.1: ">=21.3.2"
+  flatted@<=3.4.1: ">=3.4.2"
+  path-to-regexp@<0.1.13: ">=0.1.13"
+  picomatch@>=4.0.0 <4.0.4: ">=4.0.4"
+  vite@>=7.0.0 <=7.3.1: ">=7.3.2"
+  vite@>=7.1.0 <=7.3.1: ">=7.3.2"

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -101,7 +101,6 @@ import {ContentNamedEvent} from '../event/ContentNamedEvent';
 import {ContentRequiresSaveEvent} from '../event/ContentRequiresSaveEvent';
 import {type ContentServerChangeItem} from '../event/ContentServerChangeItem';
 import {ContentServerEventsHandler} from '../event/ContentServerEventsHandler';
-import {InspectEvent} from '../event/InspectEvent';
 import {ViewExtensionEvent} from '../event/ViewExtensionEvent';
 import {type ContentType} from '../inputtype/schema/ContentType';
 import {ImageErrorEvent} from '../inputtype/ui/selector/image/ImageErrorEvent';
@@ -162,7 +161,6 @@ import {PageComponentsView} from './PageComponentsView';
 import {PageComponentsWizardStep} from './PageComponentsWizardStep';
 import {PageComponentsWizardStepForm} from './PageComponentsWizardStepForm';
 import {PageEventsManager} from './PageEventsManager';
-import {PageNavigationEventSource} from './PageNavigationEventData';
 import {PersistNewContentRoutine} from './PersistNewContentRoutine';
 import {ThumbnailUploaderEl} from './ThumbnailUploaderEl';
 import {UpdatePersistedContentRoutine} from './UpdatePersistedContentRoutine';
@@ -1419,22 +1417,6 @@ export class ContentWizardPanel
                     this.pageComponentsWizardStep.getTabBarItem().select();
                 }
             }
-        });
-
-        InspectEvent.on((event: InspectEvent) => {
-            this.isRenderable().then((renderable: boolean) => {
-
-                const minimizeWizard = event.isShowPanel() &&
-                                       event.getSource() === PageNavigationEventSource.EDITOR &&
-                                       !this.isMinimized() &&
-                                       renderable &&
-                                       this.getLivePanel().isShown() &&
-                                       !this.contextSplitPanel.isMobileMode() &&
-                                       ResponsiveRanges._1380_1620.isFitOrSmaller(this.getEl().getWidthWithBorder());
-                if (minimizeWizard) {
-                    this.toggleMinimize();
-                }
-            });
         });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
@@ -93,11 +93,7 @@ export class LiveEditPageProxy
 
     private liveEditIFrame?: IFrameEl;
 
-    // private liveEditWindow: Window;
-
     private isFrameLoaded: boolean = false;
-
-    // private livejq: JQueryStatic;
 
     private dragMask: DragMask;
 
@@ -574,7 +570,7 @@ export class LiveEditPageProxy
         PageState.getEvents().onComponentUpdated((event: ComponentUpdatedEvent) => {
             new PageStateEvent(PageState.getState().toJson()).fire();
 
-            if (event instanceof ComponentTextUpdatedEvent && event.getText()) {
+            if (event instanceof ComponentTextUpdatedEvent && event.getText() != null) {
                 if (this.isFrameLoaded) {
                     new UpdateTextComponentViewEvent(event.getPath(), event.getText(), event.getOrigin()).fire();
                 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -71,6 +71,8 @@ export class LiveFormPanel
     private hideLoadMaskHandler: () => void;
 
     constructor(config: LiveFormPanelConfig) {
+        // ! Necessary to keep 'live-form-panel' on iframe wrapper
+        // It's used in useInsertableDrag hook for correct drag handling
         super('live-form-panel extension-preview-panel');
 
         this.contentWizardPanel = config.contentWizardPanel;

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/bridge.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/bridge.ts
@@ -1,9 +1,15 @@
 import {PageEventsManager} from '../../../../app/wizard/PageEventsManager';
+import type {PageNavigationEvent} from '../../../../app/wizard/PageNavigationEvent';
+import {PageNavigationEventType} from '../../../../app/wizard/PageNavigationEventType';
+import type {PageNavigationHandler} from '../../../../app/wizard/PageNavigationHandler';
+import {PageNavigationMediator} from '../../../../app/wizard/PageNavigationMediator';
 import {PageState} from '../../../../app/wizard/page/PageState';
+import {setContextOpen} from '../contextWidgets.store';
 import {
     $contentContext,
     $defaultPageTemplateName,
     $hasDefaultPageTemplate,
+    $inspectedPath,
     $page,
     $pageEditorLifecycle,
     $pageVersion,
@@ -16,9 +22,7 @@ import type {InitPageEditorBridgeOptions} from './types';
 // * Bridge
 //
 
-type Unsubscribe = () => void;
-
-const cleanups: Unsubscribe[] = [];
+const cleanups: (() => void)[] = [];
 
 export function initPageEditorBridge(options?: InitPageEditorBridgeOptions): void {
     cleanupPageEditorBridge();
@@ -77,6 +81,26 @@ export function initPageEditorBridge(options?: InitPageEditorBridgeOptions): voi
     events.onPageConfigUpdated(onConfigUpdated);
     cleanups.push(() => events.unPageConfigUpdated(onConfigUpdated));
 
+    // Navigation events from PageNavigationMediator — iframe selections,
+    // legacy PageComponentsView, and ComponentInspectedEvent all feed in here.
+    const mediator = PageNavigationMediator.get();
+    const navigationHandler: PageNavigationHandler = {
+        handle(event: PageNavigationEvent): void {
+            const type = event.getType();
+            if (type === PageNavigationEventType.SELECT || type === PageNavigationEventType.INSPECT) {
+                const path = event.getData().getPath();
+                $inspectedPath.set(path?.toString() ?? null);
+                setContextOpen(true);
+                return;
+            }
+            if (type === PageNavigationEventType.DESELECT) {
+                $inspectedPath.set(null);
+            }
+        },
+    };
+    mediator.addPageNavigationHandler(navigationHandler);
+    cleanups.push(() => mediator.removePageNavigationItem(navigationHandler));
+
     // Initial sync
 
     syncPageFromState();
@@ -110,4 +134,5 @@ export function cleanupPageEditorBridge(): void {
     $hasDefaultPageTemplate.set(false);
     $defaultPageTemplateName.set(null);
     $contentContext.set(null);
+    $inspectedPath.set(null);
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/drag.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/drag.ts
@@ -1,0 +1,31 @@
+import {atom} from 'nanostores';
+
+export type PortalComponentType = 'part' | 'layout' | 'text' | 'fragment';
+
+export type DragState = {
+    itemType: PortalComponentType;
+    itemLabel: string;
+    x: number;
+    y: number;
+    dropAllowed: boolean;
+};
+
+//
+// * Drag state for v6 InsertPanel -> legacy iframe drag bridge
+//
+
+export const $dragState = atom<DragState | null>(null);
+
+export function startDrag(initial: DragState): void {
+    $dragState.set(initial);
+}
+
+export function updateDrag(partial: Partial<DragState>): void {
+    const current = $dragState.get();
+    if (current == null) return;
+    $dragState.set({...current, ...partial});
+}
+
+export function endDrag(): void {
+    $dragState.set(null);
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/index.ts
@@ -1,7 +1,8 @@
 // Read: stores
 export {$contentContext, $defaultPageTemplateName, $pageEditorLifecycle} from './store';
 export {$hasControllerOrTemplate, $isFragment, $isInsertTabAvailable} from './store';
-export {$isInspecting, $inspectedItem, $inspectedItemType} from './store';
+export {$isInspecting, $inspectedPath, $inspectedItem, $inspectedItemType} from './store';
+export {$dragState, startDrag, updateDrag, endDrag} from './drag';
 
 // Read: hooks
 export {usePageState} from './hooks';
@@ -33,3 +34,4 @@ export {initPageEditorBridge, cleanupPageEditorBridge} from './bridge';
 
 // Types
 export type {PageEditorContentContext, PageEditorLifecycle, InitPageEditorBridgeOptions} from './types';
+export type {DragState, PortalComponentType} from './drag';

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/DragPreview.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/DragPreview.tsx
@@ -1,0 +1,34 @@
+import {FilledCircleCheck, FilledCircleX} from '@enonic/ui';
+import {useStore} from '@nanostores/preact';
+import type {ReactElement} from 'react';
+import {createPortal} from 'react';
+import {$dragState} from '../../../../store/page-editor/drag';
+
+const DRAG_PREVIEW_NAME = 'DragPreview';
+
+export const DragPreview = (): ReactElement | null => {
+    const dragState = useStore($dragState);
+
+    if (dragState == null) return null;
+
+    return createPortal(
+        <div
+            data-component={DRAG_PREVIEW_NAME}
+            className="pointer-events-none fixed z-50 flex gap-4"
+            style={{top: `${dragState.y - 28}px`, left: `${dragState.x - 24}px`}}
+        >
+            <span className="relative mt-2.5 size-7 shrink-0">
+                <span className="absolute inset-[2.33px] rounded-full bg-surface-neutral" />
+                {dragState.dropAllowed
+                    ? <FilledCircleCheck className="relative size-7 text-success" />
+                    : <FilledCircleX className="relative size-7 text-error" />}
+            </span>
+            <div className="rounded-lg border border-bdr-soft bg-surface-neutral px-7.5 py-4 leading-5.5 font-semibold whitespace-nowrap text-main shadow">
+                {dragState.itemLabel}
+            </div>
+        </div>,
+        document.body,
+    );
+};
+
+DragPreview.displayName = DRAG_PREVIEW_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/PageEditorExtension.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/PageEditorExtension.tsx
@@ -3,41 +3,48 @@ import {useStore} from '@nanostores/preact';
 import {type ReactElement} from 'react';
 import {useI18n} from '../../../../hooks/useI18n';
 import {$activeWidgetId, $isContextOpen} from '../../../../store/contextWidgets.store';
-import {$isInsertTabAvailable, $isInspecting} from '../../../../store/page-editor';
+import {$dragState, $inspectedPath, $isInsertTabAvailable} from '../../../../store/page-editor';
 import {PAGE_EDITOR_WIDGET_KEY} from '../../../../utils/widget/pageEditor';
 import {usePageEditorTabs} from './hooks/usePageEditorTabs';
+import {DragPreview} from './DragPreview';
 import {InsertPanel} from './insert';
 import {InspectPanel} from './inspect';
 
 const PAGE_EDITOR_EXTENSION_NAME = 'PageEditorExtension';
 
-export const PageEditorExtension = (): ReactElement => {
+export const PageEditorExtension = (): ReactElement | null => {
     const isContextOpen = useStore($isContextOpen);
     const activeWidgetId = useStore($activeWidgetId);
     const isInsertTabAvailable = useStore($isInsertTabAvailable);
-    const isInspecting = useStore($isInspecting);
+    const inspectedPath = useStore($inspectedPath);
+    const dragState = useStore($dragState);
 
-    const {activeTab, setActiveTab} = usePageEditorTabs(isInspecting, isInsertTabAvailable);
+    const {activeTab, setActiveTab} = usePageEditorTabs(inspectedPath, isInsertTabAvailable);
 
     const insertLabel = useI18n('action.insert');
     const inspectLabel = useI18n('action.inspect');
 
-    if (!isContextOpen || activeWidgetId !== PAGE_EDITOR_WIDGET_KEY) return null;
+    if (!isContextOpen || activeWidgetId !== PAGE_EDITOR_WIDGET_KEY) {
+        return dragState ? <DragPreview /> : null;
+    }
 
     return (
-        <Tab.Root data-component={PAGE_EDITOR_EXTENSION_NAME} value={activeTab} onValueChange={setActiveTab} className="flex flex-col -mt-4">
-            <Tab.List>
-                <Tab.DefaultTrigger value="insert" disabled={!isInsertTabAvailable}>{insertLabel}</Tab.DefaultTrigger>
-                <Tab.DefaultTrigger value="inspect">{inspectLabel}</Tab.DefaultTrigger>
-            </Tab.List>
+        <>
+            <Tab.Root data-component={PAGE_EDITOR_EXTENSION_NAME} value={activeTab} onValueChange={setActiveTab} className="flex flex-col -mt-4">
+                <Tab.List>
+                    <Tab.DefaultTrigger value="insert" disabled={!isInsertTabAvailable}>{insertLabel}</Tab.DefaultTrigger>
+                    <Tab.DefaultTrigger value="inspect">{inspectLabel}</Tab.DefaultTrigger>
+                </Tab.List>
 
-            <Tab.Content value="insert">
-                <InsertPanel />
-            </Tab.Content>
-            <Tab.Content value="inspect" className="mt-0">
-                <InspectPanel />
-            </Tab.Content>
-        </Tab.Root>
+                <Tab.Content value="insert">
+                    <InsertPanel />
+                </Tab.Content>
+                <Tab.Content value="inspect" className="mt-0">
+                    <InspectPanel />
+                </Tab.Content>
+            </Tab.Root>
+            <DragPreview />
+        </>
     );
 };
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/hooks/usePageEditorTabs.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/hooks/usePageEditorTabs.ts
@@ -6,26 +6,25 @@ type UsePageEditorTabsResult = {
 };
 
 export function usePageEditorTabs(
-    isInspecting: boolean,
+    inspectedPath: string | null,
     isInsertTabAvailable: boolean,
 ): UsePageEditorTabsResult {
     const [activeTab, setActiveTab] = useState<string>('inspect');
 
-    // Auto-switch tabs based on inspection state
+    // Auto-switch tabs when the inspected item changes.
+    // Depending on the path (not just a boolean) ensures that selecting a
+    // different item re-triggers the switch — e.g. dropping a new component
+    // while another was already inspected. Also falls back to Inspect when
+    // Insert becomes unavailable.
     useEffect(() => {
-        if (isInspecting) {
+        if (inspectedPath != null) {
             setActiveTab('inspect');
         } else if (isInsertTabAvailable) {
             setActiveTab('insert');
-        }
-    }, [isInspecting, isInsertTabAvailable]);
-
-    // Fall back to Inspect tab when Insert becomes unavailable
-    useEffect(() => {
-        if (activeTab === 'insert' && !isInsertTabAvailable) {
+        } else {
             setActiveTab('inspect');
         }
-    }, [activeTab, isInsertTabAvailable]);
+    }, [inspectedPath, isInsertTabAvailable]);
 
     return {activeTab, setActiveTab};
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/insert/InsertableItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/insert/InsertableItem.tsx
@@ -1,9 +1,11 @@
 import type {LucideIcon} from 'lucide-react';
 import type {ReactElement} from 'react';
 import {ItemLabel} from '../../../../../shared/ItemLabel';
+import type {PortalComponentType} from '../../../../../store/page-editor';
+import {useInsertableDrag} from './useInsertableDrag';
 
 export type InsertableItemProps = {
-    name: string;
+    name: PortalComponentType;
     icon: LucideIcon;
     displayName: string;
     description: string;
@@ -12,8 +14,14 @@ export type InsertableItemProps = {
 const INSERTABLE_ITEM_NAME = 'InsertableItem';
 
 export const InsertableItem = ({name, icon: Icon, displayName, description}: InsertableItemProps): ReactElement => {
+    const {onMouseDown} = useInsertableDrag({itemType: name, itemLabel: displayName});
+
     return (
-        <li data-portal-component-type={name} className="p-1 rounded-sm cursor-grab select-none">
+        <li
+            data-portal-component-type={name}
+            onMouseDown={onMouseDown}
+            className="p-1 rounded-sm cursor-grab select-none"
+        >
             <ItemLabel icon={<Icon />} primary={displayName} secondary={description} />
         </li>
     );

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/insert/useInsertableDrag.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/insert/useInsertableDrag.ts
@@ -1,0 +1,154 @@
+import {useCallback, useEffect, useRef, type MouseEvent as ReactMouseEvent} from 'react';
+import {PageEventsManager} from '../../../../../../../app/wizard/PageEventsManager';
+import {CreateOrDestroyDraggableEvent} from '../../../../../../../page-editor/event/incoming/manipulation/CreateOrDestroyDraggableEvent';
+import {SetDraggableVisibleEvent} from '../../../../../../../page-editor/event/incoming/manipulation/SetDraggableVisibleEvent';
+import {endDrag, startDrag, updateDrag, type PortalComponentType} from '../../../../../store/page-editor/drag';
+
+const DRAG_THRESHOLD_PX = 4;
+const LIVE_EDIT_IFRAME_SELECTOR = '.live-form-panel iframe';
+
+export type UseInsertableDragArgs = {
+    itemType: PortalComponentType;
+    itemLabel: string;
+};
+
+export type UseInsertableDragResult = {
+    onMouseDown: (event: ReactMouseEvent<HTMLLIElement>) => void;
+};
+
+function findLiveEditIframe(): HTMLIFrameElement | null {
+    return document.querySelector<HTMLIFrameElement>(LIVE_EDIT_IFRAME_SELECTOR);
+}
+
+function isOverIframe(x: number, y: number, iframe: HTMLIFrameElement | null): boolean {
+    if (!iframe) return false;
+    return document.elementFromPoint(x, y) === iframe;
+}
+
+export function useInsertableDrag({itemType, itemLabel}: UseInsertableDragArgs): UseInsertableDragResult {
+    const activeRef = useRef(false);
+
+    const handleMouseDown = useCallback((event: ReactMouseEvent<HTMLLIElement>) => {
+        if (event.button !== 0) return;
+
+        const startX = event.clientX;
+        const startY = event.clientY;
+        let started = false;
+        let inIframe = false;
+        let outerVisible = false;
+        let cleaned = false;
+        let iframeEl: HTMLIFrameElement | null = null;
+        let cursorStyleEl: HTMLStyleElement | null = null;
+
+        const enterIframe = () => {
+            if (inIframe) return;
+            inIframe = true;
+            new SetDraggableVisibleEvent(itemType, true).fire();
+            if (outerVisible) {
+                outerVisible = false;
+                endDrag();
+            }
+        };
+
+        const leaveIframe = () => {
+            if (!inIframe) return;
+            inIframe = false;
+            new SetDraggableVisibleEvent(itemType, false).fire();
+        };
+
+        const onDocMouseOut = (e: MouseEvent) => {
+            if (e.relatedTarget != null) return;
+            if (isOverIframe(e.clientX, e.clientY, iframeEl)) {
+                enterIframe();
+            }
+        };
+
+        const onDocMouseOver = (e: MouseEvent) => {
+            if (e.relatedTarget != null) return;
+            if (!isOverIframe(e.clientX, e.clientY, iframeEl)) {
+                leaveIframe();
+            }
+        };
+
+        const beginDrag = () => {
+            if (started) return;
+            started = true;
+            activeRef.current = true;
+            cursorStyleEl = document.createElement('style');
+            cursorStyleEl.textContent = '*, *::before, *::after { cursor: grabbing !important; }';
+            document.head.appendChild(cursorStyleEl);
+            iframeEl = findLiveEditIframe();
+            new CreateOrDestroyDraggableEvent(itemType, true).fire();
+            new SetDraggableVisibleEvent(itemType, false).fire();
+            PageEventsManager.get().onComponentDragStopped(onIframeDropped);
+            iframeEl?.addEventListener('mouseenter', enterIframe);
+            iframeEl?.addEventListener('mouseleave', leaveIframe);
+            document.addEventListener('mouseout', onDocMouseOut, true);
+            document.addEventListener('mouseover', onDocMouseOver, true);
+        };
+
+        const cleanup = () => {
+            if (cleaned) return;
+            cleaned = true;
+            document.removeEventListener('mousemove', onMove, true);
+            document.removeEventListener('mouseup', onUp, true);
+            document.removeEventListener('mouseout', onDocMouseOut, true);
+            document.removeEventListener('mouseover', onDocMouseOver, true);
+            iframeEl?.removeEventListener('mouseenter', enterIframe);
+            iframeEl?.removeEventListener('mouseleave', leaveIframe);
+            PageEventsManager.get().unComponentDragStopped(onIframeDropped);
+            if (started) {
+                new CreateOrDestroyDraggableEvent(itemType, false).fire();
+                cursorStyleEl?.remove();
+                cursorStyleEl = null;
+            }
+            endDrag();
+            outerVisible = false;
+            activeRef.current = false;
+        };
+
+        const onIframeDropped = () => {
+            cleanup();
+        };
+
+        const onMove = (moveEvent: MouseEvent) => {
+            if (!started) {
+                if (Math.hypot(moveEvent.clientX - startX, moveEvent.clientY - startY) < DRAG_THRESHOLD_PX) return;
+                beginDrag();
+            }
+
+            const overIframe = isOverIframe(moveEvent.clientX, moveEvent.clientY, iframeEl);
+            if (overIframe && !inIframe) {
+                enterIframe();
+            } else if (!overIframe && inIframe) {
+                leaveIframe();
+            }
+
+            if (inIframe) return;
+
+            if (!outerVisible) {
+                outerVisible = true;
+                startDrag({itemType, itemLabel, x: moveEvent.clientX, y: moveEvent.clientY, dropAllowed: false});
+                return;
+            }
+
+            updateDrag({x: moveEvent.clientX, y: moveEvent.clientY});
+        };
+
+        const onUp = () => {
+            cleanup();
+        };
+
+        document.addEventListener('mousemove', onMove, true);
+        document.addEventListener('mouseup', onUp, true);
+    }, [itemType, itemLabel]);
+
+    useEffect(() => () => {
+        if (activeRef.current) {
+            new CreateOrDestroyDraggableEvent(itemType, false).fire();
+            endDrag();
+        }
+    }, [itemType]);
+
+    return {onMouseDown: handleMouseDown};
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/text/TextEditor.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/text/TextEditor.tsx
@@ -150,10 +150,11 @@ const TextEditorInner = ({
 
     const contentId = contentSummary?.getId();
 
+    // ? Captured once on mount — CKEditor's config ref never updates after init.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const initialPreviewContent = useMemo(() => {
         const text = textComponent.getText() ?? '';
         return contentId ? HTMLAreaHelper.convertRenderSrcToPreviewSrc(text, contentId, project) : text;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const dialogOverridesRef = useRef<DialogOverrides>({
@@ -203,7 +204,7 @@ const TextEditorInner = ({
                 if (timeout != null) {
                     clearTimeout(timeout);
                 }
-                timeout = setTimeout(fn, 200);
+                timeout = setTimeout(fn, 100);
             };
 
             fn.cancel = () => {


### PR DESCRIPTION
Made the right-side Context panel open automatically when a component is selected in the page editor, and stopped the left-side wizard form from auto-collapsing when that happens.

- `bridge.ts`: on SELECT/INSPECT, call `setContextOpen(true)` so the existing `$isContextOpen` subscription in `ContentWizardPanel` opens the panel. Export `$inspectedPath` from the page-editor store barrel.
- `ContentWizardPanel.ts`: removed the viewport-width `InspectEvent` listener that auto-collapsed the form on selection. Pruned the now unused `InspectEvent` and `PageNavigationEventSource` imports.
- `PageEditorExtension.tsx` / `usePageEditorTabs.ts`: drive the inspect-tab auto-switch from `$inspectedPath` instead of the boolean `$isInspecting`, so re-selecting a different item re-triggers the switch.
- `useInsertableDrag.ts`: use `document.elementFromPoint` for iframe hit-testing instead of raw bounding-box math.