### PR TITLE
Project selection dialog appears after a project is deleted #10272

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/settings/SettingsAppPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/SettingsAppPanel.ts
@@ -21,7 +21,7 @@ import {ProjectGetRequest} from './resource/ProjectGetRequest';
 import {ContentAppBar} from '../bar/ContentAppBar';
 import {type Equitable} from '@enonic/lib-admin-ui/Equitable';
 import {ProjectsUtil} from './resource/ProjectsUtil';
-import {removeProject, upsertProject} from '../../v6/features/store/projects.store';
+import {upsertProject} from '../../v6/features/store/projects.store';
 import {openEditProjectDialog} from '../../v6/features/store/dialogs/projectDialog.store';
 
 export class SettingsAppPanel extends NavigatedAppPanel {
@@ -163,10 +163,6 @@ export class SettingsAppPanel extends NavigatedAppPanel {
 
     private addNewProject(project: Project) {
         upsertProject(project);
-
-        const item: ProjectViewItem = ProjectViewItem.create().setData(project).build();
-
-        this.browsePanel.addSettingsItem(item);
         this.getProjectWizards().forEach((wizardPanel: ProjectWizardPanel) => {
             if (wizardPanel.isItemPersisted() && project.hasParentByName(wizardPanel.getPersistedItem().getId())) {
                 wizardPanel.setHasChildrenLayers(true);
@@ -178,7 +174,6 @@ export class SettingsAppPanel extends NavigatedAppPanel {
         upsertProject(project);
 
         const item: ProjectViewItem = ProjectViewItem.create().setData(project).build();
-        this.browsePanel.updateSettingsItem(item);
         this.updateProjectWizards(item);
     }
 
@@ -221,9 +216,7 @@ export class SettingsAppPanel extends NavigatedAppPanel {
     }
 
     private handleItemDeleted(itemId: string): void {
-        removeProject(itemId);
         this.deletedIds.push(itemId);
-        this.browsePanel.deleteSettingsItem(itemId);
 
         this.getProjectWizards()
             .filter((p: ProjectWizardPanel) => p.isItemPersisted())

--- a/modules/lib/src/main/resources/assets/js/app/settings/browse/SettingsBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/browse/SettingsBrowsePanel.ts
@@ -4,14 +4,13 @@ import {ListBoxToolbar} from '@enonic/lib-admin-ui/ui/selector/list/ListBoxToolb
 import {SelectableListBoxWrapper} from '@enonic/lib-admin-ui/ui/selector/list/SelectableListBoxWrapper';
 import {SelectableTreeListBoxKeyNavigator} from '@enonic/lib-admin-ui/ui/selector/list/SelectableTreeListBoxKeyNavigator';
 import type Q from 'q';
-import {reloadProjects, removeProject, upsertProject} from '../../../v6/features/store/projects.store';
+import {reloadProjects} from '../../../v6/features/store/projects.store';
 import {getSettingsItem, hasSettingsItem} from '../../../v6/features/store/settings-tree.store';
 import {SettingsItemPanelElement} from '../../../v6/features/views/browse/settings/item-panel/SettingsItemPanelElement';
 import {SettingsTreeListElement} from '../../../v6/features/views/browse/settings/SettingsTreeListElement';
 import {SettingsBrowseToolbarElement} from '../../../v6/features/views/browse/toolbar/SettingsBrowseToolbar';
 import {SettingsTreeList} from '../SettingsTreeList';
 import {SettingsTreeActions} from '../tree/SettingsTreeActions';
-import {type ProjectViewItem} from '../view/ProjectViewItem';
 import {type SettingsViewItem} from '../view/SettingsViewItem';
 import {SettingsBrowseToolbar} from './SettingsBrowseToolbar';
 import {SettingsTreeListSelectablePanelProxy} from './SettingsTreeListSelectablePanelProxy';
@@ -77,18 +76,6 @@ export class SettingsBrowsePanel
 
     hasItemWithId(id: string) {
         return hasSettingsItem(id);
-    }
-
-    addSettingsItem(item: ProjectViewItem) {
-        upsertProject(item.getData());
-    }
-
-    updateSettingsItem(item: ProjectViewItem) {
-        upsertProject(item.getData());
-    }
-
-    deleteSettingsItem(id: string) {
-        removeProject(id);
     }
 
     getItemById(id: string): SettingsViewItem | undefined {

--- a/modules/lib/src/main/resources/assets/js/app/settings/browse/action/DeleteSettingsItemTreeAction.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/browse/action/DeleteSettingsItemTreeAction.ts
@@ -2,15 +2,10 @@ import {Action} from '@enonic/lib-admin-ui/ui/Action';
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
 import {type SettingsViewItem} from '../../view/SettingsViewItem';
-import {ProjectDeleteRequest} from '../../resource/ProjectDeleteRequest';
-import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
-import {showFeedback} from '@enonic/lib-admin-ui/notify/MessageBus';
 import {ProjectViewItem} from '../../view/ProjectViewItem';
 import {getCurrentItems} from '../../../../v6/features/store/settingsTreeSelection.store';
 import {openDeleteSettingsDialog} from '../../../../v6/features/store/dialogs/deleteSettingsDialog.store';
-import {ConfirmValueDialog} from '../../../remove/ConfirmValueDialog';
-import {TextInputSize} from '@enonic/lib-admin-ui/ui/text/TextInput';
-import {type SelectableListBoxWrapper} from '@enonic/lib-admin-ui/ui/selector/list/SelectableListBoxWrapper';
+import {isActiveProject} from '../../../../v6/features/store/projects.store';
 
 export class DeleteSettingsItemTreeAction
     extends Action {
@@ -28,6 +23,8 @@ export class DeleteSettingsItemTreeAction
         if (!selectedItem || !ObjectHelper.iFrameSafeInstanceOf(selectedItem, ProjectViewItem)) return;
 
         const projectItem = selectedItem as ProjectViewItem;
-        openDeleteSettingsDialog(projectItem.getId(), projectItem.getName());
+        const navigateAfterDeletion = isActiveProject(projectItem.getName());
+
+        openDeleteSettingsDialog(projectItem.getId(), projectItem.getName(), navigateAfterDeletion);
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/ProjectWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/wizard/panel/ProjectWizardPanel.ts
@@ -31,6 +31,8 @@ import {ProjectApplicationsWizardStepForm} from './form/ProjectApplicationsWizar
 import {type ApplicationConfig} from '@enonic/lib-admin-ui/application/ApplicationConfig';
 import {Locale} from '@enonic/lib-admin-ui/locale/Locale';
 import {LangDirection} from '@enonic/lib-admin-ui/dom/Element';
+import {clearPendingDeletedProject, isActiveProject, markPendingDeletedProject} from '../../../../v6/features/store/projects.store';
+import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
 
 export class ProjectWizardPanel
     extends SettingsDataItemWizardPanel<ProjectViewItem> {
@@ -193,6 +195,19 @@ export class ProjectWizardPanel
 
     protected getSuccessfulDeleteMessage(): string {
         return i18n('notify.settings.project.deleted', this.getPersistedItem().getName());
+    }
+
+    protected deletePersistedItem() {
+        const projectName = this.getPersistedItem().getName();
+        markPendingDeletedProject(projectName, isActiveProject(projectName));
+
+        this.createDeleteRequest().sendAndParse().then(() => {
+            showFeedback(this.getSuccessfulDeleteMessage());
+            this.close();
+        }).catch((reason) => {
+            clearPendingDeletedProject(projectName);
+            DefaultErrorHandler.handle(reason);
+        });
     }
 
     protected getSuccessfulCreateMessage(name: string): string {

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProjectSelectionDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProjectSelectionDialog.tsx
@@ -17,6 +17,8 @@ export const ProjectSelectionDialog = (): ReactElement => {
     const {projectSelectionDialogOpen} = useStore($dialogs);
 
     const title = useI18n('text.selectContext');
+    const createProject = useI18n('settings.field.project.create');
+    const getAccess = useI18n('settings.field.project.access');
     const noProjectsText = useI18n('notify.settings.project.notInitialized');
     const noProjectsAvailableText = useI18n('notify.settings.project.notAvailable');
     const createProjectLabel = useI18n('dialog.project.wizard.noProjects.action');
@@ -25,11 +27,14 @@ export const ProjectSelectionDialog = (): ReactElement => {
 
     const flatProjects = useMemo(() => flattenProjects(projects), [projects]);
     const projectByName = useMemo(() => new Map(flatProjects.map(({project}) => [project.getName(), project])), [flatProjects]);
+    const hasAvailableProjects = useMemo(
+        () => flatProjects.some(({project}) => ProjectHelper.isAvailable(project)),
+        [flatProjects]
+    );
 
     // TODO: Enonic UI - Move auth data to store
     // It's currently okay, as authentication data is loaded from CONFIG and can be considered static
     const isAdmin = AuthHelper.isContentAdmin();
-    const hasProjects = flatProjects.length > 0;
 
     return (
         <Dialog.Root open={projectSelectionDialogOpen} onOpenChange={setProjectSelectionDialogOpen}>
@@ -45,9 +50,9 @@ export const ProjectSelectionDialog = (): ReactElement => {
                         listRef.current?.focus();
                     }}
                 >
-                    <ConfirmationDialog.DefaultHeader title={title} withClose />
+                    <ConfirmationDialog.DefaultHeader title={hasAvailableProjects ? title : isAdmin ? createProject : getAccess} withClose />
 
-                    {!hasProjects ? (
+                    {!hasAvailableProjects ? (
                         <ConfirmationDialog.Body className="flex flex-col gap-4 p-2 -m-2">
                             <p className="text-subtle">{isAdmin ? noProjectsAvailableText : noProjectsText}</p>
                             {isAdmin && (
@@ -78,17 +83,27 @@ export const ProjectSelectionDialog = (): ReactElement => {
                                     className="gap-2.5 max-h-full max-w-full pb-10 items-stretch"
                                     aria-label={title}
                                 >
-                                    {flatProjects.map(({project, level}) => (
-                                        <Listbox.Item
-                                            key={project.getName()}
-                                            value={project.getName()}
-                                            className="group flex self-stretch w-full min-w-full px-2.5"
-                                            style={{paddingInlineStart: level * 20 + 10}}
-                                            data-tone={project.getName() === activeProjectId ? 'inverse' : undefined}
-                                        >
-                                            <ProjectLabel project={project} className="w-full px-0 py-1.25" />
-                                        </Listbox.Item>
-                                    ))}
+                                    {flatProjects.map(({project, level}) => {
+                                        const isUnavailable = !ProjectHelper.isAvailable(project);
+
+                                        return (
+                                            <Listbox.Item
+                                                key={project.getName()}
+                                                value={project.getName()}
+                                                className="group flex self-stretch w-full min-w-full px-2.5"
+                                                style={{paddingInlineStart: level * 20 + 10}}
+                                                data-tone={project.getName() === activeProjectId ? 'inverse' : undefined}
+                                            >
+                                                <ProjectLabel
+                                                    project={project}
+                                                    className={cn(
+                                                        'w-full px-0 py-1.25',
+                                                        isUnavailable && 'opacity-50'
+                                                    )}
+                                                />
+                                            </Listbox.Item>
+                                        );
+                                    })}
                                 </Listbox.Content>
                             </Listbox.Root>
                         </ConfirmationDialog.Body>

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/deleteSettingsDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/deleteSettingsDialog.store.ts
@@ -3,27 +3,31 @@ import {showFeedback} from '@enonic/lib-admin-ui/notify/MessageBus';
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {map} from 'nanostores';
 import {ProjectDeleteRequest} from '../../../../app/settings/resource/ProjectDeleteRequest';
+import {clearPendingDeletedProject, markPendingDeletedProject} from '../projects.store';
 
 type DeleteSettingsDialogStore = {
     open: boolean;
     expected: string;
     projectName: string;
+    navigateAfterDeletion: boolean;
 };
 
 const initialState: DeleteSettingsDialogStore = {
     open: false,
     expected: '',
     projectName: '',
+    navigateAfterDeletion: false,
 };
 
 export const $deleteSettingsDialog = map<DeleteSettingsDialogStore>(structuredClone(initialState));
 
-export const openDeleteSettingsDialog = (expected: string, projectName: string): void => {
+export const openDeleteSettingsDialog = (expected: string, projectName: string, navigateAfterDeletion: boolean = false): void => {
     $deleteSettingsDialog.set({
         ...structuredClone(initialState),
         open: true,
         expected,
         projectName,
+        navigateAfterDeletion,
     });
 };
 
@@ -32,12 +36,17 @@ export const closeDeleteSettingsDialog = (): void => {
 };
 
 export const executeDeleteSettingsDialogAction = (): void => {
-    const {projectName} = $deleteSettingsDialog.get();
+    const {projectName, navigateAfterDeletion} = $deleteSettingsDialog.get();
 
     if (!projectName) return;
+
+    markPendingDeletedProject(projectName, navigateAfterDeletion);
 
     new ProjectDeleteRequest(projectName).sendAndParse().then(() => {
         closeDeleteSettingsDialog();
         showFeedback(i18n('notify.settings.project.deleted', projectName));
-    }).catch(DefaultErrorHandler.handle);
+    }).catch((error) => {
+        clearPendingDeletedProject(projectName);
+        DefaultErrorHandler.handle(error);
+    });
 };

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.test.ts
@@ -1,0 +1,207 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+type MockProject = {
+    getName(): string;
+    getDisplayName(): string;
+    getLanguage(): string;
+    getParents(): string[];
+};
+
+const {
+    deletedHandlers,
+    mockProjectListSendAndParse,
+    mockSetProjectSelectionDialogOpen,
+    mockProjectContextSetProject,
+    mockProjectContextSetNotAvailable,
+} = vi.hoisted(() => ({
+    deletedHandlers: [] as ((event: {getProjectName(): string}) => void)[],
+    mockProjectListSendAndParse: vi.fn(),
+    mockSetProjectSelectionDialogOpen: vi.fn(),
+    mockProjectContextSetProject: vi.fn(),
+    mockProjectContextSetNotAvailable: vi.fn(),
+}));
+
+vi.mock('../../../app/settings/resource/ProjectListRequest', () => ({
+    ProjectListRequest: class {
+        sendAndParse = mockProjectListSendAndParse;
+    },
+}));
+
+vi.mock('../../../app/settings/event/ProjectUpdatedEvent', () => ({
+    ProjectUpdatedEvent: {
+        on: vi.fn(),
+    },
+}));
+
+vi.mock('../../../app/settings/event/ProjectCreatedEvent', () => ({
+    ProjectCreatedEvent: {
+        on: vi.fn(),
+    },
+}));
+
+vi.mock('../../../app/settings/event/ProjectDeletedEvent', () => ({
+    ProjectDeletedEvent: {
+        on: vi.fn((handler: (event: {getProjectName(): string}) => void) => {
+            deletedHandlers.push(handler);
+        }),
+    },
+}));
+
+vi.mock('../utils/storage/sync', () => ({
+    syncMapStore: vi.fn(),
+}));
+
+vi.mock('./config.store', () => ({
+    $config: {
+        get: () => ({appId: 'contentstudio'}),
+    },
+}));
+
+vi.mock('./dialogs.store', () => ({
+    setProjectSelectionDialogOpen: mockSetProjectSelectionDialogOpen,
+}));
+
+vi.mock('../../../app/project/ProjectContext', () => ({
+    ProjectContext: {
+        get: () => ({
+            setProject: mockProjectContextSetProject,
+            setNotAvailable: mockProjectContextSetNotAvailable,
+        }),
+    },
+}));
+
+vi.mock('./tree-list.store', () => ({
+    resetTree: vi.fn(),
+}));
+
+vi.mock('./contentTreeSelection.store', () => ({
+    clearSelection: vi.fn(),
+    setActive: vi.fn(),
+}));
+
+vi.mock('./contentFilter.store', () => ({
+    setContentFilterOpen: vi.fn(),
+    resetContentFilter: vi.fn(),
+}));
+
+vi.mock('../api/content-fetcher', () => ({
+    deactivateFilter: vi.fn(),
+}));
+
+vi.mock('../utils/widget/versions/versionsCache', () => ({
+    clearVersionsCache: vi.fn(),
+}));
+
+function createProject(name: string, parents: string[] = []): MockProject {
+    return {
+        getName: () => name,
+        getDisplayName: () => name,
+        getLanguage: () => '',
+        getParents: () => parents,
+    };
+}
+
+function emitDeleted(projectName: string): void {
+    deletedHandlers.forEach((handler) => handler({
+        getProjectName: () => projectName,
+    }));
+}
+
+async function flushPromises(times: number = 5): Promise<void> {
+    for (let i = 0; i < times; i++) {
+        await Promise.resolve();
+    }
+}
+
+async function loadStore(projects: MockProject[], currentProjectId: string) {
+    vi.resetModules();
+    deletedHandlers.length = 0;
+    mockProjectListSendAndParse.mockReset().mockResolvedValue(projects);
+    mockSetProjectSelectionDialogOpen.mockReset();
+    mockProjectContextSetProject.mockReset();
+    mockProjectContextSetNotAvailable.mockReset();
+    window.history.pushState({}, '', `/contentstudio/cms/${currentProjectId}/browse`);
+
+    const store = await import('./projects.store');
+    await flushPromises();
+
+    mockSetProjectSelectionDialogOpen.mockClear();
+    mockProjectContextSetProject.mockClear();
+    mockProjectContextSetNotAvailable.mockClear();
+
+    return store;
+}
+
+describe('projects.store delete intent', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        deletedHandlers.length = 0;
+    });
+
+    it('reports whether a project is active', async () => {
+        const parent = createProject('parent');
+        const current = createProject('current');
+        const store = await loadStore([parent, current], 'current');
+
+        expect(store.isActiveProject('current')).toBe(true);
+        expect(store.isActiveProject('parent')).toBe(false);
+    });
+
+    it('uses explicit intent to fall back to parent project', async () => {
+        const parent = createProject('parent');
+        const child = createProject('child', ['parent']);
+        const current = createProject('current');
+        const store = await loadStore([parent, child, current], 'current');
+
+        store.markPendingDeletedProject('child', true);
+        emitDeleted('child');
+
+        expect(store.$projects.get().activeProjectId).toBe('parent');
+        expect(mockSetProjectSelectionDialogOpen).toHaveBeenCalledWith(false);
+        expect(mockProjectContextSetProject).toHaveBeenCalledWith(parent);
+        expect(mockProjectContextSetNotAvailable).not.toHaveBeenCalled();
+    });
+
+    it('uses explicit intent to fall back to first remaining project when deleted project has no parent', async () => {
+        const orphan = createProject('orphan');
+        const alpha = createProject('alpha');
+        const beta = createProject('beta');
+        const store = await loadStore([orphan, alpha, beta], 'beta');
+
+        store.markPendingDeletedProject('orphan', true);
+        emitDeleted('orphan');
+
+        expect(store.$projects.get().activeProjectId).toBe('alpha');
+        expect(mockSetProjectSelectionDialogOpen).toHaveBeenCalledWith(false);
+        expect(mockProjectContextSetProject).toHaveBeenCalledWith(alpha);
+        expect(mockProjectContextSetNotAvailable).not.toHaveBeenCalled();
+    });
+
+    it('uses explicit intent to enter empty-project state when no projects remain', async () => {
+        const orphan = createProject('orphan');
+        const store = await loadStore([orphan], 'orphan');
+
+        store.markPendingDeletedProject('orphan', true);
+        emitDeleted('orphan');
+
+        expect(store.$projects.get().projects).toEqual([]);
+        expect(store.$projects.get().activeProjectId).toBeUndefined();
+        expect(mockSetProjectSelectionDialogOpen).toHaveBeenCalledWith(true);
+        expect(mockProjectContextSetNotAvailable).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not jump active project when unrelated delete has no explicit intent', async () => {
+        const parent = createProject('parent');
+        const child = createProject('child', ['parent']);
+        const current = createProject('current');
+        const store = await loadStore([parent, child, current], 'current');
+
+        emitDeleted('child');
+
+        expect(store.$projects.get().activeProjectId).toBe('current');
+        expect(store.$projects.get().projects.map((project) => project.getName())).toEqual(['parent', 'current']);
+        expect(mockSetProjectSelectionDialogOpen).not.toHaveBeenCalled();
+        expect(mockProjectContextSetProject).not.toHaveBeenCalled();
+        expect(mockProjectContextSetNotAvailable).not.toHaveBeenCalled();
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.test.ts
@@ -1,4 +1,4 @@
-import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 type MockProject = {
     getName(): string;
@@ -113,7 +113,7 @@ async function flushPromises(times: number = 5): Promise<void> {
     }
 }
 
-async function loadStore(projects: MockProject[], currentProjectId: string) {
+async function loadStore(projects: MockProject[], currentProjectId: string): Promise<typeof import('./projects.store')> {
     vi.resetModules();
     deletedHandlers.length = 0;
     mockProjectListSendAndParse.mockReset().mockResolvedValue(projects);
@@ -136,6 +136,10 @@ describe('projects.store delete intent', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         deletedHandlers.length = 0;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('reports whether a project is active', async () => {
@@ -202,6 +206,20 @@ describe('projects.store delete intent', () => {
         expect(store.$projects.get().projects.map((project) => project.getName())).toEqual(['parent', 'current']);
         expect(mockSetProjectSelectionDialogOpen).not.toHaveBeenCalled();
         expect(mockProjectContextSetProject).not.toHaveBeenCalled();
+        expect(mockProjectContextSetNotAvailable).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to navigation when the active project is deleted without explicit intent', async () => {
+        const parent = createProject('parent');
+        const child = createProject('child', ['parent']);
+        const current = createProject('current');
+        const store = await loadStore([parent, child, current], 'current');
+
+        emitDeleted('current');
+
+        expect(store.$projects.get().activeProjectId).toBe('parent');
+        expect(mockSetProjectSelectionDialogOpen).toHaveBeenCalledWith(false);
+        expect(mockProjectContextSetProject).toHaveBeenCalledWith(parent);
         expect(mockProjectContextSetNotAvailable).not.toHaveBeenCalled();
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
@@ -45,7 +45,9 @@ syncMapStore($projects, SYNC_NAME, {
 });
 
 export const $activeProject = computed($projects, (store) => {
-    return store.projects.find((p) => getProjectId(p) === store.activeProjectId);
+    const activeProject = store.projects.find((p) => getProjectId(p) === store.activeProjectId);
+
+    return isAvailableProject(activeProject) ? activeProject : undefined;
 });
 
 export const $activeProjectName = computed($activeProject, (activeProject) => {
@@ -76,6 +78,10 @@ function getProjectId(project: Readonly<Project> | undefined): string | undefine
     return project?.getName();
 }
 
+function isAvailableProject(project: Readonly<Project> | undefined): boolean {
+    return !!project?.getDisplayName();
+}
+
 function getProjectIdFromUrl(): string | undefined {
     const viewPath = window.location.href.split($config.get().appId)[1];
     const normalizedPath = viewPath?.replace(/\/[^\/]+/, '') || '/';
@@ -94,6 +100,12 @@ function selectProjectById(projectId: string | undefined): void {
     } else {
         clearActiveProject();
     }
+}
+
+function resolveFallbackProjectId(projects: Readonly<Project>[], activeProjectId: string | undefined): string | undefined {
+    const activeProject = projects.find((project) => getProjectId(project) === activeProjectId);
+
+    return resolveActiveProjectIdAfterDeletion(projects, activeProject);
 }
 
 //
@@ -134,8 +146,9 @@ function updateActiveProject(): void {
         return;
     }
 
-    const {projects} = $projects.get();
-    const nextProjectId = resolveActiveProjectId(projects, getProjectIdFromUrl());
+    const {projects, activeProjectId} = $projects.get();
+    const nextProjectId = resolveActiveProjectId(projects, getProjectIdFromUrl())
+        ?? resolveFallbackProjectId(projects, activeProjectId);
 
     if (nextProjectId) {
         selectProjectById(nextProjectId);

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
@@ -105,6 +105,10 @@ function selectProjectById(projectId: string | undefined): void {
 function resolveFallbackProjectId(projects: Readonly<Project>[], activeProjectId: string | undefined): string | undefined {
     const activeProject = projects.find((project) => getProjectId(project) === activeProjectId);
 
+    if (!activeProject) {
+        return undefined;
+    }
+
     return resolveActiveProjectIdAfterDeletion(projects, activeProject);
 }
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
@@ -13,6 +13,7 @@ import {clearSelection, setActive} from './contentTreeSelection.store';
 import {setContentFilterOpen, resetContentFilter} from './contentFilter.store';
 import {deactivateFilter} from '../api/content-fetcher';
 import {clearVersionsCache} from '../utils/widget/versions/versionsCache';
+import {resolveActiveProjectId, resolveActiveProjectIdAfterDeletion} from '../utils/cms/projects/projectSelection';
 
 /*
 TODO: Enonic UI - Feature
@@ -64,6 +65,10 @@ export function setActiveProject(project: Readonly<Project> | undefined): void {
     $projects.setKey('activeProjectId', getProjectId(project));
 }
 
+export function isActiveProject(projectName: string | undefined): boolean {
+    return $projects.get().activeProjectId === projectName;
+}
+
 //
 // * Utilities
 //
@@ -77,11 +82,27 @@ function getProjectIdFromUrl(): string | undefined {
     return normalizedPath.split('/')[1];
 }
 
+function clearActiveProject(): void {
+    $projects.setKey('activeProjectId', undefined);
+}
+
+function selectProjectById(projectId: string | undefined): void {
+    const project = $projects.get().projects.find((candidate) => getProjectId(candidate) === projectId);
+
+    if (project) {
+        setActiveProject(project);
+    } else {
+        clearActiveProject();
+    }
+}
+
 //
 // * Internal
 //
 let isLoading = false;
 let needsReload = false;
+const pendingDeletedProjectNavigation = new Map<string, boolean>();
+
 async function loadProjects(): Promise<void> {
     if (isLoading) {
         needsReload = true;
@@ -114,17 +135,35 @@ function updateActiveProject(): void {
     }
 
     const {projects} = $projects.get();
+    const nextProjectId = resolveActiveProjectId(projects, getProjectIdFromUrl());
 
-    if (projects.length === 1) {
-        setActiveProject(projects[0]);
+    if (nextProjectId) {
+        selectProjectById(nextProjectId);
+        setProjectSelectionDialogOpen(false);
         return;
     }
 
-    const projectFromUrl = projects.find((p) => getProjectId(p) === getProjectIdFromUrl());
-    if (projectFromUrl) {
-        setActiveProject(projectFromUrl);
+    clearActiveProject();
+
+    if (projects.length === 0) {
+        ProjectContext.get().setNotAvailable();
     }
 
+    setProjectSelectionDialogOpen(true);
+}
+
+function updateActiveProjectAfterDeletion(deletedProject: Readonly<Project> | undefined): void {
+    const {projects} = $projects.get();
+    const nextProjectId = resolveActiveProjectIdAfterDeletion(projects, deletedProject);
+
+    if (nextProjectId) {
+        selectProjectById(nextProjectId);
+        setProjectSelectionDialogOpen(false);
+        return;
+    }
+
+    clearActiveProject();
+    ProjectContext.get().setNotAvailable();
     setProjectSelectionDialogOpen(true);
 }
 
@@ -155,10 +194,8 @@ ProjectCreatedEvent.on(() => {
 });
 
 ProjectDeletedEvent.on((event: ProjectDeletedEvent) => {
-    const {projects} = $projects.get();
-    const updatedProjects = projects.filter((p) => getProjectId(p) !== event.getProjectName());
-    $projects.setKey('projects', updatedProjects);
-    updateActiveProject();
+    const deletedProjectId = event.getProjectName();
+    removeProject(deletedProjectId, resolveDeleteNavigation(deletedProjectId));
 });
 
 //
@@ -168,6 +205,29 @@ export function reloadProjects(): void {
     void loadProjects();
 }
 
+export function markPendingDeletedProject(projectName: string, navigateAfterDeletion: boolean = false): void {
+    pendingDeletedProjectNavigation.set(projectName, navigateAfterDeletion);
+}
+
+export function clearPendingDeletedProject(projectName?: string): void {
+    if (projectName === undefined) {
+        pendingDeletedProjectNavigation.clear();
+        return;
+    }
+
+    pendingDeletedProjectNavigation.delete(projectName);
+}
+
+function consumePendingDeletedProject(projectName: string): boolean | undefined {
+    const navigateAfterDeletion = pendingDeletedProjectNavigation.get(projectName);
+    pendingDeletedProjectNavigation.delete(projectName);
+    return navigateAfterDeletion;
+}
+
+function resolveDeleteNavigation(projectName: string): boolean {
+    return consumePendingDeletedProject(projectName) ?? isActiveProject(projectName);
+}
+
 export function upsertProject(project: Readonly<Project>): void {
     const {projects} = $projects.get();
     const updatedProjects = [...projects.filter((p) => getProjectId(p) !== getProjectId(project)), project as Project];
@@ -175,10 +235,17 @@ export function upsertProject(project: Readonly<Project>): void {
     updateActiveProject();
 }
 
-export function removeProject(projectName: string): void {
+export function removeProject(projectName: string, navigateAfterDeletion: boolean = false): void {
     const {projects} = $projects.get();
+    const deletedProject = projects.find((p) => getProjectId(p) === projectName);
     const updatedProjects = projects.filter((p) => getProjectId(p) !== projectName);
     $projects.setKey('projects', updatedProjects);
+
+    if (navigateAfterDeletion) {
+        updateActiveProjectAfterDeletion(deletedProject);
+        return;
+    }
+
     updateActiveProject();
 }
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
@@ -144,11 +144,7 @@ function updateActiveProject(): void {
     }
 
     clearActiveProject();
-
-    if (projects.length === 0) {
-        ProjectContext.get().setNotAvailable();
-    }
-
+    ProjectContext.get().setNotAvailable();
     setProjectSelectionDialogOpen(true);
 }
 
@@ -225,6 +221,8 @@ function consumePendingDeletedProject(projectName: string): boolean | undefined 
 }
 
 function resolveDeleteNavigation(projectName: string): boolean {
+    // ? Explicit intent from markPendingDeletedProject wins; otherwise default to
+    // ? navigating when the deleted project is currently active (covers cross-tab deletes).
     return consumePendingDeletedProject(projectName) ?? isActiveProject(projectName);
 }
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.test.ts
@@ -1,21 +1,16 @@
 import {describe, expect, it} from 'vitest';
+import {Project} from '../../../../../app/settings/data/project/Project';
 import {resolveActiveProjectId, resolveActiveProjectIdAfterDeletion} from './projectSelection';
-
-type MockProject = {
-    getName(): string;
-    getParents(): string[];
-    getDisplayName(): string;
-};
 
 const createProject = (
     name: string,
     parents: string[] = [],
     displayName: string = name,
-): MockProject => ({
-    getName: () => name,
-    getParents: () => parents,
-    getDisplayName: () => displayName,
-});
+): Project => Project.create()
+    .setName(name)
+    .setParents(parents)
+    .setDisplayName(displayName)
+    .build();
 
 describe('resolveActiveProjectId', () => {
     it('should pick the only remaining project', () => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it} from 'vitest';
+import {resolveActiveProjectId, resolveActiveProjectIdAfterDeletion} from './projectSelection';
+
+type MockProject = {
+    getName(): string;
+    getParents(): string[];
+};
+
+const createProject = (name: string, parents: string[] = []): MockProject => ({
+    getName: () => name,
+    getParents: () => parents,
+});
+
+describe('resolveActiveProjectId', () => {
+    it('should pick the only remaining project', () => {
+        expect(resolveActiveProjectId([createProject('alpha')], 'missing')).toBe('alpha');
+    });
+
+    it('should use the project from the url when it exists', () => {
+        expect(resolveActiveProjectId([createProject('alpha'), createProject('beta')], 'beta')).toBe('beta');
+    });
+
+    it('should require manual selection when multiple projects remain and url does not match', () => {
+        expect(resolveActiveProjectId([createProject('alpha'), createProject('beta')], 'missing')).toBeUndefined();
+    });
+});
+
+describe('resolveActiveProjectIdAfterDeletion', () => {
+    it('should select the parent project after deleting a child project', () => {
+        const remainingProjects = [createProject('parent'), createProject('sibling')];
+        const deletedProject = createProject('child', ['parent']);
+
+        expect(resolveActiveProjectIdAfterDeletion(remainingProjects, deletedProject)).toBe('parent');
+    });
+
+    it('should select the first remaining project when the deleted project has no parent', () => {
+        const remainingProjects = [createProject('alpha'), createProject('beta')];
+        const deletedProject = createProject('orphan');
+
+        expect(resolveActiveProjectIdAfterDeletion(remainingProjects, deletedProject)).toBe('alpha');
+    });
+
+    it('should return undefined when there are no projects left', () => {
+        expect(resolveActiveProjectIdAfterDeletion([], createProject('orphan'))).toBeUndefined();
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.test.ts
@@ -4,11 +4,17 @@ import {resolveActiveProjectId, resolveActiveProjectIdAfterDeletion} from './pro
 type MockProject = {
     getName(): string;
     getParents(): string[];
+    getDisplayName(): string;
 };
 
-const createProject = (name: string, parents: string[] = []): MockProject => ({
+const createProject = (
+    name: string,
+    parents: string[] = [],
+    displayName: string = name,
+): MockProject => ({
     getName: () => name,
     getParents: () => parents,
+    getDisplayName: () => displayName,
 });
 
 describe('resolveActiveProjectId', () => {
@@ -38,6 +44,14 @@ describe('resolveActiveProjectIdAfterDeletion', () => {
         const deletedProject = createProject('orphan');
 
         expect(resolveActiveProjectIdAfterDeletion(remainingProjects, deletedProject)).toBe('alpha');
+    });
+
+    it('should skip unavailable projects when selecting fallback after deletion', () => {
+        const unavailableParent = createProject('parent', [], '');
+        const availableSibling = createProject('sibling');
+        const deletedProject = createProject('child', ['parent']);
+
+        expect(resolveActiveProjectIdAfterDeletion([unavailableParent, availableSibling], deletedProject)).toBe('sibling');
     });
 
     it('should return undefined when there are no projects left', () => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.ts
@@ -1,0 +1,27 @@
+import {type Project} from '../../../../../app/settings/data/project/Project';
+
+type ProjectLike = Pick<Project, 'getName' | 'getParents'>;
+
+export function resolveActiveProjectId(
+    projects: Readonly<ProjectLike>[],
+    projectIdFromUrl: string | undefined
+): string | undefined {
+    if (projects.length === 1) {
+        return projects[0].getName();
+    }
+
+    return projects.some((project) => project.getName() === projectIdFromUrl) ? projectIdFromUrl : undefined;
+}
+
+export function resolveActiveProjectIdAfterDeletion(
+    remainingProjects: Readonly<ProjectLike>[],
+    deletedProject: ProjectLike | undefined
+): string | undefined {
+    const remainingByName = new Map(remainingProjects.map((project) => [project.getName(), project]));
+
+    const parentProject = (deletedProject?.getParents() ?? [])
+        .map((parentName) => remainingByName.get(parentName))
+        .find((project) => project !== undefined);
+
+    return parentProject?.getName() ?? remainingProjects[0]?.getName();
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.ts
@@ -1,25 +1,23 @@
 import {type Project} from '../../../../../app/settings/data/project/Project';
 
-type ProjectLike = Pick<Project, 'getName' | 'getParents' | 'getDisplayName'>;
-
-function isAvailableProject(project: ProjectLike): boolean {
+function isAvailableProject(project: Readonly<Project>): boolean {
     return !!project.getDisplayName();
 }
 
 function getMainParentName(
-    project: ProjectLike,
-    projectsByName: ReadonlyMap<string, ProjectLike>
+    project: Readonly<Project>,
+    projectsByName: ReadonlyMap<string, Readonly<Project>>
 ): string | undefined {
     const mainParentName = project.getParents()?.[0];
 
     return mainParentName && projectsByName.has(mainParentName) ? mainParentName : undefined;
 }
 
-function getProjectsInDisplayOrder(projects: Readonly<ProjectLike>[]): ProjectLike[] {
+function getProjectsInDisplayOrder(projects: Readonly<Project>[]): Readonly<Project>[] {
     const sortedProjects = [...projects].sort((a, b) => a.getName().localeCompare(b.getName()));
     const projectsByName = new Map(sortedProjects.map((project) => [project.getName(), project]));
-    const childrenByParentName = new Map<string, ProjectLike[]>();
-    const rootProjects: ProjectLike[] = [];
+    const childrenByParentName = new Map<string, Readonly<Project>[]>();
+    const rootProjects: Readonly<Project>[] = [];
 
     for (const project of sortedProjects) {
         const parentName = getMainParentName(project, projectsByName);
@@ -36,9 +34,9 @@ function getProjectsInDisplayOrder(projects: Readonly<ProjectLike>[]): ProjectLi
         }
     }
 
-    const orderedProjects: ProjectLike[] = [];
+    const orderedProjects: Readonly<Project>[] = [];
 
-    const visit = (project: ProjectLike): void => {
+    const visit = (project: Readonly<Project>): void => {
         orderedProjects.push(project);
         childrenByParentName.get(project.getName())?.forEach(visit);
     };
@@ -49,8 +47,8 @@ function getProjectsInDisplayOrder(projects: Readonly<ProjectLike>[]): ProjectLi
 }
 
 function resolveClosestAvailableAncestorId(
-    deletedProject: ProjectLike | undefined,
-    remainingByName: ReadonlyMap<string, ProjectLike>
+    deletedProject: Readonly<Project> | undefined,
+    remainingByName: ReadonlyMap<string, Readonly<Project>>
 ): string | undefined {
     let currentParentName = deletedProject?.getParents()?.[0];
 
@@ -71,12 +69,12 @@ function resolveClosestAvailableAncestorId(
     return undefined;
 }
 
-function resolveFirstAvailableProjectId(projects: Readonly<ProjectLike>[]): string | undefined {
+function resolveFirstAvailableProjectId(projects: Readonly<Project>[]): string | undefined {
     return getProjectsInDisplayOrder(projects).find((project) => isAvailableProject(project))?.getName();
 }
 
 export function resolveActiveProjectId(
-    projects: Readonly<ProjectLike>[],
+    projects: Readonly<Project>[],
     projectIdFromUrl: string | undefined
 ): string | undefined {
     if (projects.length === 1) {
@@ -89,8 +87,8 @@ export function resolveActiveProjectId(
 }
 
 export function resolveActiveProjectIdAfterDeletion(
-    remainingProjects: Readonly<ProjectLike>[],
-    deletedProject: ProjectLike | undefined
+    remainingProjects: Readonly<Project>[],
+    deletedProject: Readonly<Project> | undefined
 ): string | undefined {
     const remainingByName = new Map(remainingProjects.map((project) => [project.getName(), project]));
     const closestAvailableAncestorId = resolveClosestAvailableAncestorId(deletedProject, remainingByName);

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.ts
@@ -1,9 +1,9 @@
 import {type Project} from '../../../../../app/settings/data/project/Project';
 
-type ProjectLike = Pick<Project, 'getName' | 'getParents'> & Partial<Pick<Project, 'getDisplayName'>>;
+type ProjectLike = Pick<Project, 'getName' | 'getParents' | 'getDisplayName'>;
 
 function isAvailableProject(project: ProjectLike): boolean {
-    return typeof project.getDisplayName !== 'function' || !!project.getDisplayName();
+    return !!project.getDisplayName();
 }
 
 function getMainParentName(

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/projects/projectSelection.ts
@@ -1,16 +1,91 @@
 import {type Project} from '../../../../../app/settings/data/project/Project';
 
-type ProjectLike = Pick<Project, 'getName' | 'getParents'>;
+type ProjectLike = Pick<Project, 'getName' | 'getParents'> & Partial<Pick<Project, 'getDisplayName'>>;
+
+function isAvailableProject(project: ProjectLike): boolean {
+    return typeof project.getDisplayName !== 'function' || !!project.getDisplayName();
+}
+
+function getMainParentName(
+    project: ProjectLike,
+    projectsByName: ReadonlyMap<string, ProjectLike>
+): string | undefined {
+    const mainParentName = project.getParents()?.[0];
+
+    return mainParentName && projectsByName.has(mainParentName) ? mainParentName : undefined;
+}
+
+function getProjectsInDisplayOrder(projects: Readonly<ProjectLike>[]): ProjectLike[] {
+    const sortedProjects = [...projects].sort((a, b) => a.getName().localeCompare(b.getName()));
+    const projectsByName = new Map(sortedProjects.map((project) => [project.getName(), project]));
+    const childrenByParentName = new Map<string, ProjectLike[]>();
+    const rootProjects: ProjectLike[] = [];
+
+    for (const project of sortedProjects) {
+        const parentName = getMainParentName(project, projectsByName);
+
+        if (parentName) {
+            const siblings = childrenByParentName.get(parentName);
+            if (siblings) {
+                siblings.push(project);
+            } else {
+                childrenByParentName.set(parentName, [project]);
+            }
+        } else {
+            rootProjects.push(project);
+        }
+    }
+
+    const orderedProjects: ProjectLike[] = [];
+
+    const visit = (project: ProjectLike): void => {
+        orderedProjects.push(project);
+        childrenByParentName.get(project.getName())?.forEach(visit);
+    };
+
+    rootProjects.forEach(visit);
+
+    return orderedProjects;
+}
+
+function resolveClosestAvailableAncestorId(
+    deletedProject: ProjectLike | undefined,
+    remainingByName: ReadonlyMap<string, ProjectLike>
+): string | undefined {
+    let currentParentName = deletedProject?.getParents()?.[0];
+
+    while (currentParentName) {
+        const currentParent = remainingByName.get(currentParentName);
+
+        if (!currentParent) {
+            return undefined;
+        }
+
+        if (isAvailableProject(currentParent)) {
+            return currentParent.getName();
+        }
+
+        currentParentName = currentParent.getParents()?.[0];
+    }
+
+    return undefined;
+}
+
+function resolveFirstAvailableProjectId(projects: Readonly<ProjectLike>[]): string | undefined {
+    return getProjectsInDisplayOrder(projects).find((project) => isAvailableProject(project))?.getName();
+}
 
 export function resolveActiveProjectId(
     projects: Readonly<ProjectLike>[],
     projectIdFromUrl: string | undefined
 ): string | undefined {
     if (projects.length === 1) {
-        return projects[0].getName();
+        return isAvailableProject(projects[0]) ? projects[0].getName() : undefined;
     }
 
-    return projects.some((project) => project.getName() === projectIdFromUrl) ? projectIdFromUrl : undefined;
+    const projectFromUrl = projects.find((project) => project.getName() === projectIdFromUrl);
+
+    return projectFromUrl && isAvailableProject(projectFromUrl) ? projectIdFromUrl : undefined;
 }
 
 export function resolveActiveProjectIdAfterDeletion(
@@ -18,10 +93,7 @@ export function resolveActiveProjectIdAfterDeletion(
     deletedProject: ProjectLike | undefined
 ): string | undefined {
     const remainingByName = new Map(remainingProjects.map((project) => [project.getName(), project]));
+    const closestAvailableAncestorId = resolveClosestAvailableAncestorId(deletedProject, remainingByName);
 
-    const parentProject = (deletedProject?.getParents() ?? [])
-        .map((parentName) => remainingByName.get(parentName))
-        .find((project) => project !== undefined);
-
-    return parentProject?.getName() ?? remainingProjects[0]?.getName();
+    return closestAvailableAncestorId ?? resolveFirstAvailableProjectId(remainingProjects);
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/settings/SettingsTreeList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/settings/SettingsTreeList.tsx
@@ -1,12 +1,11 @@
 import {cn, VirtualizedTreeList} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
 import {Folder, FolderOpen} from 'lucide-react';
-import {ReactElement, useCallback, useMemo, useRef} from 'react';
+import {type ReactElement, useCallback, useMemo, useRef} from 'react';
 import type {ListRange, VirtuosoHandle} from 'react-virtuoso';
 import {Virtuoso} from 'react-virtuoso';
 import {EditSettingsItemEvent} from '../../../../../app/settings/event/EditSettingsItemEvent';
-import {SettingsDataViewItem} from '../../../../../app/settings/view/SettingsDataViewItem';
-import {SettingsViewItem} from '../../../../../app/settings/view/SettingsViewItem';
+import {type SettingsViewItem} from '../../../../../app/settings/view/SettingsViewItem';
 import {ProjectHelper} from '../../../../../app/settings/data/project/ProjectHelper';
 import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
 import {virtuosoComponents} from '../../../shared/lists';
@@ -17,6 +16,7 @@ import type {FlatNode} from '../../../lib/tree-store';
 import {$settingsFlatNodes, collapseSettingsNode, expandSettingsNode} from '../../../store/settings-tree.store';
 import {$activeId, $selection, clearSelection, setActive, setSelection} from '../../../store/settingsTreeSelection.store';
 import {SettingsTreeContextMenu, type SettingsTreeContextMenuProps} from './SettingsTreeContextMenu';
+import {ProjectViewItem} from '../../../../../app/settings/view/ProjectViewItem';
 
 type SettingsFlatNode = FlatNode<SettingsViewItem>;
 
@@ -26,8 +26,8 @@ export type SettingsTreeListProps = {
 
 const SETTINGS_TREE_LIST_NAME = 'SettingsTreeList';
 
-const isSettingsDataItem = (item: SettingsViewItem): item is SettingsDataViewItem<any> =>
-    ObjectHelper.iFrameSafeInstanceOf(item, SettingsDataViewItem);
+const isProjectViewItem = (item: SettingsViewItem): item is ProjectViewItem =>
+    ObjectHelper.iFrameSafeInstanceOf(item, ProjectViewItem);
 
 export const SettingsTreeList = ({contextMenuActions = []}: SettingsTreeListProps): ReactElement => {
     const virtuosoRef = useRef<VirtuosoHandle>(null);
@@ -49,7 +49,7 @@ export const SettingsTreeList = ({contextMenuActions = []}: SettingsTreeListProp
         const node = flatNodes.find((n) => n.id === id);
         if (!node?.data) return;
 
-        if (ObjectHelper.iFrameSafeInstanceOf(node.data, SettingsDataViewItem)) {
+        if (ObjectHelper.iFrameSafeInstanceOf(node.data, ProjectViewItem)) {
             new EditSettingsItemEvent([node.data]).fire();
         }
     }, [flatNodes]);
@@ -113,7 +113,7 @@ export const SettingsTreeList = ({contextMenuActions = []}: SettingsTreeListProp
                                 const isSelected = selection.has(id);
 
                                 const secondaryText = data.getDescription() || `<${noDescription}>`;
-                                const isUnavailable = isSettingsDataItem(data)
+                                const isUnavailable = isProjectViewItem(data)
                                     ? !ProjectHelper.isAvailable(data.getData())
                                     : false;
 
@@ -179,7 +179,7 @@ export const SettingsTreeList = ({contextMenuActions = []}: SettingsTreeListProp
                                             />
                                         </VirtualizedTreeList.RowLeft>
                                         <VirtualizedTreeList.RowContent>
-                                            {isSettingsDataItem(data) ? (
+                                            {isProjectViewItem(data) ? (
                                                 <ProjectLabel
                                                     project={data.getData()}
                                                     className={isUnavailable ? 'opacity-50' : undefined}

--- a/modules/lib/src/main/resources/i18n/phrases.properties
+++ b/modules/lib/src/main/resources/i18n/phrases.properties
@@ -509,6 +509,7 @@ settings.items.type.layer=Layer
 settings.items.type.layerDescription=Create a new repository with content inherited from a parent project
 settings.field.project.name=Identifier
 settings.field.project.access=Project access
+settings.field.project.create=Create a project
 notify.settings.project.created=Project "{0}" has been created.
 notify.settings.project.modified=Project "{0}" has been modified.
 notify.settings.project.deleted=Project "{0}" has been deleted.


### PR DESCRIPTION
Reimplement legacy logic, deleting current project redirects to the parent project then first project in project lists. If now other projects open create project dialog.