### PR TITLE
New content dialog: double 'createMedia' request is sent #10244

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/DropZone.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/DropZone.tsx
@@ -41,6 +41,7 @@ export const DropZone = ({
 
     const handleDrop = useCallback((e: ReactDragEvent<HTMLDivElement>) => {
         e.preventDefault();
+        e.stopPropagation();
         setInternalDragging(false);
 
         const {files} = e.dataTransfer;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/new-content/NewContentDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/new-content/NewContentDialog.tsx
@@ -1,11 +1,12 @@
 import {cn, Dialog, Tab} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
-import {type KeyboardEvent, type ReactElement, useEffect, useRef, useState} from 'react';
+import {type KeyboardEvent, type ReactElement, useEffect, useRef} from 'react';
 import {useI18n} from '../../../hooks/useI18n';
 import {
     $newContentDialog,
     closeNewContentDialog,
     setInputValue,
+    setIsDragging,
     setSelectedTab,
     uploadDragImages,
     uploadMediaFiles,
@@ -21,7 +22,6 @@ export const NewContentDialog = (): ReactElement => {
     const inputRef = useRef<HTMLInputElement>(null);
     const dialogContentRef = useRef<HTMLDivElement>(null);
     const shouldFocusInput = useRef(false);
-    const [isDragging, setIsDragging] = useState(false);
     const {open, selectedTab, inputValue, parentContent, filteredBaseContentTypes, filteredSuggestedContentTypes} = useStore($newContentDialog);
     const isMediaTab = selectedTab === 'media';
     const isInputEmpty = inputValue.length === 0;
@@ -193,7 +193,7 @@ export const NewContentDialog = (): ReactElement => {
                                     parentContent={parentContent}
                                 />
 
-                                <NewContentDialogMediaTab tabName="media" isDragging={isDragging} />
+                                <NewContentDialogMediaTab tabName="media" />
                             </div>
                         </Dialog.Body>
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/new-content/NewContentDialogMediaTab.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/new-content/NewContentDialogMediaTab.tsx
@@ -6,6 +6,7 @@ import {useI18n} from '../../../hooks/useI18n';
 import {
     $newContentDialog,
     closeNewContentDialog,
+    setIsDragging,
     uploadMediaFiles,
 } from '../../../store/dialogs/newContentDialog.store';
 import {DropZone} from '../../DropZone';
@@ -14,17 +15,17 @@ const NEW_CONTENT_DIALOG_MEDIA_TAB_NAME = 'NewContentDialogMediaTab';
 
 type NewContentDialogMediaTabProps = {
     tabName: string;
-    isDragging?: boolean;
 };
 
 export const NewContentDialogMediaTab = ({
     tabName,
-    isDragging = false,
 }: NewContentDialogMediaTabProps): ReactElement => {
-    const {parentContent} = useStore($newContentDialog);
+    const {parentContent, isDragging} = useStore($newContentDialog, {keys: ['parentContent', 'isDragging']});
     const hintLabel = useI18n('dialog.new.hint.upload');
 
     const handleFiles = useCallback((files: FileList) => {
+        setIsDragging(false);
+
         const dataTransfer = new DataTransfer();
         Array.from(files).forEach((file) => dataTransfer.items.add(file));
 
@@ -34,7 +35,7 @@ export const NewContentDialogMediaTab = ({
         });
 
         closeNewContentDialog();
-    }, [parentContent]);
+    }, [parentContent, setIsDragging]);
 
     return (
         <Tab.Content value={tabName} className='mt-0 h-full' data-component={NEW_CONTENT_DIALOG_MEDIA_TAB_NAME}>

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/newContentDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/newContentDialog.store.ts
@@ -36,6 +36,7 @@ type NewContentDialogStore = {
     //failed: boolean;
     inputValue: string;
     selectedTab: string;
+    isDragging: boolean;
     // Content
     parentContent?: ContentSummary;
     baseContentTypes: ContentTypeSummary[];
@@ -50,6 +51,7 @@ const initialState: NewContentDialogStore = {
     //failed: false,
     inputValue: '',
     selectedTab: 'all',
+    isDragging: false,
     parentContent: undefined,
     baseContentTypes: [],
     suggestedContentTypes: [],
@@ -132,6 +134,10 @@ export const setInputValue = (value: string): void => {
 
 export const setSelectedTab = (tab: string): void => {
     $newContentDialog.setKey('selectedTab', tab);
+};
+
+export const setIsDragging = (isDragging: boolean): void => {
+    $newContentDialog.setKey('isDragging', isDragging);
 };
 
 // TODO: replace places invoking this function with the useUploadMedia hook


### PR DESCRIPTION
## Problem:
Dropping a media file on the New Content dialog fired two createMedia requests. The server rejected the second as a duplicate (500), while the first succeeded (200).

## Cause: 
Two drop handlers were both reacting to the same drop:
  1. DropZone (inside the Media tab) — calls uploadMediaFiles via onFiles.
  2. NewContentDialog's Dialog.Content — outer onDrop that also calls uploadMediaFiles.
  
The drop event ran on DropZone and then bubbled up to the dialog, so the same files were uploaded twice.

## Fix:
  - DropZone.handleDrop now calls e.stopPropagation(), so when the inner zone handles the drop, the outer dialog handler does not run again.
  - As a small cleanup, isDragging was moved out of local useState in NewContentDialog into the newContentDialog store.