### PR TITLE
PageComponentsView: replace legacy context menu with the Page Editor's context menu #10294

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/insert/InsertPanel.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/insert/InsertPanel.tsx
@@ -1,6 +1,6 @@
 import {cn} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
-import {Box, Columns2, Layers, PenLine} from 'lucide-react';
+import {Box, Columns2, PenLine, Puzzle} from 'lucide-react';
 import type {ReactElement} from 'react';
 import {useI18n} from '../../../../../hooks/useI18n';
 import {$isFragment} from '../../../../../store/page-editor';
@@ -31,7 +31,7 @@ export const InsertPanel = ({className}: Props): ReactElement => {
                 <InsertableItem name="layout" icon={Columns2} displayName={layoutLabel} description={layoutDescription} />
             )}
             <InsertableItem name="text" icon={PenLine} displayName={textLabel} description={textDescription} />
-            <InsertableItem name="fragment" icon={Layers} displayName={fragmentLabel} description={fragmentDescription} />
+            <InsertableItem name="fragment" icon={Puzzle} displayName={fragmentLabel} description={fragmentDescription} />
         </ul>
     );
 };

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/fragment/FragmentContentSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/fragment/FragmentContentSelector.tsx
@@ -25,7 +25,7 @@ export const FragmentContentSelector = (): ReactElement | null => {
     if (isLoading) return null;
 
     if (isEmpty) {
-        return <p className="text-sm text-subtle">{label}</p>;
+        return <p className="text-subtle font-semibold leading-5.5 truncate">{label}</p>;
     }
 
     return (

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentDataView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentDataView.tsx
@@ -1,6 +1,0 @@
-import {type ReactElement} from 'react';
-import {ContentForm} from './ContentForm';
-
-export const ContentDataView = (): ReactElement => <ContentForm />;
-
-ContentDataView.displayName = 'ContentDataView';

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
@@ -1,15 +1,17 @@
-import {useStore} from '@nanostores/preact';
-import {type ReactElement, useEffect, useMemo} from 'react';
 import {RawValueProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
 import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
+import {useStore} from '@nanostores/preact';
+import {type ReactElement, useEffect, useMemo} from 'react';
+import {FormRenderer} from '../../../shared/form';
+import {HtmlAreaProvider} from '../../../shared/form/input-types/html-area';
 import {$contextContent} from '../../../store/context/contextContent.store';
 import {$activeProject} from '../../../store/projects.store';
 import {$contentType, $wizardDraftData, notifyContentFormMounted} from '../../../store/wizardContent.store';
 import {$validationVisibility, getContentRawValueMap} from '../../../store/wizardValidation.store';
-import {FormRenderer} from '../../../shared/form';
-import {HtmlAreaProvider} from '../../../shared/form/input-types/html-area';
 import {DisplayNameInput} from './DisplayNameInput';
 import {useApplicationKeys} from './useApplicationKeys';
+
+const CONTENT_FORM_NAME = 'ContentForm';
 
 export const ContentForm = (): ReactElement | null => {
     const contentType = useStore($contentType);
@@ -43,7 +45,7 @@ export const ContentForm = (): ReactElement | null => {
     }
 
     return (
-        <div className="flex flex-col gap-7.5">
+        <div data-component={CONTENT_FORM_NAME} className="flex flex-col gap-7.5">
             <DisplayNameInput />
             <ValidationVisibilityProvider visibility={visibility}>
                 <RawValueProvider map={rawValueMap}>
@@ -65,4 +67,4 @@ export const ContentForm = (): ReactElement | null => {
     );
 };
 
-ContentForm.displayName = 'ContentForm';
+ContentForm.displayName = CONTENT_FORM_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentWizardTabs.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentWizardTabs.tsx
@@ -11,10 +11,10 @@ import {
 } from '../../../store/wizardContent.store';
 import {$invalidTabs, $validationVisibility} from '../../../store/wizardValidation.store';
 import {CollapsedFormPanel} from './CollapsedFormPanel';
-import {ContentDataView} from './ContentDataView';
+import {ContentForm} from './ContentForm';
 import {MixinView} from './MixinView';
-import {PageView} from './PageView';
 import {ToggleFormButton} from './ToggleFormButton';
+import {PageComponentsView} from './page-components/PageComponentsView';
 
 type ContentWizardTabsProps = {
     tabListAction?: ReactElement;
@@ -64,12 +64,12 @@ export const ContentWizardTabs = ({tabListAction}: ContentWizardTabsProps): Reac
             </div>
 
             <Tab.Content value="content">
-                <ContentDataView />
+                <ContentForm />
             </Tab.Content>
 
             {hasPage && (
                 <Tab.Content value="page">
-                    <PageView />
+                    <PageComponentsView showTitle />
                 </Tab.Content>
             )}
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/PageView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/PageView.tsx
@@ -1,8 +1,0 @@
-import {type ReactElement} from 'react';
-import {PageComponentsView} from './page-components/PageComponentsView';
-
-export const PageView = (): ReactElement => {
-    return <PageComponentsView showTitle />;
-};
-
-PageView.displayName = 'PageView';

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsContextMenu.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsContextMenu.tsx
@@ -1,6 +1,6 @@
 import {ContextMenu} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
-import {Box, ChevronDown, ChevronUp, Columns2, Puzzle, Type} from 'lucide-react';
+import {Box, Columns2, PenLine, Puzzle} from 'lucide-react';
 import {type ReactElement, type ReactNode, useCallback, useState} from 'react';
 import {SaveAsTemplateAction} from '../../../../../../app/wizard/action/SaveAsTemplateAction';
 import {ComponentPath} from '../../../../../../app/page/region/ComponentPath';
@@ -40,6 +40,7 @@ export type PageComponentsContextMenuProps = {
 //
 
 const PAGE_COMPONENTS_CONTEXT_MENU_NAME = 'PageComponentsContextMenu';
+const ROOT_NODE_ID = '/';
 
 export const PageComponentsContextMenu = ({node, children}: PageComponentsContextMenuProps): ReactElement => {
     const data = node.data;
@@ -61,10 +62,11 @@ export const PageComponentsContextMenu = ({node, children}: PageComponentsContex
         return <>{children}</>;
     }
 
-    // Page/fragment root: show Reset and Save as Template
-    if (data.nodeType === 'page' || node.id === '/') {
+    const isPageRoot = data.nodeType === 'page' || node.id === ROOT_NODE_ID;
+
+    if (isPageRoot) {
         const handleReset = isFragment
-            ? () => requestComponentReset(ComponentPath.fromString('/'))
+            ? () => requestComponentReset(ComponentPath.fromString(ROOT_NODE_ID))
             : () => setConfirmResetOpen(true);
 
         return (
@@ -73,6 +75,7 @@ export const PageComponentsContextMenu = ({node, children}: PageComponentsContex
                     <ContextMenu.Trigger className="flex-1 min-w-0">{children}</ContextMenu.Trigger>
                     <ContextMenu.Portal>
                         <ContextMenu.Content className="min-w-48">
+                            <InspectItem nodeId={ROOT_NODE_ID} label={inspectLabel} />
                             <PageResetItem label={resetLabel} onSelect={handleReset} />
                             {!isFragment && !contentContext?.isPageTemplate && (
                                 <SaveAsTemplateItem label={saveAsTemplateLabel} />
@@ -113,9 +116,7 @@ export const PageComponentsContextMenu = ({node, children}: PageComponentsContex
             <ContextMenu.Portal>
                 <ContextMenu.Content className="min-w-48">
                     <SelectParentItem nodeId={node.id} label={selectParentLabel} />
-
-                    <InsertSection nodeId={node.id} label={insertLabel} />
-
+                    <InsertSubMenu nodeId={node.id} label={insertLabel} />
                     {isComponent && (
                         <>
                             <InspectItem nodeId={node.id} label={inspectLabel} />
@@ -279,20 +280,17 @@ const SaveAsFragmentItem = ({nodeId, label}: MenuItemProps): ReactElement => {
 SaveAsFragmentItem.displayName = 'SaveAsFragmentItem';
 
 //
-// * Insert section
+// * Insert submenu
 //
 
-const INSERT_TYPES = [
-    {type: 'part', Icon: Box, label: 'Part'},
-    {type: 'layout', Icon: Columns2, label: 'Layout'},
-    {type: 'text', Icon: Type, label: 'Text'},
-    {type: 'fragment', Icon: Puzzle, label: 'Fragment'},
-] as const;
-
-const InsertSection = ({nodeId, label}: MenuItemProps): ReactElement => {
-    const [open, setOpen] = useState(true);
+const InsertSubMenu = ({nodeId, label}: MenuItemProps): ReactElement => {
     const treeState = $componentsTreeState.get();
     const insideLayout = hasLayoutAncestor(treeState, nodeId);
+
+    const partLabel = useI18n('field.part');
+    const layoutLabel = useI18n('field.layout');
+    const textLabel = useI18n('field.text');
+    const fragmentLabel = useI18n('field.fragment');
 
     const handleInsert = useCallback((typeShortName: string) => {
         const currentState = $componentsTreeState.get();
@@ -319,36 +317,32 @@ const InsertSection = ({nodeId, label}: MenuItemProps): ReactElement => {
         }
     }, [nodeId]);
 
-    const toggleOpen = useCallback(() => {
-        setOpen(prev => !prev);
-    }, []);
-
-    const Chevron = open ? ChevronUp : ChevronDown;
+    const items = [
+        {type: 'part', Icon: Box, label: partLabel, disabled: false},
+        {type: 'layout', Icon: Columns2, label: layoutLabel, disabled: insideLayout},
+        {type: 'text', Icon: PenLine, label: textLabel, disabled: false},
+        {type: 'fragment', Icon: Puzzle, label: fragmentLabel, disabled: false},
+    ];
 
     return (
-        <>
-            <div
-                role="button"
-                className="flex w-full items-center justify-between px-4.5 py-2.5 text-sm cursor-pointer hover:bg-surface-neutral-hover"
-                onClick={toggleOpen}
-            >
-                <span>{label}</span>
-                <Chevron className="size-4 text-subtle" />
-            </div>
-
-            {open && INSERT_TYPES.map(({type, Icon, label: typeLabel}) => (
-                <ContextMenu.Item
-                    key={type}
-                    className="ps-8"
-                    disabled={type === 'layout' && insideLayout}
-                    onSelect={() => handleInsert(type)}
-                >
-                    <Icon className="size-4 me-2 shrink-0" />
-                    {typeLabel}
-                </ContextMenu.Item>
-            ))}
-        </>
+        <ContextMenu.Sub>
+            <ContextMenu.SubTrigger>{label}</ContextMenu.SubTrigger>
+            <ContextMenu.Portal>
+                <ContextMenu.SubContent className="min-w-48">
+                    {items.map(({type, Icon, label: itemLabel, disabled}) => (
+                        <ContextMenu.Item
+                            key={type}
+                            disabled={disabled}
+                            onSelect={() => handleInsert(type)}
+                        >
+                            <Icon className="size-4 me-2 shrink-0" />
+                            {itemLabel}
+                        </ContextMenu.Item>
+                    ))}
+                </ContextMenu.SubContent>
+            </ContextMenu.Portal>
+        </ContextMenu.Sub>
     );
 };
 
-InsertSection.displayName = 'InsertSection';
+InsertSubMenu.displayName = 'InsertSubMenu';

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsItem.tsx
@@ -1,6 +1,6 @@
 import type {SortableListItemContext} from '@enonic/lib-admin-ui/form2/components';
 import {cn} from '@enonic/ui';
-import {Box, ChevronRight, Columns2, Globe, type LucideIcon, OctagonAlert, Puzzle, Type,} from 'lucide-react';
+import {Box, ChevronRight, Columns2, Globe, type LucideIcon, OctagonAlert, PenLine, Puzzle} from 'lucide-react';
 import {type MouseEvent, type ReactElement} from 'react';
 import type {FlatNode} from '../../../../lib/tree-store';
 import type {PageComponentNodeData, PageComponentNodeType} from './types';
@@ -25,7 +25,7 @@ const NODE_TYPE_ICON: Partial<Record<PageComponentNodeType, LucideIcon>> = {
     page: Globe,
     part: Box,
     layout: Columns2,
-    text: Type,
+    text: PenLine,
     fragment: Puzzle,
 };
 
@@ -87,8 +87,8 @@ export const PageComponentsItem = ({
                     type="button"
                     tabIndex={-1}
                     className={cn(
-                        'flex items-center justify-center size-5 shrink-0 cursor-pointer',
-                        selected ? 'text-alt' : 'text-subtle hover:text-primary',
+                        'flex items-center justify-center size-5 shrink-0 cursor-pointer hover:text-main',
+                        selected ? 'text-alt' : 'text-subtle',
                     )}
                     onClick={handleToggleClick}
                 >

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -45,12 +45,13 @@ export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps 
     const invalidComponentPaths = useStore($invalidComponentPaths);
     const validationVisibility = useStore($validationVisibility);
     const showErrors = validationVisibility === 'all';
+    const inspectedPath = useStore($inspectedPath);
     const [flatNodes, setFlatNodes] = useState(() => [...$componentsFlatNodes.get()]);
+
     useEffect(() => {
         setFlatNodes([...$componentsFlatNodes.get()]);
         return $componentsFlatNodes.listen((nodes) => setFlatNodes([...nodes]));
     }, []);
-    const inspectedPath = useStore($inspectedPath);
 
     useEffect(() => {
         rebuildComponentsTree();


### PR DESCRIPTION
Rewrote `PageComponentsContextMenu` to mirror the modernized Page Editor's context menu (without the type-name header). Both call sites (`DetachedPageComponentsView` and the regular Components tab) get the new menu.

- Replaced the inline collapsible Insert section with a `ContextMenu.Sub` submenu.
- Added `Inspect` to the page-root menu.
- Switched the Text insert icon from `Type` to `PenLine` to match the editor.
- Localized Insert item labels via `field.part` / `field.layout` / `field.text` / `field.fragment`.

Closes #10294

<sub>*Drafted with AI assistance*</sub>
