### PR TITLE
Page Editor: prevent full reload after changing part descriptor #10320

### DIFF
--- a/modules/app/src/main/resources/assets/js/page-editor.ts
+++ b/modules/app/src/main/resources/assets/js/page-editor.ts
@@ -1,10 +1,8 @@
 import {HTMLAreaHelper} from '@enonic/lib-contentstudio/app/inputtype/ui/text/HTMLAreaHelper';
 import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
-import {DescriptorBasedComponent} from '@enonic/lib-contentstudio/app/page/region/DescriptorBasedComponent';
 import {FragmentComponent} from '@enonic/lib-contentstudio/app/page/region/FragmentComponent';
 import {RenderingMode} from '@enonic/lib-contentstudio/app/rendering/RenderingMode';
 import {UriHelper} from '@enonic/lib-contentstudio/app/rendering/UriHelper';
-import {PageHelper} from '@enonic/lib-contentstudio/app/util/PageHelper';
 import {PageState} from '@enonic/lib-contentstudio/app/wizard/page/PageState';
 import {ComponentPath as EditorComponentPath, EditorEvent, EditorEvents, PageEditor} from '@enonic/page-editor';
 import DOMPurify from 'dompurify';
@@ -26,7 +24,7 @@ async function handleComponentLoad(path: EditorComponentPath, isExisting: boolea
     try {
         const response = await fetch(resolveComponentUrl(path));
 
-        if (!isExisting && needsPageReload(path, response.headers)) {
+        if (!isExisting && needsPageReload(response.headers)) {
             PageEditor.reloadPage();
             return;
         }
@@ -43,17 +41,12 @@ function resolveComponentUrl(path: EditorComponentPath): string {
     return UriHelper.getComponentUri(contentId, toComponentPath(path), RenderingMode.EDIT);
 }
 
-function needsPageReload(path: EditorComponentPath, headers: Headers): boolean {
-    if (!headers.has('X-Has-Contributions')) return false;
-
-    const component = PageState.getComponentByPath(toComponentPath(path));
-    if (!(component instanceof DescriptorBasedComponent)) return false;
-
-    const key = component.getDescriptorKey();
-    return !PageHelper.flattenPageComponents(PageState.getState())
-        .some(c => !c.getPath().equals(path)
-            && c instanceof DescriptorBasedComponent
-            && c.getDescriptorKey()?.equals(key));
+// ! Reload when the component declares page contributions — they must be
+// ! injected into <head>/<body>, which only a full reload does. We don't dedup
+// ! against other instances of the same descriptor: the iframe's PageState is
+// ! a separate singleton from the parent's, so the lookup can't function here.
+function needsPageReload(headers: Headers): boolean {
+    return headers.has('X-Has-Contributions');
 }
 
 function sanitizeComponentHtml(html: string, path: EditorComponentPath): string {

--- a/modules/lib/src/main/resources/assets/js/app/page/region/ConfigBasedComponent.ts
+++ b/modules/lib/src/main/resources/assets/js/app/page/region/ConfigBasedComponent.ts
@@ -1,11 +1,11 @@
-import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
 import {type Equitable} from '@enonic/lib-admin-ui/Equitable';
-import {PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
+import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
 import {type PropertyEvent} from '@enonic/lib-admin-ui/data/PropertyEvent';
+import {PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
 import {PropertyTreeHelper} from '@enonic/lib-admin-ui/util/PropertyTreeHelper';
 import {Component, ComponentBuilder} from './Component';
-import {type ConfigBasedComponentJson} from './ConfigBasedComponentJson';
 import {ComponentConfigUpdatedEvent} from './ComponentConfigUpdatedEvent';
+import {type ConfigBasedComponentJson} from './ConfigBasedComponentJson';
 
 
 export abstract class ConfigBasedComponent
@@ -57,7 +57,11 @@ export abstract class ConfigBasedComponent
 
         const other: ConfigBasedComponent = o as ConfigBasedComponent;
 
-        return PropertyTreeHelper.propertyTreesEqual(this.config, other.config, false);
+        // ! Ignore empty values when comparing component configs. v6 form
+        // ! rendering (useSetPropertyArray) lazily seeds empty PropertyArrays
+        // ! onto the live PropertyTree, which would otherwise keep the wizard
+        // ! permanently dirty after save. Aligns with Page.equals default.
+        return PropertyTreeHelper.propertyTreesEqual(this.config, other.config);
     }
 }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -157,6 +157,7 @@ import {type DefaultModels} from './page/DefaultModels';
 import {LiveEditPageProxy} from './page/LiveEditPageProxy';
 import {LiveFormPanel, type LiveFormPanelConfig} from './page/LiveFormPanel';
 import {PageState} from './page/PageState';
+import {PageStateEvent} from '../../page-editor/event/incoming/common/PageStateEvent';
 import {PageComponentsView} from './PageComponentsView';
 import {PageComponentsWizardStep} from './PageComponentsWizardStep';
 import {PageComponentsWizardStepForm} from './PageComponentsWizardStepForm';
@@ -1882,6 +1883,18 @@ export class ContentWizardPanel
             this.updateSiteModel(site);
         } else if (site) {
             this.initSiteModel(site);
+        }
+
+        // ! Sync PageState with the persisted page after save. Otherwise the
+        // ! onContentUpdated path sees viewedContent ≠ contentAfterLayout and
+        // ! triggers a full iframe reload via debouncedEditorReload.
+        // ! PageStateEvent mirrors the new state into the iframe; setState
+        // ! alone fires no event.
+        const incomingPage = content.getPage();
+        const stalePage = PageState.getState();
+        if (stalePage !== incomingPage) {
+            PageState.setState(incomingPage ? incomingPage.clone() : null);
+            new PageStateEvent(PageState.getState()?.toJson() ?? null).fire();
         }
 
         this.liveEditModel = this.initLiveEditModel(content);

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/PageState.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/PageState.ts
@@ -257,7 +257,11 @@ export class PageStateEventHandler {
             const item: PageItem = PageState.getState().getComponentByPath(path);
 
             if (item instanceof DescriptorBasedComponent) {
-                const notifyReload = () => PageEventsManager.get().notifyComponentReloadRequested(path, true);
+                // ! existing=false so the iframe-side handler can check the
+                // ! X-Has-Contributions response header and reload the page
+                // ! when the new descriptor brings contributions that must be
+                // ! injected into <head>/<body>.
+                const notifyReload = () => PageEventsManager.get().notifyComponentReloadRequested(path, false);
                 if (descriptorKey) {
                     new GetComponentDescriptorRequest(descriptorKey.toString(), item.getType()).sendAndParse()
                         .then((descriptor: Descriptor) => item.setDescriptor(descriptor))


### PR DESCRIPTION
Fixes four bugs that combined to make Page Editor reload the entire content on descriptor change, leave the wizard permanently dirty, and skip the reload that parts with `pageContributions` actually need.

- `ContentWizardPanel.updateLiveEditModel`: sync `PageState` with the persisted page after save and mirror to the iframe via `PageStateEvent`. Without this, `fetchContentAndUpdate` saw `viewedContent` ≠ `contentAfterLayout` and triggered a full iframe reload through `debouncedEditorReload`.
- `ConfigBasedComponent.equals`: drop the strict third argument so component-config comparison ignores empty values, matching `Page.equals`. Form rendering (`useSetPropertyArray`) lazily seeds empty `PropertyArray`s onto the live tree, which kept the Save button stuck under strict comparison.
- `PageState.onComponentDescriptorSetRequested`: pass `existing=false` so the iframe-side `!isExisting && needsPageReload(...)` check actually runs for descriptor changes. Apply button (form-only edits) still uses `existing=true`.
- `modules/app/.../page-editor.ts` `needsPageReload`: reduce to a header-only check. The previous descriptor-dedup compared two distinct `ComponentPath` classes (lib-contentstudio vs `@enonic/page-editor`'s re-export) whose `equals()` rejects each other, so the current component always self-matched. The dedup also can't function from iframe scope — `PageState` there is a separate singleton.

Closes #10320

<sub>*Drafted with AI assistance*</sub>
