### PR TITLE
Page Editor: cannot add components inside a newly added layout #10336

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -25,6 +25,7 @@ import {AppHelper} from '@enonic/lib-admin-ui/util/AppHelper';
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {type ValidityChangedEvent} from '@enonic/lib-admin-ui/ValidityChangedEvent';
 import Q from 'q';
+import {PageStateEvent} from '../../page-editor/event/incoming/common/PageStateEvent';
 import {LiveEditModel} from '../../page-editor/LiveEditModel';
 import {compareContent} from '../../v6/features/api/compare';
 import {cleanupWizardMixinsService, initWizardMixinsService} from '../../v6/features/services/wizardMixins.service';
@@ -40,10 +41,10 @@ import {
     requestDisplayNameInputFocus,
     resetWizardContent,
     setContentFormExpanded,
-    setContentType as setWizardContentType,
     setDraftPage,
-    setPersistedContent as setWizardPersistedContent,
+    setContentType as setWizardContentType,
     setWizardMarkedAsReady,
+    setPersistedContent as setWizardPersistedContent,
     setWizardReadOnly,
 } from '../../v6/features/store/wizardContent.store';
 import {escalateVisibility, initializeValidation, setServerValidationErrors} from '../../v6/features/store/wizardValidation.store';
@@ -112,7 +113,6 @@ import {type DefaultModels} from './page/DefaultModels';
 import {LiveEditPageProxy} from './page/LiveEditPageProxy';
 import {LiveFormPanel, type LiveFormPanelConfig} from './page/LiveFormPanel';
 import {PageState} from './page/PageState';
-import {PageStateEvent} from '../../page-editor/event/incoming/common/PageStateEvent';
 import {PageEventsManager} from './PageEventsManager';
 import {PersistNewContentRoutine} from './PersistNewContentRoutine';
 import {ThumbnailUploaderEl} from './ThumbnailUploaderEl';
@@ -1246,18 +1246,6 @@ export class ContentWizardPanel
     private updateLiveEditModel(content: Content): void {
         if (ContentWizardPanel.debug) {
             console.debug('ContentWizardPanel.updateLiveEditModel for: ' + content.getPath().toString());
-        }
-
-        // ! Sync PageState with the persisted page after save. Otherwise the
-        // ! onContentUpdated path sees viewedContent ≠ contentAfterLayout and
-        // ! triggers a full iframe reload via debouncedEditorReload.
-        // ! PageStateEvent mirrors the new state into the iframe; setState
-        // ! alone fires no event.
-        const incomingPage = content.getPage();
-        const stalePage = PageState.getState();
-        if (stalePage !== incomingPage) {
-            PageState.setState(incomingPage ? incomingPage.clone() : null);
-            new PageStateEvent(PageState.getState()?.toJson() ?? null).fire();
         }
 
         this.liveEditModel = this.initLiveEditModel(content);


### PR DESCRIPTION
Reverted the `PageState.setState` block introduced in `ContentWizardPanel.updateLiveEditModel` by #10320.

`PageState.setState` swaps the singleton's state reference without firing `PageEventsHolder.notifyPageUpdated`, so the v6 store's `$page` atom never re-syncs and the components tree keeps reading the stale pre-sync Page. Inserts mutated the new Page in `PageState`; the tree never reflected them.

The lenient `ConfigBasedComponent.equals` fix from #10320 already covers the `viewedContent` vs `contentAfterLayout` divergence the sync was meant to address. Removing the sync restores pre-#10320 behavior while keeping the original wizard-dirty and full-iframe-reload fixes intact.

Closes #10336

<sub>*Drafted with AI assistance*</sub>
