### PR TITLE
Alternative text input should be disabled when the radio button is not selected #10332

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-image/ImageAccessibilityField.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-image/ImageAccessibilityField.tsx
@@ -53,16 +53,15 @@ export const ImageAccessibilityField = (): ReactElement => {
                 </RadioGroup.Item>
             </RadioGroup.Root>
 
-            {accessibility === 'informative' && (
                 <div ref={scrollRef}>
                     <Input
                         value={altText}
                         placeholder={altTextPlaceholder}
                         onChange={(event) => setAltText(event.currentTarget.value)}
                         error={altTextError}
+                        disabled={accessibility !== 'informative'}
                     />
                 </div>
-            )}
         </div>
     );
 };


### PR DESCRIPTION
Display alternative text as disabled when an image is set as decorative and enabled when the alternative text is chosen.
<img width="896" height="1094" alt="image" src="https://github.com/user-attachments/assets/e1826464-f0b2-40bb-92ee-516e87a2ddad" />
<img width="896" height="1094" alt="image" src="https://github.com/user-attachments/assets/a7e7d9de-7a3a-45b7-a997-5338d8e891f3" />
