### PR TITLE
PageComponentsView: keep regions expanded by default #10326

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -1,7 +1,7 @@
 import {SortableList, type SortableListItemContext} from '@enonic/lib-admin-ui/form2/components';
 import {cn} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
-import {type ReactElement, useCallback, useEffect, useState} from 'react';
+import {type ReactElement, useCallback, useEffect, useRef, useState} from 'react';
 import {ComponentPath} from '../../../../../../app/page/region/ComponentPath';
 import {PageNavigationEvent} from '../../../../../../app/wizard/PageNavigationEvent';
 import {PageNavigationEventData} from '../../../../../../app/wizard/PageNavigationEventData';
@@ -20,6 +20,7 @@ import {
     $componentsTreeState,
     collapseComponentNode,
     computeMovedItemPath,
+    expandPathToComponent,
     hasLayoutAncestor,
     rebuildComponentsTree,
     remapExpandedIdsAfterMove,
@@ -40,6 +41,7 @@ export type PageComponentsViewProps = {
 };
 
 export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps = {}): ReactElement => {
+    const containerRef = useRef<HTMLDivElement>(null);
     const componentsLabel = useI18n('field.components');
     const pageVersion = useStore($pageVersion);
     const invalidComponentPaths = useStore($invalidComponentPaths);
@@ -56,6 +58,18 @@ export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps 
     useEffect(() => {
         rebuildComponentsTree();
     }, [pageVersion]);
+
+    useEffect(() => {
+        if (inspectedPath == null) return;
+        expandPathToComponent(inspectedPath);
+        const handle = requestAnimationFrame(() => {
+            const el = containerRef.current?.querySelector<HTMLElement>(
+                `[data-node-id="${CSS.escape(inspectedPath)}"]`,
+            );
+            el?.scrollIntoView({behavior: 'smooth', block: 'nearest', inline: 'nearest'});
+        });
+        return () => cancelAnimationFrame(handle);
+    }, [inspectedPath]);
 
     const handleMove = useCallback((fromIndex: number, toIndex: number): void => {
         const sourceNode = flatNodes[fromIndex];
@@ -165,7 +179,7 @@ export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps 
     }, [handleSelect, inspectedPath, showErrors, invalidComponentPaths]);
 
     return (
-        <div data-component={PAGE_COMPONENTS_VIEW_NAME} className="flex flex-col gap-1 py-2">
+        <div ref={containerRef} data-component={PAGE_COMPONENTS_VIEW_NAME} className="flex flex-col gap-1 py-2">
             {showTitle && <h3 className="text-base font-semibold">{componentsLabel}</h3>}
             <SortableList
                 items={flatNodes}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/pageComponents.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/pageComponents.store.ts
@@ -13,6 +13,7 @@ import {
     createEmptyState,
     expand,
     expandAll,
+    expandToNode,
     flattenTree,
     getAncestorIds,
     getNode,
@@ -63,6 +64,10 @@ export function expandComponentNode(id: string): void {
 
 export function collapseComponentNode(id: string): void {
     $componentsTreeState.set(collapse($componentsTreeState.get(), id));
+}
+
+export function expandPathToComponent(id: string): void {
+    $componentsTreeState.set(expandToNode($componentsTreeState.get(), id));
 }
 
 export function computeMovedItemPath(fromPath: string, toPath: string): string {
@@ -161,6 +166,14 @@ function buildTreeFromPage(
         // First build: expand all nodes that have children
         state = expandAll(state);
     }
+
+    const expandedIds = new Set(state.expandedIds);
+    for (const [id, node] of state.nodes) {
+        if (node.data?.nodeType === 'region' && node.childIds.length === 0) {
+            expandedIds.add(id);
+        }
+    }
+    state = {...state, expandedIds};
 
     return state;
 }


### PR DESCRIPTION
- Force-expanded any region with no children after rebuilding the tree, so empty regions stay open and never hide newly added items.
- Added `expandPathToComponent` and subscribed the view to `$inspectedPath` so ancestors of the selected node auto-expand on every selection source (tree, preview, context menu, post-move).
- Scrolled the matched `[data-node-id]` into view via `scrollIntoView` with `behavior: 'smooth'` and `block`/`inline: 'nearest'`, deferred in `requestAnimationFrame` to run after the expansion-driven re-render.

Closes #10326 