### PR TITLE
InspectPanel: switch to Insert panel after page controller selection …

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/index.ts
@@ -2,6 +2,7 @@
 export {$contentContext, $defaultPageTemplateName, $pageEditorLifecycle} from './store';
 export {$hasControllerOrTemplate, $isFragment, $isInsertTabAvailable} from './store';
 export {$isInspecting, $inspectedPath, $inspectedItem, $inspectedItemType, $selectionEventNonce} from './store';
+export {$insertTabActivateNonce, bumpInsertTabActivateNonce} from './store';
 export {$dragState, startDrag, updateDrag, endDrag} from './drag';
 
 // Read: hooks

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/store.ts
@@ -34,6 +34,8 @@ export const $inspectedPath = atom<string | null>(null);
 // ? with an identical value would otherwise swallow.
 export const $selectionEventNonce = atom<number>(0);
 
+export const $insertTabActivateNonce = atom<number>(0);
+
 //
 // * Computed
 //
@@ -87,6 +89,10 @@ export function bumpPageVersion(): void {
 
 export function bumpSelectionEventNonce(): void {
     $selectionEventNonce.set($selectionEventNonce.get() + 1);
+}
+
+export function bumpInsertTabActivateNonce(): void {
+    $insertTabActivateNonce.set($insertTabActivateNonce.get() + 1);
 }
 
 export function syncPageFromState(): void {

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/PageEditorExtension.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/PageEditorExtension.tsx
@@ -3,7 +3,7 @@ import {useStore} from '@nanostores/preact';
 import {type ReactElement} from 'react';
 import {useI18n} from '../../../../hooks/useI18n';
 import {$activeWidgetId, $isContextOpen} from '../../../../store/contextWidgets.store';
-import {$dragState, $inspectedPath, $isInsertTabAvailable, $selectionEventNonce} from '../../../../store/page-editor';
+import {$dragState, $inspectedPath, $insertTabActivateNonce, $isInsertTabAvailable, $selectionEventNonce} from '../../../../store/page-editor';
 import {PAGE_EDITOR_WIDGET_KEY} from '../../../../utils/widget/pageEditor';
 import {usePageEditorTabs} from './hooks/usePageEditorTabs';
 import {DragPreview} from './insert/DragPreview';
@@ -18,9 +18,10 @@ export const PageEditorExtension = (): ReactElement | null => {
     const isInsertTabAvailable = useStore($isInsertTabAvailable);
     const inspectedPath = useStore($inspectedPath);
     const selectionEventNonce = useStore($selectionEventNonce);
+    const insertTabActivateNonce = useStore($insertTabActivateNonce);
     const dragState = useStore($dragState);
 
-    const {activeTab, setActiveTab} = usePageEditorTabs(inspectedPath, isInsertTabAvailable, selectionEventNonce);
+    const {activeTab, setActiveTab} = usePageEditorTabs(inspectedPath, isInsertTabAvailable, selectionEventNonce, insertTabActivateNonce);
 
     const insertLabel = useI18n('action.insert');
     const inspectLabel = useI18n('action.inspect');

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/hooks/usePageEditorTabs.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/hooks/usePageEditorTabs.ts
@@ -9,6 +9,7 @@ export function usePageEditorTabs(
     inspectedPath: string | null,
     isInsertTabAvailable: boolean,
     selectionEventNonce: number,
+    insertTabActivateNonce: number,
 ): UsePageEditorTabsResult {
     const [activeTab, setActiveTab] = useState<string>('inspect');
 
@@ -30,6 +31,12 @@ export function usePageEditorTabs(
             setActiveTab('inspect');
         }
     }, [activeTab, isInsertTabAvailable]);
+
+    useEffect(() => {
+        if (insertTabActivateNonce > 0 && isInsertTabAvailable) {
+            setActiveTab('insert');
+        }
+    }, [insertTabActivateNonce, isInsertTabAvailable]);
 
     return {activeTab, setActiveTab};
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/hooks/usePageControllerSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/hooks/usePageControllerSelector.ts
@@ -7,6 +7,7 @@ import {useI18n} from '../../../../../../../hooks/useI18n';
 import {
     $contentContext,
     $defaultPageTemplateName,
+    bumpInsertTabActivateNonce,
     executePageReset,
     requestSetPageController,
     requestSetPageTemplate,
@@ -135,10 +136,16 @@ export function usePageControllerSelector(): UsePageControllerSelectorResult {
                 executePageReset();
             } else if (newType === 'template') {
                 const template = templates.find(t => t.getKey().toString() === newKey);
-                if (template) requestSetPageTemplate(template.getKey());
+                if (template) {
+                    requestSetPageTemplate(template.getKey());
+                    bumpInsertTabActivateNonce();
+                }
             } else {
                 const controller = controllers.find(c => c.getKey().toString() === newKey);
-                if (controller) requestSetPageController(controller.getKey());
+                if (controller) {
+                    requestSetPageController(controller.getKey());
+                    bumpInsertTabActivateNonce();
+                }
             }
         },
         [getOptionType, templates, controllers],


### PR DESCRIPTION
…#10325

Added $insertTabActivateNonce nanostore plus bumpInsertTabActivateNonce helper. Bumped from usePageControllerSelector after a controller or template is set (skipped on Automatic reset). usePageEditorTabs now takes the nonce and surfaces the Insert tab when it changes and the tab is available.