### PR TITLE
ItemViewContextMenu: adopt new context menu design #10323

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/WizardExtensionRenderingHandler.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/WizardExtensionRenderingHandler.ts
@@ -4,94 +4,53 @@ import {DivEl} from '@enonic/lib-admin-ui/dom/DivEl';
 import {type ViewExtensionEvent} from '../event/ViewExtensionEvent';
 import {type ContentSummary} from '../content/ContentSummary';
 import Q from 'q';
-import {i18n} from '@enonic/lib-admin-ui/util/Messages';
-import {PageNavigationMediator} from './PageNavigationMediator';
-import {PageNavigationEvent} from './PageNavigationEvent';
-import {PageNavigationEventType} from './PageNavigationEventType';
-import {PageNavigationEventData} from './PageNavigationEventData';
-import {ComponentPath} from '../page/region/ComponentPath';
-import {ItemViewContextMenu} from '../../page-editor/ItemViewContextMenu';
-import {Action} from '@enonic/lib-admin-ui/ui/Action';
-import {PageViewContextMenuTitle} from '../../page-editor/PageViewContextMenuTitle';
-import {type ItemViewContextMenuTitle} from '../../page-editor/ItemViewContextMenuTitle';
+import {PreviewContextMenuElement} from '../../v6/features/shared/PreviewContextMenu';
 
 export class WizardExtensionRenderingHandler
     extends ExtensionRenderingHandler {
 
     private hasControllersDeferred: Q.Deferred<boolean>;
     private hasPageDeferred: Q.Deferred<boolean>;
-    private contextMenu: ItemViewContextMenu;
-    private contextMenuTitle: ItemViewContextMenuTitle;
-    private shader: DivEl;
+    private emptyMenu: PreviewContextMenuElement;
+    private errorMenu: PreviewContextMenuElement;
 
     constructor(renderer: ExtensionRenderer) {
         super(renderer);
         this.mode = RenderingMode.EDIT;
-        this.contextMenu = this.initContextMenu();
-        this.shader = new DivEl('shader');
-        this.contextMenu.onShown((e) => this.shader.addClass('visible'));
-        this.contextMenu.onHidden((e) => this.shader.removeClass('visible'));
     }
 
     protected createEmptyView(): DivEl {
-        const placeholderView = super.createMessageView(this.getDefaultMessage(), 'no-selection-message');
-
-        const handler = this.clickHandler.bind(this)
-
-        placeholderView.onClicked(handler);
-        placeholderView.onContextMenu(handler);
-
-        return placeholderView;
+        const wrapper = new DivEl('no-selection-message');
+        this.emptyMenu = new PreviewContextMenuElement({
+            pageName: '',
+            messages: [this.getDefaultMessage()],
+            showIcon: false,
+        });
+        wrapper.appendChild(this.emptyMenu);
+        return wrapper;
     }
 
     protected createErrorView(): DivEl {
-        const errorView = super.createErrorView();
-
-        const handler = this.clickHandler.bind(this)
-
-        errorView.onClicked(handler);
-        errorView.onContextMenu(handler);
-
-        return errorView;
+        const wrapper = new DivEl('no-preview-message bg-surface-primary');
+        this.errorMenu = new PreviewContextMenuElement({
+            pageName: '',
+            messages: [this.getDefaultMessage()],
+            showIcon: true,
+        });
+        wrapper.appendChild(this.errorMenu);
+        return wrapper;
     }
 
-    private clickHandler(event: MouseEvent): void {
-        event.stopPropagation();
-        event.preventDefault();
-        const isMenuVisible = this.contextMenu.isVisible();
-        if (isMenuVisible) {
-            this.contextMenu.hide();
-        } else {
-            this.contextMenu.showAt(event.pageX, event.pageY);
-        }
-    };
-
-    private initContextMenu(): ItemViewContextMenu {
-        const unlockAction = new Action(i18n('action.page.settings'));
-        unlockAction.onExecuted(() => {
-            PageNavigationMediator.get().notify(
-                new PageNavigationEvent(PageNavigationEventType.INSPECT, new PageNavigationEventData(ComponentPath.root())));
-        });
-
-        this.contextMenuTitle = new PageViewContextMenuTitle('');
-
-        const contextMenu = new ItemViewContextMenu(this.contextMenuTitle, [unlockAction]);
-        contextMenu.onTouchEnd((event: TouchEvent) => {
-            event.stopPropagation();
-        });
-
-        return contextMenu;
-    }
-
-    layout() {
-        super.layout();
-        this.renderer.getChildrenContainer().appendChild(this.shader);
+    protected showPreviewMessages(messages: string[]) {
+        this.errorMenu?.setProps({messages, showIcon: true});
     }
 
     async render(summary: ContentSummary, widget): Promise<boolean> {
         this.hasControllersDeferred = Q.defer<boolean>();
         this.hasPageDeferred = Q.defer<boolean>();
-        this.contextMenuTitle.setMainName(summary.getDisplayName());
+        const pageName = summary.getDisplayName();
+        this.emptyMenu?.setProps({pageName});
+        this.errorMenu?.setProps({pageName});
         return super.render(summary, widget);
     }
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/PreviewContextMenu.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/PreviewContextMenu.tsx
@@ -1,0 +1,81 @@
+import {ContextMenu} from '@enonic/ui';
+import {Globe} from 'lucide-react';
+import {type MouseEvent as ReactMouseEvent, type ReactElement, useCallback} from 'react';
+import {ComponentPath} from '../../../app/page/region/ComponentPath';
+import {PageNavigationEvent} from '../../../app/wizard/PageNavigationEvent';
+import {PageNavigationEventData} from '../../../app/wizard/PageNavigationEventData';
+import {PageNavigationEventType} from '../../../app/wizard/PageNavigationEventType';
+import {PageNavigationMediator} from '../../../app/wizard/PageNavigationMediator';
+import {useI18n} from '../hooks/useI18n';
+import {LegacyElement} from './LegacyElement';
+import {PreviewLabel} from './PreviewLabel';
+
+const PREVIEW_CONTEXT_MENU_NAME = 'PreviewContextMenu';
+
+export type PreviewContextMenuProps = {
+    pageName: string;
+    messages: string[];
+    showIcon?: boolean;
+};
+
+export const PreviewContextMenu = ({pageName, messages, showIcon}: PreviewContextMenuProps): ReactElement => {
+    const inspectLabel = useI18n('action.page.settings');
+
+    // Re-route primary clicks as contextmenu events so the placeholder opens
+    // the menu on click as well as on right-click, preserving the legacy UX.
+    const handleClick = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+        if (event.button !== 0) return;
+        event.preventDefault();
+        event.currentTarget.dispatchEvent(new MouseEvent('contextmenu', {
+            bubbles: true,
+            cancelable: true,
+            clientX: event.clientX,
+            clientY: event.clientY,
+            button: 2,
+            view: window,
+        }));
+    }, []);
+
+    const handleInspect = useCallback(() => {
+        PageNavigationMediator.get().notify(
+            new PageNavigationEvent(PageNavigationEventType.INSPECT, new PageNavigationEventData(ComponentPath.root())),
+        );
+    }, []);
+
+    return (
+        <ContextMenu data-component={PREVIEW_CONTEXT_MENU_NAME}>
+            <ContextMenu.Trigger
+                className="flex h-full w-full items-center justify-center"
+                onClick={handleClick}
+            >
+                <PreviewLabel messages={messages} showIcon={showIcon} className="text-xl" />
+            </ContextMenu.Trigger>
+            <ContextMenu.Portal>
+                <ContextMenu.Content className="min-w-48">
+                    <div className="flex items-center gap-2 px-2 py-1.5 text-sm font-semibold text-main">
+                        <Globe className="size-4 shrink-0" aria-hidden />
+                        <span className="truncate">{pageName}</span>
+                    </div>
+                    <div className="my-1 border-t border-bdr-soft" aria-hidden />
+                    <ContextMenu.Item onSelect={handleInspect}>
+                        {inspectLabel}
+                    </ContextMenu.Item>
+                </ContextMenu.Content>
+            </ContextMenu.Portal>
+        </ContextMenu>
+    );
+};
+
+PreviewContextMenu.displayName = PREVIEW_CONTEXT_MENU_NAME;
+
+//
+// * Backward compatibility
+//
+
+export class PreviewContextMenuElement extends LegacyElement<typeof PreviewContextMenu> {
+
+    constructor(props: PreviewContextMenuProps) {
+        super(props, PreviewContextMenu);
+        this.addClass('size-full');
+    }
+}


### PR DESCRIPTION
Introduced PreviewContextMenu in v6/features/shared, a Radix-based @enonic/ui ContextMenu that wraps the empty/error iframe placeholder and surfaces the page title + an Inspect Page action.

Refactored WizardExtensionRenderingHandler to render the new bridge inside the no-selection / no-preview wrappers, dropped the legacy ItemViewContextMenu, draggable title, and shader plumbing.

Click on the placeholder is re-routed as a synthetic contextmenu event so left-click and right-click both open the menu, preserving the legacy UX.