### PR TITLE
Changing a current project disrupts requests in Content Wizard #10334

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
@@ -41,7 +41,7 @@ export const $projects = map<ProjectsStore>({
 syncMapStore($projects, SYNC_NAME, {
     keys: ['activeProjectId'],
     loadInitial: true,
-    syncTabs: true,
+    syncTabs: false,
 });
 
 export const $activeProject = computed($projects, (store) => {


### PR DESCRIPTION
- Don't sync active project in-between tabs, each must handle active project independently