### PR TITLE
Page Editor: unify Reset confirmation dialog and fix Reset flow #10364

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -856,7 +856,17 @@ export class ContentWizardPanel
 
         PageState.getEvents().onPageReset(() => {
             this.setMarkedAsReady(false);
-            this.saveChanges(true).catch(DefaultErrorHandler.handle);
+
+            // ! When persisted content already has no page (e.g. after a prior
+            // ! reset followed by Customize Page, which mutates only in-memory
+            // ! PageState), saveChanges short-circuits and never reloads the
+            // ! iframe — leaving the customized page visible. Force a reload
+            // ! in that case; otherwise saveChanges handles it.
+            if (this.getPersistedItem()?.getPage()) {
+                this.saveChanges(true).catch(DefaultErrorHandler.handle);
+            } else {
+                void this.getLivePanel()?.loadPage(true);
+            }
         });
 
         // to be changed: make default models static and remove that call by directly using DefaultModels in PageState

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/PageState.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/PageState.ts
@@ -41,8 +41,6 @@ import {type PageTemplate} from '../../content/PageTemplate';
 import {LayoutComponent} from '../../page/region/LayoutComponent';
 import Q from 'q';
 import {type ComponentTextUpdatedOrigin} from '../../page/region/ComponentTextUpdatedOrigin';
-import {ConfirmationDialog} from '@enonic/lib-admin-ui/ui/dialog/ConfirmationDialog';
-import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {PageStateEvent} from '../../../page-editor/event/incoming/common/PageStateEvent';
 
 export class PageState {
@@ -238,16 +236,8 @@ export class PageStateEventHandler {
             });
         });
 
-        PageEventsManager.get().onPageResetRequested(() => {
-            new ConfirmationDialog()
-                .setQuestion(i18n('dialog.page.reset.confirmation'))
-                .setYesCallback(() => {
-                    PageState.setState(null);
-                    new PageStateEvent(null).fire();
-                    this.pageEventsHolder.notifyPageReset();
-                })
-                .open();
-        });
+        // ! Page reset confirmation is owned by the v6 PageResetDialog which
+        // ! listens for `onPageResetRequested` and calls `executePageReset`.
 
         PageEventsManager.get().onComponentDescriptorSetRequested((path: ComponentPath, descriptorKey: DescriptorKey) => {
             if (!PageState.getState()) {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/commands.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/page-editor/commands.ts
@@ -6,6 +6,7 @@ import type {PageTemplateKey} from '../../../../app/page/PageTemplateKey';
 import {PageStateEvent} from '../../../../page-editor/event/incoming/common/PageStateEvent';
 import {PageEventsManager} from '../../../../app/wizard/PageEventsManager';
 import {PageState} from '../../../../app/wizard/page/PageState';
+import {setDraftPage} from '../wizardContent.store';
 import {$hasDefaultPageTemplate, $inspectedPath, $pageEditorLifecycle, bumpSelectionEventNonce} from './store';
 
 //
@@ -44,10 +45,12 @@ export function requestPageReset(): void {
     PageEventsManager.get().notifyPageResetRequested();
 }
 
-// ? Performs the page reset directly, bypassing the legacy
-// ? confirmation dialog in PageState.onPageResetRequested.
+// ? $wizardDraftPage must be cleared before notifyPageReset fires —
+// ? the save listener synchronously reads it via buildViewedContentFromStore,
+// ? and the listener that syncs the draft from PageState runs too late.
 export function executePageReset(): void {
     PageState.setState(null);
+    setDraftPage(null);
     new PageStateEvent(null).fire();
     PageState.getEvents().notifyPageReset();
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageInspectionPanel.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageInspectionPanel.tsx
@@ -4,7 +4,13 @@ import {type ReactElement, useCallback, useState} from 'react';
 import {useI18n} from '../../../../../../hooks/useI18n';
 import {ConfirmationDialog} from '../../../../../../shared/dialogs/ConfirmationDialog';
 import {FormRenderer} from '../../../../../../shared/form/FormRenderer';
-import {$contentContext, $pageEditorLifecycle, requestCustomizePage, usePageState} from '../../../../../../store/page-editor';
+import {
+    $contentContext,
+    $pageEditorLifecycle,
+    bumpInsertTabActivateNonce,
+    requestCustomizePage,
+    usePageState,
+} from '../../../../../../store/page-editor';
 import {$isCustomizeVisible, $pageConfigDescriptor} from '../../../../../../store/page-inspection.store';
 import {useInspectFormTracking} from '../useInspectFormTracking';
 import {PageControllerSelector} from "./PageControllerSelector";
@@ -29,7 +35,13 @@ export const PageInspectionPanel = (): ReactElement => {
     const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogState | null>(null);
 
     const handleCustomize = useCallback((): void => {
-        setConfirmDialog({question: customizeQuestion, onConfirm: requestCustomizePage});
+        setConfirmDialog({
+            question: customizeQuestion,
+            onConfirm: () => {
+                requestCustomizePage();
+                bumpInsertTabActivateNonce();
+            },
+        });
     }, [customizeQuestion]);
 
     const hasController = page?.hasController() ?? false;

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/hooks/usePageControllerSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/hooks/usePageControllerSelector.ts
@@ -9,6 +9,7 @@ import {
     $defaultPageTemplateName,
     bumpInsertTabActivateNonce,
     executePageReset,
+    requestPageReset,
     requestSetPageController,
     requestSetPageTemplate,
     usePageState,
@@ -67,7 +68,6 @@ export function usePageControllerSelector(): UsePageControllerSelectorResult {
     const autoLabel = useI18n('widget.pagetemplate.automatic');
     const noDefaultLabel = useI18n('field.page.template.noDefault');
     const noDescriptionLabel = useI18n('text.noDescription');
-    const resetQuestion = useI18n('dialog.page.reset.confirmation');
     const templateChangeQuestion = useI18n('dialog.template.change');
     const controllerChangeQuestion = useI18n('dialog.controller.change');
 
@@ -164,9 +164,10 @@ export function usePageControllerSelector(): UsePageControllerSelectorResult {
             const oldType = selectedKey ? getOptionType(selectedKey) : undefined;
             const newType = getOptionType(newKey);
 
-            // Transitions to auto (reset) need confirmation
+            // Transitions to auto (reset) — delegated to the global PageResetDialog,
+            // which owns confirmation and calls executePageReset() on confirm.
             if (newType === 'auto' && oldType && oldType !== 'auto') {
-                setConfirmDialog({question: resetQuestion, onConfirm: () => executeSelection(newKey)});
+                requestPageReset();
                 return;
             }
 
@@ -183,7 +184,7 @@ export function usePageControllerSelector(): UsePageControllerSelectorResult {
                 executeSelection(newKey);
             }
         },
-        [selectedKey, getOptionType, executeSelection, resetQuestion, templateChangeQuestion, controllerChangeQuestion],
+        [selectedKey, getOptionType, executeSelection, templateChangeQuestion, controllerChangeQuestion],
     );
 
     const selection = selectedKey ? [selectedKey] : [];

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsContextMenu.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsContextMenu.tsx
@@ -1,7 +1,7 @@
 import {ContextMenu} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
 import {Box, Columns2, PenLine, Puzzle} from 'lucide-react';
-import {type ReactElement, type ReactNode, useCallback, useState} from 'react';
+import {type ReactElement, type ReactNode, useCallback} from 'react';
 import {SaveAsTemplateAction} from '../../../../../../app/wizard/action/SaveAsTemplateAction';
 import {ComponentPath} from '../../../../../../app/page/region/ComponentPath';
 import {ComponentType} from '../../../../../../app/page/region/ComponentType';
@@ -12,15 +12,14 @@ import {PageNavigationMediator} from '../../../../../../app/wizard/PageNavigatio
 import type {FlatNode} from '../../../../lib/tree-store';
 import {getNode} from '../../../../lib/tree-store';
 import {useI18n} from '../../../../hooks/useI18n';
-import {ConfirmationDialog} from '../../../../shared/dialogs/ConfirmationDialog';
 import {
-    executePageReset,
     inspectItem,
     requestComponentAdd,
     requestComponentCreateFragment,
     requestComponentDuplicate,
     requestComponentRemove,
     requestComponentReset,
+    requestPageReset,
 } from '../../../../store/page-editor/commands';
 import {$contentContext, $isFragment} from '../../../../store/page-editor/store';
 import {$componentsTreeState, expandComponentNode, hasLayoutAncestor, rebuildComponentsTree} from './pageComponents.store';
@@ -46,7 +45,6 @@ export const PageComponentsContextMenu = ({node, children}: PageComponentsContex
     const data = node.data;
     const isFragment = useStore($isFragment);
     const contentContext = useStore($contentContext);
-    const [confirmResetOpen, setConfirmResetOpen] = useState(false);
 
     const selectParentLabel = useI18n('action.component.select.parent');
     const insertLabel = useI18n('widget.components.insert');
@@ -56,7 +54,6 @@ export const PageComponentsContextMenu = ({node, children}: PageComponentsContex
     const duplicateLabel = useI18n('action.component.duplicate');
     const saveAsFragmentLabel = useI18n('action.component.create.fragment');
     const saveAsTemplateLabel = useI18n('action.saveAsTemplate');
-    const resetConfirmation = useI18n('dialog.page.reset.confirmation');
 
     if (data == null) {
         return <>{children}</>;
@@ -65,44 +62,19 @@ export const PageComponentsContextMenu = ({node, children}: PageComponentsContex
     const isPageRoot = data.nodeType === 'page' || node.id === ROOT_NODE_ID;
 
     if (isPageRoot) {
-        const handleReset = isFragment
-            ? () => requestComponentReset(ComponentPath.fromString(ROOT_NODE_ID))
-            : () => setConfirmResetOpen(true);
-
         return (
-            <>
-                <ContextMenu data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
-                    <ContextMenu.Trigger className="flex-1 min-w-0">{children}</ContextMenu.Trigger>
-                    <ContextMenu.Portal>
-                        <ContextMenu.Content className="min-w-48">
-                            <InspectItem nodeId={ROOT_NODE_ID} label={inspectLabel} />
-                            <PageResetItem label={resetLabel} onSelect={handleReset} />
-                            {!isFragment && !contentContext?.isPageTemplate && (
-                                <SaveAsTemplateItem label={saveAsTemplateLabel} />
-                            )}
-                        </ContextMenu.Content>
-                    </ContextMenu.Portal>
-                </ContextMenu>
-
-                {!isFragment && (
-                    <ConfirmationDialog.Root open={confirmResetOpen} onOpenChange={setConfirmResetOpen}>
-                        <ConfirmationDialog.Portal>
-                            <ConfirmationDialog.Overlay />
-                            <ConfirmationDialog.Content>
-                                <ConfirmationDialog.Body>{resetConfirmation}</ConfirmationDialog.Body>
-                                <ConfirmationDialog.Footer
-                                    intent="danger"
-                                    onConfirm={() => {
-                                        executePageReset();
-                                        setConfirmResetOpen(false);
-                                    }}
-                                    onCancel={() => setConfirmResetOpen(false)}
-                                />
-                            </ConfirmationDialog.Content>
-                        </ConfirmationDialog.Portal>
-                    </ConfirmationDialog.Root>
-                )}
-            </>
+            <ContextMenu data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
+                <ContextMenu.Trigger className="flex-1 min-w-0">{children}</ContextMenu.Trigger>
+                <ContextMenu.Portal>
+                    <ContextMenu.Content className="min-w-48">
+                        <InspectItem nodeId={ROOT_NODE_ID} label={inspectLabel} />
+                        <PageResetItem label={resetLabel} onSelect={requestPageReset} />
+                        {!isFragment && !contentContext?.isPageTemplate && (
+                            <SaveAsTemplateItem label={saveAsTemplateLabel} />
+                        )}
+                    </ContextMenu.Content>
+                </ContextMenu.Portal>
+            </ContextMenu>
         );
     }
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/layout/PageResetDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/layout/PageResetDialog.tsx
@@ -1,0 +1,52 @@
+import {useEffect, useState, type ReactElement} from 'react';
+import {ComponentPath} from '../../../../../app/page/region/ComponentPath';
+import {PageEventsManager} from '../../../../../app/wizard/PageEventsManager';
+import {useI18n} from '../../../hooks/useI18n';
+import {ConfirmationDialog} from '../../../shared/dialogs/ConfirmationDialog';
+import {$isFragment, executePageReset, requestComponentReset} from '../../../store/page-editor';
+
+const PAGE_RESET_DIALOG_NAME = 'PageResetDialog';
+const ROOT_PATH = '/';
+
+export const PageResetDialog = (): ReactElement => {
+    const [open, setOpen] = useState(false);
+    const question = useI18n('dialog.page.reset.confirmation');
+
+    useEffect(() => {
+        const handler = () => {
+            // ? Fragments delegate to a component reset on the root —
+            // ? no page-level confirmation is needed in that case.
+            if ($isFragment.get()) {
+                requestComponentReset(ComponentPath.fromString(ROOT_PATH));
+                return;
+            }
+            setOpen(true);
+        };
+
+        PageEventsManager.get().onPageResetRequested(handler);
+        return () => PageEventsManager.get().unPageResetRequested(handler);
+    }, []);
+
+    const handleConfirm = () => {
+        executePageReset();
+        setOpen(false);
+    };
+
+    return (
+        <ConfirmationDialog.Root open={open} onOpenChange={setOpen}>
+            <ConfirmationDialog.Portal>
+                <ConfirmationDialog.Overlay />
+                <ConfirmationDialog.Content data-component={PAGE_RESET_DIALOG_NAME}>
+                    <ConfirmationDialog.Body>{question}</ConfirmationDialog.Body>
+                    <ConfirmationDialog.Footer
+                        intent="danger"
+                        onConfirm={handleConfirm}
+                        onCancel={() => setOpen(false)}
+                    />
+                </ConfirmationDialog.Content>
+            </ConfirmationDialog.Portal>
+        </ConfirmationDialog.Root>
+    );
+};
+
+PageResetDialog.displayName = PAGE_RESET_DIALOG_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/layout/WizardAppShell.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/layout/WizardAppShell.tsx
@@ -13,6 +13,7 @@ import {UnpublishDialog} from '../../../shared/dialogs/unpublish/UnpublishDialog
 import {PermissionsDialog} from '../../../shared/dialogs/permissions/PermissionsDialog';
 import {NewContentDialog} from '../../../shared/dialogs/new-content/NewContentDialog';
 import {DetachedPageComponentsView} from './DetachedPageComponentsView';
+import {PageResetDialog} from './PageResetDialog';
 
 export const WizardAppShell = (): ReactElement => {
     return (
@@ -31,6 +32,7 @@ export const WizardAppShell = (): ReactElement => {
             <RenameContentDialog />
             <UnpublishDialog />
             <SortDialog />
+            <PageResetDialog />
             <DetachedPageComponentsView />
         </>
     );


### PR DESCRIPTION
Unified the Page Editor Reset confirmation behind a single v6 `PageResetDialog` and fixed the underlying reset flow.

- Added `PageResetDialog` mounted in `WizardAppShell`; listens for `onPageResetRequested` and runs `executePageReset` on confirm.
- Removed the legacy lib-admin-ui `ConfirmationDialog` from `PageState` and the inline reset dialogs in `PageComponentsContextMenu` and `usePageControllerSelector`; all entry points now call `requestPageReset`.
- Cleared `$wizardDraftPage` inside `executePageReset` so `buildViewedContentFromStore` reads the new state synchronously and the save payload carries `page: null`.
- Forced `loadPage(true)` in `ContentWizardPanel.onPageReset` when persisted content has no page — fixes Reset → Customize → Reset, where `saveChanges` short-circuited and left the in-memory customized page on screen.
- Switched the page editor to the Insert tab after Customize Page via `bumpInsertTabActivateNonce`, matching the controller/template selector behavior from #10325.

Closes #10364

<sub>*Drafted with AI assistance*</sub>
