### PR TITLE
PageInspectionPanel: show empty-state message when site has no application #10366

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/WizardExtensionRenderingHandler.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/WizardExtensionRenderingHandler.ts
@@ -1,10 +1,11 @@
-import {RenderingMode} from '../rendering/RenderingMode';
-import {ExtensionRenderingHandler, type ExtensionRenderer, PREVIEW_TYPE} from '../view/ExtensionRenderingHandler';
 import {DivEl} from '@enonic/lib-admin-ui/dom/DivEl';
-import {type ViewExtensionEvent} from '../event/ViewExtensionEvent';
-import {type ContentSummary} from '../content/ContentSummary';
 import Q from 'q';
 import {PreviewContextMenuElement} from '../../v6/features/shared/PreviewContextMenu';
+import {capitalize} from '../../v6/features/utils/format/capitalize';
+import {type ContentSummary} from '../content/ContentSummary';
+import {type ViewExtensionEvent} from '../event/ViewExtensionEvent';
+import {RenderingMode} from '../rendering/RenderingMode';
+import {ExtensionRenderingHandler, PREVIEW_TYPE, type ExtensionRenderer} from '../view/ExtensionRenderingHandler';
 
 export class WizardExtensionRenderingHandler
     extends ExtensionRenderingHandler {
@@ -49,8 +50,10 @@ export class WizardExtensionRenderingHandler
         this.hasControllersDeferred = Q.defer<boolean>();
         this.hasPageDeferred = Q.defer<boolean>();
         const pageName = summary.getDisplayName();
-        this.emptyMenu?.setProps({pageName});
-        this.errorMenu?.setProps({pageName});
+        const localName = summary.getType()?.getLocalName() ?? '';
+        const pageType = localName ? capitalize(localName) : '';
+        this.emptyMenu?.setProps({pageName, pageType});
+        this.errorMenu?.setProps({pageName, pageType});
         return super.render(summary, widget);
     }
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/PreviewContextMenu.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/PreviewContextMenu.tsx
@@ -14,11 +14,12 @@ const PREVIEW_CONTEXT_MENU_NAME = 'PreviewContextMenu';
 
 export type PreviewContextMenuProps = {
     pageName: string;
+    pageType?: string;
     messages: string[];
     showIcon?: boolean;
 };
 
-export const PreviewContextMenu = ({pageName, messages, showIcon}: PreviewContextMenuProps): ReactElement => {
+export const PreviewContextMenu = ({pageName, pageType, messages, showIcon}: PreviewContextMenuProps): ReactElement => {
     const inspectLabel = useI18n('action.page.settings');
 
     // Re-route primary clicks as contextmenu events so the placeholder opens
@@ -54,9 +55,8 @@ export const PreviewContextMenu = ({pageName, messages, showIcon}: PreviewContex
                 <ContextMenu.Content className="min-w-48">
                     <div className="flex items-center gap-2 px-2 py-1.5 text-sm font-semibold text-main">
                         <Globe className="size-4 shrink-0" aria-hidden />
-                        <span className="truncate">{pageName}</span>
+                        <span className="truncate">{pageName || pageType}</span>
                     </div>
-                    <div className="my-1 border-t border-bdr-soft" aria-hidden />
                     <ContextMenu.Item onSelect={handleInspect}>
                         {inspectLabel}
                     </ContextMenu.Item>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/status/StatusBadge.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/status/StatusBadge.tsx
@@ -16,7 +16,7 @@ export const StatusBadge = ({status, className}: Props) => {
     const isOffline = status === PublishStatus.OFFLINE;
 
     return (
-        <span data-component={STATUS_BADGE_NAME} className={cn('text-sm capitalize group-data-[tone=inverse]:text-alt', isOnline && 'text-success', isOffline && 'text-muted', className)}>
+        <span data-component={STATUS_BADGE_NAME} className={cn('text-sm capitalize group-data-[tone=inverse]:text-alt', isOnline && 'text-success', isOffline && 'text-subtle', className)}>
             {label}
         </span>
     );

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/page-inspection.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/page-inspection.store.ts
@@ -1,7 +1,10 @@
 import {atom, computed} from 'nanostores';
 import type {PageTemplate} from '../../../app/content/PageTemplate';
 import type {Descriptor} from '../../../app/page/Descriptor';
+import {createDebounce} from '../utils/timing/createDebounce';
 import {$contentContext, $page, $pageEditorLifecycle, $pageVersion} from './page-editor/store';
+import type {PageEditorContentContext} from './page-editor/types';
+import {$contentUpdated} from './socket.store';
 
 //
 // * State
@@ -37,6 +40,14 @@ export const $isCustomizeVisible = computed(
     },
 );
 
+export const $isPageInspectionEmpty = computed(
+    [$pageTemplateOptions, $pageControllerOptions, $isPageInspectionLoading],
+    (templates, controllers, isLoading): boolean => {
+        if (isLoading) return false;
+        return templates.length === 0 && controllers.length === 0;
+    },
+);
+
 //
 // * Service
 //
@@ -44,38 +55,76 @@ export const $isCustomizeVisible = computed(
 let abortController: AbortController | null = null;
 const cleanups: (() => void)[] = [];
 
+async function loadTemplatesAndControllers(ctx: PageEditorContentContext): Promise<void> {
+    $isPageInspectionLoading.set(true);
+    abortController?.abort();
+    abortController = new AbortController();
+    const {signal} = abortController;
+
+    try {
+        const {loadPageTemplatesByCanRender, loadPageControllers} = await import('../api/pageInspection');
+
+        const [templates, controllers] = await Promise.all([
+            ctx.siteId ? loadPageTemplatesByCanRender(ctx.siteId, ctx.contentTypeName) : Promise.resolve([]),
+            loadPageControllers(ctx.contentId),
+        ]);
+
+        if (!signal.aborted) {
+            $pageTemplateOptions.set(templates);
+            $pageControllerOptions.set(controllers);
+        }
+    } catch {
+        // Aborted or failed
+    } finally {
+        if (!signal.aborted) {
+            $isPageInspectionLoading.set(false);
+        }
+    }
+}
+
 export function initPageInspectionService(): void {
     cleanupPageInspection();
 
     // Load templates and controllers when content context becomes available
     const unsubContext = $contentContext.subscribe((ctx) => {
         if (!ctx) return;
-
-        $isPageInspectionLoading.set(true);
-        abortController?.abort();
-        abortController = new AbortController();
-
-        void (async () => {
-            try {
-                const {loadPageTemplatesByCanRender, loadPageControllers} = await import('../api/pageInspection');
-
-                const [templates, controllers] = await Promise.all([
-                    ctx.siteId ? loadPageTemplatesByCanRender(ctx.siteId, ctx.contentTypeName) : Promise.resolve([]),
-                    loadPageControllers(ctx.contentId),
-                ]);
-
-                if (!abortController.signal.aborted) {
-                    $pageTemplateOptions.set(templates);
-                    $pageControllerOptions.set(controllers);
-                }
-            } catch {
-                // Aborted or failed
-            } finally {
-                $isPageInspectionLoading.set(false);
-            }
-        })();
+        void loadTemplatesAndControllers(ctx);
     });
     cleanups.push(unsubContext);
+
+    // Reload when the current content, the site, or a descendant page-template is updated.
+    // Site updates may add or remove applications, changing available templates and controllers.
+    const reloadDebounced = createDebounce(() => {
+        const ctx = $contentContext.get();
+        if (ctx) void loadTemplatesAndControllers(ctx);
+    }, 300);
+
+    const unsubContentUpdated = $contentUpdated.subscribe((event) => {
+        if (!event) return;
+
+        const ctx = $contentContext.get();
+        if (!ctx) return;
+
+        const contentIdStr = ctx.contentId.toString();
+        const siteIdStr = ctx.siteId?.toString();
+        const sitePath = ctx.sitePath;
+
+        const shouldReload = event.data.some((summary) => {
+            const id = summary.getContentId().toString();
+            if (id === contentIdStr) return true;
+            if (siteIdStr && id === siteIdStr) return true;
+            if (sitePath && summary.getType().isPageTemplate()) {
+                return summary.getPath().toString().startsWith(`${sitePath}/`);
+            }
+            return false;
+        });
+
+        if (shouldReload) reloadDebounced();
+    });
+    cleanups.push(() => {
+        reloadDebounced.cancel();
+        unsubContentUpdated();
+    });
 
     // Load descriptor when controller changes
     let lastControllerKey: string | null = null;

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/format/camelCase.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/format/camelCase.ts
@@ -1,3 +1,5 @@
+import {capitalize} from "./capitalize";
+
 export function camelCase(str: string): string {
     const words = str
         .replace(/([a-z])([A-Z])/g, '$1 $2')
@@ -8,7 +10,7 @@ export function camelCase(str: string): string {
     return words
         .map((word, i) => {
             const lower = word.toLowerCase();
-            return i === 0 ? lower : lower.charAt(0).toUpperCase() + lower.slice(1);
+            return i === 0 ? lower : capitalize(lower);
         })
         .join('');
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageControllerSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageControllerSelector.tsx
@@ -17,18 +17,12 @@ export const PageControllerSelector = (): ReactElement | null => {
         confirmDialog,
         setConfirmDialog,
         isLoading,
-        isEmpty,
     } = usePageControllerSelector();
 
     const templateLabel = useI18n('field.page.template');
-    const noControllersLabel = useI18n('text.notemplatesorblocks');
     const searchPlaceholder = useI18n('field.option.placeholder');
 
     if (isLoading) return null;
-
-    if (isEmpty) {
-        return <p className="text-sm text-subtle">{noControllersLabel}</p>;
-    }
 
     return (
         <>

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageInspectionPanel.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageInspectionPanel.tsx
@@ -11,7 +11,7 @@ import {
     requestCustomizePage,
     usePageState,
 } from '../../../../../../store/page-editor';
-import {$isCustomizeVisible, $pageConfigDescriptor} from '../../../../../../store/page-inspection.store';
+import {$isCustomizeVisible, $isPageInspectionEmpty, $pageConfigDescriptor} from '../../../../../../store/page-inspection.store';
 import {useInspectFormTracking} from '../useInspectFormTracking';
 import {PageControllerSelector} from "./PageControllerSelector";
 
@@ -28,9 +28,11 @@ export const PageInspectionPanel = (): ReactElement => {
     const lifecycle = useStore($pageEditorLifecycle);
     const descriptor = useStore($pageConfigDescriptor);
     const isCustomizeVisible = useStore($isCustomizeVisible);
+    const isEmpty = useStore($isPageInspectionEmpty);
 
     const customizeLabel = useI18n("action.page.customize");
     const customizeQuestion = useI18n("dialog.page.customize.confirmation");
+    const noTemplatesLabel = useI18n('text.notemplatesorblocks');
 
     const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogState | null>(null);
 
@@ -49,6 +51,14 @@ export const PageInspectionPanel = (): ReactElement => {
     const configRoot = hasController ? (page?.getConfig()?.getRoot() ?? null) : null;
 
     useInspectFormTracking(configForm, configRoot);
+
+    if (isEmpty) {
+        return (
+            <div data-component={PAGE_INSPECTION_PANEL_NAME} className="flex flex-col -mx-5 p-5 bg-surface-primary">
+                <p className="text-sm text-subtle">{noTemplatesLabel}</p>
+            </div>
+        );
+    }
 
     return (
         <div data-component={PAGE_INSPECTION_PANEL_NAME} className="flex flex-col gap-5">

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/hooks/usePageControllerSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/hooks/usePageControllerSelector.ts
@@ -53,7 +53,6 @@ type UsePageControllerSelectorResult = {
     confirmDialog: ConfirmDialogState | null;
     setConfirmDialog: (state: ConfirmDialogState | null) => void;
     isLoading: boolean;
-    isEmpty: boolean;
 };
 
 export function usePageControllerSelector(): UsePageControllerSelectorResult {
@@ -188,7 +187,6 @@ export function usePageControllerSelector(): UsePageControllerSelectorResult {
     );
 
     const selection = selectedKey ? [selectedKey] : [];
-    const isEmpty = options.length === 0 && !page?.hasController();
 
     return {
         options,
@@ -201,6 +199,5 @@ export function usePageControllerSelector(): UsePageControllerSelectorResult {
         confirmDialog,
         setConfirmDialog,
         isLoading,
-        isEmpty,
     };
 }


### PR DESCRIPTION
Show the `text.notemplatesorblocks` message in the page inspection panel when no controllers or templates are available — for both initial open and after the site's applications change.

Added `$isPageInspectionEmpty` computed in `page-inspection.store.ts` driven solely by loaded templates, controllers, and loading state. `PageInspectionPanel` renders the empty message inside the styled selector container when the panel is empty. Removed the redundant local empty-state branch from `PageControllerSelector` and the `isEmpty` flag from `usePageControllerSelector`.

Subscribed the page inspection service to `$contentUpdated` and reload templates and controllers when the current content, the site, or a descendant page-template changes. Extracted the load logic into `loadTemplatesAndControllers` and aborted in-flight loads via `AbortController`.

Closes #10366

<sub>*Drafted with AI assistance*</sub>
