### PR TITLE
Page Components tree: keep regions always expanded #10378

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/pageComponents.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/pageComponents.store.ts
@@ -179,19 +179,24 @@ function buildTreeFromPage(
         }
     } else {
         for (const [id, node] of state.nodes) {
-            if (isDefaultCollapsed(node)) continue;
+            if (isNestedLayout(node)) continue;
             if (node.hasChildren || node.childIds.length > 0) {
                 expandedIds.add(id);
             }
         }
     }
 
+    for (const [id, node] of state.nodes) {
+        if (node.data?.nodeType === 'region') {
+            expandedIds.add(id);
+        }
+    }
+
     return {...state, expandedIds};
 }
 
-function isDefaultCollapsed(node: TreeNode<PageComponentNodeData>): boolean {
-    const type = node.data?.nodeType;
-    return type === 'region' || (type === 'layout' && node.parentId !== null);
+function isNestedLayout(node: TreeNode<PageComponentNodeData>): boolean {
+    return node.data?.nodeType === 'layout' && node.parentId !== null;
 }
 
 function collectLayouts(page: Page | null): Map<string, LayoutComponent> {


### PR DESCRIPTION
Restored regions to always start expanded; smart collapse/expand introduced in cbf0ed2db now applies only to layouts. Renamed `isDefaultCollapsed` to `isNestedLayout`, and added a final pass in `buildTreeFromPage` that adds every region to `expandedIds`.

Closes #10378

<sub>*Drafted with AI assistance*</sub>
