### PR TITLE
Inspect panel Apply button: mirror Save action enable state #10381

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/inspect-panel.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/inspect-panel.store.ts
@@ -9,9 +9,7 @@ export const $inspectSaveAction = atom<Action | null>(null);
 
 export const $inspectFormPresent = atom<boolean>(false);
 
-export const $inspectFormDirty = atom<boolean>(false);
-
-export const $inspectFormValid = atom<boolean>(true);
+const $inspectSaveActionEnabled = atom<boolean>(false);
 
 //
 // * Computed
@@ -20,34 +18,42 @@ export const $inspectFormValid = atom<boolean>(true);
 export const $isApplyVisible = computed($inspectFormPresent, (present): boolean => present);
 
 export const $isApplyEnabled = computed(
-    [$inspectFormPresent, $inspectFormDirty, $inspectFormValid, $inspectSaveAction],
-    (present, dirty, valid, action): boolean => present && dirty && valid && action != null,
+    [$inspectFormPresent, $inspectSaveActionEnabled],
+    (present, enabled): boolean => present && enabled,
 );
 
 //
 // * Commands
 //
 
+let unsubscribeSaveAction: (() => void) | null = null;
+
 export function setInspectSaveAction(action: Action | null): void {
+    unsubscribeSaveAction?.();
+    unsubscribeSaveAction = null;
+
     $inspectSaveAction.set(action);
+
+    if (action == null) {
+        $inspectSaveActionEnabled.set(false);
+        return;
+    }
+
+    const sync = (): void => {
+        $inspectSaveActionEnabled.set(action.isEnabled());
+    };
+
+    sync();
+    action.onPropertyChanged(sync);
+    unsubscribeSaveAction = () => action.unPropertyChanged(sync);
 }
 
 export function setInspectFormPresent(present: boolean): void {
     $inspectFormPresent.set(present);
 }
 
-export function setInspectFormDirty(dirty: boolean): void {
-    $inspectFormDirty.set(dirty);
-}
-
-export function setInspectFormValid(valid: boolean): void {
-    $inspectFormValid.set(valid);
-}
-
 export function resetInspectFormTracking(): void {
     $inspectFormPresent.set(false);
-    $inspectFormDirty.set(false);
-    $inspectFormValid.set(true);
 }
 
 export function executeInspectSave(): void {

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/ApplyButton.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/ApplyButton.tsx
@@ -3,7 +3,7 @@ import {useStore} from '@nanostores/preact';
 import type {ReactElement} from 'react';
 import {useI18n} from '../../../../../hooks/useI18n';
 import {$inspectedItem, $inspectedItemType, requestReloadComponent} from '../../../../../store/page-editor';
-import {$isApplyEnabled, executeInspectSave, setInspectFormDirty} from '../../../../../store/inspect-panel.store';
+import {$isApplyEnabled, executeInspectSave} from '../../../../../store/inspect-panel.store';
 
 const APPLY_BUTTON_NAME = 'InspectApplyButton';
 
@@ -19,7 +19,6 @@ export const ApplyButton = (): ReactElement => {
         const typeKey = itemType?.toString();
         if (item && typeKey && RELOADABLE_TYPES.has(typeKey)) {
             requestReloadComponent(item.getPath(), true);
-            setInspectFormDirty(false);
             return;
         }
         executeInspectSave();

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/text/TextEditor.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/text/TextEditor.tsx
@@ -36,7 +36,6 @@ import type {HtmlAreaConfig} from '../../../../../../shared/form/input-types/htm
 import {getCursorPosition, setupEditor, setupEditorUi, type DialogOverrides} from '../../../../../../shared/form/input-types/html-area/setupEditor';
 import {useCKEditorConfig} from '../../../../../../shared/form/input-types/html-area/useCKEditorConfig';
 import {$contextContent} from '../../../../../../store/context/contextContent.store';
-import {setInspectFormDirty} from '../../../../../../store/inspect-panel.store';
 import {requestUpdateTextComponent} from '../../../../../../store/page-editor';
 import {$activeProject} from '../../../../../../store/projects.store';
 import {useApplicationKeys} from '../../../../../wizard/content-wizard-tabs/useApplicationKeys';
@@ -150,10 +149,6 @@ const TextEditorInner = ({
     const didAutoFocusRef = useRef(false);
     const textComponentRef = useRef(textComponent);
     textComponentRef.current = textComponent;
-
-    // ? Last persisted content. Dirty is derived as current !== baseline,
-    // ? so typing + undoing back to the saved value clears Apply.
-    const baselineRef = useRef<string>('');
 
     useInspectTextTracking();
 
@@ -293,49 +288,6 @@ const TextEditorInner = ({
             editor.removeListener('change', debouncedOnChange.trigger);
         };
     }, [status, editor, contentSummary, project, applicationKeys, assetsUri, editableSourceCode, debouncedOnChange]);
-
-    //
-    // * Dirty flag — current content vs. last persisted baseline
-    //
-
-    useEffect(() => {
-        if (status !== 'ready' || !editor) {
-            return;
-        }
-
-        // Capture initial baseline from the editor's own normalized output.
-        baselineRef.current = editor.getData();
-        setInspectFormDirty(false);
-
-        const onChange = () => {
-            setInspectFormDirty(editor.getData() !== baselineRef.current);
-        };
-
-        editor.on('change', onChange);
-
-        return () => {
-            editor.removeListener('change', onChange);
-        };
-    }, [status, editor]);
-
-    // Advance the baseline when the wizard actually persists the content —
-    // fires for both the wizard Save action and the inspect Apply path.
-    useEffect(() => {
-        if (status !== 'ready' || !editor) {
-            return;
-        }
-
-        const handler = () => {
-            baselineRef.current = editor.getData();
-            setInspectFormDirty(false);
-        };
-
-        BeforeContentSavedEvent.on(handler);
-
-        return () => {
-            BeforeContentSavedEvent.un(handler);
-        };
-    }, [status, editor]);
 
     //
     // * One-shot auto-focus on first ready
@@ -529,10 +481,7 @@ const TextEditorInner = ({
             const previewContent = contentId
                 ? HTMLAreaHelper.convertRenderSrcToPreviewSrc(text, contentId, project)
                 : text;
-            editor.setData(previewContent, () => {
-                baselineRef.current = editor.getData();
-                setInspectFormDirty(false);
-            });
+            editor.setData(previewContent);
         };
 
         PageState.getEvents().onComponentUpdated(handler);

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/text/useInspectTextTracking.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/text/useInspectTextTracking.ts
@@ -1,14 +1,9 @@
 import {useEffect} from 'react';
-import {
-    resetInspectFormTracking,
-    setInspectFormPresent,
-    setInspectFormValid,
-} from '../../../../../../store/inspect-panel.store';
+import {resetInspectFormTracking, setInspectFormPresent} from '../../../../../../store/inspect-panel.store';
 
 export function useInspectTextTracking(): void {
     useEffect(() => {
         setInspectFormPresent(true);
-        setInspectFormValid(true);
 
         return () => {
             resetInspectFormTracking();

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/useInspectFormTracking.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/useInspectFormTracking.ts
@@ -1,13 +1,7 @@
 import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
 import type {Form} from '@enonic/lib-admin-ui/form/Form';
-import {validateForm} from '@enonic/lib-admin-ui/form2';
 import {useEffect} from 'react';
-import {
-    resetInspectFormTracking,
-    setInspectFormDirty,
-    setInspectFormPresent,
-    setInspectFormValid,
-} from '../../../../../store/inspect-panel.store';
+import {resetInspectFormTracking, setInspectFormPresent} from '../../../../../store/inspect-panel.store';
 
 export function useInspectFormTracking(form: Form | null, propertySet: PropertySet | null): void {
     useEffect(() => {
@@ -17,21 +11,8 @@ export function useInspectFormTracking(form: Form | null, propertySet: PropertyS
         }
 
         setInspectFormPresent(true);
-        setInspectFormDirty(false);
-
-        const initialResult = validateForm(form, propertySet);
-        setInspectFormValid(initialResult.isValid);
-
-        const handleChanged = (): void => {
-            setInspectFormDirty(true);
-            const result = validateForm(form, propertySet);
-            setInspectFormValid(result.isValid);
-        };
-
-        propertySet.onChanged(handleChanged);
 
         return () => {
-            propertySet.unChanged(handleChanged);
             resetInspectFormTracking();
         };
     }, [form, propertySet]);


### PR DESCRIPTION
Replaced the inspect panel's bespoke dirty/valid bookkeeping with a reactive subscription to the wizard `saveAction.onPropertyChanged`. Apply now enables exactly when Save does — fixes the case where reverting a form value to its original left Apply enabled, and removes the validation gate so inline errors no longer block Apply.

- Dropped `$inspectFormDirty` / `$inspectFormValid` and their setters from `inspect-panel.store`.
- Simplified `useInspectFormTracking` and `useInspectTextTracking` to track only form presence.
- Removed baseline-vs-current dirty tracking from `TextEditor`.
- Removed the redundant `setInspectFormDirty(false)` from `ApplyButton` after `requestReloadComponent`.

Tracking Save button was chosen to have a simplified implementation, since  Save action's enabled state is derived from four inputs (`$wizardHasChanges`, `persistedContent.isEditable()`, `this.userCanModify`, `!persistedContent.isDataInherited()`), and only 1 is a store. Should be updated once all our states will be in stores.

Closes #10381

<sub>*Drafted with AI assistance*</sub>
