### PR TITLE
Move attachment textContent to media data

### DIFF
--- a/modules/app/src/main/java/com/enonic/app/contentstudio/json/content/attachment/AttachmentJson.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/json/content/attachment/AttachmentJson.java
@@ -41,11 +41,6 @@ public class AttachmentJson
         return this.attachment.getSha512();
     }
 
-    public String getTextContent()
-    {
-        return this.attachment.getTextContent();
-    }
-
     @JsonIgnore
     public Attachment getAttachment()
     {

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentResource.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentResource.java
@@ -1755,7 +1755,6 @@ public final class ContentResource
             .name( attachmentName )
             .mimeType( mediaFile.getContentType().toString() )
             .byteSource( mediaFile.getBytes() )
-            .text( extractedData.getText() )
             .build();
 
         final UpdateContentParams params = new UpdateContentParams().contentId( ContentId.from( form.getAsString( "id" ) ) )

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentResource.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentResource.java
@@ -1738,7 +1738,6 @@ public final class ContentResource
                 .name( sourceAttachment.getName() )
                 .mimeType( sourceAttachment.getMimeType() )
                 .byteSource( sourceBinary )
-                .text( sourceAttachment.getTextContent() )
                 .label( sourceAttachment.getLabel() )
                 .build();
         }

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/json/content/attachment/AttachmentJsonTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/json/content/attachment/AttachmentJsonTest.java
@@ -18,7 +18,6 @@ class AttachmentJsonTest
             .mimeType( "application/pdf" )
             .size( 12345 )
             .sha512( "abc123" )
-            .textContent( "extracted text" )
             .build();
 
         final AttachmentJson json = new AttachmentJson( attachment );
@@ -28,12 +27,11 @@ class AttachmentJsonTest
         assertEquals( "application/pdf", json.getMimeType() );
         assertEquals( 12345L, json.getSize() );
         assertEquals( "abc123", json.getSha512() );
-        assertEquals( "extracted text", json.getTextContent() );
         assertEquals( attachment, json.getAttachment() );
     }
 
     @Test
-    void nullSha512AndTextContent()
+    void nullSha512()
     {
         final Attachment attachment = Attachment.create()
             .name( "image.png" )
@@ -44,6 +42,5 @@ class AttachmentJsonTest
         final AttachmentJson json = new AttachmentJson( attachment );
 
         assertNull( json.getSha512() );
-        assertNull( json.getTextContent() );
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/attachment/Attachment.ts
+++ b/modules/lib/src/main/resources/assets/js/app/attachment/Attachment.ts
@@ -19,15 +19,12 @@ export class Attachment
 
     private sha512: string;
 
-    private textContent: string;
-
     constructor(builder: AttachmentBuilder) {
         this.name = builder.name;
         this.label = builder.label;
         this.mimeType = builder.mimeType;
         this.size = builder.size;
         this.sha512 = builder.sha512;
-        this.textContent = builder.textContent;
     }
 
     getBinaryReference(): BinaryReference {
@@ -52,10 +49,6 @@ export class Attachment
 
     getSha512(): string {
         return this.sha512;
-    }
-
-    getTextContent(): string {
-        return this.textContent;
     }
 
     equals(o: Equitable): boolean {
@@ -90,8 +83,7 @@ export class Attachment
             label: this.getLabel(),
             mimeType: this.getMimeType(),
             size: this.getSize(),
-            sha512: this.getSha512(),
-            textContent: this.getTextContent()
+            sha512: this.getSha512()
         };
     }
 
@@ -118,11 +110,9 @@ export class AttachmentBuilder {
 
     sha512: string;
 
-    textContent: string;
-
     public fromJson(json: AttachmentJson): AttachmentBuilder {
         this.setName(new AttachmentName(json.name)).setLabel(json.label).setSize(json.size).setMimeType(json.mimeType)
-            .setSha512(json.sha512).setTextContent(json.textContent);
+            .setSha512(json.sha512);
         return this;
     }
 
@@ -148,11 +138,6 @@ export class AttachmentBuilder {
 
     public setSha512(value: string): AttachmentBuilder {
         this.sha512 = value;
-        return this;
-    }
-
-    public setTextContent(value: string): AttachmentBuilder {
-        this.textContent = value;
         return this;
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/attachment/AttachmentJson.ts
+++ b/modules/lib/src/main/resources/assets/js/app/attachment/AttachmentJson.ts
@@ -9,6 +9,4 @@ export interface AttachmentJson {
     size: number;
 
     sha512?: string;
-
-    textContent?: string;
 }


### PR DESCRIPTION
Follow-up to PR #10388. PR #10388 added `sha512` and `textContent` to `AttachmentJson` (Java + TS). The `sha512` half is correct — it's a binary-level concern. The `textContent` half is misplaced: it's the Tika-extracted text from a media binary, so it's meaningful only for media content types (PDFs, docs, …), not for every attachment. Non-media attachments (page banners, source attachments, …) always carried a null `textContent`, which is misleading both in the JSON preview and in any consumer code that reads it.

The XP follow-up at https://github.com/enonic/xp/pull/12021 moves `textContent` off `Attachment` and onto the media content's own data at `data.media.text`. This PR is the contentstudio-side correction.

Changes:

- `AttachmentJson.java` — drop `getTextContent()`. Keep `getSha512()`.
- `AttachmentJsonTest.java` — drop the `textContent` assertions; rename `nullSha512AndTextContent` to `nullSha512`. Keep the sha512 ones.
- `Attachment.ts` — drop the `textContent` field, `getTextContent()`, `setTextContent()`, the `fromJson` assignment, and the `toJson` output. Keep `sha512`.
- `AttachmentJson.ts` — drop the optional `textContent?` field.
- `ContentResource.java` — drop `.text(sourceAttachment.getTextContent())` in `createAttachment(...)`, since `CreateAttachment.text(...)` and `Attachment.getTextContent()` are removed upstream.

Surfacing `textContent` on the media-data view: no contentstudio code change needed. The content's `data` tree (including `data.media.text` once the XP PR lands) is already rendered as JSON in the inspect/preview panels — no place in contentstudio currently special-cases `data.media`.

Sequencing: this PR's TS surface tolerates `textContent` being absent from `AttachmentJson` (the field on the XP side is removed entirely; `AttachmentJson.ts` already had it as optional, so it's forward- and backward-compatible). The Java side compiles against the published XP today and will continue to compile once the new XP snapshot lands, since we're only removing calls.

References

- https://github.com/enonic/app-contentstudio/pull/10388 (the PR being amended)
- https://github.com/enonic/xp/pull/12021 (paired XP follow-up)

<sub>*Drafted with AI assistance*</sub>