### PR TITLE
Page controlllers and templates are broken #10386

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -896,6 +896,9 @@ export class ContentWizardPanel
         });
 
         PageState.getEvents().onPageUpdated((event: PageUpdatedEvent) => {
+            // ! Sync draft before saveChanges — diff reads $wizardDraftPage,
+            // ! the updateTabsElement listener fires later in the chain.
+            setDraftPage(PageState.getState());
             this.setMarkedAsReady(false);
 
             if (event instanceof PageControllerCustomizedEvent) {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -174,6 +174,10 @@ export class LiveFormPanel
         ShowContentFormEvent.un(this.hideLoadMaskHandler);
 
         this.liveEditPageProxy.remove();
+        cleanupComponentInspection();
+        cleanupFragmentInspection();
+        cleanupPageInspection();
+        cleanupPageEditorBridge();
         super.remove();
         return this;
     }
@@ -206,8 +210,8 @@ export class LiveFormPanel
             contentContext: {
                 contentId: content.getContentId(),
                 contentTypeName: content.getType(),
-                siteId: siteModel?.getSiteId() ?? null,
-                sitePath: siteModel?.getSite().getPath().toString() ?? null,
+                siteId: site?.getContentId() ?? null,
+                sitePath: site?.getPath().toString() ?? null,
                 isPageTemplate: content.isPageTemplate(),
                 isInherited: content.isInherited(),
                 isDataInherited: content.isDataInherited(),
@@ -215,8 +219,8 @@ export class LiveFormPanel
             },
         });
 
-        initPageInspectionService();
-        initComponentInspectionService();
+        initPageInspectionService(siteModel);
+        initComponentInspectionService(siteModel);
         initFragmentInspectionService();
 
         // Sync renderable state that may have been set before bridge init
@@ -281,12 +285,11 @@ export class LiveFormPanel
     }
 
     unloadPage(): void {
+        // ! Iframe-only unload. Inspection stores stay alive so the inspect
+        // ! panel keeps showing controllers while the iframe is not renderable.
+        // ! Store cleanup runs in remove() when the wizard is destroyed.
         this.liveEditPageProxy?.unload();
         this.liveEditModel = null;
-        cleanupComponentInspection();
-        cleanupFragmentInspection();
-        cleanupPageInspection();
-        cleanupPageEditorBridge();
     }
 
     handle(event: PageNavigationEvent): void {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/component-inspection.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/component-inspection.store.ts
@@ -1,6 +1,9 @@
 import {atom, computed} from 'nanostores';
 import type {Descriptor} from '../../../app/page/Descriptor';
 import {DescriptorBasedComponent} from '../../../app/page/region/DescriptorBasedComponent';
+import type {SiteModel} from '../../../app/site/SiteModel';
+import {createDebounce} from '../utils/timing/createDebounce';
+import type {PageEditorContentContext} from './page-editor/types';
 import {$contentContext, $inspectedItem, $pageVersion} from './page-editor/store';
 
 //
@@ -36,40 +39,62 @@ export const $selectedComponentDescriptorKey = computed(
 let abortController: AbortController | null = null;
 const cleanups: (() => void)[] = [];
 
-// TODO: reload descriptors on SiteModel app lifecycle changes (add/remove/unavailable)
+async function loadDescriptors(ctx: PageEditorContentContext): Promise<void> {
+    $isComponentInspectionLoading.set(true);
+    abortController?.abort();
+    abortController = new AbortController();
+    const {signal} = abortController;
 
-export function initComponentInspectionService(): void {
+    try {
+        const {loadComponentDescriptors} = await import('../api/componentInspection');
+
+        const [parts, layouts] = await Promise.all([
+            loadComponentDescriptors('part', ctx.contentId),
+            loadComponentDescriptors('layout', ctx.contentId),
+        ]);
+
+        if (!signal.aborted) {
+            $partDescriptorOptions.set(parts);
+            $layoutDescriptorOptions.set(layouts);
+        }
+    } catch {
+        // Aborted or failed
+    } finally {
+        if (!signal.aborted) {
+            $isComponentInspectionLoading.set(false);
+        }
+    }
+}
+
+export function initComponentInspectionService(siteModel?: SiteModel | null): void {
     cleanupComponentInspection();
 
-    // Load part and layout descriptor options when content context becomes available
     const unsubContext = $contentContext.subscribe((ctx) => {
         if (!ctx) return;
-
-        $isComponentInspectionLoading.set(true);
-        abortController?.abort();
-        abortController = new AbortController();
-
-        void (async () => {
-            try {
-                const {loadComponentDescriptors} = await import('../api/componentInspection');
-
-                const [parts, layouts] = await Promise.all([
-                    loadComponentDescriptors('part', ctx.contentId),
-                    loadComponentDescriptors('layout', ctx.contentId),
-                ]);
-
-                if (!abortController.signal.aborted) {
-                    $partDescriptorOptions.set(parts);
-                    $layoutDescriptorOptions.set(layouts);
-                }
-            } catch {
-                // Aborted or failed
-            } finally {
-                $isComponentInspectionLoading.set(false);
-            }
-        })();
+        void loadDescriptors(ctx);
     });
     cleanups.push(unsubContext);
+
+    // Reload when applications change in the SiteConfigurator dialog before any server round-trip.
+    const reloadDebounced = createDebounce(() => {
+        const ctx = $contentContext.get();
+        if (ctx) void loadDescriptors(ctx);
+    }, 300);
+
+    if (siteModel) {
+        const onSiteModelChange = (): void => reloadDebounced();
+        siteModel.onApplicationAdded(onSiteModelChange);
+        siteModel.onApplicationRemoved(onSiteModelChange);
+        siteModel.onSiteModelUpdated(onSiteModelChange);
+        cleanups.push(() => {
+            reloadDebounced.cancel();
+            siteModel.unApplicationAdded(onSiteModelChange);
+            siteModel.unApplicationRemoved(onSiteModelChange);
+            siteModel.unSiteModelUpdated(onSiteModelChange);
+        });
+    } else {
+        cleanups.push(() => reloadDebounced.cancel());
+    }
 
     // Load the active descriptor when the inspected component's descriptor key changes
     let lastKey: string | null = null;

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/page-inspection.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/page-inspection.store.ts
@@ -1,6 +1,7 @@
 import {atom, computed} from 'nanostores';
 import type {PageTemplate} from '../../../app/content/PageTemplate';
 import type {Descriptor} from '../../../app/page/Descriptor';
+import type {SiteModel} from '../../../app/site/SiteModel';
 import {createDebounce} from '../utils/timing/createDebounce';
 import {$contentContext, $page, $pageEditorLifecycle, $pageVersion} from './page-editor/store';
 import type {PageEditorContentContext} from './page-editor/types';
@@ -82,10 +83,9 @@ async function loadTemplatesAndControllers(ctx: PageEditorContentContext): Promi
     }
 }
 
-export function initPageInspectionService(): void {
+export function initPageInspectionService(siteModel?: SiteModel | null): void {
     cleanupPageInspection();
 
-    // Load templates and controllers when content context becomes available
     const unsubContext = $contentContext.subscribe((ctx) => {
         if (!ctx) return;
         void loadTemplatesAndControllers(ctx);
@@ -93,7 +93,6 @@ export function initPageInspectionService(): void {
     cleanups.push(unsubContext);
 
     // Reload when the current content, the site, or a descendant page-template is updated.
-    // Site updates may add or remove applications, changing available templates and controllers.
     const reloadDebounced = createDebounce(() => {
         const ctx = $contentContext.get();
         if (ctx) void loadTemplatesAndControllers(ctx);
@@ -125,6 +124,19 @@ export function initPageInspectionService(): void {
         reloadDebounced.cancel();
         unsubContentUpdated();
     });
+
+    // Reload when applications change in the SiteConfigurator dialog before any server round-trip.
+    if (siteModel) {
+        const onSiteModelChange = (): void => reloadDebounced();
+        siteModel.onApplicationAdded(onSiteModelChange);
+        siteModel.onApplicationRemoved(onSiteModelChange);
+        siteModel.onSiteModelUpdated(onSiteModelChange);
+        cleanups.push(() => {
+            siteModel.unApplicationAdded(onSiteModelChange);
+            siteModel.unApplicationRemoved(onSiteModelChange);
+            siteModel.unSiteModelUpdated(onSiteModelChange);
+        });
+    }
 
     // Load descriptor when controller changes
     let lastControllerKey: string | null = null;


### PR DESCRIPTION
Fixes the page-editor inspection panel for site content. Four overlapping defects were causing the symptoms described in the issue (empty panel, missing templates, controller selection not applying or persisting):

- `LiveFormPanel.setModel` resolved `siteId`/`sitePath` from `liveEditModel.getSiteModel()`, which is null when editing a site itself. The v6 page-inspection store then skipped `loadPageTemplatesByCanRender` and the templates list was always empty. Both fields now read from the locally derived `site` value, which already handles the `content.isSite()` case.
- v6 page- and component-inspection stores reloaded only on `$contentContext` change or on `$contentUpdated` socket events. Adding an application via `SiteConfiguratorDialog` updates the legacy `SiteModel` synchronously without firing either trigger, so descriptors stayed stale until a manual reload. Both `init*InspectionService` functions now accept a `SiteModel` and subscribe to `onApplicationAdded`/`onApplicationRemoved`/`onSiteModelUpdated`, matching the legacy `DescriptorBasedComponentInspectionPanel` behavior. `component-inspection.store.ts` extracts its loader so the new debounced reload can reuse it.
- `LiveFormPanel.unloadPage` cleared the v6 inspection stores. `ContentWizardPanel.refreshLivePanel` calls `unloadPage` whenever the iframe is not yet renderable — exactly when the user still needs the controller list visible to pick a controller. The store cleanups moved from `unloadPage` to `LiveFormPanel.remove`; `unloadPage` now only unloads the iframe.
- The `PageState.onPageUpdated` listener that calls `saveChanges` ran before the listener that calls `setDraftPage`, so `UpdatePersistedContentRoutine` saw a null `$wizardDraftPage` and detected no diff. Selecting a controller never produced a `CreatePageRequest` and the Save button blinked then disabled. The save handler now calls `setDraftPage(PageState.getState())` before `saveChanges`, so the diff fires the page CUD request.

Closes #10386

<sub>*Drafted with AI assistance*</sub>
