### PR TITLE
Cancel in-progress Gradle CI runs on PR branches

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,7 +4,9 @@ on:
   push:
   workflow_dispatch:
 
-concurrency: build-${{ github.ref }}
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/6.') }}
 
 jobs:
   publish_vars:


### PR DESCRIPTION
Added `cancel-in-progress` to the gradle workflow concurrency group, scoped to non-publishing branches (branches we use for publish, e.g. `master` and `6.*` are unaffected). 
Pushing new commits to a PR or feature branch now aborts the running build and Selenium suite instead of waiting in line, freeing runners and giving faster feedback on the latest commit. This should really help to make checks faster after consecutive pushes (regular commits, rebases, force pushes).