### PR TITLE
HtmlAreaContext is missing in some render locations #10406

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/hooks/useApplicationKeys.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/hooks/useApplicationKeys.ts
@@ -1,10 +1,10 @@
 import type {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
 import {useStore} from '@nanostores/preact';
 import {useEffect, useMemo, useState} from 'react';
-import type {Site} from '../../../../../app/content/Site';
-import {loadNearestSite} from '../../../api/details';
-import {$activeProject} from '../../../store/projects.store';
-import {$contextContent} from '../../../store/context/contextContent.store';
+import type {Site} from '../../../app/content/Site';
+import {loadNearestSite} from '../api/details';
+import {$activeProject} from '../store/projects.store';
+import {$contextContent} from '../store/context/contextContent.store';
 
 export function useApplicationKeys(): ApplicationKey[] {
     const contextContent = useStore($contextContent);

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormRenderer.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormRenderer.tsx
@@ -1,9 +1,15 @@
 import type {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
 import type {Form} from '@enonic/lib-admin-ui/form/Form';
 import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
-import {type ReactElement} from 'react';
+import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
+import {useStore} from '@nanostores/preact';
+import {type ReactElement, type ReactNode} from 'react';
+import {useApplicationKeys} from '../../hooks/useApplicationKeys';
+import {$contextContent} from '../../store/context/contextContent.store';
+import {$activeProject} from '../../store/projects.store';
 import {FormRenderProvider} from './FormRenderContext';
 import {FormItemRenderer} from './FormItemRenderer';
+import {HtmlAreaProvider, useOptionalHtmlAreaContext} from './input-types/html-area';
 
 type FormRendererProps = {
     form: Form;
@@ -13,7 +19,9 @@ type FormRendererProps = {
 };
 
 export const FormRenderer = ({form, propertySet, enabled = true, applicationKey}: FormRendererProps): ReactElement => {
-    return (
+    const existingHtmlAreaContext = useOptionalHtmlAreaContext();
+
+    const renderedForm = (
         <FormRenderProvider enabled={enabled} applicationKey={applicationKey}>
             <div className="flex flex-col gap-7.5" data-component="FormRenderer">
                 {form.getFormItems().map(item => (
@@ -22,6 +30,37 @@ export const FormRenderer = ({form, propertySet, enabled = true, applicationKey}
             </div>
         </FormRenderProvider>
     );
+
+    if (existingHtmlAreaContext) {
+        return renderedForm;
+    }
+
+    return <HtmlAreaShell>{renderedForm}</HtmlAreaShell>;
 };
 
 FormRenderer.displayName = 'FormRenderer';
+
+//
+// * HtmlAreaShell
+//
+
+// Mounts only when no HtmlAreaProvider exists above. Subscriptions live here
+// so nested FormRenderers inheriting an existing provider don't pay for them.
+const HtmlAreaShell = ({children}: {children: ReactNode}): ReactElement => {
+    const contextContent = useStore($contextContent);
+    const activeProject = useStore($activeProject);
+    const applicationKeys = useApplicationKeys();
+
+    return (
+        <HtmlAreaProvider
+            contentSummary={contextContent ?? undefined}
+            project={activeProject}
+            applicationKeys={applicationKeys}
+            assetsUri={CONFIG.getString('assetsUri')}
+        >
+            {children}
+        </HtmlAreaProvider>
+    );
+};
+
+HtmlAreaShell.displayName = 'HtmlAreaShell';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/html-area/HtmlAreaContext.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/html-area/HtmlAreaContext.tsx
@@ -46,3 +46,7 @@ export const useHtmlAreaContext = (): HtmlAreaContextValue => {
 
     return context;
 };
+
+export const useOptionalHtmlAreaContext = (): HtmlAreaContextValue | undefined => {
+    return useContext(HtmlAreaContext);
+};

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/html-area/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/html-area/index.ts
@@ -1,4 +1,4 @@
 export type {HtmlAreaConfig} from './HtmlAreaConfig';
 export {HtmlAreaDescriptor} from './HtmlAreaDescriptor';
 export {HtmlAreaInput} from './HtmlAreaInput';
-export {HtmlAreaProvider, useHtmlAreaContext} from './HtmlAreaContext';
+export {HtmlAreaProvider, useHtmlAreaContext, useOptionalHtmlAreaContext} from './HtmlAreaContext';

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/text/TextEditor.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/text/TextEditor.tsx
@@ -38,7 +38,7 @@ import {useCKEditorConfig} from '../../../../../../shared/form/input-types/html-
 import {$contextContent} from '../../../../../../store/context/contextContent.store';
 import {requestUpdateTextComponent} from '../../../../../../store/page-editor';
 import {$activeProject} from '../../../../../../store/projects.store';
-import {useApplicationKeys} from '../../../../../wizard/content-wizard-tabs/useApplicationKeys';
+import {useApplicationKeys} from '../../../../../../hooks/useApplicationKeys';
 import {useInspectTextTracking} from './useInspectTextTracking';
 
 const sanitizer = new HtmlAreaSanitizer();

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
@@ -1,25 +1,17 @@
 import {RawValueProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
-import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
 import {useStore} from '@nanostores/preact';
 import {type ReactElement, useEffect, useMemo} from 'react';
 import {FormRenderer} from '../../../shared/form';
-import {HtmlAreaProvider} from '../../../shared/form/input-types/html-area';
-import {$contextContent} from '../../../store/context/contextContent.store';
-import {$activeProject} from '../../../store/projects.store';
 import {$contentType, $wizardDraftData, notifyContentFormMounted} from '../../../store/wizardContent.store';
 import {$validationVisibility, getContentRawValueMap} from '../../../store/wizardValidation.store';
 import {DisplayNameInput} from './DisplayNameInput';
-import {useApplicationKeys} from './useApplicationKeys';
 
 const CONTENT_FORM_NAME = 'ContentForm';
 
 export const ContentForm = (): ReactElement | null => {
     const contentType = useStore($contentType);
     const draftData = useStore($wizardDraftData);
-    const contextContent = useStore($contextContent);
-    const activeProject = useStore($activeProject);
     const visibility = useStore($validationVisibility);
-    const applicationKeys = useApplicationKeys();
 
     const isReady = contentType != null && draftData != null;
 
@@ -31,14 +23,10 @@ export const ContentForm = (): ReactElement | null => {
 
     const rawValueMap = useMemo(() => getContentRawValueMap(), []);
 
-    const contentSummary = contextContent ?? undefined;
-
     const applicationKey = useMemo(
         () => contentType?.getContentTypeName().getApplicationKey(),
         [contentType],
     );
-
-    const assetsUri = CONFIG.getString('assetsUri');
 
     if (!isReady) {
         return null;
@@ -49,18 +37,11 @@ export const ContentForm = (): ReactElement | null => {
             <DisplayNameInput />
             <ValidationVisibilityProvider visibility={visibility}>
                 <RawValueProvider map={rawValueMap}>
-                    <HtmlAreaProvider
-                        contentSummary={contentSummary}
-                        project={activeProject}
-                        applicationKeys={applicationKeys}
-                        assetsUri={assetsUri}
-                    >
-                        <FormRenderer
-                            form={contentType.getForm()}
-                            propertySet={draftData.getRoot()}
-                            applicationKey={applicationKey}
-                        />
-                    </HtmlAreaProvider>
+                    <FormRenderer
+                        form={contentType.getForm()}
+                        propertySet={draftData.getRoot()}
+                        applicationKey={applicationKey}
+                    />
                 </RawValueProvider>
             </ValidationVisibilityProvider>
         </div>

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/MixinView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/MixinView.tsx
@@ -3,15 +3,10 @@ import {useStore} from '@nanostores/preact';
 import {OctagonAlert} from 'lucide-react';
 import {type ReactElement, useCallback, useEffect, useMemo} from 'react';
 import {RawValueProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
-import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
 import {useI18n} from '../../../hooks/useI18n';
-import {$contextContent} from '../../../store/context/contextContent.store';
-import {$activeProject} from '../../../store/projects.store';
 import {$mixinsDescriptors, $wizardDraftMixins, notifyMixinMounted, setDraftMixinEnabled} from '../../../store/wizardContent.store';
 import {$validationVisibility, getMixinRawValueMap} from '../../../store/wizardValidation.store';
 import {FormRenderer} from '../../../shared/form';
-import {HtmlAreaProvider} from '../../../shared/form/input-types/html-area';
-import {useApplicationKeys} from './useApplicationKeys';
 
 type MixinViewProps = {
     mixinName: string;
@@ -20,18 +15,11 @@ type MixinViewProps = {
 export const MixinView = ({mixinName}: MixinViewProps): ReactElement | null => {
     const descriptors = useStore($mixinsDescriptors);
     const draftMixins = useStore($wizardDraftMixins);
-    const contextContent = useStore($contextContent);
-    const activeProject = useStore($activeProject);
     const visibility = useStore($validationVisibility);
-    const applicationKeys = useApplicationKeys();
     const unknownMessage = useI18n('field.mixin.unavailable');
     const detachLabel = useI18n('action.mixin.detach');
 
     const rawValueMap = useMemo(() => getMixinRawValueMap(mixinName), [mixinName]);
-
-    const contentSummary = contextContent ?? undefined;
-
-    const assetsUri = CONFIG.getString('assetsUri');
 
     const descriptor = useMemo(
         () => descriptors.find((d) => d.getName() === mixinName),
@@ -83,18 +71,11 @@ export const MixinView = ({mixinName}: MixinViewProps): ReactElement | null => {
     return (
         <ValidationVisibilityProvider visibility={visibility}>
             <RawValueProvider map={rawValueMap}>
-                <HtmlAreaProvider
-                    contentSummary={contentSummary}
-                    project={activeProject}
-                    applicationKeys={applicationKeys}
-                    assetsUri={assetsUri}
-                >
-                    <FormRenderer
-                        form={form}
-                        propertySet={mixinData.getRoot()}
-                        applicationKey={applicationKey}
-                    />
-                </HtmlAreaProvider>
+                <FormRenderer
+                    form={form}
+                    propertySet={mixinData.getRoot()}
+                    applicationKey={applicationKey}
+                />
             </RawValueProvider>
         </ValidationVisibilityProvider>
     );


### PR DESCRIPTION
Centralized `HtmlAreaProvider` mount in `FormRenderer` via `HtmlAreaShell` so HTML area context is available wherever forms are rendered. Added `useOptionalHtmlAreaContext` to skip nested provider mounts when a parent already supplies the context. Moved `useApplicationKeys` from `content-wizard-tabs/` to shared `features/hooks/` and updated import sites. Removed redundant `HtmlAreaProvider` wrappers from `ContentForm`, `MixinView`, and `ComponentInspectionPanel`.

Closes #10406

<sub>*Drafted with AI assistance*</sub>
