### PR TITLE
Move Image Editor to preview panel #10175

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/view/ContentItemPreviewPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/ContentItemPreviewPanel.ts
@@ -9,6 +9,7 @@ import {AppHelper} from '@enonic/lib-admin-ui/util/AppHelper';
 import {cn} from '@enonic/ui';
 import Q from 'q';
 import {$activeWidget} from '../../v6/features/store/liveViewWidgets.store';
+import {$isPreviewPanelVisible} from '../../v6/features/store/previewPanel.store';
 import {PreviewToolbarElement} from '../../v6/features/views/browse/layout/preview/PreviewToolbar';
 import {type ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
 import {ContentSummaryAndCompareStatusHelper} from '../content/ContentSummaryAndCompareStatusHelper';
@@ -33,9 +34,9 @@ export class ContentItemPreviewPanel extends Panel implements ExtensionRenderer 
         super('item-preview-panel content-item-preview-panel extension-preview-panel');
 
         this.toolbar = this.createToolbar();
-        this.mask = new LoadMask(this);
         this.frame = new IFrameEl();
         this.wrapper = new DivEl('wrapper');
+        this.mask = new LoadMask(this.wrapper);
         this.wrapper.appendChild(this.frame);
         this.appendChildren(this.toolbar, this.wrapper, this.mask);
 
@@ -132,7 +133,12 @@ export class ContentItemPreviewPanel extends Panel implements ExtensionRenderer 
 
     private setupListeners() {
 
+        this.onShown(() => {
+            $isPreviewPanelVisible.set(true);
+        });
+
         this.onHidden((event) => {
+            $isPreviewPanelVisible.set(false);
             if (this.mask.isVisible()) {
                 this.hideMask();
             }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -9,7 +9,7 @@ import {Body} from '@enonic/lib-admin-ui/dom/Body';
 import {DivEl} from '@enonic/lib-admin-ui/dom/DivEl';
 import {showFeedback} from '@enonic/lib-admin-ui/notify/MessageBus';
 import {NotifyManager} from '@enonic/lib-admin-ui/notify/NotifyManager';
-import {ContentTypeName} from '@enonic/lib-admin-ui/schema/content/ContentTypeName';
+import {type ContentTypeName} from '@enonic/lib-admin-ui/schema/content/ContentTypeName';
 import {Action} from '@enonic/lib-admin-ui/ui/Action';
 import {KeyBindings} from '@enonic/lib-admin-ui/ui/KeyBindings';
 import {LoadMask} from '@enonic/lib-admin-ui/ui/mask/LoadMask';
@@ -31,6 +31,7 @@ import {compareContent} from '../../v6/features/api/compare';
 import {cleanupWizardMixinsService, initWizardMixinsService} from '../../v6/features/services/wizardMixins.service';
 import {setWizardContent} from '../../v6/features/store/context/contextContent.store';
 import {$isContextOpen, setContextOpen} from '../../v6/features/store/contextWidgets.store';
+import {$isPreviewPanelVisible} from '../../v6/features/store/previewPanel.store';
 import {
     $displayNameInputFocusRequested,
     $isContentFormExpanded,
@@ -284,6 +285,7 @@ export class ContentWizardPanel
             if (this.minimizedFromFormOnly) {
                 this.splitPanel.removeClass('toggle-form').addClass('toggle-split');
                 this.splitPanel.showSecondPanel();
+                this.syncPreviewPanelVisibility();
             }
 
             this.splitPanel.savePanelSizesAndDistribute(SplitPanelSize.PIXELS(60));
@@ -293,6 +295,7 @@ export class ContentWizardPanel
                 this.splitPanel.removeClass('toggle-split').addClass('toggle-form');
                 this.splitPanel.hideSecondPanel();
                 this.minimizedFromFormOnly = false;
+                this.syncPreviewPanelVisibility();
             }
 
             this.splitPanel.loadPanelSizesAndDistribute();
@@ -550,7 +553,9 @@ export class ContentWizardPanel
         // always create live panel because
         // JSON widget is always able to render content
         this.livePanel = this.createLivePanel();
-        this.liveMask = new LoadMask(this.livePanel).addClass('live-load-mask') as LoadMask;
+        // Scope the load mask to the frame contents (image editor + iframe wrapper) so
+        // the preview toolbar above them stays interactive while the preview is loading.
+        this.liveMask = new LoadMask(this.livePanel.getFrameContainer().getContents()).addClass('live-load-mask') as LoadMask;
 
         return super.doRenderOnDataLoaded(rendered).then(() => {
             if (ContentWizardPanel.debug) {
@@ -1430,12 +1435,23 @@ export class ContentWizardPanel
         return $wizardIsMarkedAsReady.get();
     }
 
+    // `$isPreviewPanelVisible` is read by `ContentForm` to decide whether to exclude
+    // the ImageUploader input from the form (it is excluded when the preview is
+    // visible because `LiveViewImageEditor` renders it there instead).
     showForm(): void {
         this.wizardActions.getShowFormAction().execute();
+        this.syncPreviewPanelVisibility();
     }
 
     showLiveEdit(): void {
         this.wizardActions.getShowLiveEditAction().execute();
+        this.syncPreviewPanelVisibility();
+    }
+
+    // Derived from the splitPanel mode classes so the atom stays correct regardless
+    // of which path mutated the layout (action, minimize toggle, responsive change).
+    private syncPreviewPanelVisibility(): void {
+        $isPreviewPanelVisible.set(this.isSplitView() || this.isLiveView());
     }
 
     private isSplitView(): boolean {
@@ -1490,8 +1506,11 @@ export class ContentWizardPanel
         return this.contentType ? this.contentType.getContentTypeName() : this.getCurrentItem().getType();
     }
 
+    // Image content types previously opted out of the live editor and showed the form
+    // panel only. They now open the editor by default so `LiveViewImageEditor` can
+    // render the image-uploader under the preview toolbar.
     private shouldOpenEditorByDefault(): Q.Promise<boolean> {
-        return Q.resolve(this.contentType && !ContentTypeName.IMAGE.equals(this.contentType.getContentTypeName()));
+        return Q.resolve(!!this.contentType);
     }
 
     private shouldAndCanOpenEditorByDefault(): Q.Promise<boolean> {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/FrameContainer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/FrameContainer.ts
@@ -1,7 +1,9 @@
 import {DivEl} from '@enonic/lib-admin-ui/dom/DivEl';
 import {type Element} from '@enonic/lib-admin-ui/dom/Element';
 import {Panel} from '@enonic/lib-admin-ui/ui/panel/Panel';
+import {LiveViewImageEditorElement} from '../../../v6/features/views/wizard/layout/LiveViewImageEditor';
 import {PreviewToolbarElement} from '../../../v6/features/views/browse/layout/preview/PreviewToolbar';
+import {$isLiveViewImageEditorActive} from '../../../v6/features/store/liveViewWidgets.store';
 import {type LiveEditPageProxy} from './LiveEditPageProxy';
 
 export interface FrameContainerConfig {
@@ -10,8 +12,11 @@ export interface FrameContainerConfig {
 
 export class FrameContainer extends Panel {
     private readonly toolbar: PreviewToolbarElement;
+    private readonly contents: DivEl;
+    private readonly imageEditor: LiveViewImageEditorElement;
     private readonly proxy: LiveEditPageProxy;
     private readonly wrapper: DivEl;
+    private readonly unsubscribers: (() => void)[] = [];
 
     constructor(config: FrameContainerConfig) {
         super('frame-container');
@@ -19,12 +24,28 @@ export class FrameContainer extends Panel {
 
         this.proxy = config.proxy;
         this.toolbar = new PreviewToolbarElement();
+        this.imageEditor = new LiveViewImageEditorElement();
 
         this.wrapper = new DivEl('wrapper');
-
         this.wrapper.appendChild(this.proxy.getIFrame());
 
-        this.appendChildren<Element>(this.toolbar, this.wrapper, this.proxy.getDragMask());
+        // `frame-contents` groups the image editor and the iframe wrapper so the live
+        // load mask can be scoped to them and leave the toolbar interactive.
+        this.contents = new DivEl('frame-contents');
+        this.contents.appendChild(this.imageEditor);
+        this.contents.appendChild(this.wrapper);
+
+        this.appendChildren<Element>(this.toolbar, this.contents, this.proxy.getDragMask());
+
+        this.unsubscribers.push($isLiveViewImageEditorActive.subscribe(() => this.updateIframeVisibility()));
+
+        this.onRemoved(() => {
+            this.unsubscribers.forEach((unsub) => unsub());
+        });
+    }
+
+    private updateIframeVisibility(): void {
+        this.wrapper.setVisible(!$isLiveViewImageEditorActive.get());
     }
 
     public getToolbar(): PreviewToolbarElement {
@@ -33,5 +54,9 @@ export class FrameContainer extends Panel {
 
     public getWrapper(): DivEl {
         return this.wrapper;
+    }
+
+    public getContents(): DivEl {
+        return this.contents;
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveFormPanel.ts
@@ -10,7 +10,7 @@ import type {default as Q} from 'q';
 import {type LiveEditModel} from '../../../page-editor/LiveEditModel';
 import {cleanupComponentInspection, initComponentInspectionService} from '../../../v6/features/store/component-inspection.store';
 import {cleanupFragmentInspection, initFragmentInspectionService} from '../../../v6/features/store/fragment-inspection.store';
-import {$activeWidget} from '../../../v6/features/store/liveViewWidgets.store';
+import {$activeWidget, $isLiveViewImageEditorActive} from '../../../v6/features/store/liveViewWidgets.store';
 import {cleanupPageEditorBridge, initPageEditorBridge, syncInitialRenderable} from '../../../v6/features/store/page-editor';
 import {cleanupPageInspection, initPageInspectionService} from '../../../v6/features/store/page-inspection.store';
 import {type Content} from '../../content/Content';
@@ -251,6 +251,11 @@ export class LiveFormPanel
         }
 
         if (this.pageSkipReload) {
+            return Promise.resolve(false);
+        }
+
+        // Image content types under the auto widget are handled by `LiveViewImageEditor`.
+        if ($isLiveViewImageEditorActive.get()) {
             return Promise.resolve(false);
         }
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormRenderer.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormRenderer.tsx
@@ -3,10 +3,12 @@ import type {Form} from '@enonic/lib-admin-ui/form/Form';
 import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
 import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
 import {useStore} from '@nanostores/preact';
-import {type ReactElement, type ReactNode} from 'react';
+import {type ReactElement, type ReactNode, useMemo} from 'react';
 import {useApplicationKeys} from '../../hooks/useApplicationKeys';
 import {$contextContent} from '../../store/context/contextContent.store';
 import {$activeProject} from '../../store/projects.store';
+import {Input} from '@enonic/lib-admin-ui/form/Input';
+import {instanceOf} from '../../utils/object/instanceOf';
 import {FormRenderProvider} from './FormRenderContext';
 import {FormItemRenderer} from './FormItemRenderer';
 import {HtmlAreaProvider, useOptionalHtmlAreaContext} from './input-types/html-area';
@@ -16,15 +18,26 @@ type FormRendererProps = {
     propertySet: PropertySet;
     enabled?: boolean;
     applicationKey?: ApplicationKey;
+    excludeInputTypes?: string[];
 };
 
-export const FormRenderer = ({form, propertySet, enabled = true, applicationKey}: FormRendererProps): ReactElement => {
+export const FormRenderer = ({form, propertySet, enabled = true, applicationKey, excludeInputTypes}: FormRendererProps): ReactElement => {
     const existingHtmlAreaContext = useOptionalHtmlAreaContext();
+
+    const excluded = useMemo(() => new Set((excludeInputTypes ?? []).map((name) => name.toLowerCase())), [excludeInputTypes]);
+
+    const items =
+        excluded.size === 0
+            ? form.getFormItems()
+            : form.getFormItems().filter((item) => {
+                  if (!instanceOf(item, Input)) return true;
+                  return !excluded.has(item.getInputType().getName().toLowerCase());
+              });
 
     const renderedForm = (
         <FormRenderProvider enabled={enabled} applicationKey={applicationKey}>
             <div className="flex flex-col gap-7.5" data-component="FormRenderer">
-                {form.getFormItems().map(item => (
+                {items.map((item) => (
                     <FormItemRenderer key={item.getName()} formItem={item} propertySet={propertySet} />
                 ))}
             </div>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderContext.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderContext.tsx
@@ -166,7 +166,7 @@ export const ImageUploaderProvider = ({values, enabled, children}: ImageUploader
         const newCrop = adjustCropToBaseOrientation(denormalizedCrop, committedOrientation, dimensions);
         setCrop(newCrop);
         prevCropRef.current = newCrop;
-    }, [dimensions, committedOrientation]);
+    }, [dimensions, committedOrientation, value]);
 
     // ============================================================
     // Focus
@@ -209,9 +209,25 @@ export const ImageUploaderProvider = ({values, enabled, children}: ImageUploader
         };
 
         setFocus(adjustFocusToBaseOrientation(denormalizedFocus, committedOrientation, dimensions));
-    }, [dimensions, committedOrientation, crop]);
+    }, [dimensions, committedOrientation, crop, value]);
 
     useEffect(() => {
+        // When entering focus mode with no focus set, initialize it to the crop/image
+        // center so Apply persists the same point the SVG displays by default.
+        if (mode !== 'focus' || focus || !dimensions) return;
+
+        const cropForOri = crop ? adjustCropForOrientation(crop, committedOrientation, dimensions) : null;
+        const center: Point = cropForOri
+            ? {x: (cropForOri.x1 + cropForOri.x2) / 2, y: (cropForOri.y1 + cropForOri.y2) / 2}
+            : {x: dimensions.w / 2, y: dimensions.h / 2};
+
+        setFocus(adjustFocusToBaseOrientation(center, committedOrientation, dimensions));
+    }, [mode, focus, crop, dimensions, committedOrientation]);
+
+    useEffect(() => {
+        // Recenter focus after the crop is applied (mode transitions out of 'crop'),
+        // not while the user is still drawing/adjusting the crop rectangle.
+        if (mode === 'crop') return;
         if (!crop || !dimensions) return;
 
         const prev = prevCropRef.current;
@@ -231,7 +247,7 @@ export const ImageUploaderProvider = ({values, enabled, children}: ImageUploader
         const newFocus = adjustFocusToBaseOrientation(cropCenter, committedOrientation, dimensions);
         setFocus(newFocus);
         setFocusInPropertySet(value, newFocus, dimensions);
-    }, [crop, dimensions, committedOrientation, value]);
+    }, [crop, dimensions, committedOrientation, value, mode]);
 
     // ============================================================
     // Reset (atomic, stable, no closure staleness)
@@ -242,9 +258,16 @@ export const ImageUploaderProvider = ({values, enabled, children}: ImageUploader
         setOrientation(1);
         setCommittedOrientation(1);
         setCrop(null);
-        setFocus(null);
+        if (dimensions) {
+            const sideways = committedOrientation >= 5;
+            const baseW = sideways ? dimensions.h : dimensions.w;
+            const baseH = sideways ? dimensions.w : dimensions.h;
+            setFocus({x: baseW / 2, y: baseH / 2});
+        } else {
+            setFocus(null);
+        }
         setMode('ready');
-    }, []);
+    }, [dimensions, committedOrientation]);
 
     // ============================================================
     // Provider

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInput.tsx
@@ -11,7 +11,7 @@ export const ImageUploaderInput = ({values, enabled}: SelfManagedComponentProps<
     if (values.length === 0) return null;
 
     return (
-        <div data-component={IMAGE_UPLOADER_INPUT_NAME}>
+        <div data-component={IMAGE_UPLOADER_INPUT_NAME} className="flex flex-col flex-1 min-h-0">
             <ImageUploaderProvider values={values} enabled={enabled}>
                 <ImageUploaderInputControls />
                 <ImageUploaderInputImage />

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputControls/ImageUploaderInputApplyButton.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputControls/ImageUploaderInputApplyButton.tsx
@@ -21,7 +21,7 @@ export const ImageUploaderInputApplyButton = (): ReactElement => {
     }, [value, mode, setMode, focus, crop, dimensions]);
 
     return (
-        <Button variant="filled" size="sm" onClick={handleApply}>
+        <Button variant="filled" onClick={handleApply}>
             {applyLabel}
         </Button>
     );

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputControls/ImageUploaderInputResetButton.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputControls/ImageUploaderInputResetButton.tsx
@@ -4,6 +4,7 @@ import {useI18n} from '../../../../../hooks/useI18n';
 import {InlineButton} from '../../../../InlineButton';
 import {useImageUploaderContext} from '../ImageUploaderContext';
 import {isPropertySetDirty, resetCropInPropertySet, resetFocusInPropertySet, resetPropertySet} from '../lib/propertySet';
+import {Button} from '@enonic/ui';
 
 export const ImageUploaderInputResetButton = (): ReactElement | null => {
     const {contentId, mode, value, crop, focus, dimensions, setCrop, setFocus, reset} = useImageUploaderContext();
@@ -33,8 +34,11 @@ export const ImageUploaderInputResetButton = (): ReactElement | null => {
     const handleCropReset = useCallback(() => {
         if (resetCropInPropertySet(value)) {
             setCrop(null);
+            if (dimensions) {
+                setFocus({x: dimensions.w / 2, y: dimensions.h / 2});
+            }
         }
-    }, [value, setCrop]);
+    }, [value, dimensions, setCrop, setFocus]);
 
     const handleFocusReset = useCallback(() => {
         if (resetFocusInPropertySet(value)) {
@@ -48,23 +52,27 @@ export const ImageUploaderInputResetButton = (): ReactElement | null => {
 
     if (mode === 'crop') {
         return (
-            <InlineButton onClick={handleCropReset} disabled={!crop}>
+            <Button variant="text" onClick={handleCropReset} disabled={!crop}>
                 {resetLabel}
-            </InlineButton>
+            </Button>
         );
     }
 
     if (mode === 'focus') {
         return (
-            <InlineButton onClick={handleFocusReset} disabled={!focus}>
+            <Button variant="text" onClick={handleFocusReset} disabled={!focus}>
                 {resetLabel}
-            </InlineButton>
+            </Button>
         );
     }
 
     if (!isDirty) return null;
 
-    return <InlineButton onClick={handleReset}>{resetLabel}</InlineButton>;
+    return (
+        <Button variant="text" onClick={handleReset}>
+            {resetLabel}
+        </Button>
+    );
 };
 
 ImageUploaderInputResetButton.displayName = 'ImageUploaderInputResetButton';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputImage/ImageUploaderInputCropSvg.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputImage/ImageUploaderInputCropSvg.tsx
@@ -69,13 +69,30 @@ export const ImageUploaderInputCropSvg = (): ReactElement => {
     return (
         <svg
             viewBox={`0 0 ${dimensions.w} ${dimensions.h}`}
-            className="w-full h-auto cursor-crosshair"
+            className="w-full h-full cursor-crosshair"
+            style={{maxWidth: dimensions?.w, maxHeight: dimensions?.h}}
             onClick={handleClick}
             onMouseMove={handleMouseMove}
         >
             <image href={base64Image} width={dimensions.w} height={dimensions.h} />
 
-            {!rect && <rect x={0} y={0} width={dimensions.w} height={dimensions.h} fill="black" fillOpacity={0.5} />}
+            {!rect && (
+                <>
+                    <rect x={0} y={0} width={dimensions.w} height={dimensions.h} fill="black" fillOpacity={0.5} />
+                    {/* TODO: remove this harcoded text when crop is behavior gets updated */}
+                    <text
+                        x={dimensions.w / 2}
+                        y={dimensions.h / 2}
+                        textAnchor="middle"
+                        dominantBaseline="middle"
+                        fill="white"
+                        fontSize={Math.min(dimensions.w, dimensions.h) * 0.04}
+                        style={{pointerEvents: 'none'}}
+                    >
+                        Click the image to draw cropping area
+                    </text>
+                </>
+            )}
 
             {rect && (
                 <>
@@ -84,7 +101,7 @@ export const ImageUploaderInputCropSvg = (): ReactElement => {
                         fillRule="evenodd"
                         fill="black"
                         strokeWidth={strokeWidth}
-                        fillOpacity={0.4}
+                        fillOpacity={0.5}
                     />
                     <rect
                         x={rect.x1}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputImage/ImageUploaderInputFocusSvg.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputImage/ImageUploaderInputFocusSvg.tsx
@@ -1,5 +1,5 @@
 import {cn} from '@enonic/ui';
-import {useCallback, type MouseEvent, type ReactElement} from 'react';
+import {type MouseEvent, type ReactElement} from 'react';
 import {useImageUploaderContext} from '../ImageUploaderContext';
 import {type Point} from '../lib/types';
 
@@ -31,33 +31,33 @@ export const ImageUploaderInputFocusSvg = (): ReactElement => {
         };
     };
 
-    const handleClick = useCallback(
-        (e: MouseEvent<SVGSVGElement>): void => {
-            const p = toLocal(e);
-            if (!p || !isFocusing) return;
-            setFocus(p);
-        },
-        [isFocusing, setFocus]
-    );
+    const handleClick = (e: MouseEvent<SVGSVGElement>): void => {
+        const p = toLocal(e);
+        if (!p || !isFocusing) return;
+        setFocus(p);
+    };
+
+    // While in focus mode, default the circle to the crop/image center so it shows
+    // immediately on entering focus mode, before any click.
+    const displayFocus = focus ?? (isFocusing ? {x: cropXCenter, y: cropYCenter} : null);
 
     return (
         <svg
             viewBox={`${viewX} ${viewY} ${viewW} ${viewH}`}
-            className={cn('w-full h-auto', isFocusing && 'cursor-crosshair')}
+            className={cn('w-full h-full', isFocusing && 'cursor-move')}
+            style={{maxWidth: dimensions?.w, maxHeight: dimensions?.h}}
             onClick={handleClick}
         >
             <image href={base64Image} x={viewX} y={viewY} width={viewW} height={viewH} />
 
-            {isFocusing && !focus && <rect x={viewX} y={viewY} width={viewW} height={viewH} fill="black" fillOpacity={0.5} />}
-
-            {isFocusing && focus && (
+            {isFocusing && displayFocus && (
                 <>
                     <mask id="focus-mask">
                         <rect x={viewX} y={viewY} width={viewW} height={viewH} fill="white" />
-                        <circle cx={focus.x} cy={focus.y} r={radius} fill="black" />
+                        <circle cx={displayFocus.x} cy={displayFocus.y} r={radius} fill="black" />
                     </mask>
                     <rect x={viewX} y={viewY} width={viewW} height={viewH} fill="black" fillOpacity={0.5} mask="url(#focus-mask)" />
-                    <circle cx={focus.x} cy={focus.y} r={radius} fill="none" stroke="red" strokeWidth={strokeWidth} />
+                    <circle cx={displayFocus.x} cy={displayFocus.y} r={radius} fill="none" stroke="red" strokeWidth={strokeWidth} />
                 </>
             )}
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputImage/index.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputImage/index.tsx
@@ -5,7 +5,7 @@ import {ImageUploaderInputFocusSvg} from './ImageUploaderInputFocusSvg';
 import {LoaderCircle} from 'lucide-react';
 
 export const ImageUploaderInputImage = (): ReactElement | null => {
-    const {base64Image, mode, focus} = useImageUploaderContext();
+    const {base64Image, mode, focus, dimensions} = useImageUploaderContext();
 
     if (!base64Image) return null;
 
@@ -17,10 +17,16 @@ export const ImageUploaderInputImage = (): ReactElement | null => {
     const showFocus = isFocusing || (!isCropping && focus);
 
     return (
-        <div className="@container mt-5 overflow-hidden">
+        <div data-component="ImageUploaderInputImage" className="mt-5 flex flex-1 items-center justify-center min-h-0">
             {showImage && (
-                <div className="relative min-w-32 min-h-32">
-                    {base64Image && <img src={base64Image} />}
+                <div className="relative w-full h-full">
+                    {base64Image && (
+                        <img
+                            src={base64Image}
+                            className="w-full h-full object-contain"
+                            style={{maxWidth: dimensions?.w, maxHeight: dimensions?.h}}
+                        />
+                    )}
                     {isLoading && (
                         <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
                             <LoaderCircle />

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/liveViewWidgets.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/liveViewWidgets.store.ts
@@ -1,6 +1,7 @@
 import {type Extension} from '@enonic/lib-admin-ui/extension/Extension';
 import {computed, map} from 'nanostores';
 import {GetExtensionsByInterfaceRequest} from '../../../app/resource/GetExtensionsByInterfaceRequest';
+import {$contentType} from './wizardContent.store';
 
 export const WIDGET_AUTO_DESCRIPTOR = 'preview-automatic';
 
@@ -20,10 +21,12 @@ export const $activeWidget = computed($liveViewWidgets, (store) => {
 
 export const $autoModeWidgets = computed($liveViewWidgets, (store) => {
     return store.widgets.filter(
-        (item) =>
-            item.getDescriptorKey().getName() !== WIDGET_AUTO_DESCRIPTOR &&
-            item.getConfig().getProperty('auto') === 'true'
+        (item) => item.getDescriptorKey().getName() !== WIDGET_AUTO_DESCRIPTOR && item.getConfig().getProperty('auto') === 'true'
     );
+});
+
+export const $isLiveViewImageEditorActive = computed([$activeWidget, $contentType], (widget, contentType) => {
+    return widget?.getDescriptorKey().getName() === WIDGET_AUTO_DESCRIPTOR && contentType?.getContentTypeName().isImage() === true;
 });
 
 export function setActiveWidget(widget: Extension | undefined): void {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/previewPanel.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/previewPanel.store.ts
@@ -1,0 +1,6 @@
+import {atom} from 'nanostores';
+
+// Reflects whether the preview panel is currently visible to the user.
+// Set by both the wizard (ContentWizardPanel) and the browse view
+// (ContentItemPreviewPanel) so consumers can react regardless of mode.
+export const $isPreviewPanelVisible = atom<boolean>(false);

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/layout/preview/PreviewToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/layout/preview/PreviewToolbar.tsx
@@ -13,8 +13,8 @@ type PreviewToolbarProps = {
     onRefresh?: () => void;
 };
 
-const PreviewToolbar = ({item = null, onRefresh}: PreviewToolbarProps): ReactElement | undefined => {
-    if (!item) return undefined;
+const PreviewToolbar = ({item = null, onRefresh}: PreviewToolbarProps): ReactElement | null => {
+    if (!item) return null;
 
     return (
         <Toolbar>
@@ -22,11 +22,9 @@ const PreviewToolbar = ({item = null, onRefresh}: PreviewToolbarProps): ReactEle
                 aria-label="Preview toolbar"
                 className="@container bg-surface-neutral h-15 px-5 py-3.75 flex items-center justify-between border-b border-bdr-soft"
             >
-                <PreviewToolbarVersionHistoryItem
-                    contentSummary={item.getContentSummary()}
-                />
+                <PreviewToolbarVersionHistoryItem contentSummary={item.getContentSummary()} />
 
-                <div className="flex gap-2 @md:gap-5 flex-nowrap flex-shrink-0">
+                <div className="flex gap-2 @md:gap-5 flex-nowrap shrink-0">
                     <PreviewToolbarEmulatorSelector />
                     <PreviewToolbarWidgetSelector />
                 </div>
@@ -40,7 +38,6 @@ const PreviewToolbar = ({item = null, onRefresh}: PreviewToolbarProps): ReactEle
 PreviewToolbar.displayName = 'PreviewToolbar';
 
 export class PreviewToolbarElement extends LegacyElement<typeof PreviewToolbar, PreviewToolbarProps> {
-
     constructor() {
         super({}, PreviewToolbar);
     }

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
@@ -5,6 +5,8 @@ import {FormRenderer} from '../../../shared/form';
 import {$contentType, $wizardDraftData, notifyContentFormMounted} from '../../../store/wizardContent.store';
 import {$validationVisibility, getContentRawValueMap} from '../../../store/wizardValidation.store';
 import {DisplayNameInput} from './DisplayNameInput';
+import {$isPreviewPanelVisible} from '../../../store/previewPanel.store';
+import {ImageUploaderDescriptor} from '../../../shared/form/input-types/image-uploader';
 
 const CONTENT_FORM_NAME = 'ContentForm';
 
@@ -12,8 +14,11 @@ export const ContentForm = (): ReactElement | null => {
     const contentType = useStore($contentType);
     const draftData = useStore($wizardDraftData);
     const visibility = useStore($validationVisibility);
+    const isPreviewPanelVisible = useStore($isPreviewPanelVisible);
 
     const isReady = contentType != null && draftData != null;
+    const rawValueMap = useMemo(() => getContentRawValueMap(), []);
+    const applicationKey = useMemo(() => contentType?.getContentTypeName().getApplicationKey(), [contentType]);
 
     useEffect(() => {
         if (isReady) {
@@ -21,12 +26,19 @@ export const ContentForm = (): ReactElement | null => {
         }
     }, [isReady]);
 
-    const rawValueMap = useMemo(() => getContentRawValueMap(), []);
+    // For image content types, the ImageUploader is rendered by `LiveViewImageEditor`
+    // under the preview toolbar whenever the preview panel is visible. Exclude it from
+    // the form here to avoid rendering the editor twice. When the preview is hidden,
+    // fall back to the standard form rendering so the user still has access to it.
+    const excludeInputTypes = useMemo<string[]>(() => {
+        const excluded: string[] = [];
 
-    const applicationKey = useMemo(
-        () => contentType?.getContentTypeName().getApplicationKey(),
-        [contentType],
-    );
+        if (contentType?.getContentTypeName().isImage() && isPreviewPanelVisible) {
+            excluded.push(ImageUploaderDescriptor.name);
+        }
+
+        return excluded;
+    }, [contentType, isPreviewPanelVisible]);
 
     if (!isReady) {
         return null;
@@ -41,6 +53,7 @@ export const ContentForm = (): ReactElement | null => {
                         form={contentType.getForm()}
                         propertySet={draftData.getRoot()}
                         applicationKey={applicationKey}
+                        excludeInputTypes={excludeInputTypes}
                     />
                 </RawValueProvider>
             </ValidationVisibilityProvider>

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/layout/LiveViewImageEditor.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/layout/LiveViewImageEditor.tsx
@@ -1,0 +1,78 @@
+import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
+import {Input} from '@enonic/lib-admin-ui/form/Input';
+import type {FormItem} from '@enonic/lib-admin-ui/form/FormItem';
+import {RawValueProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
+import {useStore} from '@nanostores/preact';
+import {type ReactElement, useMemo} from 'react';
+import {LegacyElement} from '../../../shared/LegacyElement';
+import {FormItemRenderer, FormRenderProvider} from '../../../shared/form';
+import {ImageUploaderDescriptor} from '../../../shared/form/input-types/image-uploader/ImageUploaderDescriptor';
+import {$contentType, $wizardDraftData} from '../../../store/wizardContent.store';
+import {$validationVisibility, getContentRawValueMap} from '../../../store/wizardValidation.store';
+import {instanceOf} from '../../../utils/object/instanceOf';
+import {WIDGET_AUTO_DESCRIPTOR, $activeWidget} from '../../../store/liveViewWidgets.store';
+import {cn} from '@enonic/ui';
+
+const COMPONENT_NAME = 'LiveViewImageEditor';
+
+// Surfaces the form's ImageUploader input inside the preview area so the user can
+// crop/focus the image alongside the preview instead of in the left form panel.
+// Mounted into `FrameContainer` and active only when the auto widget is selected on
+// an image content type; `ContentForm` excludes the same input so it is not rendered
+// twice.
+const LiveViewImageEditor = (): ReactElement | null => {
+    const active = useStore($activeWidget);
+    const contentType = useStore($contentType);
+    const draftData = useStore($wizardDraftData);
+    const visibility = useStore($validationVisibility);
+
+    const rawValueMap = useMemo(() => getContentRawValueMap(), []);
+
+    const imageUploaderItem = useMemo<FormItem | undefined>(() => {
+        if (contentType == null) return undefined;
+        return contentType
+            .getForm()
+            .getFormItems()
+            .find(
+                (item) =>
+                    instanceOf(item, Input) && item.getInputType().getName().toLowerCase() === ImageUploaderDescriptor.name.toLowerCase()
+            );
+    }, [contentType]);
+
+    if (active?.getDescriptorKey().getName() !== WIDGET_AUTO_DESCRIPTOR) return null;
+    if (contentType == null || draftData == null) return null;
+    if (!contentType.getContentTypeName().isImage()) return null;
+    if (imageUploaderItem == null) return null;
+
+    const applicationKey = contentType.getContentTypeName().getApplicationKey();
+    const propertySet: PropertySet = draftData.getRoot();
+
+    return (
+        <ValidationVisibilityProvider visibility={visibility}>
+            <RawValueProvider map={rawValueMap}>
+                <FormRenderProvider enabled={true} applicationKey={applicationKey}>
+                    <div
+                        data-component={COMPONENT_NAME}
+                        className={cn(
+                            'flex flex-col flex-1 min-h-0 p-5',
+                            // Reuse the standard ImageUploader rendering but adapt it to the
+                            // preview area: hide the input label and let the input field grow
+                            // to fill the available height.
+                            "**:data-[component='InputLabel']:hidden **:data-[component='InputField']:flex-1 **:data-[component='InputField']:min-h-0"
+                        )}
+                    >
+                        <FormItemRenderer formItem={imageUploaderItem} propertySet={propertySet} />
+                    </div>
+                </FormRenderProvider>
+            </RawValueProvider>
+        </ValidationVisibilityProvider>
+    );
+};
+
+LiveViewImageEditor.displayName = COMPONENT_NAME;
+
+export class LiveViewImageEditorElement extends LegacyElement<typeof LiveViewImageEditor, Record<string, never>> {
+    constructor() {
+        super({}, LiveViewImageEditor);
+    }
+}

--- a/modules/lib/src/main/resources/assets/styles/wizard/page/live-form-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/page/live-form-panel.less
@@ -18,8 +18,18 @@
     flex-direction: column;
     align-items: stretch;
 
+    .frame-contents {
+      position: relative; // anchor the load mask to the contents area only
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+
     .wrapper {
       position: relative; // to contain the shader absolutely positioned element
+      flex: 1;
+      min-height: 0;
     }
   }
 


### PR DESCRIPTION
Image editor now appears under the preview toolbar in Automatic preview mode for image content, instead of inside the form.

**Behavior**
- Auto mode + image content -> editor renders over the preview area; the preview-widget request is skipped;
- Switch to another widget -> editor unmounts, iframe preview loads normally;
- Mobile / preview hidden -> editor falls back to inline form rendering;
- Removed the legacy special handling of the media preview where we don't open the preview panel when editing images.

**Key Changes**
- New `LiveViewImageEditor` component mounted into the preview frame container;
- New `$isLiveViewImageEditorActive` (computed) gates the iframe visibility and the preview-widget request;
- New `$isPreviewPanelVisible` atom store, shared between wizard (ContentWizardPanel) and browse (ContentItemPreviewPanel), drives whether ContentForm excludes the ImageUploader input to avoid double rendering;
- FormRenderer accepts an optional `excludeInputTypes` prop;
- Image-uploader minor visual updates.