### PR TITLE
Settings tree active row missing selected styling #10431

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/settings/SettingsTreeList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/settings/SettingsTreeList.tsx
@@ -111,6 +111,11 @@ export const SettingsTreeList = ({contextMenuActions = []}: SettingsTreeListProp
 
                                 const itemProps = getItemProps(index, node);
                                 const isSelected = selection.has(id);
+                                const isActive = activeId === id;
+                                // Active item with no selection should look like selected
+                                const showAsSelected = isSelected || (isActive && selection.size === 0);
+                                // When active-as-selected, disable active to avoid compound variant hover bg
+                                const activeAsSelected = showAsSelected && !isSelected;
 
                                 const secondaryText = data.getDescription() || `<${noDescription}>`;
                                 const isUnavailable = isProjectViewItem(data)
@@ -120,9 +125,9 @@ export const SettingsTreeList = ({contextMenuActions = []}: SettingsTreeListProp
                                 return (
                                     <VirtualizedTreeList.Row
                                         {...itemProps}
-                                        active={itemProps.active}
-                                        selected={isSelected}
-                                        data-tone={isSelected ? 'inverse' : undefined}
+                                        active={activeAsSelected ? false : itemProps.active}
+                                        selected={showAsSelected}
+                                        data-tone={showAsSelected ? 'inverse' : undefined}
                                         onContextMenu={(event) => {
                                             event.preventDefault();
                                             suppressNextClickForIdRef.current = id;
@@ -175,7 +180,7 @@ export const SettingsTreeList = ({contextMenuActions = []}: SettingsTreeListProp
                                                 expanded={isExpanded}
                                                 hasChildren={hasChildren}
                                                 onToggle={() => (isExpanded ? handleCollapse(id) : handleExpand(id))}
-                                                selected={isSelected}
+                                                selected={showAsSelected}
                                             />
                                         </VirtualizedTreeList.RowLeft>
                                         <VirtualizedTreeList.RowContent>


### PR DESCRIPTION
Mirrored `showAsSelected` derivation from `ContentTreeList` in `SettingsTreeList` so an active row with empty selection renders as `selected=true` + `data-tone="inverse"`. Suppressed compound `active` flag to avoid hover-background overlap. Wired the expand control's `selected` prop to the same value for visual parity.

Closes #10431

<sub>*Drafted with AI assistance*</sub>
