### PR TITLE
HtmlArea should use the same font style as other text inputs #10429

### DIFF
--- a/modules/lib/rspack.config.js
+++ b/modules/lib/rspack.config.js
@@ -25,8 +25,7 @@ module.exports = {
         'styles/contentlib': './styles/main.less',
         'lib/ckeditor/plugins/pasteModeSwitcher/plugin': './lib/ckeditor/plugins/pasteModeSwitcher/plugin.raw.js',
         'lib/ckeditor/plugins/findAndReplace/plugin': './lib/ckeditor/plugins/findAndReplace/plugin.ts',
-        // html editor css imported separately in the HTMLAreaBuilder for legacy mode
-        'styles/html-editor': './styles/inputtype/text/htmlarea/html-editor.less',
+        'styles/html-editor-iframe': './styles/inputtype/text/htmlarea/html-editor-iframe.less',
         'lib/ckeditor': ['./lib/ckepath.js', './lib/ckeditor/ckeditor.js']
     },
     output: {
@@ -64,7 +63,14 @@ module.exports = {
                 test: /\.(?:less|css)$/,
                 use: [
                     {loader: rspack.CssExtractRspackPlugin.loader, options: {publicPath: '../'}},
-                    {loader: 'css-loader', options: {sourceMap: !isProd, importLoaders: 1}},
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            sourceMap: !isProd,
+                            importLoaders: 1,
+                            url: {filter: url => !url.includes('admin/common/fonts/')}, // for loading fonts from lib-admin
+                        },
+                    },
                     {loader: 'less-loader', options: {sourceMap: !isProd}},
                 ],
                 type: 'javascript/auto',

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HtmlEditor.ts
@@ -1098,7 +1098,7 @@ class HtmlEditorConfigBuilder {
 
     private createConfig(): Q.Promise<CKEDITOR.config> {
         this.initCustomStyleSet();
-        const contentsCss = [this.editorParams.getAssetsUri() + '/styles/html-editor.css'];
+        const contentsCss = [this.editorParams.getAssetsUri() + '/styles/html-editor-iframe.css'];
 
         const config: CKEDITOR.config = {
             contentsCss: contentsCss,

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/html-area/useCKEditorConfig.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/html-area/useCKEditorConfig.ts
@@ -154,7 +154,7 @@ function buildConfig(params: UseCKEditorConfigParams, cssPaths: string[]): CKEDI
 
     const styleSetId = initCustomStyleSet(params.editorId, params.config.allowedHeadings, disabledTools);
 
-    const contentsCss = [params.assetsUri + '/styles/html-editor.css', ...cssPaths];
+    const contentsCss = [params.assetsUri + '/styles/html-editor-iframe.css', ...cssPaths];
 
     const config: CKEDITOR.config = {
         contentsCss,

--- a/modules/lib/src/main/resources/assets/styles/inputtype/text/htmlarea/html-editor-iframe.less
+++ b/modules/lib/src/main/resources/assets/styles/inputtype/text/htmlarea/html-editor-iframe.less
@@ -1,0 +1,246 @@
+// Loaded inside the CKEditor iframe (editor body) and popup iframes via `contentsCss`. Chrome rules live in html-editor.less.
+@import "~enonic-admin-artifacts";
+
+// ? CKEditor iframe references @font-face from lib-admin-ui.
+@font-face {
+  font-family: 'Open Sans';
+  font-display: swap;
+  font-style: normal;
+  font-weight: 100 900;
+  src: url("../admin/common/fonts/OpenSans.woff2") format("woff2");
+}
+
+@font-face {
+  font-family: 'Open Sans';
+  font-display: swap;
+  font-style: italic;
+  font-weight: 100 900;
+  src: url("../admin/common/fonts/OpenSans-Italic.woff2") format("woff2");
+}
+
+body.cke_editable {
+  font-family: @admin-font-family;
+  font-size: 16px;
+  line-height: 1.3;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
+  &.fullscreen {
+    padding: 0 20px;
+  }
+
+  @media screen and (max-width: 660px) {
+    &.fullscreen {
+      padding: 0;
+    }
+  }
+
+  strong {
+    font-family: @admin-font-family;
+  }
+
+  a:visited {
+    color: blue;
+  }
+
+  figure {
+    margin: 0;
+
+    &.editor-align-left {
+      margin-right: 20px;
+    }
+
+    &.editor-align-right {
+      margin-left: 20px;
+    }
+
+    figcaption:empty {
+      display: none;
+    }
+  }
+
+  span.shy {
+    position: relative;
+    width: 0;
+    display: inline-block;
+    height: 10px;
+    line-height: 10px;
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      width: 4px;
+      height: 100%;
+      background-color: hsl(54deg 100% 62% / 30%);
+      border: 1px solid orange;
+    }
+
+    &::before {
+      left: -4px;
+      border-right: none;
+    }
+
+    &::after {
+      right: -4px;
+      border-left: none;
+    }
+  }
+}
+
+.cke_editable {
+  table,
+  th,
+  td {
+    border: 1px solid black;
+  }
+
+  table {
+    width: 100%;
+
+    &.cke_show_border {
+      border: 1px solid black !important;
+
+      th,
+      td {
+        border: 1px solid black !important;
+      }
+    }
+  }
+}
+
+.cke__highlighted_term {
+  background-color: yellow;
+}
+
+.cke__selected_term {
+  outline: 1px solid black;
+}
+
+// Styles dropdown panel — rendered in its own popup iframe whose <html> gets these classes.
+html.cke_panel_container.cke_combopanel__styles,
+html.cke_panel_container.htmlarea-styles-popup {
+  font-family: @admin-font-family;
+  font-size: 14px;
+
+  --cke-popup-bg: #ffffff;
+  --cke-popup-bg-hover: #f1f5f6;
+  --cke-popup-border: #b2b2b2;
+  --cke-popup-text: #000000;
+  --cke-popup-text-subtle: #5b5f60;
+
+  body.cke_ltr,
+  body.cke_rtl,
+  .cke_panel_block,
+  .cke_panel_list {
+    background-color: var(--cke-popup-bg);
+    color: var(--cke-popup-text);
+  }
+
+  .cke_panel_grouptitle {
+    background-color: var(--cke-popup-bg);
+    border-bottom-color: var(--cke-popup-border);
+    color: var(--cke-popup-text-subtle);
+  }
+
+  .cke_panel_listItem a {
+    color: var(--cke-popup-text);
+  }
+
+  .cke_panel_listItem a:hover,
+  .cke_panel_listItem a:focus,
+  .cke_panel_listItem a:active,
+  .cke_panel_listItem.cke_selected a {
+    background-color: var(--cke-popup-bg-hover);
+    color: var(--cke-popup-text);
+  }
+}
+
+// ── Dark mode: editor iframe content ──
+// The 'dark-mode' class is toggled on the iframe body at runtime.
+@cke-dark-surface:       #242829;  // grey-950
+@cke-dark-surface-hover: #3d4142;  // grey-900
+@cke-dark-border:        #5b5f60;  // grey-800
+@cke-dark-text:          #ffffff;  // main
+@cke-dark-text-subtle:   #b5b9ba;  // grey-400
+@cke-dark-link:          #208ebe;  // fbk-info-subtle
+@cke-dark-link-visited:  #e46ee4;  // purple-subtle
+
+body.cke_editable.dark-mode {
+  background-color: @cke-dark-surface;
+  color: @cke-dark-text;
+
+  a {
+    color: @cke-dark-link;
+  }
+
+  a:visited {
+    color: @cke-dark-link-visited;
+  }
+
+  blockquote {
+    border-color: @cke-dark-border;
+  }
+
+  hr {
+    border-top-color: @cke-dark-border;
+  }
+
+  figure {
+    outline-color: @cke-dark-border;
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  img.right,
+  img.left {
+    border-color: @cke-dark-border;
+  }
+
+  a > img {
+    outline-color: @cke-dark-link;
+  }
+
+  .marker {
+    background-color: #5c4422; // fbk-warn-surface-dark
+    color: @cke-dark-text;
+  }
+
+  table,
+  th,
+  td {
+    border-color: @cke-dark-border;
+  }
+
+  table.cke_show_border {
+    border-color: @cke-dark-border !important;
+
+    th,
+    td {
+      border-color: @cke-dark-border !important;
+    }
+  }
+
+  .cke__highlighted_term {
+    background-color: #5c4422;
+    color: @cke-dark-text;
+  }
+
+  .cke__selected_term {
+    outline-color: @cke-dark-text-subtle;
+  }
+
+  .image-grayscale {
+    background-color: @cke-dark-surface-hover;
+    color: @cke-dark-text-subtle;
+  }
+}
+
+html.dark.cke_panel_container.cke_combopanel__styles,
+html.dark.cke_panel_container.htmlarea-styles-popup {
+  --cke-popup-bg: @cke-dark-surface;
+  --cke-popup-bg-hover: @cke-dark-surface-hover;
+  --cke-popup-border: @cke-dark-border;
+  --cke-popup-text: @cke-dark-text;
+  --cke-popup-text-subtle: @cke-dark-text-subtle;
+}

--- a/modules/lib/src/main/resources/assets/styles/inputtype/text/htmlarea/html-editor.less
+++ b/modules/lib/src/main/resources/assets/styles/inputtype/text/htmlarea/html-editor.less
@@ -1,4 +1,4 @@
-// This is redundant?
+// Outer CKEditor chrome only — iframe-scoped rules live in html-editor-iframe.less.
 @import "~enonic-admin-artifacts";
 
 .cke_button__sourcedialog {
@@ -37,75 +37,6 @@ body > .cke_panel {
   z-index: @z-index-shader !important;
 }
 
-body.cke_editable {
-  font-family: @admin-font-family;
-  font-size: 14px;
-  line-height: 1.3;
-
-  &.fullscreen {
-    padding: 0 20px;
-  }
-
-  @media screen and (max-width: 660px) {
-    &.fullscreen {
-      padding: 0;
-    }
-  }
-
-  strong {
-    font-family: @admin-font-family;
-  }
-
-  a:visited {
-    color: blue;
-  }
-
-  figure {
-    margin: 0;
-
-    &.editor-align-left {
-      margin-right: 20px;
-    }
-
-    &.editor-align-right {
-      margin-left: 20px;
-    }
-
-    figcaption:empty {
-      display: none;
-    }
-  }
-
-  span.shy {
-    position: relative;
-    width: 0;
-    display: inline-block;
-    height: 10px;
-    line-height: 10px;
-
-    &::before,
-    &::after {
-      content: '';
-      position: absolute;
-      top: 0;
-      width: 4px;
-      height: 100%;
-      background-color: hsl(54deg 100% 62% / 30%);
-      border: 1px solid orange;
-    }
-
-    &::before {
-      left: -4px;
-      border-right: none;
-    }
-
-    &::after {
-      right: -4px;
-      border-left: none;
-    }
-  }
-}
-
 .cke_top, .cke_bottom {
   background: white !important;
 }
@@ -120,44 +51,6 @@ body.cke_editable {
   border-color: #b2b2b2;
 }
 
-html.cke_panel_container.cke_combopanel__styles,
-html.cke_panel_container.htmlarea-styles-popup {
-  font-family: @admin-font-family;
-  font-size: 14px;
-
-  --cke-popup-bg: #ffffff;
-  --cke-popup-bg-hover: #f1f5f6;
-  --cke-popup-border: #b2b2b2;
-  --cke-popup-text: #000000;
-  --cke-popup-text-subtle: #5b5f60;
-
-  body.cke_ltr,
-  body.cke_rtl,
-  .cke_panel_block,
-  .cke_panel_list {
-    background-color: var(--cke-popup-bg);
-    color: var(--cke-popup-text);
-  }
-
-  .cke_panel_grouptitle {
-    background-color: var(--cke-popup-bg);
-    border-bottom-color: var(--cke-popup-border);
-    color: var(--cke-popup-text-subtle);
-  }
-
-  .cke_panel_listItem a {
-    color: var(--cke-popup-text);
-  }
-
-  .cke_panel_listItem a:hover,
-  .cke_panel_listItem a:focus,
-  .cke_panel_listItem a:active,
-  .cke_panel_listItem.cke_selected a {
-    background-color: var(--cke-popup-bg-hover);
-    color: var(--cke-popup-text);
-  }
-}
-
 .cke_combo_button {
   .cke_combo_text {
     padding-left: 5px;
@@ -167,35 +60,6 @@ html.cke_panel_container.htmlarea-styles-popup {
     margin: 1px;
     width: 15px;
   }
-}
-
-.cke_editable {
-  table,
-  th,
-  td {
-    border: 1px solid black;
-  }
-
-  table {
-    width: 100%;
-
-    &.cke_show_border {
-      border: 1px solid black !important;
-
-      th,
-      td {
-        border: 1px solid black !important;
-      }
-    }
-  }
-}
-
-.cke__highlighted_term {
-  background-color: yellow;
-}
-
-.cke__selected_term {
-  outline: 1px solid black;
 }
 
 // ── Dark mode: outer chrome (toolbar, bottom bar, dropdowns) ──
@@ -214,7 +78,6 @@ html.cke_panel_container.htmlarea-styles-popup {
 @cke-dark-text-subtle:   #b5b9ba;  // grey-400
 @cke-dark-text-muted:    #797d7e;  // grey-700
 @cke-dark-link:          #208ebe;  // fbk-info-subtle
-@cke-dark-link-visited:  #e46ee4;  // purple-subtle
 
 html.dark {
   .cke_chrome {
@@ -381,87 +244,5 @@ html.dark {
   a.cke_colormore:focus {
     border-color: @cke-dark-link;
     background-color: @cke-dark-surface-hover;
-  }
-}
-
-html.dark.cke_panel_container.cke_combopanel__styles,
-html.dark.cke_panel_container.htmlarea-styles-popup {
-  --cke-popup-bg: @cke-dark-surface;
-  --cke-popup-bg-hover: @cke-dark-surface-hover;
-  --cke-popup-border: @cke-dark-border;
-  --cke-popup-text: @cke-dark-text;
-  --cke-popup-text-subtle: @cke-dark-text-subtle;
-}
-
-// ── Dark mode: editor iframe content ──
-// These rules apply inside the CKEditor iframe via contentsCss.
-// The 'dark-mode' class is toggled on the iframe body at runtime.
-
-body.cke_editable.dark-mode {
-  background-color: @cke-dark-surface;
-  color: @cke-dark-text;
-
-  a {
-    color: @cke-dark-link;
-  }
-
-  a:visited {
-    color: @cke-dark-link-visited;
-  }
-
-  blockquote {
-    border-color: @cke-dark-border;
-  }
-
-  hr {
-    border-top-color: @cke-dark-border;
-  }
-
-  figure {
-    outline-color: @cke-dark-border;
-    background: rgba(255, 255, 255, 0.05);
-  }
-
-  img.right,
-  img.left {
-    border-color: @cke-dark-border;
-  }
-
-  a > img {
-    outline-color: @cke-dark-link;
-  }
-
-  .marker {
-    background-color: #5c4422; // fbk-warn-surface-dark
-    color: @cke-dark-text;
-  }
-
-  table,
-  th,
-  td {
-    border-color: @cke-dark-border;
-  }
-
-  table.cke_show_border {
-    border-color: @cke-dark-border !important;
-
-    th,
-    td {
-      border-color: @cke-dark-border !important;
-    }
-  }
-
-  .cke__highlighted_term {
-    background-color: #5c4422;
-    color: @cke-dark-text;
-  }
-
-  .cke__selected_term {
-    outline-color: @cke-dark-text-subtle;
-  }
-
-  .image-grayscale {
-    background-color: @cke-dark-surface-hover;
-    color: @cke-dark-text-subtle;
   }
 }


### PR DESCRIPTION
The CKEditor iframe is a separate document and does not inherit `@font-face` declarations from the parent   
admin page (where Open Sans is registered by `lib-admin-ui`). The CSS loaded into the iframe via          
`contentsCss` referenced `"Open Sans"` but did not declare its `@font-face`, so text in the editor body     
silently fell back to Helvetica.

Declared `@font-face` in a new iframe-only stylesheet `html-editor-iframe.less` and loaded it via           
`contentsCss` from both the v6 (`useCKEditorConfig.ts`) and legacy (`HtmlEditor.ts`) code paths. The `src`  
URLs point at `lib-admin-ui`'s existing fonts under `assets/admin/common/fonts/` — those files are already
merged into the final JAR via the `lib-admin-ui` dependency, so the iframe shares the same woff2 the rest of
 the admin UI uses instead of bundling a second copy. css-loader is configured to skip URL processing for
that path, since the files are not present in this module's sources at build time.

Used the opportunity to split the previously mixed `html-editor.less` along its natural seam:
- `html-editor-iframe.less` — runs inside the iframe (`body.cke_editable`, `.cke_editable` tables,          
find/replace term highlights, dark-mode iframe content, and the Styles dropdown popup-iframe rules).        
- `html-editor.less` — outer parts only (toolbar, panels, dialogs, dark-mode). Continues to ship via        
`main.less` → `contentlib.css` to the parent admin doc. 
                                                    
Closes #10429   
                                                            
<sub>*Drafted with AI assistance*</sub>  