### PR TITLE
Upgrade Enonic UI and fix PageControllerSelector blinking #10438

### DIFF
--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -218,8 +218,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@enonic/ui':
-        specifier: ~0.49.0
-        version: 0.49.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.14.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.50.1
+        version: 0.50.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.14.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.59.0)
@@ -308,8 +308,8 @@ importers:
   .xp/dev/lib-contentstudio:
     dependencies:
       '@enonic/ui':
-        specifier: ~0.50.0
-        version: 0.50.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.50.1
+        version: 0.50.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@nanostores/preact':
         specifier: ^1.0.0
         version: 1.1.0(nanostores@0.11.4)(preact@10.29.0)
@@ -648,32 +648,8 @@ packages:
     resolution: {integrity: sha512-cvRXHcI4P8QbXsRkm4qM+Zqr228RBTymX2rZlUkVJMbPwq+jucAi5GCCzNDfLqx3Uj1BjnTeOH9fQYqs8tEtpQ==}
     engines: {node: '>= 24.15.0'}
 
-  '@enonic/ui@0.49.0':
-    resolution: {integrity: sha512-htA0dEX4L+xuWo+hj5olNyX315DsyiuAKVHLch4ukCrBiroEzJ+IwSlF776vtYROcStyXZAzl8rAUVP3vEEkoQ==}
-    engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
-    peerDependencies:
-      '@radix-ui/react-slot': ^1.2.0
-      focus-trap-react: ^11.0.0
-      lucide-react: '>=0.500.0'
-      preact: '>=10.0.0'
-      react: ^19.0.0
-      react-dom: ^19.0.0
-      react-virtuoso: ^4.0.0
-      tw-animate-css: ^1.0.0
-    peerDependenciesMeta:
-      preact:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      react-virtuoso:
-        optional: true
-      tw-animate-css:
-        optional: true
-
-  '@enonic/ui@0.50.0':
-    resolution: {integrity: sha512-VTZFAvVAX5tET3PK0br6LuKFNUEgxVQxljcBN+WL5BoPMm32vhwXNboXHME2iQzwqaV4aDwfnlJjP/RAOsLVwA==}
+  '@enonic/ui@0.50.1':
+    resolution: {integrity: sha512-SW+vBqQREvU2FXLGjiFDIqN875uaA9pjcOr8cie+gmQN5GLCfY2G6wEFn0kh7tMcM7uGSLL3hOgg5Zh+FK79mA==}
     engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -5640,22 +5616,7 @@ snapshots:
       nanostores: 1.3.0
       q: 1.5.1
 
-  '@enonic/ui@0.49.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.14.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
-      class-variance-authority: 0.7.1
-      clsx: 2.1.1
-      focus-trap-react: 11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      lucide-react: 1.14.0(react@19.2.4)
-      tailwind-merge: 3.4.1
-    optionalDependencies:
-      preact: 10.29.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      tw-animate-css: 1.4.0
-
-  '@enonic/ui@0.50.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+  '@enonic/ui@0.50.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       class-variance-authority: 0.7.1
@@ -5665,6 +5626,21 @@ snapshots:
       tailwind-merge: 3.4.1
     optionalDependencies:
       preact: 10.29.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tw-animate-css: 1.4.0
+
+  '@enonic/ui@0.50.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.14.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      focus-trap-react: 11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      lucide-react: 1.14.0(react@19.2.4)
+      tailwind-merge: 3.4.1
+    optionalDependencies:
+      preact: 10.29.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/modules/lib/package.json
+++ b/modules/lib/package.json
@@ -26,7 +26,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@enonic/ui": "~0.50.0",
+    "@enonic/ui": "~0.50.1",
     "@nanostores/preact": "^1.0.0",
     "ckeditor4-react": "4.3.0",
     "class-variance-authority": "^0.7.1",

--- a/modules/lib/pnpm-lock.yaml
+++ b/modules/lib/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   .:
     dependencies:
       '@enonic/ui':
-        specifier: ~0.50.0
-        version: 0.50.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.50.1
+        version: 0.50.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@nanostores/preact':
         specifier: ^1.0.0
         version: 1.1.0(nanostores@0.11.4)(preact@10.29.0)
@@ -233,8 +233,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@enonic/ui':
-        specifier: ~0.49.0
-        version: 0.49.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.14.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.50.1
+        version: 0.50.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.14.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.59.0)
@@ -458,32 +458,8 @@ packages:
     resolution: {integrity: sha512-cvRXHcI4P8QbXsRkm4qM+Zqr228RBTymX2rZlUkVJMbPwq+jucAi5GCCzNDfLqx3Uj1BjnTeOH9fQYqs8tEtpQ==}
     engines: {node: '>= 24.15.0'}
 
-  '@enonic/ui@0.49.0':
-    resolution: {integrity: sha512-htA0dEX4L+xuWo+hj5olNyX315DsyiuAKVHLch4ukCrBiroEzJ+IwSlF776vtYROcStyXZAzl8rAUVP3vEEkoQ==}
-    engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
-    peerDependencies:
-      '@radix-ui/react-slot': ^1.2.0
-      focus-trap-react: ^11.0.0
-      lucide-react: '>=0.500.0'
-      preact: '>=10.0.0'
-      react: ^19.0.0
-      react-dom: ^19.0.0
-      react-virtuoso: ^4.0.0
-      tw-animate-css: ^1.0.0
-    peerDependenciesMeta:
-      preact:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      react-virtuoso:
-        optional: true
-      tw-animate-css:
-        optional: true
-
-  '@enonic/ui@0.50.0':
-    resolution: {integrity: sha512-VTZFAvVAX5tET3PK0br6LuKFNUEgxVQxljcBN+WL5BoPMm32vhwXNboXHME2iQzwqaV4aDwfnlJjP/RAOsLVwA==}
+  '@enonic/ui@0.50.1':
+    resolution: {integrity: sha512-SW+vBqQREvU2FXLGjiFDIqN875uaA9pjcOr8cie+gmQN5GLCfY2G6wEFn0kh7tMcM7uGSLL3hOgg5Zh+FK79mA==}
     engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -5308,22 +5284,7 @@ snapshots:
       nanostores: 1.3.0
       q: 1.5.1
 
-  '@enonic/ui@0.49.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.14.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
-      class-variance-authority: 0.7.1
-      clsx: 2.1.1
-      focus-trap-react: 11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      lucide-react: 1.14.0(react@19.2.4)
-      tailwind-merge: 3.4.1
-    optionalDependencies:
-      preact: 10.29.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      tw-animate-css: 1.4.0
-
-  '@enonic/ui@0.50.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+  '@enonic/ui@0.50.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       class-variance-authority: 0.7.1
@@ -5333,6 +5294,21 @@ snapshots:
       tailwind-merge: 3.4.1
     optionalDependencies:
       preact: 10.29.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tw-animate-css: 1.4.0
+
+  '@enonic/ui@0.50.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.14.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      focus-trap-react: 11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      lucide-react: 1.14.0(react@19.2.4)
+      tailwind-merge: 3.4.1
+    optionalDependencies:
+      preact: 10.29.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/modules/lib/src/main/resources/assets/js/v6/features/hooks/usePageOptions.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/hooks/usePageOptions.ts
@@ -28,7 +28,7 @@ export type UsePageOptionsResult = {
     options: PageOption[];
     filteredOptions: PageOption[];
     selectedOption: PageOption | undefined;
-    selectedKey: string | null;
+    selectedKey: string | undefined;
     selection: string[];
     isLoading: boolean;
 };
@@ -37,14 +37,111 @@ function getTemplateIcon(template: PageTemplate): LucideIcon {
     return template.getDisplayName() === 'Custom' ? SquareChartGantt : LayoutTemplate;
 }
 
-export function usePageOptions(searchValue?: string): UsePageOptionsResult {
+export function useSelectedPageOption(): PageOption | undefined {
     const page = usePageState();
     const ctx = useStore($contentContext);
     const defaultTemplateName = useStore($defaultPageTemplateName);
     const templates = useStore($pageTemplateOptions);
     const controllers = useStore($pageControllerOptions);
     const pageConfigDescriptor = useStore($pageConfigDescriptor);
-    const selectedKey = useStore($selectedPageOptionKey);
+    const selectedKey = useStore($selectedPageOptionKey) ?? undefined;
+
+    const autoLabel = useI18n('widget.pagetemplate.automatic');
+    const noDefaultLabel = useI18n('field.page.template.noDefault');
+    const noDescriptionLabel = useI18n('text.noDescription');
+
+    return useMemo((): PageOption | undefined => {
+        if (selectedKey === AUTO_KEY) {
+            const isFragment = page?.isFragment() ?? false;
+            const showAutoOption = ctx != null && !ctx.isPageTemplate && !isFragment;
+            if (!showAutoOption) return undefined;
+            return {
+                key: AUTO_KEY,
+                label: autoLabel,
+                description: defaultTemplateName ? `(${defaultTemplateName})` : noDefaultLabel,
+                type: 'auto',
+                icon: WandSparkles,
+            };
+        }
+
+        if (selectedKey !== undefined) {
+            const template = templates.find(t => t.getKey().toString() === selectedKey);
+            if (template != null) {
+                return {
+                    key: selectedKey,
+                    label: template.getDisplayName(),
+                    description: template.getPath()?.toString() ?? selectedKey,
+                    type: 'template',
+                    icon: getTemplateIcon(template),
+                };
+            }
+
+            const controller = controllers.find(c => c.getKey().toString() === selectedKey);
+            if (controller != null) {
+                return {
+                    key: selectedKey,
+                    label: controller.getDisplayName(),
+                    description: controller.getDescription() || noDescriptionLabel,
+                    type: 'controller',
+                    icon: SquareCode,
+                };
+            }
+        }
+
+        if (page?.hasController()) {
+            const controllerKey = page.getController();
+            const controllerKeyString = controllerKey.toString();
+            const matchingDescriptor = pageConfigDescriptor != null
+                && pageConfigDescriptor.getKey().toString() === controllerKeyString
+                ? pageConfigDescriptor
+                : null;
+
+            return {
+                key: controllerKeyString,
+                label: matchingDescriptor != null
+                    ? matchingDescriptor.getDisplayName()
+                    : controllerKey.getName().toString(),
+                description: matchingDescriptor != null
+                    ? matchingDescriptor.getDescription() || noDescriptionLabel
+                    : controllerKeyString,
+                type: 'controller',
+                icon: SquareCode,
+            };
+        }
+
+        if (page?.hasTemplate()) {
+            const templateKey = page.getTemplate().toString();
+            return {
+                key: templateKey,
+                label: templateKey,
+                description: templateKey,
+                type: 'template',
+                icon: LayoutTemplate,
+            };
+        }
+
+        return undefined;
+    }, [
+        page,
+        ctx,
+        defaultTemplateName,
+        templates,
+        controllers,
+        pageConfigDescriptor,
+        selectedKey,
+        autoLabel,
+        noDefaultLabel,
+        noDescriptionLabel,
+    ]);
+}
+
+export function usePageOptions(searchValue?: string): UsePageOptionsResult {
+    const page = usePageState();
+    const ctx = useStore($contentContext);
+    const defaultTemplateName = useStore($defaultPageTemplateName);
+    const templates = useStore($pageTemplateOptions);
+    const controllers = useStore($pageControllerOptions);
+    const selectedKey = useStore($selectedPageOptionKey) ?? undefined;
     const isLoading = useStore($isPageInspectionLoading);
 
     const autoLabel = useI18n('widget.pagetemplate.automatic');
@@ -97,53 +194,14 @@ export function usePageOptions(searchValue?: string): UsePageOptionsResult {
         return options.filter(option => option.label.toLowerCase().includes(lower));
     }, [searchValue, options]);
 
-    const selectedOption = useMemo((): PageOption | undefined => {
-        const fromOptions = options.find(option => option.key === selectedKey);
-        if (fromOptions != null) {
-            return fromOptions;
-        }
-
-        if (page?.hasController()) {
-            const controllerKey = page.getController();
-            const controllerKeyString = controllerKey.toString();
-            const matchingDescriptor = pageConfigDescriptor != null
-                && pageConfigDescriptor.getKey().toString() === controllerKeyString
-                ? pageConfigDescriptor
-                : null;
-
-            return {
-                key: controllerKeyString,
-                label: matchingDescriptor != null
-                    ? matchingDescriptor.getDisplayName()
-                    : controllerKey.getName().toString(),
-                description: matchingDescriptor != null
-                    ? matchingDescriptor.getDescription() || noDescriptionLabel
-                    : controllerKeyString,
-                type: 'controller',
-                icon: SquareCode,
-            };
-        }
-
-        if (page?.hasTemplate()) {
-            const templateKey = page.getTemplate().toString();
-            return {
-                key: templateKey,
-                label: templateKey,
-                description: templateKey,
-                type: 'template',
-                icon: LayoutTemplate,
-            };
-        }
-
-        return undefined;
-    }, [noDescriptionLabel, options, page, pageConfigDescriptor, selectedKey]);
+    const selectedOption = useSelectedPageOption();
 
     return {
         options,
         filteredOptions,
         selectedOption,
         selectedKey,
-        selection: selectedKey != null ? [selectedKey] : [],
+        selection: selectedKey !== undefined ? [selectedKey] : [],
         isLoading,
     };
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageControllerSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageControllerSelector.tsx
@@ -22,7 +22,9 @@ export const PageControllerSelector = (): ReactElement | null => {
     const templateLabel = useI18n('field.page.template');
     const searchPlaceholder = useI18n('field.option.placeholder');
 
-    if (isLoading) {
+    // ? Keep mounted on background refetch (after a controller change reloads the
+    // ? descriptor list) — only bail on the initial load with nothing to render.
+    if (isLoading && !selectedOption) {
         return null;
     }
 
@@ -36,26 +38,26 @@ export const PageControllerSelector = (): ReactElement | null => {
                     selection={selection}
                     onSelectionChange={handleSelectionChange}
                 >
-                    <Combobox.Content>
+                    <Combobox.Content data-component={PAGE_CONTROLLER_SELECTOR_NAME}>
                         <Combobox.Control>
                             <Combobox.Search>
                                 {selectedOption && (
                                     <Combobox.Value className="gap-2 w-full">
-                                        <selectedOption.icon className="size-4 shrink-0"/>
+                                        <selectedOption.icon className="size-4 shrink-0" />
                                         <span className="leading-5.5 font-semibold truncate">
                                             {selectedOption.label}
                                         </span>
                                     </Combobox.Value>
                                 )}
-                                <Combobox.Input placeholder={searchPlaceholder}/>
-                                <Combobox.Toggle/>
+                                <Combobox.Input placeholder={searchPlaceholder} />
+                                <Combobox.Toggle />
                             </Combobox.Search>
                         </Combobox.Control>
                         <Combobox.Popup>
                             <Listbox.Content className="max-h-60 rounded-sm">
                                 {filteredOptions.map(option => (
                                     <Listbox.Item key={option.key} value={option.key}>
-                                        <option.icon className="size-6 shrink-0"/>
+                                        <option.icon className="size-6 shrink-0" />
                                         <div className="flex flex-col overflow-hidden">
                                             <span className="leading-5.5 font-semibold truncate group-data-[tone=inverse]:text-alt">
                                                 {option.label}
@@ -82,7 +84,7 @@ export const PageControllerSelector = (): ReactElement | null => {
             >
                 {confirmDialog && (
                     <ConfirmationDialog.Portal>
-                        <ConfirmationDialog.Overlay/>
+                        <ConfirmationDialog.Overlay />
                         <ConfirmationDialog.Content>
                             <ConfirmationDialog.Body>
                                 {confirmDialog.question}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/hooks/usePageControllerSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/hooks/usePageControllerSelector.ts
@@ -1,4 +1,3 @@
-import {useStore} from '@nanostores/preact';
 import {useCallback, useState} from 'react';
 import {useI18n} from '../../../../../../../hooks/useI18n';
 import {
@@ -24,7 +23,6 @@ export type ConfirmDialogState = {
 };
 
 type UsePageControllerSelectorResult = {
-    options: PageOption[];
     filteredOptions: PageOption[];
     selectedOption: PageOption | undefined;
     searchValue: string | undefined;
@@ -37,9 +35,6 @@ type UsePageControllerSelectorResult = {
 };
 
 export function usePageControllerSelector(): UsePageControllerSelectorResult {
-    const templates = useStore($pageTemplateOptions);
-    const controllers = useStore($pageControllerOptions);
-
     const templateChangeQuestion = useI18n('dialog.template.change');
     const controllerChangeQuestion = useI18n('dialog.controller.change');
 
@@ -69,20 +64,20 @@ export function usePageControllerSelector(): UsePageControllerSelectorResult {
             if (newType === 'auto') {
                 executePageReset();
             } else if (newType === 'template') {
-                const template = templates.find(t => t.getKey().toString() === newKey);
+                const template = $pageTemplateOptions.get().find(t => t.getKey().toString() === newKey);
                 if (template) {
                     requestSetPageTemplate(template.getKey());
                     bumpInsertTabActivateNonce();
                 }
             } else {
-                const controller = controllers.find(c => c.getKey().toString() === newKey);
+                const controller = $pageControllerOptions.get().find(c => c.getKey().toString() === newKey);
                 if (controller) {
                     requestSetPageController(controller.getKey());
                     bumpInsertTabActivateNonce();
                 }
             }
         },
-        [getOptionType, templates, controllers],
+        [getOptionType],
     );
 
     const handleSelectionChange = useCallback(
@@ -122,7 +117,6 @@ export function usePageControllerSelector(): UsePageControllerSelectorResult {
     );
 
     return {
-        options,
         filteredOptions,
         selectedOption,
         searchValue,

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -8,7 +8,7 @@ import {PageNavigationEventData} from '../../../../../../app/wizard/PageNavigati
 import {PageNavigationEventType} from '../../../../../../app/wizard/PageNavigationEventType';
 import {PageNavigationMediator} from '../../../../../../app/wizard/PageNavigationMediator';
 import {useI18n} from '../../../../hooks/useI18n';
-import {usePageOptions} from '../../../../hooks/usePageOptions';
+import {useSelectedPageOption} from '../../../../hooks/usePageOptions';
 import type {FlatNode} from '../../../../lib/tree-store';
 import {getNode} from '../../../../lib/tree-store';
 import {inspectItem, requestComponentMove} from '../../../../store/page-editor';
@@ -50,7 +50,7 @@ export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps 
     const showErrors = validationVisibility === 'all';
     const inspectedPath = useStore($inspectedPath);
     const [flatNodes, setFlatNodes] = useState(() => [...$componentsFlatNodes.get()]);
-    const {selectedOption: selectedPageOption} = usePageOptions();
+    const selectedPageOption = useSelectedPageOption();
     const pageMetadata = useMemo<PageComponentPageMetadata | undefined>(() => {
         if (selectedPageOption == null) {
             return undefined;
@@ -158,8 +158,6 @@ export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps 
             || (sourceNode.data.nodeType === 'fragment' && sourceNode.data.layoutFragment);
 
         return !(isLayoutDrag && hasLayoutAncestor($componentsTreeState.get(), target.regionPath));
-
-
     }, [flatNodes]);
 
     const itemClassName = useCallback((


### PR DESCRIPTION
Bumped `@enonic/ui` to ~0.50.1 and refreshed the lockfiles.

Fixed `PageControllerSelector` blinking when switching the page controller — the selector now stays mounted across background descriptor refetches and only bails on the genuine initial load.

Closes #10438

<sub>*Drafted with AI assistance*</sub>
