### PR TITLE
Invalid content ID #10216

### DIFF
--- a/modules/app/src/main/resources/assets/js/main.ts
+++ b/modules/app/src/main/resources/assets/js/main.ts
@@ -171,6 +171,10 @@ const faviconCache: Record<string, HTMLElement> = {};
 
 const iconUrlResolver = new ContentIconUrlResolver();
 
+// ? dataPreloaded is set inside the preload .then so that startContentWizard can
+// ? skip favicon/title work that already happened. Safe because startApplication
+// ? is gated on preLoadPromise — by the time the wizard runs, the request has
+// ? resolved and the flag is correct.
 let dataPreloaded: boolean = false;
 
 let invalidEditUrlNotificationPending: boolean = false;
@@ -221,6 +225,9 @@ function preLoadApplication(): Promise<void> {
     const shouldPreloadTabData: boolean = !Body.get().isRendered() && !Body.get().isRendering();
 
     if (wizardParams.contentId) {
+        // ? Request fires regardless of body render state so background tabs with
+        // ? invalid bookmarks also get URL cleanup before the user focuses them.
+        // ? Favicon/title updates remain gated on shouldPreloadTabData.
         return Promise.resolve(
             new GetContentByIdRequest(wizardParams.contentId).setRequestProjectName(wizardParams.projectName).sendAndParse()
                 .then((content: Content) => {
@@ -237,6 +244,7 @@ function preLoadApplication(): Promise<void> {
                 .catch(() => {
                     invalidEditUrlNotificationPending = true;
                     history.replaceState(null, '', UrlHelper.createContentBrowseUrl(wizardParams.projectName));
+                    wizardParams = undefined;
                 })
         ).then(() => undefined);
     }
@@ -263,22 +271,12 @@ function startServerEventListeners(application: Application) {
 let connectionDetector: ConnectionDetector;
 let contentViewStarted = false;
 
-type ProjectsState = ReturnType<typeof $projects.get> & {
-    loaded?: boolean;
-    resolved?: boolean;
-    loadError?: boolean;
-};
-
-function getProjectsState(): ProjectsState {
-    return $projects.get() as ProjectsState;
-}
-
 function isProjectsResolved(): boolean {
-    return !!getProjectsState().resolved;
+    return $projects.get().resolved;
 }
 
 function hasActiveProject(): boolean {
-    return !!($activeProject.get() as unknown);
+    return $activeProject.get() != null;
 }
 
 async function startApplication() {
@@ -298,7 +296,7 @@ async function startApplication() {
             return;
         }
 
-        if (getProjectsState().loadError) {
+        if ($projects.get().loadError) {
             if (!projectInitFailureShown) {
                 projectInitFailureShown = true;
                 NotifyManager.get().showWarning(i18n('notify.settings.project.initFailed'));
@@ -568,6 +566,9 @@ async function startContentBrowser() {
 
     const preLoadPromise = preLoadApplication();
 
+    // ! startApplication must run AFTER preLoadPromise resolves so that
+    // ! isContentWizardUrl() is re-evaluated against the rewritten path
+    // ! when an invalid edit URL has been replaced with the browse URL.
     const renderListener = () => {
         preLoadPromise.then(() => startApplication());
         body.unRendered(renderListener);

--- a/modules/app/src/main/resources/assets/js/main.ts
+++ b/modules/app/src/main/resources/assets/js/main.ts
@@ -50,6 +50,7 @@ import {Router} from '@enonic/lib-contentstudio/app/Router';
 import {SettingsServerEventsListener} from '@enonic/lib-contentstudio/app/settings/event/SettingsServerEventsListener';
 import {$isDown, subscribe as subscribeToWorker} from '@enonic/lib-contentstudio/app/stores/worker';
 import {UrlAction} from '@enonic/lib-contentstudio/app/UrlAction';
+import {UrlHelper} from '@enonic/lib-contentstudio/app/util/UrlHelper';
 import {VersionHelper} from '@enonic/lib-contentstudio/app/util/VersionHelper';
 import {ContentAppHelper} from '@enonic/lib-contentstudio/app/wizard/ContentAppHelper';
 import {ContentWizardPanelParams} from '@enonic/lib-contentstudio/app/wizard/ContentWizardPanelParams';
@@ -172,6 +173,8 @@ const iconUrlResolver = new ContentIconUrlResolver();
 
 let dataPreloaded: boolean = false;
 
+let invalidEditUrlNotificationPending: boolean = false;
+
 function clearFavicon() {
     // save current favicon hrefs
     $('link[rel*=icon][sizes]').each((index, link: HTMLElement) => {
@@ -208,34 +211,47 @@ const refreshTab = function (content: ContentSummary) {
     updateTabTitle(content.getDisplayName());
 };
 
-function preLoadApplication() {
-    const application: Application = getApplication();
-    if (ContentAppHelper.isContentWizardUrl()) {
-        clearFavicon();
-        const wizardParams: ContentWizardPanelParams = ContentAppHelper.createWizardParamsFromUrl();
-
-        if (!Body.get().isRendered() && !Body.get().isRendering()) {
-            dataPreloaded = true;
-            const projectName: string = application.getPath().getElement(0);
-            // body is not rendered if the tab is in background
-            if (wizardParams.contentId) {
-                new GetContentByIdRequest(wizardParams.contentId).setRequestProjectName(projectName).sendAndParse().then(
-                    (content: Content) => {
-                        refreshTab(content);
-
-                        if (shouldUpdateFavicon(content.getType())) {
-                            refreshTabOnContentUpdate(content);
-                        }
-
-                    });
-            } else {
-                new GetContentTypeByNameRequest(wizardParams.contentTypeName).sendAndParse().then(
-                    (contentType) => {
-                        updateTabTitle(NamePrettyfier.prettifyUnnamed(contentType.getTitle()));
-                    });
-            }
-        }
+function preLoadApplication(): Promise<void> {
+    if (!ContentAppHelper.isContentWizardUrl()) {
+        return Promise.resolve();
     }
+
+    const application: Application = getApplication();
+    const wizardParams: ContentWizardPanelParams = ContentAppHelper.createWizardParamsFromUrl();
+    const projectName: string = application.getPath().getElement(0);
+    const shouldPreloadTabData: boolean = !Body.get().isRendered() && !Body.get().isRendering();
+
+    if (wizardParams.contentId) {
+        return Promise.resolve(
+            new GetContentByIdRequest(wizardParams.contentId).setRequestProjectName(projectName).sendAndParse()
+                .then((content: Content) => {
+                    if (!shouldPreloadTabData) {
+                        return;
+                    }
+                    dataPreloaded = true;
+                    clearFavicon();
+                    refreshTab(content);
+                    if (shouldUpdateFavicon(content.getType())) {
+                        refreshTabOnContentUpdate(content);
+                    }
+                })
+                .catch(() => {
+                    invalidEditUrlNotificationPending = true;
+                    history.replaceState(null, '', UrlHelper.createContentBrowseUrl(projectName));
+                })
+        ).then(() => undefined);
+    }
+
+    if (shouldPreloadTabData) {
+        dataPreloaded = true;
+        clearFavicon();
+        new GetContentTypeByNameRequest(wizardParams.contentTypeName).sendAndParse().then(
+            (contentType) => {
+                updateTabTitle(NamePrettyfier.prettifyUnnamed(contentType.getTitle()));
+            });
+    }
+
+    return Promise.resolve();
 }
 
 function startServerEventListeners(application: Application) {
@@ -483,6 +499,11 @@ async function startContentBrowser() {
     appendMenuPanel();
     Body.get().appendChild(commonWrapper);
 
+    if (invalidEditUrlNotificationPending) {
+        showError(i18n('text.content.not.found'));
+        invalidEditUrlNotificationPending = false;
+    }
+
     const NewContentDialog = (await import('@enonic/lib-contentstudio/app/create/NewContentDialog')).NewContentDialog;
 
     const newContentDialog = new NewContentDialog();
@@ -543,10 +564,10 @@ async function startContentBrowser() {
 
     const body = Body.get();
 
-    preLoadApplication();
+    const preLoadPromise = preLoadApplication();
 
     const renderListener = () => {
-        startApplication();
+        preLoadPromise.then(() => startApplication());
         body.unRendered(renderListener);
     };
     if (body.isRendered()) {

--- a/modules/app/src/main/resources/assets/js/main.ts
+++ b/modules/app/src/main/resources/assets/js/main.ts
@@ -175,6 +175,8 @@ let dataPreloaded: boolean = false;
 
 let invalidEditUrlNotificationPending: boolean = false;
 
+let wizardParams: ContentWizardPanelParams | undefined;
+
 function clearFavicon() {
     // save current favicon hrefs
     $('link[rel*=icon][sizes]').each((index, link: HTMLElement) => {
@@ -212,18 +214,15 @@ const refreshTab = function (content: ContentSummary) {
 };
 
 function preLoadApplication(): Promise<void> {
-    if (!ContentAppHelper.isContentWizardUrl()) {
+    if (!wizardParams) {
         return Promise.resolve();
     }
 
-    const application: Application = getApplication();
-    const wizardParams: ContentWizardPanelParams = ContentAppHelper.createWizardParamsFromUrl();
-    const projectName: string = application.getPath().getElement(0);
     const shouldPreloadTabData: boolean = !Body.get().isRendered() && !Body.get().isRendering();
 
     if (wizardParams.contentId) {
         return Promise.resolve(
-            new GetContentByIdRequest(wizardParams.contentId).setRequestProjectName(projectName).sendAndParse()
+            new GetContentByIdRequest(wizardParams.contentId).setRequestProjectName(wizardParams.projectName).sendAndParse()
                 .then((content: Content) => {
                     if (!shouldPreloadTabData) {
                         return;
@@ -237,7 +236,7 @@ function preLoadApplication(): Promise<void> {
                 })
                 .catch(() => {
                     invalidEditUrlNotificationPending = true;
-                    history.replaceState(null, '', UrlHelper.createContentBrowseUrl(projectName));
+                    history.replaceState(null, '', UrlHelper.createContentBrowseUrl(wizardParams.projectName));
                 })
         ).then(() => undefined);
     }
@@ -409,7 +408,6 @@ async function startContentWizard() {
     const {ContentWizardPanel} = await import('@enonic/lib-contentstudio/app/wizard/ContentWizardPanel');
     const {setMode} = await import('@enonic/lib-contentstudio/v6/features/store/mode.store');
 
-    const wizardParams = ContentAppHelper.createWizardParamsFromUrl();
     const wizard = new ContentWizardPanel(wizardParams, getTheme());
     setMode('wizard');
 
@@ -563,6 +561,10 @@ async function startContentBrowser() {
         (CONFIG.get('principals') as PrincipalJson[]).map(Principal.fromJson));
 
     const body = Body.get();
+
+    if (ContentAppHelper.isContentWizardUrl()) {
+        wizardParams = ContentAppHelper.createWizardParamsFromUrl();
+    }
 
     const preLoadPromise = preLoadApplication();
 

--- a/modules/lib/src/main/resources/assets/js/app/ContentAppContainer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/ContentAppContainer.ts
@@ -11,7 +11,6 @@ import {ToggleSearchPanelWithDependenciesGlobalEvent} from './browse/ToggleSearc
 import {ContentId} from './content/ContentId';
 import {type ContentSummaryAndCompareStatus} from './content/ContentSummaryAndCompareStatus';
 import {ContentAppPanel} from './ContentAppPanel';
-import {EditContentEvent} from './event/EditContentEvent';
 import {type Issue} from './issue/Issue';
 import {IssueDialogsManager} from './issue/IssueDialogsManager';
 import {GetIssueRequest} from './issue/resource/GetIssueRequest';
@@ -67,9 +66,6 @@ export class ContentAppContainer
         const id = path ? path.getElement(2) : null;
 
         switch (actionAsTabMode) {
-        case UrlAction.EDIT:
-            this.handleEditUrl(path);
-            break;
         case UrlAction.ISSUE:
             this.handleIssueUrl(path);
             break;
@@ -79,17 +75,6 @@ export class ContentAppContainer
         case UrlAction.OUTBOUND:
             this.handleOutboundDependencies(path);
             break;
-        }
-    }
-
-    private handleEditUrl(path?: Path): void {
-        const id = path ? path.getElement(2) : null;
-
-        if (id) {
-            new ContentSummaryAndCompareStatusFetcher().fetch(new ContentId(id)).done(
-                (content: ContentSummaryAndCompareStatus) => {
-                    new EditContentEvent([content]).fire();
-                });
         }
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentAppHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentAppHelper.ts
@@ -57,6 +57,7 @@ export class ContentAppHelper {
         const wizardParams: ContentWizardPanelParams = new ContentWizardPanelParams()
             .setContentTypeName(contentTypeName)
             .setCreateSite(contentTypeName.isSite())
+            .setProjectName(ContentAppHelper.getProjectNameFromUrl())
             .setTabId(tabId);
 
         if (actionArguments[1]) {
@@ -77,7 +78,20 @@ export class ContentAppHelper {
         return new ContentWizardPanelParams()
             .setContentId(contentId)
             .setTabId(tabId)
+            .setProjectName(ContentAppHelper.getProjectNameFromUrl())
             .setDisplayAsNew(displayAsNew)
             .setLocalized(isLocalized);
+    }
+
+    private static getProjectNameFromUrl(): string | undefined {
+        const toolUri: string = CONFIG.getString('toolUri');
+        const pathname: string = window.location.pathname;
+
+        if (!pathname.startsWith(toolUri)) {
+            return undefined;
+        }
+
+        const segments: string[] = pathname.slice(toolUri.length).split('/').filter(Boolean);
+        return segments[0];
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -368,14 +368,14 @@ export class ContentWizardPanel
                 AI.get().setCompareStatus(this.persistedCompareStatus);
             })
             .then(() => super.doLoadData())
-            .finally(() => {
+            .then((loadedContent: Content) => {
                 // persisted item is always present now
                 // for existing content it was loaded
                 // for new content it was saved in super.doLoadData()
                 const currentItem: Content = this.getCurrentItem();
                 this.liveEditModel = this.initLiveEditModel(currentItem);
 
-                return this.loadAndSetPageState(currentItem.getPage()?.clone());
+                return this.loadAndSetPageState(currentItem.getPage()?.clone()).then(() => loadedContent);
             });
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanelParams.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanelParams.ts
@@ -1,7 +1,5 @@
 import {type ContentTypeName} from '@enonic/lib-admin-ui/schema/content/ContentTypeName';
 import {type Application} from '@enonic/lib-admin-ui/app/Application';
-import {type Project} from '../settings/data/project/Project';
-import {ProjectContext} from '../project/ProjectContext';
 import {type ContentId} from '../content/ContentId';
 import {type WizardPanelParams} from '@enonic/lib-admin-ui/app/wizard/WizardPanel';
 import {type Content} from '../content/Content';
@@ -21,15 +19,11 @@ export class ContentWizardPanelParams implements WizardPanelParams<Content> {
 
     contentId: ContentId;
 
-    project: Project;
+    projectName: string;
 
     localized: boolean = false;
 
     displayAsNew: boolean = false;
-
-    constructor() {
-        this.project = ProjectContext.get().getProject();
-    }
 
     setApplication(app: Application): ContentWizardPanelParams {
         this.application = app;
@@ -61,8 +55,8 @@ export class ContentWizardPanelParams implements WizardPanelParams<Content> {
         return this;
     }
 
-    setProject(value: Project): ContentWizardPanelParams {
-        this.project = value;
+    setProjectName(value: string): ContentWizardPanelParams {
+        this.projectName = value;
         return this;
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanelParams.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanelParams.ts
@@ -19,7 +19,7 @@ export class ContentWizardPanelParams implements WizardPanelParams<Content> {
 
     contentId: ContentId;
 
-    projectName: string;
+    projectName: string | undefined;
 
     localized: boolean = false;
 
@@ -55,7 +55,7 @@ export class ContentWizardPanelParams implements WizardPanelParams<Content> {
         return this;
     }
 
-    setProjectName(value: string): ContentWizardPanelParams {
+    setProjectName(value: string | undefined): ContentWizardPanelParams {
         this.projectName = value;
         return this;
     }

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProjectSelectionDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProjectSelectionDialog.tsx
@@ -5,7 +5,7 @@ import {useMemo, useRef} from 'react';
 import {ConfirmationDialog} from './ConfirmationDialog';
 import {ProjectHelper} from '../../../../app/settings/data/project/ProjectHelper';
 import {useI18n} from '../../hooks/useI18n';
-import {setActiveProject, $projects} from '../../store/projects.store';
+import {selectProject, $projects} from '../../store/projects.store';
 import {flattenProjects} from '../../utils/cms/projects/flattenProjects';
 import {AuthHelper} from '@enonic/lib-admin-ui/auth/AuthHelper';
 import {$dialogs, setProjectSelectionDialogOpen} from '../../store/dialogs.store';
@@ -73,7 +73,7 @@ export const ProjectSelectionDialog = (): ReactElement => {
                                     const name = selection[0] ?? activeProjectId;
                                     const project = name ? projectByName.get(name) : undefined;
                                     if (project && ProjectHelper.isAvailable(project)) {
-                                        setActiveProject(project);
+                                        selectProject(project);
                                         setProjectSelectionDialogOpen(false);
                                     }
                                 }}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProjectSelectionDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProjectSelectionDialog.tsx
@@ -13,8 +13,8 @@ import {ProjectLabel} from '../project/ProjectLabel';
 import {openCreateProjectDialog} from '../../store/dialogs/projectDialog.store';
 
 export const ProjectSelectionDialog = (): ReactElement => {
-    const {projects, activeProjectId} = useStore($projects);
-    const {projectSelectionDialogOpen} = useStore($dialogs);
+    const {projects, activeProjectId} = useStore($projects, {keys: ['projects', 'activeProjectId']});
+    const {projectSelectionDialogOpen} = useStore($dialogs, {keys: ['projectSelectionDialogOpen']});
 
     const title = useI18n('text.selectContext');
     const createProject = useI18n('settings.field.project.create');

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.test.ts
@@ -57,10 +57,6 @@ vi.mock('../../../app/settings/event/ProjectDeletedEvent', () => ({
     },
 }));
 
-vi.mock('../utils/storage/sync', () => ({
-    syncMapStore: vi.fn(),
-}));
-
 vi.mock('./config.store', () => ({
     $config: {
         get: () => ({appId: 'contentstudio'}),
@@ -144,7 +140,20 @@ function resetProjectContextMocks(): void {
     mockProjectContextIsNotAvailable.mockReset().mockReturnValue(false);
 }
 
-async function loadStore(projects: MockProject[], currentProjectId: string): Promise<typeof import('./projects.store')> {
+type LoadStoreOptions = {
+    url?: string;
+    clearInitMocks?: boolean;
+};
+
+const DEFAULT_BROWSE_STORAGE_KEY = 'enonic:cs:defaultbrowseprojectid';
+
+async function loadStore(
+    projects: MockProject[],
+    currentProjectId: string,
+    options: LoadStoreOptions = {},
+): Promise<typeof import('./projects.store')> {
+    const {url, clearInitMocks = true} = options;
+
     vi.resetModules();
     createdHandlers.length = 0;
     deletedHandlers.length = 0;
@@ -153,14 +162,16 @@ async function loadStore(projects: MockProject[], currentProjectId: string): Pro
     mockProjectListSendAndParse.mockReset().mockResolvedValue(projects);
     mockSetProjectSelectionDialogOpen.mockReset();
     resetProjectContextMocks();
-    window.history.pushState({}, '', `/contentstudio/cms/${currentProjectId}/browse`);
+    window.history.pushState({}, '', url ?? `/contentstudio/cms/${currentProjectId}/browse`);
 
     const store = await import('./projects.store');
     await flushPromises();
 
-    mockSetProjectSelectionDialogOpen.mockClear();
-    mockProjectContextSetProject.mockClear();
-    mockProjectContextSetNotAvailable.mockClear();
+    if (clearInitMocks) {
+        mockSetProjectSelectionDialogOpen.mockClear();
+        mockProjectContextSetProject.mockClear();
+        mockProjectContextSetNotAvailable.mockClear();
+    }
 
     return store;
 }
@@ -173,10 +184,12 @@ describe('projects.store delete intent', () => {
         noProjectsAvailableHandlers.length = 0;
         projectChangedHandlers.length = 0;
         resetProjectContextMocks();
+        localStorage.clear();
     });
 
     afterEach(() => {
         vi.restoreAllMocks();
+        localStorage.clear();
     });
 
     it('reports whether a project is active', async () => {
@@ -317,5 +330,177 @@ describe('projects.store delete intent', () => {
         expect(mockSetProjectSelectionDialogOpen).not.toHaveBeenCalled();
         expect(mockProjectContextSetProject).not.toHaveBeenCalled();
         expect(mockProjectContextSetNotAvailable).not.toHaveBeenCalled();
+    });
+});
+
+describe('projects.store init', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        createdHandlers.length = 0;
+        deletedHandlers.length = 0;
+        noProjectsAvailableHandlers.length = 0;
+        projectChangedHandlers.length = 0;
+        resetProjectContextMocks();
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    it('uses the URL project even when storage holds a different id', async () => {
+        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('saved'));
+        const url = createProject('url-project');
+        const saved = createProject('saved');
+        const store = await loadStore([url, saved], 'url-project');
+
+        expect(store.$projects.get().activeProjectId).toBe('url-project');
+    });
+
+    it('falls back to the storage value in browse mode when the URL has no project', async () => {
+        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('saved'));
+        const saved = createProject('saved');
+        const other = createProject('other');
+        const store = await loadStore([saved, other], '', {url: '/contentstudio/cms//browse'});
+
+        expect(store.$projects.get().activeProjectId).toBe('saved');
+    });
+
+    it('does not apply the storage fallback on wizard URLs', async () => {
+        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('saved'));
+        const saved = createProject('saved');
+        const other = createProject('other');
+        const store = await loadStore([saved, other], '', {
+            url: '/contentstudio/cms//edit/abc123',
+            clearInitMocks: false,
+        });
+
+        expect(store.$projects.get().activeProjectId).toBeUndefined();
+        expect(mockSetProjectSelectionDialogOpen).toHaveBeenCalledWith(true);
+    });
+
+    it('leaves active project undefined when neither URL nor storage has a value', async () => {
+        const a = createProject('a');
+        const b = createProject('b');
+        const store = await loadStore([a, b], '', {
+            url: '/contentstudio/cms//browse',
+            clearInitMocks: false,
+        });
+
+        expect(store.$projects.get().activeProjectId).toBeUndefined();
+        expect(mockSetProjectSelectionDialogOpen).toHaveBeenCalledWith(true);
+    });
+});
+
+describe('projects.store selectProject', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        createdHandlers.length = 0;
+        deletedHandlers.length = 0;
+        noProjectsAvailableHandlers.length = 0;
+        projectChangedHandlers.length = 0;
+        resetProjectContextMocks();
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    it('updates the active project and persists the default browse id when the project is in the store', async () => {
+        const a = createProject('a');
+        const b = createProject('b');
+        const store = await loadStore([a, b], 'a');
+
+        // @ts-expect-error MockProject does not implement the full Project interface but is structurally compatible for this code path.
+        store.selectProject(b);
+
+        expect(store.$projects.get().activeProjectId).toBe('b');
+        expect(localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY)).toBe(JSON.stringify('b'));
+    });
+
+    it('leaves active project and storage untouched when the project is not in the store', async () => {
+        const a = createProject('a');
+        const stranger = createProject('stranger');
+        const store = await loadStore([a], 'a');
+
+        // @ts-expect-error MockProject does not implement the full Project interface but is structurally compatible for this code path.
+        store.selectProject(stranger);
+
+        expect(store.$projects.get().activeProjectId).toBe('a');
+        expect(localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY)).toBeNull();
+    });
+});
+
+describe('projects.store storage cleanup on deletion', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        createdHandlers.length = 0;
+        deletedHandlers.length = 0;
+        noProjectsAvailableHandlers.length = 0;
+        projectChangedHandlers.length = 0;
+        resetProjectContextMocks();
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    it('updates the default browse id to the fallback when the deleted project was the stored default', async () => {
+        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('current'));
+        const parent = createProject('parent');
+        const current = createProject('current');
+        const store = await loadStore([parent, current], 'current');
+
+        store.markPendingDeletedProject('current', true);
+        emitDeleted('current');
+
+        expect(store.$projects.get().activeProjectId).toBe('parent');
+        expect(localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY)).toBe(JSON.stringify('parent'));
+    });
+
+    it('clears the default browse id when no fallback is available', async () => {
+        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('orphan'));
+        const orphan = createProject('orphan');
+        const store = await loadStore([orphan], 'orphan');
+
+        store.markPendingDeletedProject('orphan', true);
+        emitDeleted('orphan');
+
+        expect(store.$projects.get().activeProjectId).toBeUndefined();
+        // ? syncAtomStore encodes undefined as '{}'-equivalent — atom-store stringifies undefined to "undefined" string,
+        // ? but JSON.stringify(undefined) === undefined → setItem skipped, value remains until removeItem;
+        // ? we instead expect the entry to be cleared via the listener path.
+        const stored = localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY);
+        expect(stored === null || stored === 'null').toBe(true);
+    });
+
+    it('does not touch the default browse id when an unrelated project is deleted', async () => {
+        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('current'));
+        const parent = createProject('parent');
+        const child = createProject('child', ['parent']);
+        const current = createProject('current');
+        const store = await loadStore([parent, child, current], 'current');
+
+        store.markPendingDeletedProject('child', true);
+        emitDeleted('child');
+
+        expect(localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY)).toBe(JSON.stringify('current'));
+    });
+
+    it('clears the default browse id when removeProject (no navigate) removes the stored default', async () => {
+        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('alpha'));
+        const alpha = createProject('alpha');
+        const beta = createProject('beta');
+        const store = await loadStore([alpha, beta], 'beta');
+
+        store.removeProject('alpha', false);
+
+        const stored = localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY);
+        expect(stored === null || stored === 'null').toBe(true);
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.test.ts
@@ -145,7 +145,7 @@ type LoadStoreOptions = {
     clearInitMocks?: boolean;
 };
 
-const DEFAULT_BROWSE_STORAGE_KEY = 'enonic:cs:defaultbrowseprojectid';
+const LAST_SELECTED_STORAGE_KEY = 'enonic:cs:lastselectedprojectid';
 
 async function loadStore(
     projects: MockProject[],
@@ -350,7 +350,7 @@ describe('projects.store init', () => {
     });
 
     it('uses the URL project even when storage holds a different id', async () => {
-        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('saved'));
+        localStorage.setItem(LAST_SELECTED_STORAGE_KEY, JSON.stringify('saved'));
         const url = createProject('url-project');
         const saved = createProject('saved');
         const store = await loadStore([url, saved], 'url-project');
@@ -359,7 +359,7 @@ describe('projects.store init', () => {
     });
 
     it('falls back to the storage value in browse mode when the URL has no project', async () => {
-        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('saved'));
+        localStorage.setItem(LAST_SELECTED_STORAGE_KEY, JSON.stringify('saved'));
         const saved = createProject('saved');
         const other = createProject('other');
         const store = await loadStore([saved, other], '', {url: '/contentstudio/cms//browse'});
@@ -368,7 +368,7 @@ describe('projects.store init', () => {
     });
 
     it('does not apply the storage fallback on wizard URLs', async () => {
-        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('saved'));
+        localStorage.setItem(LAST_SELECTED_STORAGE_KEY, JSON.stringify('saved'));
         const saved = createProject('saved');
         const other = createProject('other');
         const store = await loadStore([saved, other], '', {
@@ -409,7 +409,7 @@ describe('projects.store selectProject', () => {
         localStorage.clear();
     });
 
-    it('updates the active project and persists the default browse id when the project is in the store', async () => {
+    it('updates the active project and persists the last selected id when the project is in the store', async () => {
         const a = createProject('a');
         const b = createProject('b');
         const store = await loadStore([a, b], 'a');
@@ -418,7 +418,7 @@ describe('projects.store selectProject', () => {
         store.selectProject(b);
 
         expect(store.$projects.get().activeProjectId).toBe('b');
-        expect(localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY)).toBe(JSON.stringify('b'));
+        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('b'));
     });
 
     it('leaves active project and storage untouched when the project is not in the store', async () => {
@@ -430,7 +430,7 @@ describe('projects.store selectProject', () => {
         store.selectProject(stranger);
 
         expect(store.$projects.get().activeProjectId).toBe('a');
-        expect(localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY)).toBeNull();
+        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBeNull();
     });
 });
 
@@ -450,8 +450,8 @@ describe('projects.store storage cleanup on deletion', () => {
         localStorage.clear();
     });
 
-    it('updates the default browse id to the fallback when the deleted project was the stored default', async () => {
-        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('current'));
+    it('updates the last selected id to the fallback when the deleted project was the stored value', async () => {
+        localStorage.setItem(LAST_SELECTED_STORAGE_KEY, JSON.stringify('current'));
         const parent = createProject('parent');
         const current = createProject('current');
         const store = await loadStore([parent, current], 'current');
@@ -460,11 +460,11 @@ describe('projects.store storage cleanup on deletion', () => {
         emitDeleted('current');
 
         expect(store.$projects.get().activeProjectId).toBe('parent');
-        expect(localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY)).toBe(JSON.stringify('parent'));
+        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('parent'));
     });
 
-    it('clears the default browse id when no fallback is available', async () => {
-        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('orphan'));
+    it('clears the last selected id when no fallback is available', async () => {
+        localStorage.setItem(LAST_SELECTED_STORAGE_KEY, JSON.stringify('orphan'));
         const orphan = createProject('orphan');
         const store = await loadStore([orphan], 'orphan');
 
@@ -475,12 +475,12 @@ describe('projects.store storage cleanup on deletion', () => {
         // ? syncAtomStore encodes undefined as '{}'-equivalent — atom-store stringifies undefined to "undefined" string,
         // ? but JSON.stringify(undefined) === undefined → setItem skipped, value remains until removeItem;
         // ? we instead expect the entry to be cleared via the listener path.
-        const stored = localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY);
+        const stored = localStorage.getItem(LAST_SELECTED_STORAGE_KEY);
         expect(stored === null || stored === 'null').toBe(true);
     });
 
-    it('does not touch the default browse id when an unrelated project is deleted', async () => {
-        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('current'));
+    it('does not touch the last selected id when an unrelated project is deleted', async () => {
+        localStorage.setItem(LAST_SELECTED_STORAGE_KEY, JSON.stringify('current'));
         const parent = createProject('parent');
         const child = createProject('child', ['parent']);
         const current = createProject('current');
@@ -489,18 +489,18 @@ describe('projects.store storage cleanup on deletion', () => {
         store.markPendingDeletedProject('child', true);
         emitDeleted('child');
 
-        expect(localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY)).toBe(JSON.stringify('current'));
+        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('current'));
     });
 
-    it('clears the default browse id when removeProject (no navigate) removes the stored default', async () => {
-        localStorage.setItem(DEFAULT_BROWSE_STORAGE_KEY, JSON.stringify('alpha'));
+    it('clears the last selected id when removeProject (no navigate) removes the stored value', async () => {
+        localStorage.setItem(LAST_SELECTED_STORAGE_KEY, JSON.stringify('alpha'));
         const alpha = createProject('alpha');
         const beta = createProject('beta');
         const store = await loadStore([alpha, beta], 'beta');
 
         store.removeProject('alpha', false);
 
-        const stored = localStorage.getItem(DEFAULT_BROWSE_STORAGE_KEY);
+        const stored = localStorage.getItem(LAST_SELECTED_STORAGE_KEY);
         expect(stored === null || stored === 'null').toBe(true);
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
@@ -16,17 +16,10 @@ import {clearVersionsCache} from '../utils/widget/versions/versionsCache';
 import {resolveActiveProjectId, resolveActiveProjectIdAfterDeletion} from '../utils/cms/projects/projectSelection';
 import {isWizardUrl} from '../utils/url/app';
 
-/*
-TODO: Enonic UI - Feature
-- Store projects as JSON objects in the sync store.
-- Load projects from the sync store on startup if other tabs are active.
-
-? Reasoning:
-- Projects are updated via server events over WebSocket.
-- Once loaded, they will stay up to date.
-- Loading existing projects from the store is faster and more efficient.
-*/
-
+// TODO: Enonic UI - Feature: store projects as JSON objects in the sync store
+// TODO: Enonic UI - Feature: load projects from the sync store on startup if other tabs are active
+// ? Projects update via server events over WebSocket and stay up to date once loaded.
+// ? Reading existing projects from the store on startup is faster and more efficient.
 
 type ProjectsStore = {
     projects: Readonly<Project>[];
@@ -47,11 +40,12 @@ export const $projects = map<ProjectsStore>({
 });
 
 //
-// * Persisted default project for browse mode.
-// * Updated only on explicit UI selection or on deletion-driven fallback.
+// * Last user-selected project, persisted across sessions.
+// * Written only on explicit UI selection or on deletion-driven fallback.
+// * Read in browse mode when the URL has no project; ignored on wizard URLs.
 //
-const $defaultBrowseProjectId = atom<string | undefined>(undefined);
-syncAtomStore($defaultBrowseProjectId, 'defaultBrowseProjectId', {loadInitial: true});
+const $lastSelectedProjectId = atom<string | undefined>(undefined);
+syncAtomStore($lastSelectedProjectId, 'lastSelectedProjectId', {loadInitial: true});
 
 export const $activeProject = computed($projects, (store) => {
     const activeProject = store.projects.find((p) => getProjectId(p) === store.activeProjectId);
@@ -213,20 +207,20 @@ function updateActiveProject(): void {
 function updateActiveProjectAfterDeletion(deletedProject: Readonly<Project> | undefined): void {
     const {projects} = $projects.get();
     const nextProjectId = resolveActiveProjectIdAfterDeletion(projects, deletedProject);
-    const wasDefault = $defaultBrowseProjectId.get() === getProjectId(deletedProject);
+    const wasLast = $lastSelectedProjectId.get() === getProjectId(deletedProject);
 
     if (nextProjectId) {
         selectProjectById(nextProjectId);
-        if (wasDefault) {
-            $defaultBrowseProjectId.set(nextProjectId);
+        if (wasLast) {
+            $lastSelectedProjectId.set(nextProjectId);
         }
         setProjectSelectionDialogOpen(false);
         return;
     }
 
     clearActiveProject();
-    if (wasDefault) {
-        $defaultBrowseProjectId.set(undefined);
+    if (wasLast) {
+        $lastSelectedProjectId.set(undefined);
     }
     ProjectContext.get().setNotAvailable();
     setProjectSelectionDialogOpen(true);
@@ -244,7 +238,7 @@ function initializeActiveProject(): void {
     }
 
     if (!isWizardUrl()) {
-        const fromStorage = $defaultBrowseProjectId.get();
+        const fromStorage = $lastSelectedProjectId.get();
         if (fromStorage) {
             $projects.setKey('activeProjectId', fromStorage);
         }
@@ -287,16 +281,16 @@ export function reloadProjects(): void {
 }
 
 /**
- * UI-driven project selection. Updates the active project and persists it
- * as the default for browse mode. Use this from UI handlers; programmatic
- * code paths inside the store stay on the internal helpers.
+ * UI-driven project selection. Updates the active project and persists it as
+ * the last selected project. Use this from UI handlers; programmatic code
+ * paths inside the store stay on the internal helpers.
  */
 export function selectProject(project: Readonly<Project>): void {
     setActiveProject(project);
     const projectId = getProjectId(project);
     // ? Persist only if the active project actually changed (i.e., project was valid).
     if ($projects.get().activeProjectId === projectId) {
-        $defaultBrowseProjectId.set(projectId);
+        $lastSelectedProjectId.set(projectId);
     }
 }
 
@@ -343,8 +337,8 @@ export function removeProject(projectName: string, navigateAfterDeletion: boolea
         return;
     }
 
-    if ($defaultBrowseProjectId.get() === projectName) {
-        $defaultBrowseProjectId.set(undefined);
+    if ($lastSelectedProjectId.get() === projectName) {
+        $lastSelectedProjectId.set(undefined);
     }
 
     updateActiveProject();

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/projects.store.ts
@@ -4,7 +4,7 @@ import {ProjectListRequest} from '../../../app/settings/resource/ProjectListRequ
 import {ProjectUpdatedEvent} from '../../../app/settings/event/ProjectUpdatedEvent';
 import {ProjectCreatedEvent} from '../../../app/settings/event/ProjectCreatedEvent';
 import {ProjectDeletedEvent} from '../../../app/settings/event/ProjectDeletedEvent';
-import {syncMapStore} from '../utils/storage/sync';
+import {syncAtomStore} from '../utils/storage/sync';
 import {$config} from './config.store';
 import {setProjectSelectionDialogOpen} from './dialogs.store';
 import {ProjectContext} from '../../../app/project/ProjectContext';
@@ -14,6 +14,7 @@ import {setContentFilterOpen, resetContentFilter} from './contentFilter.store';
 import {deactivateFilter} from '../api/content-fetcher';
 import {clearVersionsCache} from '../utils/widget/versions/versionsCache';
 import {resolveActiveProjectId, resolveActiveProjectIdAfterDeletion} from '../utils/cms/projects/projectSelection';
+import {isWizardUrl} from '../utils/url/app';
 
 /*
 TODO: Enonic UI - Feature
@@ -27,7 +28,6 @@ TODO: Enonic UI - Feature
 */
 
 
-const SYNC_NAME = 'projects';
 type ProjectsStore = {
     projects: Readonly<Project>[];
     activeProjectId: string | undefined;
@@ -46,11 +46,12 @@ export const $projects = map<ProjectsStore>({
     noProjectMode: ProjectContext.get().isNotAvailable(),
 });
 
-syncMapStore($projects, SYNC_NAME, {
-    keys: ['activeProjectId'],
-    loadInitial: true,
-    syncTabs: false,
-});
+//
+// * Persisted default project for browse mode.
+// * Updated only on explicit UI selection or on deletion-driven fallback.
+//
+const $defaultBrowseProjectId = atom<string | undefined>(undefined);
+syncAtomStore($defaultBrowseProjectId, 'defaultBrowseProjectId', {loadInitial: true});
 
 export const $activeProject = computed($projects, (store) => {
     const activeProject = store.projects.find((p) => getProjectId(p) === store.activeProjectId);
@@ -77,7 +78,7 @@ export const $activeProjectName = computed($activeProject, (activeProject) => {
     return `${projectDisplayName} (${projectLanguage})`;
 });
 
-export function setActiveProject(project: Readonly<Project> | undefined): void {
+function setActiveProject(project: Readonly<Project> | undefined): void {
     const existsInStore = $projects.get().projects.some((p) => getProjectId(p) === getProjectId(project));
     if (!existsInStore) return;
     $projects.setKey('activeProjectId', getProjectId(project));
@@ -212,33 +213,48 @@ function updateActiveProject(): void {
 function updateActiveProjectAfterDeletion(deletedProject: Readonly<Project> | undefined): void {
     const {projects} = $projects.get();
     const nextProjectId = resolveActiveProjectIdAfterDeletion(projects, deletedProject);
+    const wasDefault = $defaultBrowseProjectId.get() === getProjectId(deletedProject);
 
     if (nextProjectId) {
         selectProjectById(nextProjectId);
+        if (wasDefault) {
+            $defaultBrowseProjectId.set(nextProjectId);
+        }
         setProjectSelectionDialogOpen(false);
         return;
     }
 
     clearActiveProject();
+    if (wasDefault) {
+        $defaultBrowseProjectId.set(undefined);
+    }
     ProjectContext.get().setNotAvailable();
     setProjectSelectionDialogOpen(true);
 }
 
 /**
- * Initialize the active project from the URL without checks.
- * It is used during startup and project would not be available in the store yet.
+ * Initialize the active project. URL takes precedence; in browse mode we
+ * fall back to the user's last UI-selected project from storage.
  */
-function initializeActiveProjectFromUrl(): void {
-    const projectIdFromUrl = getProjectIdFromUrl();
-    if (projectIdFromUrl) {
-        $projects.setKey('activeProjectId', projectIdFromUrl);
+function initializeActiveProject(): void {
+    const fromUrl = getProjectIdFromUrl();
+    if (fromUrl) {
+        $projects.setKey('activeProjectId', fromUrl);
+        return;
+    }
+
+    if (!isWizardUrl()) {
+        const fromStorage = $defaultBrowseProjectId.get();
+        if (fromStorage) {
+            $projects.setKey('activeProjectId', fromStorage);
+        }
     }
 }
 
 //
 // * Initialization
 //
-initializeActiveProjectFromUrl();
+initializeActiveProject();
 
 void loadProjects();
 
@@ -268,6 +284,20 @@ ProjectContext.get().onProjectChanged(() => {
 //
 export function reloadProjects(): void {
     void loadProjects();
+}
+
+/**
+ * UI-driven project selection. Updates the active project and persists it
+ * as the default for browse mode. Use this from UI handlers; programmatic
+ * code paths inside the store stay on the internal helpers.
+ */
+export function selectProject(project: Readonly<Project>): void {
+    setActiveProject(project);
+    const projectId = getProjectId(project);
+    // ? Persist only if the active project actually changed (i.e., project was valid).
+    if ($projects.get().activeProjectId === projectId) {
+        $defaultBrowseProjectId.set(projectId);
+    }
 }
 
 export function markPendingDeletedProject(projectName: string, navigateAfterDeletion: boolean = false): void {
@@ -311,6 +341,10 @@ export function removeProject(projectName: string, navigateAfterDeletion: boolea
     if (navigateAfterDeletion) {
         updateActiveProjectAfterDeletion(deletedProject);
         return;
+    }
+
+    if ($defaultBrowseProjectId.get() === projectName) {
+        $defaultBrowseProjectId.set(undefined);
     }
 
     updateActiveProject();


### PR DESCRIPTION
When the edit URL contains a broken content ID, the app now navigates to browse and shows a localized toast — without a full page reload.

`preLoadApplication` validates the wizard URL before the SPA mounts. On rejection it sets a module-scoped flag and calls `history.replaceState` to swap the URL in place to browse. `startApplication` then re-evaluates `isContentWizardUrl()` against the rewritten pathname and routes into `startContentBrowser`, which consumes the flag and shows the toast.

- No full page reload — `history.replaceState` instead of `window.location.replace`. Smooth transition, broken URL doesn't enter browser history.
- No sessionStorage bridge — a `boolean` flag survives the synchronous transition.
- Single routing decision point — `isContentWizardUrl()` against the live URL. The previous gating flag in `startApplication` is gone.
- Reuses `text.content.not.found` instead of adding a new phrase. No `Exception` parsing, no severity switch, no duplicated message extraction.
- `clearFavicon()` only on success — favicon stays untouched on failure instead of leaving a placeholder.
- Fixes a latent bug in `ContentWizardPanel.doLoadData` — `.finally` ran `initLiveEditModel(currentItem)` even after rejection, masking the original error with a secondary crash. Switched to `.then(() => loadedContent)` so rejections propagate cleanly.

Closes #10216

<sub>*Drafted with AI assistance*</sub>
