### PR TITLE
ProjectSelectionDialog: items unresponsive and close button shown when no active project #10454

### DIFF
--- a/modules/app/src/main/resources/assets/js/main.ts
+++ b/modules/app/src/main/resources/assets/js/main.ts
@@ -304,11 +304,11 @@ async function startApplication() {
             return;
         }
 
-        if (ContentAppHelper.isContentWizardUrl()) {
-            if (!hasActiveProject()) {
-                return;
-            }
+        if (!hasActiveProject()) {
+            return;
+        }
 
+        if (ContentAppHelper.isContentWizardUrl()) {
             contentViewStarted = true;
             startContentWizard();
             return;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProjectSelectionDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProjectSelectionDialog.tsx
@@ -27,10 +27,12 @@ export const ProjectSelectionDialog = (): ReactElement => {
 
     const flatProjects = useMemo(() => flattenProjects(projects), [projects]);
     const projectByName = useMemo(() => new Map(flatProjects.map(({project}) => [project.getName(), project])), [flatProjects]);
-    const hasAvailableProjects = useMemo(
-        () => flatProjects.some(({project}) => ProjectHelper.isAvailable(project)),
+    const firstAvailableProjectId = useMemo(
+        () => flatProjects.find(({project}) => ProjectHelper.isAvailable(project))?.project.getName(),
         [flatProjects]
     );
+    const hasAvailableProjects = firstAvailableProjectId != null;
+    const hasActiveProject = activeProjectId != null;
 
     // TODO: Enonic UI - Move auth data to store
     // It's currently okay, as authentication data is loaded from CONFIG and can be considered static
@@ -49,8 +51,13 @@ export const ProjectSelectionDialog = (): ReactElement => {
                         e.preventDefault();
                         listRef.current?.focus();
                     }}
+                    onEscapeKeyDown={hasActiveProject ? undefined : (e) => e.preventDefault()}
+                    onPointerDownOutside={hasActiveProject ? undefined : (e) => e.preventDefault()}
                 >
-                    <ConfirmationDialog.DefaultHeader title={hasAvailableProjects ? title : isAdmin ? createProject : getAccess} withClose />
+                    <ConfirmationDialog.DefaultHeader
+                        title={hasAvailableProjects ? title : isAdmin ? createProject : getAccess}
+                        withClose={hasActiveProject}
+                    />
 
                     {!hasAvailableProjects ? (
                         <ConfirmationDialog.Body className="flex flex-col gap-4 p-2 -m-2">
@@ -67,8 +74,8 @@ export const ProjectSelectionDialog = (): ReactElement => {
                         <ConfirmationDialog.Body className="p-0">
                             <Listbox.Root
                                 selectionMode="single"
-                                selection={activeProjectId ? [activeProjectId] : []}
-                                defaultActive={activeProjectId}
+                                selection={hasActiveProject ? [activeProjectId] : []}
+                                defaultActive={activeProjectId ?? firstAvailableProjectId}
                                 onSelectionChange={(selection) => {
                                     const name = selection[0] ?? activeProjectId;
                                     const project = name ? projectByName.get(name) : undefined;


### PR DESCRIPTION
Hoisted the active-project guard in `startResolvedContentView` so the legacy `AppWrapper` no longer mounts on top of the dialog when projects load with no selection — its first call to `ProjectContext.get().getProject().getName()` was throwing and freezing the listbox click handlers.

Hardened the dialog itself: hide the close button, lock escape and outside clicks, and pass a valid `defaultActive` to `Listbox` when there is no active project to fall back to.

Closes #10454

<sub>*Drafted with AI assistance*</sub>
