### PR TITLE
Stop using deprecated cms.cm.app role #10485

### DIFF
--- a/testing/libs/app_const.js
+++ b/testing/libs/app_const.js
@@ -446,7 +446,6 @@ module.exports = Object.freeze({
         WRITE_PERMISSIONS: 'Write Permissions',
     },
     roleName: {
-        CONTENT_MANAGER_APP: 'cms.cm.app',
         ADMINISTRATOR: 'system.admin',
         CM_ADMIN: 'cms.admin'
     },

--- a/testing/specs/permissions/edit.permissions.dialog.access.selector.spec.js
+++ b/testing/specs/permissions/edit.permissions.dialog.access.selector.spec.js
@@ -87,8 +87,7 @@ describe("edit.permissions.access.selector.spec:  Select 'Custom...' permissions
             let entries = await editPermissionsDialog.getNameOfAccessControlEntries();
             // 3. Verify the order of ACE:
             assert.equal(entries[0], '/roles/cms.admin', " ACL-entries should be consistently sorted by name");
-            assert.equal(entries[1], '/roles/cms.cm.app', " ACL-entries should be consistently sorted by name");
-            assert.equal(entries[2], '/roles/system.admin', " ACL-entries should be consistently sorted by name");
+            assert.equal(entries[1], '/roles/system.admin', " ACL-entries should be consistently sorted by name");
         });
 
     beforeEach(() => studioUtils.navigateToContentStudioApp());


### PR DESCRIPTION
The `cms.cm.app` role is being deprecated in Enonic XP (see [enonic/xp#12023](https://github.com/enonic/xp/issues/12023)); the platform will stop auto-provisioning it and will no longer seed it into the default ACLs for content / issue / archive roots. Content Studio's test suite still referenced the role, so it would fail on an XP build where the role does not exist.

Changes:

- `testing/libs/app_const.js` — remove the unused `CONTENT_MANAGER_APP: 'cms.cm.app'` entry from the `roleName` map. The constant has no callers elsewhere in the repo.
- `testing/specs/permissions/edit.permissions.dialog.access.selector.spec.js` — drop the assertion that `entries[1] === '/roles/cms.cm.app'` and re-index the remaining sorted-ACL assertions so `system.admin` is now expected at index 1. The spec still verifies what its name promises (ACL entries displayed in sorted order).

Production code under `modules/*/src/main/` does not reference the role as a string literal — verified by grep, no hits.

Closes #10485

<sub>*Drafted with AI assistance*</sub>