### PR TITLE
Publish Tree button is incorrectly enabled in content browse toolbar #9979

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -361,7 +361,9 @@ export class ContentBrowsePanel
 
         onActiveProjectChanged(() => {
             this.selectionWrapper.deselectAll();
-            this.updateActionsAndPreview();
+            this.getBrowseActions().updateActionsEnabledState([]);
+            this.getBrowseItemPanel().togglePreviewForItem(null);
+            this.updateContextView(null).catch(DefaultErrorHandler.handle);
             this.filterPanel.reset().then(() => {
                 this.hideFilterPanel();
                 this.toggleFilterPanelButton.removeClass('filtered');


### PR DESCRIPTION
Publish Tree button is incorrectly enabled in the content browse toolbar, actions now reset with an explicitly empty list upon opening a new project to avoid stale actions.