### PR TITLE
AI plugin protocol does not include the current user #10546

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai-protocol.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai-protocol.ts
@@ -70,6 +70,12 @@ export type AiPluginConfig = {
     licenseServiceUrl?: string;
     sharedSocketUrl?: string;
     instructions: string;
+    user?: AiUser;
+};
+
+export type AiUser = {
+    key: string;
+    displayName: string;
 };
 
 // ---- Signals (universal, CS -> plugin) --------------------------------------

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.snapshots.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.snapshots.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it, beforeEach} from 'vitest';
+import {Principal} from '@enonic/lib-admin-ui/security/Principal';
 import {$config} from '../config.store';
 import {$aiInstructions} from './ai.store';
 import {buildPluginConfig} from './ai.snapshots';
@@ -34,5 +35,21 @@ describe('buildPluginConfig', () => {
     it('falls back to an empty instructions string when none are set', () => {
         $aiInstructions.set(null);
         expect(buildPluginConfig('ai.translator').instructions).toBe('');
+    });
+
+    it('includes the current user when set', () => {
+        $config.setKey('user', Principal.fromJson({
+            key: 'user:system:edloidas',
+            displayName: 'Mikita Taukachou',
+            modifiedTime: new Date().toISOString(),
+        }));
+        expect(buildPluginConfig('ai.contentOperator').user).toEqual({
+            key: 'user:system:edloidas',
+            displayName: 'Mikita Taukachou',
+        });
+    });
+
+    it('omits user when none is set', () => {
+        expect(buildPluginConfig('ai.contentOperator').user).toBeUndefined();
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.snapshots.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.snapshots.ts
@@ -5,6 +5,7 @@ import type {
     AiPluginId,
     AiSchemaSnapshot,
     AiState,
+    AiUser,
 } from './ai-protocol';
 import {createContentData, createContentLanguage, createContentSchema} from './ai.commands';
 import {$aiInstructions} from './ai.store';
@@ -44,15 +45,29 @@ const ID_TO_LEGACY_PLUGIN: Record<AiPluginId, EnonicAiPlugin> = {
     'ai.contentOperator': 'contentOperator',
 };
 
+function buildUserSnapshot(): AiUser | undefined {
+    const user = $config.get().user;
+    if (user == null) {
+        return undefined;
+    }
+
+    return {
+        key: user.getKey().toString(),
+        displayName: user.getDisplayName(),
+    };
+}
+
 export function buildPluginConfig(id: AiPluginId): AiPluginConfig {
     const config = $config.get();
     const instructions = $aiInstructions.get()?.[ID_TO_LEGACY_PLUGIN[id]] ?? '';
+    const user = buildUserSnapshot();
 
     if (id === 'ai.contentOperator') {
         return {
             wsServiceUrl: config.services.aiContentOperatorWsServiceUrl,
             sharedSocketUrl: config.sharedSocketUrl,
             instructions,
+            user,
         };
     }
 
@@ -61,5 +76,6 @@ export function buildPluginConfig(id: AiPluginId): AiPluginConfig {
         licenseServiceUrl: config.services.aiTranslatorLicenseServiceUrl,
         sharedSocketUrl: config.sharedSocketUrl,
         instructions,
+        user,
     };
 }


### PR DESCRIPTION
Added optional `user: { key, displayName }` to `AiPluginConfig` so AI plugins receive the current user again, restoring a capability that was dropped during the new-design migration.

`buildPluginConfig` now derives the user from `$config.user` Principal when present. Existing snapshots remain stable when no user is set. Test coverage added for both cases.

Consumer side in `app-ai-content-operator` is enonic/app-ai-content-operator#776.

Closes #10546

<sub>*Drafted with AI assistance*</sub>
