### PR TITLE
The grid is not refreshed after moving content #10443

### DIFF
--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -311,8 +311,8 @@ importers:
   .xp/dev/lib-contentstudio:
     dependencies:
       '@enonic/ui':
-        specifier: ~1.0.0-beta.5
-        version: 1.0.0-beta.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~1.0.0-beta.6
+        version: 1.0.0-beta.6(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@nanostores/preact':
         specifier: ^1.0.0
         version: 1.1.0(nanostores@0.11.4)(preact@10.29.0)
@@ -644,6 +644,30 @@ packages:
 
   '@enonic/ui@1.0.0-beta.5':
     resolution: {integrity: sha512-1CBPbC8vERGWZaeovqf57W5MgEbL9/MI3cEp6nFagzK85ekbtm2gqlai9wxwIcEfPONYOQMrIbQMumNaTSXj5A==}
+    engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
+    peerDependencies:
+      '@radix-ui/react-slot': ^1.2.0
+      focus-trap-react: ^11.0.0
+      lucide-react: '>=0.500.0'
+      preact: '>=10.0.0'
+      react: ^19.0.0
+      react-dom: ^19.0.0
+      react-virtuoso: ^4.0.0
+      tw-animate-css: ^1.0.0
+    peerDependenciesMeta:
+      preact:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      react-virtuoso:
+        optional: true
+      tw-animate-css:
+        optional: true
+
+  '@enonic/ui@1.0.0-beta.6':
+    resolution: {integrity: sha512-Mj6gfkUP113VdKpIDn+aTWo3YtUq6zBzvEy9Y0tMjQxZCwNfelQxss/gVxxWTbP5papxGp9nq514GAHtTho+sA==}
     engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -5468,21 +5492,6 @@ snapshots:
       nanostores: 1.3.0
       q: 1.5.1
 
-  '@enonic/ui@1.0.0-beta.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
-      class-variance-authority: 0.7.1
-      clsx: 2.1.1
-      focus-trap-react: 11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      lucide-react: 0.577.0(react@19.2.4)
-      tailwind-merge: 3.4.1
-    optionalDependencies:
-      preact: 10.29.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      tw-animate-css: 1.4.0
-
   '@enonic/ui@1.0.0-beta.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.16.0(react@19.2.4))(preact@10.29.2)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
@@ -5493,6 +5502,21 @@ snapshots:
       tailwind-merge: 3.4.1
     optionalDependencies:
       preact: 10.29.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tw-animate-css: 1.4.0
+
+  '@enonic/ui@1.0.0-beta.6(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      focus-trap-react: 11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      lucide-react: 0.577.0(react@19.2.4)
+      tailwind-merge: 3.4.1
+    optionalDependencies:
+      preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/modules/lib/package.json
+++ b/modules/lib/package.json
@@ -26,7 +26,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@enonic/ui": "~1.0.0-beta.5",
+    "@enonic/ui": "~1.0.0-beta.6",
     "@nanostores/preact": "^1.0.0",
     "ckeditor4-react": "4.3.0",
     "class-variance-authority": "^0.7.1",

--- a/modules/lib/pnpm-lock.yaml
+++ b/modules/lib/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   .:
     dependencies:
       '@enonic/ui':
-        specifier: ~1.0.0-beta.5
-        version: 1.0.0-beta.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~1.0.0-beta.6
+        version: 1.0.0-beta.6(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@nanostores/preact':
         specifier: ^1.0.0
         version: 1.1.0(nanostores@0.11.4)(preact@10.29.0)
@@ -447,6 +447,30 @@ packages:
 
   '@enonic/ui@1.0.0-beta.5':
     resolution: {integrity: sha512-1CBPbC8vERGWZaeovqf57W5MgEbL9/MI3cEp6nFagzK85ekbtm2gqlai9wxwIcEfPONYOQMrIbQMumNaTSXj5A==}
+    engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
+    peerDependencies:
+      '@radix-ui/react-slot': ^1.2.0
+      focus-trap-react: ^11.0.0
+      lucide-react: '>=0.500.0'
+      preact: '>=10.0.0'
+      react: ^19.0.0
+      react-dom: ^19.0.0
+      react-virtuoso: ^4.0.0
+      tw-animate-css: ^1.0.0
+    peerDependenciesMeta:
+      preact:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      react-virtuoso:
+        optional: true
+      tw-animate-css:
+        optional: true
+
+  '@enonic/ui@1.0.0-beta.6':
+    resolution: {integrity: sha512-Mj6gfkUP113VdKpIDn+aTWo3YtUq6zBzvEy9Y0tMjQxZCwNfelQxss/gVxxWTbP5papxGp9nq514GAHtTho+sA==}
     engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -5112,21 +5136,6 @@ snapshots:
       typescript: 5.9.3
       typescript-eslint: 8.57.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
 
-  '@enonic/ui@1.0.0-beta.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
-      class-variance-authority: 0.7.1
-      clsx: 2.1.1
-      focus-trap-react: 11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      lucide-react: 0.577.0(react@19.2.4)
-      tailwind-merge: 3.4.1
-    optionalDependencies:
-      preact: 10.29.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      tw-animate-css: 1.4.0
-
   '@enonic/ui@1.0.0-beta.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.16.0(react@19.2.4))(preact@10.29.2)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
@@ -5137,6 +5146,21 @@ snapshots:
       tailwind-merge: 3.4.1
     optionalDependencies:
       preact: 10.29.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tw-animate-css: 1.4.0
+
+  '@enonic/ui@1.0.0-beta.6(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      focus-trap-react: 11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      lucide-react: 0.577.0(react@19.2.4)
+      tailwind-merge: 3.4.1
+    optionalDependencies:
+      preact: 10.29.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -14,7 +14,7 @@ import {AppHelper} from '@enonic/lib-admin-ui/util/AppHelper';
 import type Q from 'q';
 import {$actionsNeedRefresh, clearActionsRefreshSignal} from '../../v6/features/store/actions.store';
 import {removeContent, setContent} from '../../v6/features/store/content.store';
-import {hasFilterSet, setContentFilterOpen} from '../../v6/features/store/contentFilter.store';
+import {setContentFilterOpen} from '../../v6/features/store/contentFilter.store';
 import {hasCurrentItems} from '../../v6/features/store/contentTreeSelection.store';
 import {onActiveProjectChanged} from '../../v6/features/store/activeProject.store';
 import {onNoProjectsAvailable} from '../../v6/features/store/projects.store';
@@ -548,10 +548,6 @@ export class ContentBrowsePanel
             removeContent(id);
             removeTreeNode(id);
         });
-
-        if (hasFilterSet()) {
-            this.contentTreeList.setFilterQuery(null);
-        }
 
         this.updateContextPanelOnNodesDelete(items);
         this.refreshFilterWithDelay();

--- a/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.ts
@@ -8,9 +8,11 @@ import {ContentSummaryAndCompareStatusFetcher} from '../../../app/resource/Conte
 import {ListContentByIdRequest} from '../../../app/resource/ListContentByIdRequest';
 import {type ChildOrder} from '../../../app/resource/order/ChildOrder';
 import {Branch} from '../../../app/versioning/Branch';
-import {setContents, getMissingIds, getContents} from '../store/content.store';
+import {setContents, getMissingIds, getContents, getIdByPath} from '../store/content.store';
+import {$contentMoved} from '../store/socket.store';
 import {
     $treeState,
+    addTreeNode,
     addTreeNodes,
     setTreeChildren,
     setTreeRootIds,
@@ -1055,3 +1057,94 @@ export async function fetchFilterChildrenIdsOnly(
         setFilterNodeLoading(parentId, false);
     }
 }
+
+//
+// * Content Moved Handling
+//
+
+/**
+ * Clears a parent's loaded childIds and re-fetches them so a moved item lands at
+ * the correct sorted slot.
+ */
+export async function reloadParentChildren(parentId: string | null): Promise<string[]> {
+    if (parentId === null) {
+        setTreeRootIds([]);
+        return fetchRootChildrenIdsOnly();
+    }
+
+    const parent = $treeState.get().nodes.get(parentId);
+    if (!parent) return [];
+
+    // Force hasChildren=true and clear childIds so the fetchChildrenIdsOnly guard passes.
+    addTreeNode({id: parentId, hasChildren: true, childIds: []});
+
+    return fetchChildrenIdsOnly(parentId);
+}
+
+// Old-parent refresh handles the case where the moved item lived under an unexpanded
+// parent and was never in $treeState, so removeContentFromTree could not adjust its
+// hasChildren. Runs in filter mode too so the main tree is current when the filter clears.
+$contentMoved.subscribe((event) => {
+    if (!event?.data) return;
+
+    const state = $treeState.get();
+    const parentsToReload = new Set<string | null>();
+    const oldParentsToRefresh = new Set<string>();
+
+    for (const moved of event.data) {
+        const content = moved.item.getContentSummary();
+        const newPath = content.getPath?.();
+        if (!newPath) continue;
+        // Skip same-parent changes (renames) — the parents' listings are unaffected.
+        if (moved.oldPath.getParentPath().equals(newPath.getParentPath())) continue;
+
+        // New parent
+        const newParentPath = newPath.hasParentContent() ? newPath.getParentPath() : null;
+        const newParentId =
+            newParentPath && !newParentPath.isRoot()
+                ? getIdByPath(newParentPath.toString()) ?? null
+                : null;
+
+        if (newParentPath && !newParentPath.isRoot() && !newParentId) {
+            // New parent not in tree/cache — nothing to update on the new side.
+        } else if (newParentId === null) {
+            if (state.rootIds.length > 0) {
+                parentsToReload.add(null);
+            }
+        } else {
+            const parent = state.nodes.get(newParentId);
+            if (parent) {
+                if (parent.childIds.length > 0) {
+                    parentsToReload.add(newParentId);
+                } else if (!parent.hasChildren) {
+                    addTreeNode({id: newParentId, hasChildren: true});
+                }
+            }
+        }
+
+        // Old parent
+        const oldParentPath = moved.oldPath.hasParentContent() ? moved.oldPath.getParentPath() : null;
+        if (oldParentPath && !oldParentPath.isRoot()) {
+            const oldParentId = getIdByPath(oldParentPath.toString());
+            if (oldParentId && state.nodes.has(oldParentId)) {
+                oldParentsToRefresh.add(oldParentId);
+            }
+        }
+    }
+
+    for (const parentId of parentsToReload) {
+        void reloadParentChildren(parentId).catch(() => undefined);
+    }
+
+    for (const id of oldParentsToRefresh) {
+        void refreshContent(id)
+            .then((summary) => {
+                if (!summary) return;
+                const node = $treeState.get().nodes.get(id);
+                if (node && node.hasChildren !== summary.hasChildren()) {
+                    addTreeNode({id, hasChildren: summary.hasChildren()});
+                }
+            })
+            .catch(() => undefined);
+    }
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/content.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/content.store.ts
@@ -235,11 +235,32 @@ $contentDuplicated.subscribe((event) => {
     }
 });
 
-// Content moved - no action needed here.
-// Move operation triggers both delete (from old location) and create (at new location) events,
-// which are handled by their respective subscriptions above.
-$contentMoved.subscribe(() => {
-    // Intentionally empty - handled by delete + create events
+// $contentMoved is the only event for cross-parent moves; delete/create are not emitted.
+$contentMoved.subscribe((event) => {
+    if (!event?.data) return;
+
+    const cacheUpdates: ContentCacheState = {...$contentCache.get()};
+    const indexUpdates: Record<string, string> = {...$pathToId.get()};
+
+    for (const moved of event.data) {
+        const summary = moved.item.getContentSummary();
+        const id = summary.getId();
+        const newPath = summary.getPath?.()?.toString();
+        const oldPath = moved.oldPath.toString();
+
+        cacheUpdates[id] = summary;
+
+        if (indexUpdates[oldPath] === id) {
+            delete indexUpdates[oldPath];
+        }
+
+        if (newPath) {
+            indexUpdates[newPath] = id;
+        }
+    }
+
+    $contentCache.set(cacheUpdates);
+    $pathToId.set(indexUpdates);
 });
 
 // Content sorted - update cache with new order data

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/contentTreeSelection.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/contentTreeSelection.store.ts
@@ -4,6 +4,7 @@ import type {ContentSummary} from '../../../app/content/ContentSummary';
 import {$activeRawFlatNodes, $isFilterActive} from './active-tree.store';
 import {$contentCache} from './content.store';
 import {$filterTreeState} from './filter-tree.store';
+import {$contentArchived, $contentDeleted, $contentMoved} from './socket.store';
 import {$treeState} from './tree-list.store';
 
 //
@@ -292,4 +293,60 @@ $filterTreeState.subscribe((state) => {
     if (rootsChanged && $selectAllMode.get() && $isFilterActive.get()) {
         $selectAllMode.set(false);
     }
+});
+
+//
+// * Drop departing items from selection / active
+//
+// VirtualizedTreeList falls back to items[0] when its controlled `active` id leaves
+// the items array. Clearing here makes `active` go to null instead.
+
+function dropFromSelectionAndActive(ids: ReadonlySet<string>): void {
+    if (ids.size === 0) return;
+
+    const currentSelection = $selection.get();
+    let changed = false;
+    const nextSelection = new Set<string>();
+    for (const id of currentSelection) {
+        if (ids.has(id)) {
+            changed = true;
+        } else {
+            nextSelection.add(id);
+        }
+    }
+    if (changed) {
+        $selection.set(nextSelection);
+    }
+
+    const activeId = $activeId.get();
+    if (activeId && ids.has(activeId)) {
+        $activeId.set(null);
+    }
+}
+
+// Cross-parent moves only — same-parent renames keep the node in the tree.
+$contentMoved.subscribe((event) => {
+    if (!event?.data) return;
+
+    const ids = new Set<string>();
+    for (const moved of event.data) {
+        const summary = moved.item.getContentSummary();
+        const newPath = summary.getPath?.();
+        if (!newPath) continue;
+        if (moved.oldPath.getParentPath().equals(newPath.getParentPath())) continue;
+        ids.add(summary.getId());
+    }
+    dropFromSelectionAndActive(ids);
+});
+
+$contentDeleted.subscribe((event) => {
+    if (!event?.data) return;
+    const ids = new Set(event.data.map((item) => item.getContentId().toString()));
+    dropFromSelectionAndActive(ids);
+});
+
+$contentArchived.subscribe((event) => {
+    if (!event?.data) return;
+    const ids = new Set(event.data.map((item) => item.getContentId().toString()));
+    dropFromSelectionAndActive(ids);
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/filter-tree.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/filter-tree.store.ts
@@ -19,7 +19,7 @@ import {
     ROOT_LOADING_KEY,
 } from '../lib/tree-store';
 import {$contentCache} from './content.store';
-import {$contentDeleted, $contentArchived, $contentCreated, $contentDuplicated} from './socket.store';
+import {$contentDeleted, $contentArchived, $contentCreated, $contentDuplicated, $contentMoved} from './socket.store';
 import type {ContentData} from '../views/browse/grid/ContentData';
 import {convertToContentFlatNode} from './tree/utils';
 import type {ContentTreeNodeData, LoadingStateValue} from './tree/types';
@@ -233,6 +233,13 @@ $contentCreated.subscribe((event) => {
 
 // Content duplicated - filter may need refresh to include duplicate
 $contentDuplicated.subscribe((event) => {
+    if (event?.data) {
+        $filterRefreshNeeded.set(Date.now());
+    }
+});
+
+// Content moved - filter results depend on the new path/parent, so trigger a refresh
+$contentMoved.subscribe((event) => {
     if (event?.data) {
         $filterRefreshNeeded.set(Date.now());
     }

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.ts
@@ -1,5 +1,5 @@
 import {atom, computed} from 'nanostores';
-import {$contentDeleted, $contentArchived, $contentCreated, $contentDuplicated} from './socket.store';
+import {$contentDeleted, $contentArchived, $contentCreated, $contentDuplicated, $contentMoved} from './socket.store';
 import type {ContentSummary} from '../../../app/content/ContentSummary';
 import {calcContentState} from '../utils/cms/content/workflow';
 import {calcTreePublishStatus} from '../utils/cms/content/status';
@@ -412,6 +412,28 @@ $contentDuplicated.subscribe((event) => {
     for (const content of event.data) {
         addContentToTree(content);
     }
+});
+
+// Skip renames that leak into $contentMoved as same-parent changes — $contentCache covers them.
+// The new parent is reloaded by content-fetcher so the item lands in the correct sorted slot.
+$contentMoved.subscribe((event) => {
+    if (!event?.data) return;
+
+    const state = $treeState.get();
+    const ids: string[] = [];
+
+    for (const moved of event.data) {
+        const summary = moved.item.getContentSummary();
+        const newPath = summary.getPath?.();
+        if (!newPath) continue;
+        if (moved.oldPath.getParentPath().equals(newPath.getParentPath())) continue;
+
+        const id = summary.getId();
+        if (state.nodes.has(id)) ids.push(id);
+    }
+
+    if (ids.length === 0) return;
+    removeContentFromTree(ids);
 });
 
 //


### PR DESCRIPTION
Wired `$contentMoved` end-to-end across v6 stores so a cross-parent move updates the browse grid without page refresh.

- `content.store`: subscribe to `$contentMoved` to write the new summary to `$contentCache` and rewire `$pathToId` (drop old path, add new).
- `tree-list.store`: subscribe to drop the moved node from the main tree when the parent changes; reuses `removeContentFromTree` so the old parent collapses if it becomes empty.
- `filter-tree.store`: subscribe to bump `$filterRefreshNeeded` so an active filter re-runs its query.
- `contentTreeSelection.store`: drop departing ids from `$selection` and `$activeId` on `$contentMoved`, `$contentDeleted`, `$contentArchived` so the tree does not snap focus to the first row.
- `content-fetcher`: add `reloadParentChildren(parentId)` and subscribe to `$contentMoved` to refetch the new parent's IDs in correct sorted order, mark `hasChildren=true` on a previously empty parent, and refresh the old parent's content so its chevron drops when the moved item lived under a collapsed parent (the item was never in tree state, so `removeContentFromTree` could not update it).
- legacy `ContentBrowsePanel.handleContentDeleted`: stop calling `setFilterQuery(null)` when filter mode is active. The legacy move handler routes through `handleContentDeleted(oldPath)`, so this branch was deactivating filter mode on every cross-parent move and dropping the user back to the default tree view; v6 now handles the filter refresh via `$filterRefreshNeeded`.

Bumped `@enonic/ui` to `~1.0.0-beta.6` which ships the `useControlledStateWithNull` fix that makes the consumer-side `setActive(null)` take effect in the same render — previously the cached uncontrolled value leaked into `VirtualizedTreeList`'s items effect and snapped focus to the first row.