### PR TITLE
Duplicated item should appear next to the original #10549

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.ts
@@ -9,7 +9,7 @@ import {ListContentByIdRequest} from '../../../app/resource/ListContentByIdReque
 import {type ChildOrder} from '../../../app/resource/order/ChildOrder';
 import {Branch} from '../../../app/versioning/Branch';
 import {setContents, getMissingIds, getContents, getIdByPath} from '../store/content.store';
-import {$contentMoved} from '../store/socket.store';
+import {$contentDuplicated, $contentMoved} from '../store/socket.store';
 import {
     $treeState,
     addTreeNode,
@@ -1146,5 +1146,53 @@ $contentMoved.subscribe((event) => {
                 }
             })
             .catch(() => undefined);
+    }
+});
+
+// Refetch instead of inserting locally: the server owns the child order (it may
+// be manual) so we cannot compute the new item's slot client-side. With includeChildren,
+// descendants of a freshly duplicated node are skipped — their parent is not yet
+// loaded, lazy-load fills the subtree on expand.
+$contentDuplicated.subscribe((event) => {
+    if (!event?.data) return;
+
+    const state = $treeState.get();
+    const duplicatedIds = new Set(event.data.map((content) => content.getId()));
+    const parentsToReload = new Set<string | null>();
+
+    for (const content of event.data) {
+        const path = content.getPath?.();
+        if (!path) continue;
+
+        const newParentPath = path.hasParentContent() ? path.getParentPath() : null;
+        const newParentId =
+            newParentPath && !newParentPath.isRoot()
+                ? getIdByPath(newParentPath.toString()) ?? null
+                : null;
+
+        if (newParentId && duplicatedIds.has(newParentId)) continue;
+
+        if (newParentPath && !newParentPath.isRoot() && !newParentId) {
+            continue;
+        }
+
+        if (newParentId === null) {
+            if (state.rootIds.length > 0) {
+                parentsToReload.add(null);
+            }
+        } else {
+            const parent = state.nodes.get(newParentId);
+            if (parent) {
+                if (parent.childIds.length > 0) {
+                    parentsToReload.add(newParentId);
+                } else if (!parent.hasChildren) {
+                    addTreeNode({id: newParentId, hasChildren: true});
+                }
+            }
+        }
+    }
+
+    for (const parentId of parentsToReload) {
+        void reloadParentChildren(parentId).catch(() => undefined);
     }
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.test.ts
@@ -32,7 +32,7 @@ import {
 } from './tree-list.store';
 import {clearContentCache, setContent, setContents} from './content.store';
 import {addUpload, clearUploads} from './uploads.store';
-import {emitContentCreated, emitContentDeleted, emitContentDuplicated, emitContentArchived} from './socket.store';
+import {emitContentCreated, emitContentDeleted, emitContentArchived} from './socket.store';
 import type {ContentServerChangeItem} from '../../../app/event/ContentServerChangeItem';
 
 // Mock ContentTreeNodeData
@@ -707,54 +707,5 @@ describe('tree-list.store', () => {
             });
         });
 
-        describe('$contentDuplicated', () => {
-            it('adds duplicated content to tree when parent is loaded', () => {
-                // Setup: parent node in tree with path in cache
-                const parentContent = createMockContentWithParent('parent', '/');
-                setContents([parentContent]);
-                addTreeNode({id: 'parent', data: createNodeData('parent'), hasChildren: true, childIds: ['child1']});
-                setTreeRootIds(['parent']);
-                expandNode('parent');
-
-                // Emit: duplicated content
-                const duplicatedContent = createMockContentWithParent('duplicate', '/parent', false, 'Duplicated');
-                emitContentDuplicated([duplicatedContent]);
-
-                // Assert: duplicate appears in tree
-                expect(hasTreeNode('duplicate')).toBe(true);
-                const parent = getTreeNode('parent');
-                expect(parent?.childIds).toContain('duplicate');
-            });
-
-            it('does not add a duplicated content to the tree when parent children are not loaded yet', () => {
-                // Setup: parent node in tree with path in cache
-                const parentContent = createMockContentWithParent('parent', '/');
-                setContents([parentContent]);
-                addTreeNode({id: 'parent', data: createNodeData('parent'), hasChildren: true});
-                setTreeRootIds(['parent']);
-                expandNode('parent');
-
-                // Emit: duplicated content
-                const duplicatedContent = createMockContentWithParent('duplicate', '/parent', false, 'Duplicated');
-                emitContentDuplicated([duplicatedContent]);
-
-                // Assert: duplicate appears in tree
-                expect(hasTreeNode('duplicate')).not.toBe(true);
-                const parent = getTreeNode('parent');
-                expect(parent?.childIds).not.toContain('duplicate');
-            });
-
-            it('does not add duplicated content when parent is not in tree', () => {
-                // Setup: empty tree
-                setTreeRootIds([]);
-
-                // Emit: duplicated content with non-existent parent
-                const content = createMockContentWithParent('duplicate', '/non-existent');
-                emitContentDuplicated([content]);
-
-                // Assert: content not added
-                expect(hasTreeNode('duplicate')).toBe(false);
-            });
-        });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.ts
@@ -1,5 +1,5 @@
 import {atom, computed} from 'nanostores';
-import {$contentDeleted, $contentArchived, $contentCreated, $contentDuplicated, $contentMoved} from './socket.store';
+import {$contentDeleted, $contentArchived, $contentCreated, $contentMoved} from './socket.store';
 import type {ContentSummary} from '../../../app/content/ContentSummary';
 import {calcContentState} from '../utils/cms/content/workflow';
 import {calcTreePublishStatus} from '../utils/cms/content/status';
@@ -406,13 +406,7 @@ $contentCreated.subscribe((event) => {
     }
 });
 
-// Socket: Content duplicated
-$contentDuplicated.subscribe((event) => {
-    if (!event?.data) return;
-    for (const content of event.data) {
-        addContentToTree(content);
-    }
-});
+// Duplicates: positioned by content-fetcher's $contentDuplicated reload.
 
 // Skip renames that leak into $contentMoved as same-parent changes — $contentCache covers them.
 // The new parent is reloaded by content-fetcher so the item lands in the correct sorted slot.


### PR DESCRIPTION
Mirrored the move-content pattern for duplicates: `content-fetcher` subscribes to `$contentDuplicated` and reloads each affected new parent via `reloadParentChildren`, so the server returns the correct sorted order and the new item lands in its real slot. Removed the old `$contentDuplicated` append subscriber from `tree-list.store` so the duplicate is not briefly rendered at the wrong slot before reload. Skips descendants of a freshly duplicated node (includeChildren case) — lazy-load fills the subtree on expand.

Closes #10549

<sub>*Drafted with AI assistance*</sub>
