### PR TITLE
Exception occurs when entering text in inputs on Inspect Panel #10497

### DIFF
--- a/modules/app/src/main/java/com/enonic/app/contentstudio/LiveEditInjection.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/LiveEditInjection.java
@@ -22,6 +22,8 @@ import com.enonic.xp.portal.postprocess.HtmlTag;
 import com.enonic.xp.portal.postprocess.PostProcessInjection;
 import com.enonic.xp.portal.url.AssetUrlParams;
 import com.enonic.xp.portal.url.PortalUrlService;
+import com.enonic.xp.project.ProjectConstants;
+import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.util.Exceptions;
 
 @Component(immediate = true, service = PostProcessInjection.class, configurationPid = "com.enonic.app.contentstudio")
@@ -81,7 +83,7 @@ public final class LiveEditInjection
 
             if ( htmlTag == HtmlTag.BODY_END )
             {
-                return Collections.singletonList( injectBodyEnd() );
+                return Collections.singletonList( injectBodyEnd( portalRequest ) );
             }
         }
         finally
@@ -98,7 +100,7 @@ public final class LiveEditInjection
         {
             if ( htmlTag == HtmlTag.BODY_END )
             {
-                return Collections.singletonList( injectUsingTemplate( this.inlineBodyEndTemplate, makeModelForInjection() ) );
+                return Collections.singletonList( injectUsingTemplate( this.inlineBodyEndTemplate, makeModelForInjection( portalRequest ) ) );
             }
         }
         finally
@@ -118,9 +120,9 @@ public final class LiveEditInjection
         return finalTemplate;
     }
 
-    private String injectBodyEnd()
+    private String injectBodyEnd( final PortalRequest portalRequest )
     {
-        return injectUsingTemplate( this.bodyEndTemplate, makeModelForInjection() );
+        return injectUsingTemplate( this.bodyEndTemplate, makeModelForInjection( portalRequest ) );
     }
 
     private String injectUsingTemplate( final String template, final Map<String, String> model )
@@ -128,13 +130,20 @@ public final class LiveEditInjection
         return new StringSubstitutor( model, PREFIX, SUFFIX, ESCAPE ).replace( template );
     }
 
-    private Map<String, String> makeModelForInjection()
+    private Map<String, String> makeModelForInjection( final PortalRequest portalRequest )
     {
         final Map<String, String> map = Maps.newHashMap();
         final AssetUrlParams params = new AssetUrlParams();
         params.application( "com.enonic.app.contentstudio" );
         map.put( "assetsUrl", portalUrlService.assetUrl( params ) );
+        map.put( "project", resolveProject( portalRequest ) );
         return map;
+    }
+
+    private String resolveProject( final PortalRequest portalRequest )
+    {
+        final RepositoryId repositoryId = portalRequest.getRepositoryId();
+        return repositoryId != null ? repositoryId.toString().replace( ProjectConstants.PROJECT_REPO_ID_PREFIX, "" ) : "";
     }
 
     public String loadTemplate( final String name )

--- a/modules/app/src/main/resources/admin/tools/main/main.html
+++ b/modules/app/src/main/resources/admin/tools/main/main.html
@@ -62,7 +62,6 @@
     <link rel="stylesheet" type="text/css" href="{{assetsUri}}/admin/common/styles/lib.css">
     <link rel="stylesheet" type="text/css" href="{{assetsUri}}/styles/contentlib.css">
     <link rel="stylesheet" type="text/css" href="{{assetsUri}}/styles/index.css">
-    <script type="text/javascript" src="{{assetsUri}}/admin/common/js/lib.js"></script>
 
     {{#isAiEnabled}}
     <!-- Seed window.Enonic.AI so async plugin bundles can register before initAiHost() runs -->

--- a/modules/app/src/main/resources/assets/js/page-editor.ts
+++ b/modules/app/src/main/resources/assets/js/page-editor.ts
@@ -1,20 +1,11 @@
-import {HTMLAreaHelper} from '@enonic/lib-contentstudio/app/inputtype/ui/text/HTMLAreaHelper';
-import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
-import {RenderingMode} from '@enonic/lib-contentstudio/app/rendering/RenderingMode';
-import {UriHelper} from '@enonic/lib-contentstudio/app/rendering/UriHelper';
-import {Project} from '@enonic/lib-contentstudio/app/settings/data/project/Project';
-import {InitializeLiveEditEvent} from '@enonic/lib-contentstudio/page-editor/event/InitializeLiveEditEvent';
-import {setActiveProject} from '@enonic/lib-contentstudio/v6/features/store/activeProject.store';
+import {ALLOWED_URI_REGEXP} from '@enonic/lib-contentstudio/v6/features/utils/url/allowedUri';
 import {ComponentPath as EditorComponentPath, EditorEvent, EditorEvents, PageEditor} from '@enonic/page-editor';
 import DOMPurify from 'dompurify';
 
-PageEditor.init({editMode: true});
+const scriptElement = document.currentScript as HTMLScriptElement | null;
+const project = scriptElement?.dataset.project;
 
-// TODO: Add a new event to PageEditor.on(EditorEvents.Initialize)
-//  to encapsulate internal InitializeLiveEditEvent
-InitializeLiveEditEvent.on((event: InitializeLiveEditEvent) => {
-    setActiveProject(Project.fromJson(event.projectJson));
-});
+PageEditor.init({editMode: true});
 
 PageEditor.on(
     EditorEvents.ComponentLoadRequest,
@@ -45,7 +36,20 @@ async function handleComponentLoad(path: EditorComponentPath, isExisting: boolea
 
 function resolveComponentUrl(path: EditorComponentPath): string {
     const contentId = PageEditor.getContent().getContentId().toString();
-    return UriHelper.getComponentUri(contentId, toComponentPath(path), RenderingMode.EDIT);
+    const componentPath = path.toString().replace(/^\//, '');
+    return `${getSitePathPrefix()}/${contentId}/_/component/${componentPath}`;
+}
+
+// ? Built here instead of via UriHelper because the active project store has
+// ? a separate module instance inside this iframe bundle and is not populated.
+function getSitePathPrefix(): string {
+    if (!project) throw new Error('Cannot reload component: project is missing');
+
+    const {pathname} = window.location;
+    const siteIdx = pathname.indexOf('/site/');
+    if (siteIdx < 0) throw new Error(`Cannot derive site path prefix from ${pathname}`);
+    const adminSitePrefix = pathname.slice(0, siteIdx + '/site/'.length);
+    return `${adminSitePrefix}edit/${project}/draft`;
 }
 
 // Duplicated layouts may contain parts with contributions
@@ -60,9 +64,5 @@ function sanitizeComponentHtml(html: string, path: EditorComponentPath): string 
     if (PageEditor.getComponentAt(path)?.type !== 'fragment') {
         return html;
     }
-    return DOMPurify.sanitize(html, {ALLOWED_URI_REGEXP: HTMLAreaHelper.getAllowedUriRegexp()});
-}
-
-function toComponentPath(path: EditorComponentPath): ComponentPath {
-    return ComponentPath.fromString(path.toString());
+    return DOMPurify.sanitize(html, {ALLOWED_URI_REGEXP});
 }

--- a/modules/app/src/main/resources/com/enonic/app/contentstudio/liveEditBodyEnd.html
+++ b/modules/app/src/main/resources/com/enonic/app/contentstudio/liveEditBodyEnd.html
@@ -1,1 +1,1 @@
-<script type="text/javascript" charset="UTF-8" src="{{assetsUrl}}/page-editor/js/editor.js" data-asset-url="{{assetsUrl}}"></script>
+<script type="text/javascript" charset="UTF-8" src="{{assetsUrl}}/page-editor/js/editor.js" data-asset-url="{{assetsUrl}}" data-project="{{project}}"></script>

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/LiveEditInjectionTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/LiveEditInjectionTest.java
@@ -22,6 +22,7 @@ import com.enonic.xp.portal.RenderMode;
 import com.enonic.xp.portal.postprocess.HtmlTag;
 import com.enonic.xp.portal.url.AssetUrlParams;
 import com.enonic.xp.portal.url.PortalUrlService;
+import com.enonic.xp.project.ProjectName;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -110,6 +111,7 @@ class LiveEditInjectionTest
         mockPortalUrlService();
         this.portalRequest.setMode( RenderMode.EDIT );
         this.portalRequest.setRawRequest( this.request );
+        this.portalRequest.setRepositoryId( ProjectName.from( "myproject" ).getRepoId() );
 
         final List<String> list = this.injection.inject( this.portalRequest, this.portalResponse, HtmlTag.BODY_END );
         assertNotNull( list );

--- a/modules/app/src/test/resources/com/enonic/app/contentstudio/liveEditInjectionBodyEnd.html
+++ b/modules/app/src/test/resources/com/enonic/app/contentstudio/liveEditInjectionBodyEnd.html
@@ -1,1 +1,1 @@
-<script type="text/javascript" charset="UTF-8" src="/_/asset/com.enonic.app.contentstudio/page-editor/js/editor.js" data-asset-url="/_/asset/com.enonic.app.contentstudio"></script>
+<script type="text/javascript" charset="UTF-8" src="/_/asset/com.enonic.app.contentstudio/page-editor/js/editor.js" data-asset-url="/_/asset/com.enonic.app.contentstudio" data-project="myproject"></script>

--- a/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HTMLAreaHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/inputtype/ui/text/HTMLAreaHelper.ts
@@ -8,6 +8,7 @@ import {ContentId} from '../../../content/ContentId';
 import {type Project} from '../../../settings/data/project/Project';
 import {ProjectHelper} from '../../../settings/data/project/ProjectHelper';
 import {ImageUrlResolver} from '../../../util/ImageUrlResolver';
+import {ALLOWED_URI_REGEXP} from '../../../../v6/features/utils/url/allowedUri';
 import {HtmlAreaSanitizer} from './HtmlAreaSanitizer';
 import {Styles} from './styles/Styles';
 
@@ -135,7 +136,7 @@ export class HTMLAreaHelper {
     }
 
     public static getAllowedUriRegexp(): RegExp {
-        return /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|content|media|image):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
+        return ALLOWED_URI_REGEXP;
     }
 
     public static isNbsp(value: string): boolean {

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/url/allowedUri.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/url/allowedUri.ts
@@ -1,0 +1,1 @@
+export const ALLOWED_URI_REGEXP = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|content|media|image):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;


### PR DESCRIPTION
## Caveat

We found a module-duplication source consistent with every symptom (prod-only, only after adding a fresh part with config, healed by refresh, same class names but `equals` returning false). Removing it stops the reproduction.

We did **not** trace at runtime the exact path inside main.js where a `lib.js`-realm `ValueTypeString` reached the new part's `PropertyArray.type`. We confirmed only: two ValueType classes coexisted in main.js's window (one preserved, one minified as `class N extends e`), the mangled copy lives in `com.enonic.lib.admin.ui`'s standalone `lib.js` which `main.html` loaded alongside main.js, and removing that script tag kills the symptom. The specific bridge (lib-admin-ui's shared `Store.instance()` registry, an indirect global, or something else) is unverified.

## Fix

**`admin/tools/main/main.html`** — removed `<script src="{{assetsUri}}/admin/common/js/lib.js">`. main.js already bundles lib-admin-ui via rspack; loading the standalone `lib.js` on top kept two copies of `ValueType`/`ValueTypeString` in the same window. Under prod minification the second copy's anonymous class expression (`var ValueTypeString = class extends ValueType`) became `var N = class extends e` and lost its `.name`, breaking `iFrameSafeInstanceOf`'s class-name fallback. The tag was a leftover from before CS migrated to rspack-bundled lib-admin-ui.

## Iframe page-editor cleanup (separate intent)

Independent of the bug. We wanted `page-editor.ts` to depend on as little as possible and get its server context explicitly, instead of reading shared stores that aren't populated in its bundle.

- **`LiveEditInjection.java` + `liveEditBodyEnd.html`**: resolve the current project from `portalRequest.getRepositoryId()` and emit `data-project="{{project}}"` on the injected `editor.js` script tag.
- **`page-editor.ts`**: reads `document.currentScript.dataset.project`, builds the component-reload URL directly from `window.location.pathname` + the project attribute, drops imports of `UriHelper`, `RenderingMode`, `ComponentPath`, `getActiveProjectName`. Throws `Cannot reload component: project is missing` if the attribute is absent.
- **`v6/features/utils/url/allowedUri.ts`** (new) + **`HTMLAreaHelper.ts`**: extracted `ALLOWED_URI_REGEXP` into a zero-dependency util. The iframe bundle no longer pulls `HTMLAreaHelper`'s transitive graph (`AuthHelper`, `ImageUrlResolver`, `ProjectHelper`, `Q`, `Styles`, `HtmlAreaSanitizer`) for one regex. `HTMLAreaHelper.getAllowedUriRegexp()` delegates to the same constant for back-compat.
- **Tests**: `LiveEditInjectionTest` sets `repositoryId`; `liveEditInjectionBodyEnd.html` fixture updated.