### PR TITLE
Project Wizard: refine parent step description and hide empty block #10568

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/project/steps/ProjectDialogParentStep.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/project/steps/ProjectDialogParentStep.tsx
@@ -51,7 +51,7 @@ export const ProjectDialogParentStepContent = (): ReactElement => {
     const parentProjectLabel = useI18n('settings.field.project.parent');
     const typeToSearchLabel = useI18n('field.option.placeholder');
     const noProjectsFoundLabel = useI18n('settings.projects.notfound');
-    const hintLabel = useI18n('settings.projects.parent.helptext');
+    const helptextLabel = useI18n('dialog.project.wizard.parent.helptext');
     const projectLabel = isMultiInheritance ? parentProjectsLabel : parentProjectLabel;
     const languageLabel = useI18n('settings.projects.language.label');
     const noLanguagesFoundLabel = useI18n('dialog.project.wizard.parent.noLanguagesFound');
@@ -109,9 +109,10 @@ export const ProjectDialogParentStepContent = (): ReactElement => {
             <div className="flex flex-col">
                 {/* Project selection */}
                 <div>
-                    {mode === 'create' && (
+                    {mode === 'create' && projects.length > 0 && (
                         <ProjectSelector
                             label={projectLabel}
+                            description={helptextLabel}
                             selection={projectSelection}
                             onSelectionChange={setProjectSelection}
                             selectionMode={isMultiInheritance ? 'staged' : 'single'}
@@ -187,8 +188,6 @@ export const ProjectDialogParentStepContent = (): ReactElement => {
                             })}
                         </GridList>
                     )}
-
-                    {mode === 'create' && <span className="text-sm text-subtle italic">{hintLabel}</span>}
                 </div>
 
                 {/* Language selection */}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/ProjectSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/ProjectSelector.tsx
@@ -1,6 +1,6 @@
 import {cn, Combobox, useCombobox, VirtualizedTreeList, type ComboboxRootProps, type FlatNode} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
-import {forwardRef, useCallback, useId, useMemo, useRef, useState, type HTMLAttributes, type ReactElement} from 'react';
+import {forwardRef, useCallback, useId, useMemo, useRef, useState, type HTMLAttributes, type ReactElement, type ReactNode} from 'react';
 import {Virtuoso, type VirtuosoHandle} from 'react-virtuoso';
 import type {Project} from '../../../../app/settings/data/project/Project';
 import {$projects} from '../../store/projects.store';
@@ -12,6 +12,7 @@ type ProjectSelectorProps = {
     onSelectionChange: (selection: readonly string[]) => void;
     selectionMode?: ComboboxRootProps['selectionMode'];
     label?: string;
+    description?: ReactNode;
     placeholder?: string;
     emptyLabel?: string;
     closeOnBlur?: boolean;
@@ -21,7 +22,7 @@ type ProjectSelectorProps = {
 const PROJECT_SELECTOR_NAME = 'ProjectSelector';
 
 export const ProjectSelector = (props: ProjectSelectorProps): ReactElement => {
-    const {selection, onSelectionChange, selectionMode = 'single', label, placeholder, emptyLabel, closeOnBlur, className} = props;
+    const {selection, onSelectionChange, selectionMode = 'single', label, description, placeholder, emptyLabel, closeOnBlur, className} = props;
 
     // Hooks
     const {projects} = useStore($projects);
@@ -49,7 +50,12 @@ export const ProjectSelector = (props: ProjectSelectorProps): ReactElement => {
 
     return (
         <div data-component={PROJECT_SELECTOR_NAME} className={cn('flex flex-col gap-2', className)}>
-            {label && <label htmlFor={inputId} className="font-semibold">{label}</label>}
+            {(label || description) && (
+                <div className="flex flex-col gap-1">
+                    {label && <label htmlFor={inputId} className="font-semibold">{label}</label>}
+                    {description && <div className="text-sm text-subtle">{description}</div>}
+                </div>
+            )}
             <Combobox.Root
                 value={searchValue}
                 onChange={setSearchValue}

--- a/modules/lib/src/main/resources/i18n/dialogs.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs.properties
@@ -197,6 +197,7 @@ dialog.project.wizard.next=Next
 dialog.project.wizard.parent.title=1. Language and content layering
 dialog.project.wizard.parent.stepTitle=Language and content
 dialog.project.wizard.parent.description=To set up synchronization of a content with another project, select it here (optional)
+dialog.project.wizard.parent.helptext=Select to inherit content from another project. This can't be changed later.
 dialog.project.wizard.parent.noLanguagesFound=No languages found
 dialog.project.wizard.name.title=2. Name your project
 dialog.project.wizard.name.stepTitle=Name

--- a/modules/lib/src/main/resources/i18n/dialogs_be.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_be.properties
@@ -111,6 +111,7 @@ dialog.project.wizard.noProjects.action = Запусціць Майстар
 dialog.project.wizard.noProjects.text = Калі ласка, выкарастайце Майстар для стварэння новага кантэнт-праекта.
 dialog.project.wizard.noProjects.title = Даступныя праекты не знойдзены
 dialog.project.wizard.parent.description = Каб наладзіць сінхранізацыю кантэнту з іншым праектам выберыце яго тут (неабавязкова)
+dialog.project.wizard.parent.helptext = Абярыце, каб успадкоўваць кантэнт з іншага праекта. Гэта нельга змяніць пазней.
 dialog.project.wizard.summary.description = Прагляд уласцівасцей новага праекта
 dialog.project.wizard.title = Стварыць праект
 dialog.projectAccess = Рэжым доступу

--- a/modules/lib/src/main/resources/i18n/dialogs_es.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_es.properties
@@ -111,6 +111,7 @@ dialog.project.wizard.noProjects.action = Iniciar asistente
 dialog.project.wizard.noProjects.text = Por favor, complete el Asistente para crear un nuevo proyecto de contenido.
 dialog.project.wizard.noProjects.title = No se encontraron proyectos disponibles
 dialog.project.wizard.parent.description = Para configurar la sincronización de un contenido con otro proyecto, selecciónelo aquí (opcional)
+dialog.project.wizard.parent.helptext = Selecciona para heredar contenido de otro proyecto. Esto no se puede cambiar después.
 dialog.project.wizard.summary.description = Ver resumen de un nuevo proyecto
 dialog.project.wizard.title = Crear Proyecto
 dialog.projectAccess = Modo de acceso

--- a/modules/lib/src/main/resources/i18n/dialogs_fr.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_fr.properties
@@ -111,6 +111,7 @@ dialog.project.wizard.noProjects.action = Démarrer l'assistant
 dialog.project.wizard.noProjects.text = Veuillez compléter l'assistant de création d'un nouveau projet de contenu.
 dialog.project.wizard.noProjects.title = Aucun projet disponible
 dialog.project.wizard.parent.description = Pour mettre en place la synchronisation d'un contenu avec un autre projet, sélectionnez-le ici (optionnel)
+dialog.project.wizard.parent.helptext = Sélectionnez pour hériter du contenu d'un autre projet. Cela ne pourra pas être modifié ultérieurement.
 dialog.project.wizard.summary.description = Voir le résumé d'un nouveau projet
 dialog.project.wizard.title = Créer un projet
 dialog.projectAccess = Mode d’accès

--- a/modules/lib/src/main/resources/i18n/dialogs_it.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_it.properties
@@ -111,6 +111,7 @@ dialog.project.wizard.noProjects.action = Avvia procedura guidata
 dialog.project.wizard.noProjects.text = Completa la procedura guidata per la creazione di un nuovo progetto di contenuto.
 dialog.project.wizard.noProjects.title = Nessun progetto disponibile trovato
 dialog.project.wizard.parent.description = Per impostare la sincronizzazione di un contenuto con un altro progetto, selezionarlo qui (facoltativo)
+dialog.project.wizard.parent.helptext = Seleziona per ereditare contenuti da un altro progetto. Questo non potrà essere modificato in seguito.
 dialog.project.wizard.summary.description = Visualizza il riepilogo di un nuovo progetto
 dialog.project.wizard.title = Crea progetto
 dialog.projectAccess = Modalità di accesso

--- a/modules/lib/src/main/resources/i18n/dialogs_nl.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_nl.properties
@@ -111,6 +111,7 @@ dialog.project.wizard.noProjects.action = Wizard starten
 dialog.project.wizard.noProjects.text = Voltooi de Wizard voor het maken van een nieuw inhoudsproject.
 dialog.project.wizard.noProjects.title = Geen beschikbare projecten gevonden
 dialog.project.wizard.parent.description = Om synchronisatie van inhoud met een ander project in te stellen, selecteer het hier (optioneel)
+dialog.project.wizard.parent.helptext = Selecteer om inhoud van een ander project te erven. Dit kan later niet worden gewijzigd.
 dialog.project.wizard.summary.description = Overzicht van een nieuw project bekijken
 dialog.project.wizard.title = Project aanmaken
 dialog.projectAccess = Toegangsmodus

--- a/modules/lib/src/main/resources/i18n/dialogs_no.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_no.properties
@@ -199,6 +199,7 @@ dialog.project.wizard.noProjects.text = Fullfør veiviseren for å opprette et n
 dialog.project.wizard.noProjects.title = Ingen tilgjengelige prosjekter funnet
 dialog.project.wizard.parent.description = Hvis du vil konfigurere synkronisering av et innhold med et annet prosjekt, velger du det her (valgfritt)
 dialog.project.wizard.parent.edit.title = 1. Standardspråk for prosjektinnhold
+dialog.project.wizard.parent.helptext = Velg for å arve innhold fra et annet prosjekt. Dette kan ikke endres senere.
 dialog.project.wizard.parent.noLanguagesFound = Ingen språk funnet
 dialog.project.wizard.parent.stepTitle = Språk og innhold
 dialog.project.wizard.parent.title = 1. Lagdeling av språk og innhold

--- a/modules/lib/src/main/resources/i18n/dialogs_pl.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_pl.properties
@@ -111,6 +111,7 @@ dialog.project.wizard.noProjects.action = Uruchom kreator
 dialog.project.wizard.noProjects.text = Proszę ukończyć Kreatora tworzenia nowego projektu treści.
 dialog.project.wizard.noProjects.title = Nie znaleziono dostępnych projektów
 dialog.project.wizard.parent.description = Aby skonfigurować synchronizację treści z innym projektem, wybierz go tutaj (opcjonalnie)
+dialog.project.wizard.parent.helptext = Wybierz, aby dziedziczyć zawartość z innego projektu. Tego nie można później zmienić.
 dialog.project.wizard.summary.description = Zobacz podsumowanie nowego projektu
 dialog.project.wizard.title = Utwórz projekt
 dialog.projectAccess = Tryb dostępu

--- a/modules/lib/src/main/resources/i18n/dialogs_pt.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_pt.properties
@@ -115,6 +115,7 @@ dialog.project.wizard.noProjects.action = Iniciar assistente
 dialog.project.wizard.noProjects.text = Por favor, complete o Assistente para criar um novo projeto.
 dialog.project.wizard.noProjects.title = Não foram encontrados projetos disponíveis
 dialog.project.wizard.parent.description = Para configurar a sincronização de um conteúdo com outro projeto, selecione-o aqui (opcional)
+dialog.project.wizard.parent.helptext = Selecione para herdar conteúdo de outro projeto. Isto não pode ser alterado depois.
 dialog.project.wizard.summary.description = Ver resumo de um novo projeto
 dialog.project.wizard.title = Criar projeto
 dialog.projectAccess = Modo de acesso

--- a/modules/lib/src/main/resources/i18n/dialogs_ru.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_ru.properties
@@ -115,6 +115,7 @@ dialog.project.wizard.noProjects.action = Открыть диалог
 dialog.project.wizard.noProjects.text = Пожалуйста, создайте новый проект с помощью мультишагового диалога.
 dialog.project.wizard.noProjects.title = Доступные проекты не найдены
 dialog.project.wizard.parent.description = Чтобы настроить синхронизацию контента с другим проектом, выберите его здесь (опционально)
+dialog.project.wizard.parent.helptext = Выберите, чтобы наследовать контент из другого проекта. Это нельзя изменить позже.
 dialog.project.wizard.summary.description = Проверьте параметры нового проекта
 dialog.project.wizard.title = Создать проект
 dialog.projectAccess = Режим доступа

--- a/modules/lib/src/main/resources/i18n/dialogs_sv.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_sv.properties
@@ -115,6 +115,7 @@ dialog.project.wizard.noProjects.action = Starta vägledaren
 dialog.project.wizard.noProjects.text = Fullför vägledaren för att skapa ett nytt innehållsprojekt.
 dialog.project.wizard.noProjects.title = Inga tillgängliga projekt hittade
 dialog.project.wizard.parent.description = Om du vill ställa in synkronisering av ett innehåll med ett annat projekt, välj det här (valfritt)
+dialog.project.wizard.parent.helptext = Välj för att ärva innehåll från ett annat projekt. Detta kan inte ändras senare.
 dialog.project.wizard.summary.description = Visa en sammanfattning av ett nytt projekt
 dialog.project.wizard.title = Skapa Projekt
 dialog.projectAccess = Tillgångsläge


### PR DESCRIPTION
Added `description` prop to `ProjectSelector` rendered under the label, matching the `Input` component pattern from Enonic UI.
Hid the parent project block on the first wizard step in create mode when no projects are available.
Replaced the bottom hint (`settings.projects.parent.helptext`) with a clearer in-field description using the new `dialog.project.wizard.parent.helptext` key.
Localized the new key across all 11 dialog locale files (en, be, es, fr, it, nl, no, pl, pt, ru, sv).

Closes #10568

<sub>*Drafted with AI assistance*</sub>
