### PR TITLE
Content Tree: data is not refreshed on project change #10557

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.test.ts
@@ -1,7 +1,9 @@
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import type {ContentSummary} from '../../../app/content/ContentSummary';
-import {clearContentCache, getContent, hasContent, setContent, getMissingIds} from '../store/content.store';
-import {addTreeNodes, resetTree, setTreeRootIds, $treeState} from '../store/tree-list.store';
+import {clearAllContentCaches, clearProjectContentCache, getContent, hasContent, setContent, getMissingIds} from '../store/content.store';
+import {$activeProject} from '../store/activeProject.store';
+import type {Project} from '../../../app/settings/data/project/Project';
+import {addTreeNodes, hasTreeNode, resetTree, setTreeRootIds, $treeState} from '../store/tree-list.store';
 import {addFilterNodes, resetFilterTree, setFilterRootIds, $filterTreeState} from '../store/filter-tree.store';
 import {
     clearChildrenIdsRetryCooldown,
@@ -77,9 +79,10 @@ function createMockContent(id: string, displayName?: string): ContentSummary {
 
 describe('content-fetcher store integration', () => {
     beforeEach(() => {
+        $activeProject.set({getName: () => 'default'} as unknown as Project);
         resetTree();
         resetFilterTree();
-        clearContentCache();
+        clearAllContentCaches();
         mockFetchByIds.mockReset();
         mockUpdateReadOnly.mockReset().mockImplementation((items: unknown[]) => Promise.resolve(items));
         mockFetchChildrenIds.mockReset();
@@ -91,6 +94,7 @@ describe('content-fetcher store integration', () => {
     });
 
     afterEach(() => {
+        $activeProject.set(undefined);
         vi.useRealTimers();
     });
 
@@ -157,11 +161,11 @@ describe('content-fetcher store integration', () => {
             expect(getContent('1')?.getDisplayName()).toBe('Updated');
         });
 
-        it('clearContentCache removes all content', () => {
+        it('clearProjectContentCache removes content of the active project', () => {
             setContent(createMockContent('1'));
             setContent(createMockContent('2'));
 
-            clearContentCache();
+            clearProjectContentCache();
 
             expect(hasContent('1')).toBe(false);
             expect(hasContent('2')).toBe(false);
@@ -457,6 +461,82 @@ describe('content-fetcher store integration', () => {
             mockFetchChildrenIds.mockResolvedValue([{toString: () => 'child-filter-ok'}]);
             await expect(fetchFilterChildrenIdsOnly('parent-filter-3x')).resolves.toEqual(['child-filter-ok']);
             expect(isFilterChildrenIdsLoadFailed('parent-filter-3x')).toBe(false);
+        });
+    });
+
+    describe('project-switch race protection', () => {
+        const projectA = {getName: () => 'projectA'} as unknown as Project;
+        const projectB = {getName: () => 'projectB'} as unknown as Project;
+
+        it('fetchVisibleContentData: stale response writes to source partition but not the new tree', async () => {
+            $activeProject.set(projectA);
+            addTreeNodes([{id: 'race-1', data: null, parentId: null, hasChildren: false}]);
+            setTreeRootIds(['race-1']);
+
+            let resolveFetch!: (value: ContentSummary[]) => void;
+            mockFetchByIds.mockImplementation(
+                () => new Promise<ContentSummary[]>((resolve) => {
+                    resolveFetch = resolve;
+                }),
+            );
+
+            const pending = fetchVisibleContentData(['race-1']);
+
+            // User switches mid-flight: tree resets, $activeProject moves to B.
+            $activeProject.set(projectB);
+            resetTree();
+
+            // The slow response for project A arrives.
+            resolveFetch([createMockContent('race-1', 'A version')]);
+            await pending;
+
+            // Project B's tree must not have absorbed A's response.
+            expect(hasTreeNode('race-1')).toBe(false);
+
+            // But A's partition gets the data — useful when the user returns to A.
+            expect(getContent('race-1', 'projectA')?.getDisplayName()).toBe('A version');
+            // And B's partition stays clean.
+            expect(getContent('race-1', 'projectB')).toBeUndefined();
+        });
+
+        it('fetchChildrenIdsOnly: stale response does not seed the new tree', async () => {
+            $activeProject.set(projectA);
+
+            let resolveIds!: (value: {toString: () => string}[]) => void;
+            mockFetchChildrenIds.mockImplementation(
+                () => new Promise<{toString: () => string}[]>((resolve) => {
+                    resolveIds = resolve;
+                }),
+            );
+
+            const pending = fetchRootChildrenIdsOnly();
+
+            // Switch projects before the IDs land.
+            $activeProject.set(projectB);
+            resetTree();
+
+            resolveIds([{toString: () => 'stale-root-1'}, {toString: () => 'stale-root-2'}]);
+            const result = await pending;
+
+            // Helper returns an empty list on stale; new tree stays empty.
+            expect(result).toEqual([]);
+            expect($treeState.get().rootIds).toEqual([]);
+            expect(hasTreeNode('stale-root-1')).toBe(false);
+        });
+
+        it('does not gate when no project was captured at request start', async () => {
+            // No active project at capture time: skip the staleness check entirely.
+            $activeProject.set(undefined);
+            addTreeNodes([{id: 'no-capture', data: null, parentId: null, hasChildren: false}]);
+            setTreeRootIds(['no-capture']);
+
+            mockFetchByIds.mockResolvedValue([createMockContent('no-capture', 'still-fetched')]);
+
+            await fetchVisibleContentData(['no-capture']);
+
+            // Tree still updates because there was no project to be stale against.
+            const node = $treeState.get().nodes.get('no-capture');
+            expect(node?.data).not.toBeNull();
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/api/content-fetcher.ts
@@ -8,6 +8,7 @@ import {ContentSummaryAndCompareStatusFetcher} from '../../../app/resource/Conte
 import {ListContentByIdRequest} from '../../../app/resource/ListContentByIdRequest';
 import {type ChildOrder} from '../../../app/resource/order/ChildOrder';
 import {Branch} from '../../../app/versioning/Branch';
+import {$activeProject} from '../store/activeProject.store';
 import {setContents, getMissingIds, getContents, getIdByPath} from '../store/content.store';
 import {$contentDuplicated, $contentMoved} from '../store/socket.store';
 import {
@@ -27,6 +28,18 @@ import type {CreateNodeOptions} from '../lib/tree-store';
 import {calcContentState} from '../utils/cms/content/workflow';
 import {calcTreePublishStatus} from '../utils/cms/content/status';
 import {resolveDisplayName, resolveSubName} from '../utils/cms/content/prettify';
+
+// Snapshot the active project at request start; gate tree writes against it
+// after each await so a project switch cannot land stale data on the new tree.
+// Cache writes stay safe because they target the captured partition.
+function captureActiveProjectName(): string | undefined {
+    return $activeProject.get()?.getName();
+}
+
+function isProjectStale(captured: string | undefined): boolean {
+    if (captured == null) return false;
+    return $activeProject.get()?.getName() !== captured;
+}
 
 //
 // * Constants
@@ -148,7 +161,8 @@ export async function fetchChildren(
     size: number = DEFAULT_BATCH_SIZE,
     childOrder?: ChildOrder
 ): Promise<FetchChildrenResult> {
-    // Set loading state
+    const projectName = captureActiveProjectName();
+
     setNodeLoading(parentId, true);
 
     try {
@@ -164,29 +178,25 @@ export async function fetchChildren(
         const total = metadata.getTotalHits();
         const hasMore = offset + summaries.length < total;
 
-        // Update readonly status
         await fetcher.updateReadOnly(summaries);
 
-        // Update content cache
-        setContents(summaries);
+        setContents(summaries, projectName);
 
-        // Create tree nodes
+        if (isProjectStale(projectName)) {
+            return {ids: [], hasMore: false, total: 0};
+        }
+
         const nodeOptions: CreateNodeOptions<ContentTreeNodeData>[] = summaries.map((content) => toNodeOptions(content, parentId));
-
-        // Update tree
         addTreeNodes(nodeOptions);
 
         const childIds = summaries.map((c) => c.getId());
 
         if (offset === 0) {
-            // First batch - set children
             setTreeChildren(parentId, childIds);
         } else {
-            // Pagination - append children
             appendTreeChildren(parentId, childIds);
         }
 
-        // Update totalChildren for pagination
         if (parentId) {
             setNodeTotalChildren(parentId, total);
         } else {
@@ -242,12 +252,12 @@ export async function fetchFilteredRootChildren(
     offset: number = 0,
     size: number = DEFAULT_BATCH_SIZE
 ): Promise<FetchChildrenResult> {
+    const projectName = captureActiveProjectName();
+
     setNodeLoading(null, true);
 
     try {
         const configuredQuery = configureContentQuery(query, offset, size);
-
-        // Execute query
         const request = new ContentQueryRequest<ContentSummaryJson, ContentSummary>(configuredQuery)
             .setTargetBranch(Branch.DRAFT)
             .setExpand(Expand.SUMMARY);
@@ -258,15 +268,16 @@ export async function fetchFilteredRootChildren(
         const total = metadata.getTotalHits();
         const hasMore = offset + summaries.length < total;
 
-        // Update readonly status
         await fetcher.updateReadOnly(summaries);
 
-        // Update content cache
-        setContents(summaries);
+        setContents(summaries, projectName);
 
-        // Create tree nodes (all as root since it's a flat query result)
+        if (isProjectStale(projectName)) {
+            return {ids: [], hasMore: false, total: 0};
+        }
+
+        // Flat query result, every item is at root level.
         const nodeOptions: CreateNodeOptions<ContentTreeNodeData>[] = summaries.map((content) => toNodeOptions(content, null));
-
         addTreeNodes(nodeOptions);
 
         const childIds = summaries.map((c) => c.getId());
@@ -277,7 +288,6 @@ export async function fetchFilteredRootChildren(
             appendTreeChildren(null, childIds);
         }
 
-        // Update root total children for pagination
         setRootTotalChildren(total);
 
         return {ids: childIds, hasMore, total};
@@ -296,19 +306,21 @@ export async function fetchFilteredRootChildren(
 export async function fetchContentByIds(ids: string[]): Promise<ContentSummary[]> {
     if (ids.length === 0) return [];
 
+    const projectName = captureActiveProjectName();
+
     // Check what's missing from cache
-    const missingIds = getMissingIds(ids);
+    const missingIds = getMissingIds(ids, projectName);
 
     // Fetch missing content
     if (missingIds.length > 0) {
         const contentIds = missingIds.map((id) => new ContentId(id));
         const fetched = await fetcher.fetchByIds(contentIds);
         await fetcher.updateReadOnly(fetched);
-        setContents(fetched);
+        setContents(fetched, projectName);
     }
 
     // Return all requested content from cache
-    return getContents(ids);
+    return getContents(ids, projectName);
 }
 
 /**
@@ -316,24 +328,28 @@ export async function fetchContentByIds(ids: string[]): Promise<ContentSummary[]
  * Useful for prefetching visible nodes.
  */
 export async function fetchMissingContent(ids: string[]): Promise<void> {
-    const missingIds = getMissingIds(ids);
+    const projectName = captureActiveProjectName();
+
+    const missingIds = getMissingIds(ids, projectName);
     if (missingIds.length === 0) return;
 
     const contentIds = missingIds.map((id) => new ContentId(id));
     const fetched = await fetcher.fetchByIds(contentIds);
     await fetcher.updateReadOnly(fetched);
-    setContents(fetched);
+    setContents(fetched, projectName);
 }
 
 /**
  * Force refreshes a single content item in the cache.
  */
 export async function refreshContent(id: string): Promise<ContentSummary | undefined> {
+    const projectName = captureActiveProjectName();
+
     const contentId = new ContentId(id);
     const summaries = await fetcher.fetchByIds([contentId]);
     if (summaries.length > 0) {
         await fetcher.updateReadOnly(summaries);
-        setContents(summaries);
+        setContents(summaries, projectName);
         return summaries[0];
     }
     return undefined;
@@ -345,10 +361,12 @@ export async function refreshContent(id: string): Promise<ContentSummary | undef
 export async function refreshContents(ids: string[]): Promise<ContentSummary[]> {
     if (ids.length === 0) return [];
 
+    const projectName = captureActiveProjectName();
+
     const contentIds = ids.map((id) => new ContentId(id));
     const summaries = await fetcher.fetchByIds(contentIds);
     await fetcher.updateReadOnly(summaries);
-    setContents(summaries);
+    setContents(summaries, projectName);
     return summaries;
 }
 
@@ -385,6 +403,7 @@ export async function fetchChildrenIdsOnly(
     parentId: string | null,
     childOrder?: ChildOrder
 ): Promise<string[]> {
+    const projectName = captureActiveProjectName();
     const state = $treeState.get();
 
     if (parentId === null) {
@@ -407,6 +426,8 @@ export async function fetchChildrenIdsOnly(
 
         // Convert ContentId[] to string[]
         const idStrings = ids.map((id) => id.toString());
+
+        if (isProjectStale(projectName)) return [];
 
         // Create placeholder nodes (no data yet)
         const placeholderNodes: CreateNodeOptions<ContentTreeNodeData>[] = idStrings.map((id) => ({
@@ -676,6 +697,7 @@ export function resetVisibleFilterContentDataRetryState(): void {
  * @param ids - Content IDs to fetch data for
  */
 export async function fetchVisibleContentData(ids: string[]): Promise<void> {
+    const projectName = captureActiveProjectName();
     const state = $treeState.get();
 
     // Filter to IDs that need tree node update:
@@ -695,10 +717,10 @@ export async function fetchVisibleContentData(ids: string[]): Promise<void> {
     if (idsNeedingUpdate.length === 0) return;
 
     // Check content cache - separate cached vs uncached
-    const cachedContents = getContents(idsNeedingUpdate);
+    const cachedContents = getContents(idsNeedingUpdate, projectName);
     const cachedIds = new Set(cachedContents.map((c) => c.getId()));
 
-    // Update tree nodes with cached content immediately (no fetch needed)
+    // Sync path before any await — no project staleness possible here.
     if (cachedContents.length > 0) {
         updateTreeNodesWithData(cachedContents);
         clearBatchFailure(visibleDataBatchState, visibleDataFailedIds, cachedContents.map((c) => c.getId()));
@@ -724,8 +746,11 @@ export async function fetchVisibleContentData(ids: string[]): Promise<void> {
                 const fetchedIds = new Set(summaries.map((content) => content.getId()));
                 const unresolvedIds = batch.filter((id) => !fetchedIds.has(id));
 
-                // Update content cache
-                setContents(summaries);
+                setContents(summaries, projectName);
+
+                // Project switched — drop this and remaining batches; the new
+                // project's loader will fetch its own.
+                if (isProjectStale(projectName)) return;
 
                 // Update tree node data
                 updateTreeNodesWithData(summaries);
@@ -846,6 +871,8 @@ async function fetchFilteredContentForFilterTree(
     offset: number,
     size: number
 ): Promise<FetchChildrenResult> {
+    const projectName = captureActiveProjectName();
+
     const configuredQuery = configureContentQuery(query, offset, size);
 
     // Execute query
@@ -862,8 +889,11 @@ async function fetchFilteredContentForFilterTree(
     // Update readonly status
     await fetcher.updateReadOnly(summaries);
 
-    // Update content cache
-    setContents(summaries);
+    setContents(summaries, projectName);
+
+    if (isProjectStale(projectName)) {
+        return {ids: [], hasMore: false, total: 0};
+    }
 
     // Create filter tree nodes (all as root since it's a flat query result)
     const nodeOptions: CreateNodeOptions<ContentTreeNodeData>[] = summaries.map((content) => toNodeOptions(content, null));
@@ -921,6 +951,7 @@ export async function fetchMoreFilteredResults(
  * @param ids - Content IDs to fetch data for
  */
 export async function fetchVisibleFilterContentData(ids: string[]): Promise<void> {
+    const projectName = captureActiveProjectName();
     const state = $filterTreeState.get();
 
     // Filter to IDs that need tree node update:
@@ -940,10 +971,11 @@ export async function fetchVisibleFilterContentData(ids: string[]): Promise<void
     if (idsNeedingUpdate.length === 0) return;
 
     // Check content cache - separate cached vs uncached
-    const cachedContents = getContents(idsNeedingUpdate);
+    const cachedContents = getContents(idsNeedingUpdate, projectName);
     const cachedIds = new Set(cachedContents.map((c) => c.getId()));
 
-    // Update filter tree nodes with cached content immediately (no fetch needed)
+    // Update filter tree nodes with cached content immediately (no fetch needed).
+    // Synchronous, no await — no staleness check needed.
     if (cachedContents.length > 0) {
         const updates: CreateNodeOptions<ContentTreeNodeData>[] = cachedContents.map((content) => ({
             id: content.getId(),
@@ -975,8 +1007,9 @@ export async function fetchVisibleFilterContentData(ids: string[]): Promise<void
                 const fetchedIds = new Set(summaries.map((content) => content.getId()));
                 const unresolvedIds = batch.filter((id) => !fetchedIds.has(id));
 
-                // Update content cache
-                setContents(summaries);
+                setContents(summaries, projectName);
+
+                if (isProjectStale(projectName)) return;
 
                 // Update filter tree node data
                 const updates: CreateNodeOptions<ContentTreeNodeData>[] = summaries.map((content) => ({
@@ -1018,6 +1051,7 @@ export async function fetchFilterChildrenIdsOnly(
     parentId: string,
     childOrder?: ChildOrder
 ): Promise<string[]> {
+    const projectName = captureActiveProjectName();
     const state = $filterTreeState.get();
     const parent = state.nodes.get(parentId);
 
@@ -1034,6 +1068,8 @@ export async function fetchFilterChildrenIdsOnly(
 
         // Convert ContentId[] to string[]
         const idStrings = ids.map((id) => id.toString());
+
+        if (isProjectStale(projectName)) return [];
 
         // Create placeholder nodes (no data yet)
         const placeholderNodes: CreateNodeOptions<ContentTreeNodeData>[] = idStrings.map((id) => ({

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/content.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/content.store.test.ts
@@ -5,7 +5,8 @@ import {
     setContents,
     removeContent,
     removeContents,
-    clearContentCache,
+    clearAllContentCaches,
+    clearProjectContentCache,
     getContent,
     getContents,
     hasContent,
@@ -13,6 +14,7 @@ import {
     getAllContentIds,
     getIdByPath,
 } from './content.store';
+import {$activeProject} from './activeProject.store';
 import {
     emitContentUpdated,
     emitContentCreated,
@@ -21,6 +23,13 @@ import {
     emitContentPublished,
 } from './socket.store';
 import type {ContentSummary} from '../../../app/content/ContentSummary';
+import type {Project} from '../../../app/settings/data/project/Project';
+
+const DEFAULT_TEST_PROJECT = 'default';
+
+function mockProject(name: string): Project {
+    return {getName: () => name} as unknown as Project;
+}
 
 // Mock ContentSummary
 function createMockContent(id: string, displayName?: string): ContentSummary {
@@ -64,7 +73,12 @@ function createMockChangeItem(id: string): {getContentId: () => {toString: () =>
 
 describe('content.store', () => {
     beforeEach(() => {
-        clearContentCache();
+        $activeProject.set(mockProject(DEFAULT_TEST_PROJECT));
+        clearAllContentCaches();
+    });
+
+    afterEach(() => {
+        $activeProject.set(undefined);
     });
 
     describe('setContent', () => {
@@ -146,11 +160,11 @@ describe('content.store', () => {
         });
     });
 
-    describe('clearContentCache', () => {
+    describe('clearProjectContentCache', () => {
         it('removes all content from cache', () => {
             setContents([createMockContent('1'), createMockContent('2')]);
 
-            clearContentCache();
+            clearProjectContentCache();
 
             expect(getAllContentIds()).toEqual([]);
         });
@@ -246,7 +260,7 @@ describe('content.store', () => {
     // They persist for the application lifetime and don't need explicit subscription.
     describe('socket subscriptions (self-initializing)', () => {
         afterEach(() => {
-            clearContentCache();
+            clearAllContentCaches();
         });
 
         it('updates cache on contentUpdated event', () => {
@@ -372,18 +386,90 @@ describe('content.store', () => {
             });
         });
 
-        describe('clearContentCache clears path index', () => {
+        describe('clearProjectContentCache clears path index', () => {
             it('clears path index when cache is cleared', () => {
                 setContents([
                     createMockContentWithPath('1', '/content/site'),
                     createMockContentWithPath('2', '/content/folder'),
                 ]);
 
-                clearContentCache();
+                clearProjectContentCache();
 
                 expect(getIdByPath('/content/site')).toBeUndefined();
                 expect(getIdByPath('/content/folder')).toBeUndefined();
             });
+        });
+    });
+
+    describe('project partitioning', () => {
+        // Synchronous isolation only. Async race-protection (a fetch started in
+        // project A whose response arrives after a switch to B) is exercised in
+        // content-fetcher.test.ts under 'project-switch race protection'.
+        it('partitions content storage by project name (sync writes)', () => {
+            $activeProject.set(mockProject('projectA'));
+            setContent(createMockContent('shared-id', 'A version'));
+
+            $activeProject.set(mockProject('projectB'));
+            expect(getContent('shared-id')).toBeUndefined();
+            expect(hasContent('shared-id')).toBe(false);
+
+            setContent(createMockContent('shared-id', 'B version'));
+            expect(getContent('shared-id')?.getDisplayName()).toBe('B version');
+
+            $activeProject.set(mockProject('projectA'));
+            expect(getContent('shared-id')?.getDisplayName()).toBe('A version');
+        });
+
+        it('keeps path index separate per project', () => {
+            $activeProject.set(mockProject('projectA'));
+            setContent(createMockContentWithPath('a1', '/content/site'));
+
+            $activeProject.set(mockProject('projectB'));
+            expect(getIdByPath('/content/site')).toBeUndefined();
+
+            setContent(createMockContentWithPath('b1', '/content/site'));
+            expect(getIdByPath('/content/site')).toBe('b1');
+
+            $activeProject.set(mockProject('projectA'));
+            expect(getIdByPath('/content/site')).toBe('a1');
+        });
+
+        it('writes accept an explicit projectName, bypassing the active project', () => {
+            $activeProject.set(mockProject('projectA'));
+            setContents([createMockContent('x', 'from-B')], 'projectB');
+
+            expect(getContent('x')).toBeUndefined();
+            expect(getContent('x', 'projectB')?.getDisplayName()).toBe('from-B');
+        });
+
+        it('clearProjectContentCache(name) wipes only that project', () => {
+            $activeProject.set(mockProject('projectA'));
+            setContent(createMockContent('a1'));
+            $activeProject.set(mockProject('projectB'));
+            setContent(createMockContent('b1'));
+
+            clearProjectContentCache('projectA');
+
+            expect(getContent('a1', 'projectA')).toBeUndefined();
+            expect(getContent('b1', 'projectB')?.getId()).toBe('b1');
+        });
+
+        it('no-ops writes when there is no active project and no override', () => {
+            $activeProject.set(undefined);
+            setContent(createMockContent('orphan'));
+
+            $activeProject.set(mockProject(DEFAULT_TEST_PROJECT));
+            expect(hasContent('orphan')).toBe(false);
+        });
+
+        it('$contentCache exposes the active project slice reactively', () => {
+            $activeProject.set(mockProject('projectA'));
+            setContent(createMockContent('a1'));
+
+            expect($contentCache.get()['a1']?.getId()).toBe('a1');
+
+            $activeProject.set(mockProject('projectB'));
+            expect($contentCache.get()['a1']).toBeUndefined();
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/content.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/content.store.ts
@@ -1,6 +1,7 @@
-import {map} from 'nanostores';
+import {computed, map} from 'nanostores';
 import type {ContentSummary} from '../../../app/content/ContentSummary';
 import {ContentSummaryAndCompareStatus} from '../../../app/content/ContentSummaryAndCompareStatus';
+import {$activeProject} from './activeProject.store';
 import {
     $contentArchived,
     $contentCreated,
@@ -18,42 +19,81 @@ import {
 // * Types
 //
 
-type ContentCacheState = Record<string, ContentSummary>;
+type ProjectCache = Record<string, ContentSummary>;
+type PathIndex = Record<string, string>;
 
 //
 // * Store
 //
 
-/** Global content cache - stores all loaded content by ID */
-export const $contentCache = map<ContentCacheState>({});
+// Frozen empties guard against accidental mutation of the shared reference.
+const EMPTY_CACHE: ProjectCache = Object.freeze({});
+const EMPTY_INDEX: PathIndex = Object.freeze({});
 
-/** Path string to content ID index for O(1) lookups */
-const $pathToId = map<Record<string, string>>({});
+const $contentCacheByProject = map<Record<string, ProjectCache>>({});
+const $pathToIdByProject = map<Record<string, PathIndex>>({});
+
+/** Active project's slice. Shape kept as Record<id, ContentSummary> for legacy consumers. */
+export const $contentCache = computed(
+    [$contentCacheByProject, $activeProject],
+    (byProject, project): ProjectCache => {
+        const name = project?.getName();
+        if (!name) return EMPTY_CACHE;
+        return byProject[name] ?? EMPTY_CACHE;
+    },
+);
+
+//
+// * Internal helpers
+//
+
+function resolveProjectName(projectName?: string): string | undefined {
+    return projectName ?? $activeProject.get()?.getName();
+}
+
+function readProjectCache(projectName: string): ProjectCache {
+    return $contentCacheByProject.get()[projectName] ?? EMPTY_CACHE;
+}
+
+function readPathIndex(projectName: string): PathIndex {
+    return $pathToIdByProject.get()[projectName] ?? EMPTY_INDEX;
+}
+
+function writeProjectCache(projectName: string, next: ProjectCache): void {
+    $contentCacheByProject.setKey(projectName, next);
+}
+
+function writePathIndex(projectName: string, next: PathIndex): void {
+    $pathToIdByProject.setKey(projectName, next);
+}
 
 //
 // * Actions
 //
+// Writers accept an optional projectName so async callers can capture the
+// project at request start and stay consistent across awaits. Defaults to active.
+//
 
-export function setContent(content: ContentSummary): void {
+export function setContent(content: ContentSummary, projectName?: string): void {
+    const name = resolveProjectName(projectName);
+    if (!name) return;
+
     const id = content.getId();
     const path = content.getPath?.()?.toString();
-    $contentCache.setKey(id, content);
+
+    writeProjectCache(name, {...readProjectCache(name), [id]: content});
     if (path) {
-        $pathToId.setKey(path, id);
+        writePathIndex(name, {...readPathIndex(name), [path]: id});
     }
 }
 
-/**
- * Adds or updates multiple content items in the cache.
- * More efficient than calling setContent multiple times.
- */
-export function setContents(contents: ContentSummary[]): void {
+export function setContents(contents: ContentSummary[], projectName?: string): void {
     if (contents.length === 0) return;
+    const name = resolveProjectName(projectName);
+    if (!name) return;
 
-    const currentCache = $contentCache.get();
-    const currentIndex = $pathToId.get();
-    const cacheUpdates: ContentCacheState = {...currentCache};
-    const indexUpdates: Record<string, string> = {...currentIndex};
+    const cacheUpdates: ProjectCache = {...readProjectCache(name)};
+    const indexUpdates: PathIndex = {...readPathIndex(name)};
 
     for (const content of contents) {
         const id = content.getId();
@@ -64,134 +104,136 @@ export function setContents(contents: ContentSummary[]): void {
         }
     }
 
-    $contentCache.set(cacheUpdates);
-    $pathToId.set(indexUpdates);
+    writeProjectCache(name, cacheUpdates);
+    writePathIndex(name, indexUpdates);
 }
 
-export function removeContent(id: string): void {
-    const currentCache = $contentCache.get();
-    if (!(id in currentCache)) return;
+export function removeContent(id: string, projectName?: string): void {
+    const name = resolveProjectName(projectName);
+    if (!name) return;
 
-    const content = currentCache[id];
+    const cache = readProjectCache(name);
+    if (!(id in cache)) return;
+
+    const content = cache[id];
     const path = content?.getPath?.()?.toString();
 
-    const {[id]: _, ...restCache} = currentCache;
-    $contentCache.set(restCache);
+    const {[id]: _, ...restCache} = cache;
+    writeProjectCache(name, restCache);
 
     if (path) {
-        const currentIndex = $pathToId.get();
-        const {[path]: __, ...restIndex} = currentIndex;
-        $pathToId.set(restIndex);
+        const index = readPathIndex(name);
+        const {[path]: __, ...restIndex} = index;
+        writePathIndex(name, restIndex);
     }
 }
 
-export function removeContents(ids: string[]): void {
+export function removeContents(ids: string[], projectName?: string): void {
     if (ids.length === 0) return;
+    const name = resolveProjectName(projectName);
+    if (!name) return;
 
-    const currentCache = $contentCache.get();
-    const currentIndex = $pathToId.get();
+    const cache = readProjectCache(name);
+    const index = readPathIndex(name);
     const idsSet = new Set(ids);
 
-    // Collect paths to remove
     const pathsToRemove: string[] = [];
     for (const id of ids) {
-        const content = currentCache[id];
+        const content = cache[id];
         const path = content?.getPath?.()?.toString();
         if (path) pathsToRemove.push(path);
     }
 
-    const filteredCache = Object.fromEntries(Object.entries(currentCache).filter(([id]) => !idsSet.has(id)));
+    const filteredCache = Object.fromEntries(Object.entries(cache).filter(([cid]) => !idsSet.has(cid)));
     const pathsSet = new Set(pathsToRemove);
-    const filteredIndex = Object.fromEntries(Object.entries(currentIndex).filter(([path]) => !pathsSet.has(path)));
+    const filteredIndex = Object.fromEntries(Object.entries(index).filter(([p]) => !pathsSet.has(p)));
 
-    $contentCache.set(filteredCache);
-    $pathToId.set(filteredIndex);
+    writeProjectCache(name, filteredCache);
+    writePathIndex(name, filteredIndex);
 }
 
-export function clearContentCache(): void {
-    $contentCache.set({});
-    $pathToId.set({});
+/** Clears one project's slice. Defaults to the active project; no-op if none. */
+export function clearProjectContentCache(projectName?: string): void {
+    const name = resolveProjectName(projectName);
+    if (!name) return;
+
+    writeProjectCache(name, EMPTY_CACHE);
+    writePathIndex(name, EMPTY_INDEX);
+}
+
+/** Wipes every project's slice. For tests and explicit full resets. */
+export function clearAllContentCaches(): void {
+    $contentCacheByProject.set({});
+    $pathToIdByProject.set({});
 }
 
 //
-// * Selectors (synchronous lookups)
+// * Selectors
 //
 
-/**
- * Gets content by ID from cache (synchronous).
- * Returns undefined if not in cache.
- */
-export function getContent(id: string): ContentSummary | undefined {
-    return $contentCache.get()[id];
+export function getContent(id: string, projectName?: string): ContentSummary | undefined {
+    const name = resolveProjectName(projectName);
+    if (!name) return undefined;
+    return readProjectCache(name)[id];
 }
 
-/**
- * Gets multiple content items by IDs from cache (synchronous).
- * Missing items are not included in the result.
- */
-export function getContents(ids: string[]): ContentSummary[] {
-    const cache = $contentCache.get();
+export function getContents(ids: string[], projectName?: string): ContentSummary[] {
+    const name = resolveProjectName(projectName);
+    if (!name) return [];
+    const cache = readProjectCache(name);
     return ids.map((id) => cache[id]).filter(Boolean);
 }
 
-/** Get content wrapped as CSCS for legacy code that requires ContentSummaryAndCompareStatus */
-export function getContentAsCSCS(id: string): ContentSummaryAndCompareStatus | undefined {
-    const summary = getContent(id);
+/** Wraps cached summary as CSCS for legacy code paths. */
+export function getContentAsCSCS(id: string, projectName?: string): ContentSummaryAndCompareStatus | undefined {
+    const summary = getContent(id, projectName);
     return summary ? ContentSummaryAndCompareStatus.fromContentSummary(summary) : undefined;
 }
 
-export function hasContent(id: string): boolean {
-    return id in $contentCache.get();
+export function hasContent(id: string, projectName?: string): boolean {
+    const name = resolveProjectName(projectName);
+    if (!name) return false;
+    return id in readProjectCache(name);
 }
 
-/**
- * Gets content ID by path from the path index (O(1) lookup).
- * Returns undefined if path is not in index.
- */
-export function getIdByPath(pathStr: string): string | undefined {
-    return $pathToId.get()[pathStr];
+export function getIdByPath(pathStr: string, projectName?: string): string | undefined {
+    const name = resolveProjectName(projectName);
+    if (!name) return undefined;
+    return readPathIndex(name)[pathStr];
 }
 
-/**
- * Gets IDs that are missing from the cache.
- */
-export function getMissingIds(ids: string[]): string[] {
-    const cache = $contentCache.get();
+export function getMissingIds(ids: string[], projectName?: string): string[] {
+    const name = resolveProjectName(projectName);
+    if (!name) return ids.slice();
+    const cache = readProjectCache(name);
     return ids.filter((id) => !(id in cache));
 }
 
-/**
- * Gets all content IDs currently in cache.
- */
-export function getAllContentIds(): string[] {
-    return Object.keys($contentCache.get());
+export function getAllContentIds(projectName?: string): string[] {
+    const name = resolveProjectName(projectName);
+    if (!name) return [];
+    return Object.keys(readProjectCache(name));
 }
 
 //
-// * Self-initializing Socket Subscriptions
+// * Socket Subscriptions
 //
-// These subscriptions run at module load and persist for the application lifetime.
-// They are NOT cleaned up because:
-// 1. The content store is a global singleton
-// 2. The app requires real-time updates throughout its lifecycle
-// 3. Cleanup would break functionality when re-entering the content browser
+// Self-initialise at module load and live for the app's lifetime.
+// Server-side subscriptions are per-active-project, so writes target that partition.
 //
 
-// Content updated - update cache with new data
 $contentUpdated.subscribe((event) => {
     if (event?.data) {
         setContents(event.data);
     }
 });
 
-// Content created - add to cache
 $contentCreated.subscribe((event) => {
     if (event?.data) {
         setContents(event.data);
     }
 });
 
-// Content deleted - remove from cache
 $contentDeleted.subscribe((event) => {
     if (event?.data) {
         const ids = event.data.map((item) => item.getContentId().toString());
@@ -199,14 +241,12 @@ $contentDeleted.subscribe((event) => {
     }
 });
 
-// Content renamed - update cache with new data
 $contentRenamed.subscribe((event) => {
     if (event?.data?.items) {
         setContents(event.data.items);
     }
 });
 
-// Content archived - remove from cache
 $contentArchived.subscribe((event) => {
     if (event?.data) {
         const ids = event.data.map((item) => item.getContentId().toString());
@@ -214,21 +254,18 @@ $contentArchived.subscribe((event) => {
     }
 });
 
-// Content published - update cache
 $contentPublished.subscribe((event) => {
     if (event?.data) {
         setContents(event.data);
     }
 });
 
-// Content unpublished - update cache
 $contentUnpublished.subscribe((event) => {
     if (event?.data) {
         setContents(event.data);
     }
 });
 
-// Content duplicated - add to cache
 $contentDuplicated.subscribe((event) => {
     if (event?.data) {
         setContents(event.data);
@@ -239,8 +276,11 @@ $contentDuplicated.subscribe((event) => {
 $contentMoved.subscribe((event) => {
     if (!event?.data) return;
 
-    const cacheUpdates: ContentCacheState = {...$contentCache.get()};
-    const indexUpdates: Record<string, string> = {...$pathToId.get()};
+    const name = $activeProject.get()?.getName();
+    if (!name) return;
+
+    const cacheUpdates: ProjectCache = {...readProjectCache(name)};
+    const indexUpdates: PathIndex = {...readPathIndex(name)};
 
     for (const moved of event.data) {
         const summary = moved.item.getContentSummary();
@@ -259,24 +299,17 @@ $contentMoved.subscribe((event) => {
         }
     }
 
-    $contentCache.set(cacheUpdates);
-    $pathToId.set(indexUpdates);
+    writeProjectCache(name, cacheUpdates);
+    writePathIndex(name, indexUpdates);
 });
 
-// Content sorted - update cache with new order data
 $contentSorted.subscribe((event) => {
     if (event?.data) {
         setContents(event.data);
     }
 });
 
-/**
- * @deprecated Socket subscriptions are now self-initializing at module load.
- * This function is kept for backwards compatibility but does nothing.
- */
+/** @deprecated Subscriptions self-initialise at module load. Kept for back-compat. */
 export function subscribeToContentEvents(): () => void {
-    // No-op - subscriptions are now self-initializing
-    return () => {
-        // No-op
-    };
+    return () => undefined;
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/contentTreeSelection.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/contentTreeSelection.store.test.ts
@@ -3,7 +3,9 @@ import {beforeEach, describe, expect, it} from 'vitest';
 import type {ContentSummary} from '../../../app/content/ContentSummary';
 import {PublishStatus} from '../../../app/publish/PublishStatus';
 import {setFilterActive} from './active-tree.store';
-import {clearContentCache, setContent} from './content.store';
+import {$activeProject} from './activeProject.store';
+import {clearAllContentCaches, setContent} from './content.store';
+import type {Project} from '../../../app/settings/data/project/Project';
 import {
     $activeId,
     $currentIds,
@@ -55,10 +57,11 @@ function createMockContent(id: string, name?: string): ContentSummary {
 describe('contentTreeSelection.store', () => {
     beforeEach(() => {
         // Reset all state
+        $activeProject.set({getName: () => 'default'} as unknown as Project);
         $selection.set(new Set());
         $activeId.set(null);
         $selectAllMode.set(false);
-        clearContentCache();
+        clearAllContentCaches();
         resetTree();
         setFilterActive(false);
     });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.test.ts
@@ -30,8 +30,10 @@ import {
     getTreeDescendantIds,
     type ContentTreeNodeData,
 } from './tree-list.store';
-import {clearContentCache, setContent, setContents} from './content.store';
+import {clearAllContentCaches, setContent, setContents} from './content.store';
+import {$activeProject} from './activeProject.store';
 import {addUpload, clearUploads} from './uploads.store';
+import type {Project} from '../../../app/settings/data/project/Project';
 import {emitContentCreated, emitContentDeleted, emitContentArchived} from './socket.store';
 import type {ContentServerChangeItem} from '../../../app/event/ContentServerChangeItem';
 
@@ -153,8 +155,9 @@ function createMockChangeItem(id: string): ContentServerChangeItem {
 
 describe('tree-list.store', () => {
     beforeEach(() => {
+        $activeProject.set({getName: () => 'default'} as unknown as Project);
         resetTree();
-        clearContentCache();
+        clearAllContentCaches();
         clearUploads();
     });
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/tree/TreeListToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/tree/TreeListToolbar.tsx
@@ -6,7 +6,7 @@ import {type ReactElement, useMemo} from 'react';
 import {activateFilter, fetchRootChildrenIdsOnly, getFilterQuery} from '../../../api/content-fetcher';
 import {useI18n} from '../../../hooks/useI18n';
 import {$isFilterActive} from '../../../store/active-tree.store';
-import {clearContentCache} from '../../../store/content.store';
+import {clearProjectContentCache} from '../../../store/content.store';
 import {$isAllLoadedSelected, $isNoneSelected, $selectionCount, clearSelection, selectAll} from '../../../store/contentTreeSelection.store';
 import {$rootLoadingState, resetTree} from '../../../store/tree-list.store';
 
@@ -20,7 +20,7 @@ const handleReload = (): void => {
         if (query) void activateFilter(query);
     } else {
         resetTree();
-        clearContentCache();
+        clearProjectContentCache();
         void fetchRootChildrenIdsOnly();
     }
 };


### PR DESCRIPTION
# Partition content cache by project; fix tree race on project switch

## Summary

The content cache used to be one shared bucket across all projects. Now each project has its own bucket. This also fixes a bug where a slow server response from one project could corrupt the tree after the user switched to another project.

## Why

- One shared cache mixed data from every project visited in a session. If the same content existed in multiple projects with different status or permissions, values from one project could briefly appear in another.
- When the user switched projects, the tree was reset, but slow responses from the old project kept arriving and inserted their data into the new project's tree.

## How

- The cache now stores content per project (`projectName → id → ContentSummary`). The exported `$contentCache` shows the active project's data only, with the same shape as before, so existing consumers do not need changes.
- Each async fetch remembers which project it was started for. Its cache writes go into that project's bucket. Before writing to the tree, it checks whether the user is still in the same project — if not, the tree write is skipped.

## Behavior changes

- `clearContentCache()` is replaced by two functions: `clearProjectContentCache(projectName?)` (one project, active by default) and `clearAllContentCaches()` (everything). The old "pass `null` to wipe all" trick is gone.
- Cache reads and writes do nothing when no project is active (used to write into the shared bucket).
- The Reload button now clears only the active project's cache instead of every cached project.

## Tests

Added partitioning tests in `content.store.test.ts` and race-protection tests in `content-fetcher.test.ts`. 1011/1011 vitest pass; type-check and lint clean.

<sub>*Drafted with AI assistance*</sub>
