### PR TITLE
Content grid is not updated after adding items to empty grid #10574

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.test.ts
@@ -21,6 +21,7 @@ import {
     setNodeLoading,
     resetTree,
     setNodeTotalChildren,
+    setRootTotalChildren,
     getTreeNode,
     hasTreeNode,
     isNodeExpanded,
@@ -607,6 +608,37 @@ describe('tree-list.store', () => {
                 const state = $treeState.get();
                 expect(state.rootIds).toContain('new-root');
                 expect(state.rootIds[0]).toBe('new-root'); // Prepended
+            });
+
+            it('adds root-level content when root is loaded but empty', () => {
+                // Setup: root has been loaded for an empty project. rootTotalChildren=0
+                // marks the empty state as verified (vs. undefined = not yet loaded).
+                setTreeRootIds([]);
+                setRootTotalChildren(0);
+
+                // Emit: first root-level content created
+                const rootContent = createMockContentWithParent('new-root', '/');
+                emitContentCreated([rootContent]);
+
+                // Assert: new item appears in the empty root
+                const state = $treeState.get();
+                expect(hasTreeNode('new-root')).toBe(true);
+                expect(state.rootIds).toEqual(['new-root']);
+            });
+
+            it('does not add root-level content when root has never been loaded', () => {
+                // Setup: tree was never loaded — rootTotalChildren stays undefined
+                // after resetTree() in beforeEach.
+                setTreeRootIds([]);
+
+                // Emit: root-level content created before initial root fetch
+                const rootContent = createMockContentWithParent('new-root', '/');
+                emitContentCreated([rootContent]);
+
+                // Assert: item is dropped to avoid polluting an unloaded tree;
+                // the upcoming root fetch will populate it.
+                expect(hasTreeNode('new-root')).toBe(false);
+                expect($treeState.get().rootIds).toEqual([]);
             });
 
             it('updates parent hasChildren when first child created', () => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/tree-list.store.ts
@@ -362,7 +362,9 @@ function addContentToTree(content: ContentSummary): void {
         if (parentId === null) {
             // If this content is not root-level, do not insert it as root.
             if (hasParentPath) return state;
-            if (state.rootIds.length === 0) return state;
+            // Skip only when the root has never been loaded; a verified-empty root
+            // (rootTotalChildren === 0) should still accept new root-level items.
+            if (state.rootIds.length === 0 && $rootTotalChildren.get() === undefined) return state;
         } else {
             const parent = state.nodes.get(parentId);
             if (!parent) return state;


### PR DESCRIPTION
Root-level content created via socket event was dropped whenever `rootIds` was empty, so the first folder added to a freshly created (empty) project did not appear in the grid until manual reload. The guard now uses `$rootTotalChildren` to distinguish a not-yet-loaded root from a verified-empty one and only skips the former.

- `tree-list.store.ts` — only skip root insert when `$rootTotalChildren` is `undefined`
- `tree-list.store.test.ts` — added coverage for the verified-empty root and the still-skip pre-load case

Closes #10574

<sub>*Drafted with AI assistance*</sub>
