### PR TITLE
Enonic UI: DeleteDialog key navigation #9565

### DIFF
--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -2924,6 +2924,12 @@ packages:
     peerDependencies:
       postcss: ^8.4.32
 
+  cssnano-utils@5.0.3:
+    resolution: {integrity: sha512-ynIREMICLxkxm7e9bCR9sh75s4Q5drICi0ua1yxo5jH2XPBqSKkl4dOh4EbFqtUmnTMhRffHgYL0EKKkMjtJTg==}
+    engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
+    peerDependencies:
+      postcss: ^8.5.13
+
   cssnano-utils@6.0.0:
     resolution: {integrity: sha512-ztS9W/+uaDn+bkYmDhs+GdMveHJ3CL8IPNHpRqDUQXv5GJOTQAJjV1XUOInr9esLXSabQV1pLRZlJpyUwEqDyQ==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
@@ -7745,7 +7751,7 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.28.2
-      caniuse-lite: 1.0.30001780
+      caniuse-lite: 1.0.30001791
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
@@ -7924,7 +7930,7 @@ snapshots:
 
   cssnano-preset-default@7.0.11(postcss@8.5.15):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       css-declaration-sorter: 7.3.1(postcss@8.5.15)
       cssnano-utils: 5.0.1(postcss@8.5.15)
       postcss: 8.5.15
@@ -7990,6 +7996,10 @@ snapshots:
       postcss-unique-selectors: 8.0.0(postcss@8.5.15)
 
   cssnano-utils@5.0.1(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
+  cssnano-utils@5.0.3(postcss@8.5.15):
     dependencies:
       postcss: 8.5.15
 
@@ -9621,7 +9631,7 @@ snapshots:
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      cssnano-utils: 5.0.1(postcss@8.5.15)
+      cssnano-utils: 5.0.3(postcss@8.5.15)
       postcss: 8.5.15
       postcss-selector-parser: 7.1.1
 
@@ -9646,7 +9656,7 @@ snapshots:
   postcss-minify-gradients@7.0.1(postcss@8.5.15):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 5.0.1(postcss@8.5.15)
+      cssnano-utils: 5.0.3(postcss@8.5.15)
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
@@ -9660,7 +9670,7 @@ snapshots:
   postcss-minify-params@7.0.6(postcss@8.5.15):
     dependencies:
       browserslist: 4.28.2
-      cssnano-utils: 5.0.1(postcss@8.5.15)
+      cssnano-utils: 5.0.3(postcss@8.5.15)
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
@@ -9806,7 +9816,7 @@ snapshots:
 
   postcss-ordered-values@7.0.2(postcss@8.5.15):
     dependencies:
-      cssnano-utils: 5.0.1(postcss@8.5.15)
+      cssnano-utils: 5.0.3(postcss@8.5.15)
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/ContentReferencesLink.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/ContentReferencesLink.tsx
@@ -1,11 +1,11 @@
-import {cn, Link, LinkProps} from '@enonic/ui';
-import {useMemo} from 'react';
+import {cn, Link, type LinkProps} from '@enonic/ui';
+import {forwardRef, useMemo} from 'react';
 
 import type {ContentTypeName} from '@enonic/lib-admin-ui/schema/content/ContentTypeName';
 import {useStore} from '@nanostores/preact';
 import {DependencyType} from '../../../app/browse/DependencyType';
 import {UrlHelper} from '../../../app/util/UrlHelper';
-import {Branch} from '../../../app/versioning/Branch';
+import {type Branch} from '../../../app/versioning/Branch';
 import {useI18n} from '../hooks/useI18n';
 import {$activeProject} from '../store/activeProject.store';
 
@@ -13,18 +13,19 @@ export type ContentReferencesLinkProps = {
     contentId: string;
     branch: Branch;
     contentTypeName?: ContentTypeName;
+    'data-active'?: boolean;
     'data-component'?: string;
 } & Omit<LinkProps, 'href' | 'newTab'>;
 
 const CONTENT_REFERENCES_LINK_NAME = 'ContentReferencesLink';
-export function ContentReferencesLink({
+export const ContentReferencesLink = forwardRef<HTMLAnchorElement, ContentReferencesLinkProps>(({
     contentId,
     branch,
     contentTypeName,
     className,
     'data-component': componentName = CONTENT_REFERENCES_LINK_NAME,
     ...props
-}: ContentReferencesLinkProps) {
+}: ContentReferencesLinkProps, ref) => {
     const label = useI18n('action.showReferences');
     const projectName = useStore($activeProject)?.getName();
     const contentType = contentTypeName?.toString();
@@ -36,7 +37,11 @@ export function ContentReferencesLink({
 
     return (
         <Link
-            className={cn('visited:text-main', className)}
+            ref={ref}
+            className={cn(
+                className,
+                'visited:text-main h-12 px-2 active:bg-transparent data-[active=true]:bg-transparent',
+            )}
             href={href}
             newTab
             data-component={componentName}
@@ -45,6 +50,6 @@ export function ContentReferencesLink({
             {label}
         </Link>
     );
-}
+});
 
 ContentReferencesLink.displayName = CONTENT_REFERENCES_LINK_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ContentReferenceList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ContentReferenceList.tsx
@@ -1,0 +1,332 @@
+import {cn, Separator} from '@enonic/ui';
+import {
+    type KeyboardEvent,
+    type MouseEvent,
+    type ReactElement,
+    useCallback,
+    useEffect,
+    useId,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import type {ContentSummary} from '../../../../app/content/ContentSummary';
+import {type Branch} from '../../../../app/versioning/Branch';
+import type {ContentLabelVariant} from '../content/ContentLabel';
+import {ContentListItemWithReference} from '../items';
+
+type ContentReferenceAction = 'content' | 'reference';
+
+type ActiveReferenceAction = {
+    rowIndex: number;
+    action: ContentReferenceAction;
+} | null;
+
+type ContentReferenceRow = {
+    content: ContentSummary;
+    hasInbound: boolean;
+    key: string;
+    rowIndex: number;
+    section: 'main' | 'dependant';
+    variant: ContentLabelVariant;
+};
+
+export type ContentReferenceListProps = {
+    items: ContentSummary[];
+    dependants?: ContentSummary[];
+    dependantsLabel?: string;
+    branch: Branch;
+    isInbound: (content: ContentSummary) => boolean;
+    label?: string;
+    mainVariant?: ContentLabelVariant;
+    dependantVariant?: ContentLabelVariant;
+    mainListClassName?: string;
+    dependantListClassName?: string;
+    dependantSectionClassName?: string;
+    'data-component'?: string;
+};
+
+const CONTENT_REFERENCE_LIST_NAME = 'ContentReferenceList';
+const ACTIVE_ACTION_CLASS = [
+    'data-[active=true]:ring-3',
+    'data-[active=true]:ring-ring-offset',
+    'data-[active=true]:ring-inset',
+    'data-[active=true]:ring-offset-3',
+    'data-[active=true]:ring-offset-ring',
+].join(' ');
+const ACTIVE_REFERENCE_LINK_CLASS = cn(
+    'rounded-sm',
+    'data-[active=true]:bg-btn-active data-[active=true]:text-alt',
+    ACTIVE_ACTION_CLASS,
+);
+
+function getActionKey(rowIndex: number, action: ContentReferenceAction): string {
+    return `${rowIndex}-${action}`;
+}
+
+function getActionId(baseId: string, rowIndex: number, action: ContentReferenceAction): string {
+    return `${baseId}-content-reference-list-${rowIndex}-${action}`;
+}
+
+function normalizeActiveAction(active: ActiveReferenceAction, rows: ContentReferenceRow[]): ActiveReferenceAction {
+    if (rows.length === 0) {
+        return null;
+    }
+
+    if (!active) {
+        return {rowIndex: 0, action: 'content'};
+    }
+
+    const rowIndex = Math.min(Math.max(active.rowIndex, 0), rows.length - 1);
+    const row = rows[rowIndex];
+    const action = active.action === 'reference' && row.hasInbound ? 'reference' : 'content';
+
+    return {rowIndex, action};
+}
+
+function isSameActiveAction(left: ActiveReferenceAction, right: ActiveReferenceAction): boolean {
+    return left?.rowIndex === right?.rowIndex && left?.action === right?.action;
+}
+
+function getLastActiveAction(rows: ContentReferenceRow[]): ActiveReferenceAction {
+    if (rows.length === 0) {
+        return null;
+    }
+
+    const rowIndex = rows.length - 1;
+    const row = rows[rowIndex];
+
+    return {rowIndex, action: row.hasInbound ? 'reference' : 'content'};
+}
+
+export const ContentReferenceList = ({
+    items,
+    dependants = [],
+    dependantsLabel,
+    branch,
+    isInbound,
+    label,
+    mainVariant = 'normal',
+    dependantVariant = 'normal',
+    mainListClassName,
+    dependantListClassName,
+    dependantSectionClassName,
+    'data-component': componentName = CONTENT_REFERENCE_LIST_NAME,
+}: ContentReferenceListProps): ReactElement => {
+    const baseId = useId();
+    const actionRefs = useRef(new Map<string, HTMLElement>());
+    const [activeAction, setActiveAction] = useState<ActiveReferenceAction>(null);
+    const [focused, setFocused] = useState(false);
+
+    const rows = useMemo<ContentReferenceRow[]>(() => {
+        const mainRows = items.map((content) => ({
+            content,
+            hasInbound: isInbound(content),
+            key: `main-${content.getId()}`,
+            section: 'main' as const,
+            variant: mainVariant,
+        }));
+        const dependantRows = dependants.map((content) => ({
+            content,
+            hasInbound: isInbound(content),
+            key: `dep-${content.getId()}`,
+            section: 'dependant' as const,
+            variant: dependantVariant,
+        }));
+
+        return [...mainRows, ...dependantRows].map((row, rowIndex) => ({
+            ...row,
+            key: `${row.key}-${rowIndex}`,
+            rowIndex,
+        }));
+    }, [items, dependants, isInbound, mainVariant, dependantVariant]);
+
+    const normalizedActiveAction = useMemo(() => normalizeActiveAction(activeAction, rows), [activeAction, rows]);
+    const mainRows = useMemo(() => rows.filter(row => row.section === 'main'), [rows]);
+    const dependantRows = useMemo(() => rows.filter(row => row.section === 'dependant'), [rows]);
+
+    useEffect(() => {
+        setActiveAction(current => {
+            const next = normalizeActiveAction(current, rows);
+            return isSameActiveAction(current, next) ? current : next;
+        });
+    }, [rows]);
+
+    useEffect(() => {
+        if (!focused || !normalizedActiveAction) {
+            return;
+        }
+
+        actionRefs.current.get(getActionKey(normalizedActiveAction.rowIndex, normalizedActiveAction.action))?.scrollIntoView({
+            block: 'nearest',
+            inline: 'nearest',
+        });
+    }, [focused, normalizedActiveAction]);
+
+    const setActionElement = useCallback((
+        rowIndex: number,
+        action: ContentReferenceAction,
+        element: HTMLElement | null,
+    ): void => {
+        const key = getActionKey(rowIndex, action);
+        if (element) {
+            actionRefs.current.set(key, element);
+        } else {
+            actionRefs.current.delete(key);
+        }
+    }, []);
+
+    const handleFocus = (): void => {
+        setFocused(true);
+        setActiveAction(current => normalizeActiveAction(current, rows));
+    };
+
+    const handleBlur = (): void => setFocused(false);
+
+    const handleActionMouseDown = useCallback((
+        event: MouseEvent<HTMLElement>,
+        rowIndex: number,
+        action: ContentReferenceAction,
+    ): void => {
+        event.preventDefault();
+        setActiveAction({rowIndex, action});
+    }, []);
+
+    const moveActiveRow = useCallback((direction: -1 | 1): void => {
+        setActiveAction(current => {
+            const active = normalizeActiveAction(current, rows);
+            if (!active) {
+                return null;
+            }
+
+            const rowIndex = Math.min(Math.max(active.rowIndex + direction, 0), rows.length - 1);
+            const row = rows[rowIndex];
+            const action = active.action === 'reference' && row.hasInbound ? 'reference' : 'content';
+
+            return {rowIndex, action};
+        });
+    }, [rows]);
+
+    const moveActiveAction = useCallback((action: ContentReferenceAction): void => {
+        setActiveAction(current => {
+            const active = normalizeActiveAction(current, rows);
+            if (!active) {
+                return null;
+            }
+
+            const row = rows[active.rowIndex];
+            if (action === 'reference' && !row.hasInbound) {
+                return active;
+            }
+
+            return {...active, action};
+        });
+    }, [rows]);
+
+    const activateCurrentAction = useCallback((): void => {
+        const active = normalizeActiveAction(activeAction, rows);
+        if (!active) {
+            return;
+        }
+
+        actionRefs.current.get(getActionKey(active.rowIndex, active.action))?.click();
+    }, [activeAction, rows]);
+
+    const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>): void => {
+        switch (event.key) {
+        case 'ArrowDown':
+            event.preventDefault();
+            moveActiveRow(1);
+            break;
+        case 'ArrowUp':
+            event.preventDefault();
+            moveActiveRow(-1);
+            break;
+        case 'ArrowRight':
+            event.preventDefault();
+            moveActiveAction('reference');
+            break;
+        case 'ArrowLeft':
+            event.preventDefault();
+            moveActiveAction('content');
+            break;
+        case 'Home':
+            event.preventDefault();
+            setActiveAction(normalizeActiveAction(null, rows));
+            break;
+        case 'End':
+            event.preventDefault();
+            setActiveAction(getLastActiveAction(rows));
+            break;
+        case 'Enter':
+        case ' ':
+        case 'Spacebar':
+            event.preventDefault();
+            activateCurrentAction();
+            break;
+        }
+    }, [activateCurrentAction, moveActiveAction, moveActiveRow, rows]);
+
+    const isActionActive = (rowIndex: number, action: ContentReferenceAction): boolean => {
+        return focused && normalizedActiveAction?.rowIndex === rowIndex && normalizedActiveAction.action === action;
+    };
+
+    const renderRow = (row: ContentReferenceRow): ReactElement => (
+        <ContentListItemWithReference
+            key={row.key}
+            id={`${baseId}-content-reference-list-row-${row.rowIndex}`}
+            role='row'
+            aria-rowindex={row.rowIndex + 1}
+            variant={row.variant}
+            content={row.content}
+            branch={branch}
+            hasInbound={row.hasInbound}
+            contentButtonRef={(element) => setActionElement(row.rowIndex, 'content', element)}
+            contentButtonProps={{
+                id: getActionId(baseId, row.rowIndex, 'content'),
+                tabIndex: -1,
+                'data-active': isActionActive(row.rowIndex, 'content') || undefined,
+                className: ACTIVE_ACTION_CLASS,
+                onMouseDown: (event) => handleActionMouseDown(event, row.rowIndex, 'content'),
+            }}
+            referenceLinkRef={(element) => setActionElement(row.rowIndex, 'reference', element)}
+            referenceLinkProps={{
+                id: getActionId(baseId, row.rowIndex, 'reference'),
+                tabIndex: -1,
+                'data-active': isActionActive(row.rowIndex, 'reference') || undefined,
+                className: ACTIVE_REFERENCE_LINK_CLASS,
+                onMouseDown: (event) => handleActionMouseDown(event, row.rowIndex, 'reference'),
+            }}
+        />
+    );
+
+    return (
+        <div
+            role='grid'
+            aria-label={label}
+            aria-rowcount={rows.length}
+            aria-activedescendant={normalizedActiveAction ?
+                getActionId(baseId, normalizedActiveAction.rowIndex, normalizedActiveAction.action) :
+                undefined}
+            tabIndex={rows.length > 0 ? 0 : undefined}
+            className='flex flex-col gap-y-10 outline-none'
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+            data-component={componentName}
+        >
+            <ul role='presentation' className={cn('flex flex-col gap-y-2.5', mainListClassName)}>
+                {mainRows.map(renderRow)}
+            </ul>
+
+            <div className={cn('flex flex-col gap-y-7.5', dependantRows.length === 0 && 'hidden', dependantSectionClassName)}>
+                {dependantsLabel && <Separator className='pr-1' label={dependantsLabel} />}
+                <ul role='presentation' className={cn('flex flex-col gap-y-1.5', dependantListClassName)}>
+                    {dependantRows.map(renderRow)}
+                </ul>
+            </div>
+        </div>
+    );
+};
+
+ContentReferenceList.displayName = CONTENT_REFERENCE_LIST_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/delete/DeleteDialogMainContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/delete/DeleteDialogMainContent.tsx
@@ -1,6 +1,6 @@
-import {Button, Dialog, Separator, cn} from '@enonic/ui';
+import {Button, Dialog} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
-import {useMemo, useRef, type ReactElement} from 'react';
+import {useCallback, useMemo, useRef, type ReactElement} from 'react';
 import type {ContentSummary} from '../../../../../app/content/ContentSummary';
 import {Branch} from '../../../../../app/versioning/Branch';
 import {useI18n} from '../../../hooks/useI18n';
@@ -12,7 +12,7 @@ import {
     $isDeleteDialogReady,
     ignoreDeleteInboundDependencies,
 } from '../../../store/dialogs/deleteDialog.store';
-import {ContentListItemWithReference} from '../../items/ContentListItemWithReference';
+import {ContentReferenceList} from '../ContentReferenceList';
 import {InboundStatusBar} from '../status-bar/InboundStatusBar';
 
 type DeleteDialogMainContentProps = {
@@ -32,7 +32,8 @@ export const DeleteDialogMainContent = ({
     const total = useStore($deleteItemsCount);
     const inboundIds = useStore($deleteInboundIds);
     const inboundSet = useMemo(() => new Set(inboundIds), [inboundIds]);
-    const isInbound = (content: ContentSummary) => inboundSet.has(content.getContentId().toString());
+    const isInbound = useCallback((content: ContentSummary) =>
+        inboundSet.has(content.getContentId().toString()), [inboundSet]);
 
     const single = useI18n('dialog.delete.single');
     const multiple = useI18n('dialog.delete.multiple');
@@ -45,12 +46,12 @@ export const DeleteDialogMainContent = ({
     const actionButtonRef = useRef<HTMLButtonElement>(null);
 
     useOnceWhen(() => {
-        actionButtonRef.current?.focus({focusVisible: true});
+        actionButtonRef.current?.focus();
     }, ready);
 
-    const handleOpenAutoFocus = (event: FocusEvent) => {
+    const handleOpenAutoFocus = (event: Event) => {
         event.preventDefault();
-        actionButtonRef.current?.focus({focusVisible: true});
+        actionButtonRef.current?.focus();
     };
 
     const inboundCount = useMemo(() => {
@@ -80,33 +81,16 @@ export const DeleteDialogMainContent = ({
                 }}
             />
 
-            <Dialog.Body className="flex flex-col gap-y-10">
-                <ul className="flex flex-col gap-y-2.5">
-                    {items.map(item => (
-                        <ContentListItemWithReference
-                            key={`main-${item.getId()}`}
-                            variant='normal'
-                            content={item}
-                            branch={Branch.DRAFT}
-                            hasInbound={isInbound(item)}
-                        />
-                    ))}
-                </ul>
-
-                <div className={cn('flex flex-col gap-y-7.5', dependants.length === 0 && 'hidden')}>
-                    <Separator className="pr-1" label={dependantsLabel} />
-                    <ul className="flex flex-col gap-y-1.5">
-                        {dependants.map(item => (
-                            <ContentListItemWithReference
-                                key={`dep-${item.getId()}`}
-                                variant='compact'
-                                content={item}
-                                branch={Branch.DRAFT}
-                                hasInbound={isInbound(item)}
-                            />
-                        ))}
-                    </ul>
-                </div>
+            <Dialog.Body>
+                <ContentReferenceList
+                    items={items}
+                    dependants={dependants}
+                    dependantsLabel={dependantsLabel}
+                    branch={Branch.DRAFT}
+                    isInbound={isInbound}
+                    label={title}
+                    dependantVariant='compact'
+                />
             </Dialog.Body>
 
             <Dialog.Footer className="flex items-center gap-2.5">

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/unpublish/UnpublishDialogMainContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/unpublish/UnpublishDialogMainContent.tsx
@@ -1,6 +1,6 @@
-import {Button, Dialog, Separator, cn} from '@enonic/ui';
+import {Button, Dialog} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
-import {useMemo, useRef, type ReactElement} from 'react';
+import {useCallback, useMemo, useRef, type ReactElement} from 'react';
 import type {ContentSummary} from '../../../../../app/content/ContentSummary';
 import {Branch} from '../../../../../app/versioning/Branch';
 import {useI18n} from '../../../hooks/useI18n';
@@ -10,8 +10,7 @@ import {
     $unpublishInboundIds,
     $unpublishItemsCount, ignoreUnpublishInboundDependencies
 } from '../../../store/dialogs/unpublishDialog.store';
-import {ContentListItem} from '../../items/ContentListItem';
-import {ContentListItemWithReference} from '../../items/ContentListItemWithReference';
+import {ContentReferenceList} from '../ContentReferenceList';
 import {InboundStatusBar} from '../status-bar/InboundStatusBar';
 
 type UnpublishDialogMainContentProps = {
@@ -31,7 +30,8 @@ export const UnpublishDialogMainContent = ({
     const total = useStore($unpublishItemsCount);
     const inboundIds = useStore($unpublishInboundIds);
     const inboundSet = useMemo(() => new Set(inboundIds), [inboundIds]);
-    const isInbound = (content: ContentSummary) => inboundSet.has(content.getContentId().toString());
+    const isInbound = useCallback((content: ContentSummary) =>
+        inboundSet.has(content.getContentId().toString()), [inboundSet]);
 
     const title = useI18n('dialog.unpublish');
     const dependantsLabel = useI18n('dialog.unpublish.dependants');
@@ -41,12 +41,12 @@ export const UnpublishDialogMainContent = ({
     const unpublishButtonRef = useRef<HTMLButtonElement>(null);
 
     useOnceWhen(() => {
-        unpublishButtonRef.current?.focus({focusVisible: true});
+        unpublishButtonRef.current?.focus();
     }, ready);
 
-    const handleOpenAutoFocus = (event: FocusEvent) => {
+    const handleOpenAutoFocus = (event: Event) => {
         event.preventDefault();
-        unpublishButtonRef.current?.focus({focusVisible: true});
+        unpublishButtonRef.current?.focus();
     };
 
     const inboundCount = useMemo(() => {
@@ -76,34 +76,15 @@ export const UnpublishDialogMainContent = ({
                 }}
             />
 
-            <Dialog.Body className="flex flex-col gap-y-10">
-                <ul className="flex flex-col gap-y-2.5">
-                    {items.map(item => (
-                        <ContentListItemWithReference
-                            key={`main-${item.getId()}`}
-                            variant='normal'
-                            content={item}
-                            branch={Branch.DRAFT}
-                            hasInbound={isInbound(item)}
-                        />
-                    ))}
-                </ul>
-
-                <div className={cn('flex flex-col gap-y-7.5', dependants.length === 0 && 'hidden')}>
-                    <Separator className="pr-1" label={dependantsLabel} />
-                    <ul className="flex flex-col gap-y-1.5">
-                        {dependants.map(item => (
-                            <ContentListItemWithReference
-                                key={`main-${item.getId()}`}
-                                variant='normal'
-                                content={item}
-                                branch={Branch.DRAFT}
-                                hasInbound={isInbound(item)}
-                            />
-                        ))}
-                    </ul>
-                </div>
-
+            <Dialog.Body>
+                <ContentReferenceList
+                    items={items}
+                    dependants={dependants}
+                    dependantsLabel={dependantsLabel}
+                    branch={Branch.DRAFT}
+                    isInbound={isInbound}
+                    label={title}
+                />
             </Dialog.Body>
 
             <Dialog.Footer className="flex items-center gap-1">

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/items/ContentListItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/items/ContentListItem.tsx
@@ -1,15 +1,21 @@
-import {Button, cn, ListItem, type ListItemProps} from '@enonic/ui';
-import React, {type ReactNode} from 'react';
+import {Button, cn, ListItem, type ButtonProps, type ListItemProps} from '@enonic/ui';
+import React, {type ReactNode, type Ref} from 'react';
 import type {ContentSummary} from '../../../../app/content/ContentSummary';
 import {EditContentEvent} from '../../../../app/event/EditContentEvent';
 import {ContentLabel, type ContentLabelVariant} from '../content/ContentLabel';
 import {LegacyElement} from '../LegacyElement';
 import {DiffStatusBadge} from '../status/DiffStatusBadge';
 
+export type ContentButtonProps = Omit<ButtonProps, 'children'> & {
+    'data-active'?: boolean;
+};
+
 export type ContentItemProps = {
     content: ContentSummary;
     variant?: ContentLabelVariant;
     rightSlotOrder?: 'before-status' | 'after-status';
+    contentButtonProps?: ContentButtonProps;
+    contentButtonRef?: Ref<HTMLButtonElement>;
     'data-component'?: string;
     children?: ReactNode;
 } & Omit<ListItemProps, 'children'>;
@@ -22,20 +28,41 @@ export const ContentListItem = ({
                                     rightSlotOrder = 'before-status',
                                     selected = false,
                                     className,
+                                    contentButtonProps,
+                                    contentButtonRef,
                                     children,
                                     'data-component': componentName = CONTENT_LIST_ITEM_NAME,
                                     ...props
                                 }: ContentItemProps): React.ReactElement => {
     const isCompact = variant === 'compact';
+    const {
+        className: contentButtonClassName,
+        onClick: onContentButtonClick,
+        ...restContentButtonProps
+    } = contentButtonProps ?? {};
 
-    const handleClick = () => {
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        onContentButtonClick?.(event);
+        if (event.defaultPrevented) {
+            return;
+        }
         new EditContentEvent([content]).fire();
     };
 
     return (
         <ListItem selected={selected} data-component={componentName} className={cn('pl-0 py-0', className)} {...props}>
             <ListItem.Content className='flex'>
-                <Button onClick={handleClick} className={cn('box-content justify-start flex-1 px-2.5 py-1', isCompact && 'h-6')}>
+                <Button
+                    ref={contentButtonRef}
+                    onClick={handleClick}
+                    className={cn(
+                        'box-content justify-start flex-1 px-2.5 py-1',
+                        'active:bg-transparent data-[active=true]:bg-transparent',
+                        isCompact && 'h-6',
+                        contentButtonClassName,
+                    )}
+                    {...restContentButtonProps}
+                >
                     <ContentLabel content={content} variant={variant}/>
                 </Button>
             </ListItem.Content>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/items/ContentListItemWithReference.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/items/ContentListItemWithReference.tsx
@@ -1,10 +1,13 @@
-import {Branch} from '../../../../app/versioning/Branch';
-import {ContentReferencesLink} from '../ContentReferencesLink';
-import {ContentItemProps, ContentListItem} from './ContentListItem';
+import {type Ref} from 'react';
+import {type Branch} from '../../../../app/versioning/Branch';
+import {ContentReferencesLink, type ContentReferencesLinkProps} from '../ContentReferencesLink';
+import {type ContentItemProps, ContentListItem} from './ContentListItem';
 
 export type ContentListItemWithReferenceProps = {
     branch: Branch;
     hasInbound: boolean;
+    referenceLinkProps?: Omit<ContentReferencesLinkProps, 'contentId' | 'branch'>;
+    referenceLinkRef?: Ref<HTMLAnchorElement>;
 } & ContentItemProps;
 
 const CONTENT_LIST_ITEM_WITH_REFERENCE_NAME = 'ContentListItemWithReference';
@@ -13,13 +16,22 @@ export const ContentListItemWithReference = ({
     content,
     branch,
     hasInbound,
+    referenceLinkProps,
+    referenceLinkRef,
     'data-component': componentName = CONTENT_LIST_ITEM_WITH_REFERENCE_NAME,
     ...props
 }: ContentListItemWithReferenceProps): React.ReactElement => {
     const contentId = content.getContentId().toString();
     return (
         <ContentListItem content={content} data-component={componentName} {...props}>
-            {hasInbound && <ContentReferencesLink contentId={contentId} branch={branch} />}
+            {hasInbound && (
+                <ContentReferencesLink
+                    ref={referenceLinkRef}
+                    contentId={contentId}
+                    branch={branch}
+                    {...referenceLinkProps}
+                />
+            )}
         </ContentListItem>
     );
 }


### PR DESCRIPTION
Separated list focus from active item behavior so keyboard users can arrow through content/reference actions and tab out of long lists. Added shared ContentReferenceGridList and reused it in both delete and unpublish dialogs for consistent navigation and focus styling.