### PR TITLE
Grid keeps selecting an item after delete or reset selection #10034

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/duplicate/DuplicateDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/duplicate/DuplicateDialog.tsx
@@ -9,7 +9,7 @@ import {
     cancelDuplicateDialog,
     executeDuplicateDialogAction
 } from '../../../store/dialogs/duplicateDialog.store';
-import {resetSelection} from '../../../store/contentTreeSelection.store';
+import {clearSelection, setActive} from '../../../store/contentTreeSelection.store';
 import {DuplicateDialogMainContent} from './DuplicateDialogMainContent';
 import {DuplicateDialogProgressContent} from './DuplicateDialogProgressContent';
 
@@ -46,7 +46,8 @@ export const DuplicateDialog = (): ReactElement => {
         setView('progress');
         const started = await executeDuplicateDialogAction();
         if (started) {
-            resetSelection();
+            setActive(null);
+            clearSelection();
             return;
         }
         setView('main');

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/move/MoveDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/move/MoveDialog.tsx
@@ -11,7 +11,7 @@ import {
     cancelMoveDialog,
     executeMoveDialogAction,
 } from '../../../store/dialogs/moveDialog.store';
-import {resetSelection} from '../../../store/contentTreeSelection.store';
+import {clearSelection, setActive} from '../../../store/contentTreeSelection.store';
 import {MoveDialogMainContent} from './MoveDialogMainContent';
 import {MoveDialogProgressContent} from './MoveDialogProgressContent';
 
@@ -45,7 +45,8 @@ export const MoveDialog = (): ReactElement => {
         setView('progress');
         const started = await executeMoveDialogAction();
         if (started) {
-            resetSelection();
+            setActive(null);
+            clearSelection();
             return;
         }
         resetView();

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/grid/ContentTreeList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/grid/ContentTreeList.tsx
@@ -470,6 +470,7 @@ export const ContentTreeList = ({contextMenuActions = {}}: ContentTreeListProps)
             selectionMode="multiple"
             active={activeId}
             onActiveChange={setActive}
+            preserveFilteredSelection={isFilterActive}
             onExpand={handleExpand}
             onCollapse={handleCollapse}
             onActivate={handleActivate}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/tree/TreeListToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/tree/TreeListToolbar.tsx
@@ -5,23 +5,39 @@ import {RefreshCcw} from 'lucide-react';
 import {type ReactElement, useMemo} from 'react';
 import {activateFilter, fetchRootChildrenIdsOnly, getFilterQuery} from '../../../api/content-fetcher';
 import {useI18n} from '../../../hooks/useI18n';
-import {$isFilterActive} from '../../../store/active-tree.store';
+import {$activeRawFlatNodes, $isFilterActive} from '../../../store/active-tree.store';
 import {clearProjectContentCache} from '../../../store/content.store';
-import {$isAllLoadedSelected, $isNoneSelected, $selectionCount, clearSelection, selectAll} from '../../../store/contentTreeSelection.store';
+import {$activeId, $isAllLoadedSelected, $isNoneSelected, $selectionCount, clearSelection, selectAll, setActive} from '../../../store/contentTreeSelection.store';
 import {$rootLoadingState, resetTree} from '../../../store/tree-list.store';
 
 type TreeListToolbarProps = {
     enabled?: boolean;
 };
 
-const handleReload = (): void => {
-    if ($isFilterActive.get()) {
-        const query = getFilterQuery();
-        if (query) void activateFilter(query);
-    } else {
-        resetTree();
-        clearProjectContentCache();
-        void fetchRootChildrenIdsOnly();
+const restoreActiveAfterReload = (activeId: string | null): void => {
+    if (!activeId) {
+        setActive(null);
+        return;
+    }
+
+    const activeExists = $activeRawFlatNodes.get().some((node) => node.nodeType === 'node' && node.id === activeId);
+    setActive(activeExists ? activeId : null);
+};
+
+const handleReload = async (): Promise<void> => {
+    const activeId = $activeId.get();
+
+    try {
+        if ($isFilterActive.get()) {
+            const query = getFilterQuery();
+            if (query) await activateFilter(query);
+        } else {
+            resetTree();
+            clearProjectContentCache();
+            await fetchRootChildrenIdsOnly();
+        }
+    } finally {
+        restoreActiveAfterReload(activeId);
     }
 };
 


### PR DESCRIPTION
Active and checked items are now cleared upon, duplicate, move, delete and refresh. Replaced deprecated resetSelection() with clearSelection() and setActive().