### PR TITLE
Version History: adjustments (part 8) #10609

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/context/versionPublishState.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/context/versionPublishState.ts
@@ -181,13 +181,14 @@ export const $publishBadgeByVersionId = computed(
     [$allPublishBadges, $onlineVersionId],
     (badges, onlineVersionId): ReadonlyMap<string, ItemPublishBadge> => {
         const map = new Map<string, ItemPublishBadge>();
+        const onlineBadgeId = onlineVersionId != null ? badges[0]?.versionId : undefined;
         for (const badge of badges) {
             map.set(badge.versionId, {
                 status: badge.publishStatus,
                 publishedFrom: badge.publishedFrom,
                 publishedTo: badge.publishedTo,
                 unpublishedAt: badge.unpublishedAt,
-                isOnline: onlineVersionId != null && badge.versionId === onlineVersionId,
+                isOnline: onlineBadgeId != null && badge.versionId === onlineBadgeId,
             });
         }
         return map;

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/context/versionStore.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/context/versionStore.ts
@@ -3,6 +3,7 @@ import {type ContentVersion, ContentVersionBuilder} from '../../../../app/Conten
 import {
     getFormattedVersionDate,
     isStandardModeVersion,
+    isVersionComparable,
     isVersionToBeDisplayedInFullMode,
     resolveVersionOperationType,
     SYNTHETIC_VERSION_ID,
@@ -84,6 +85,13 @@ export const $versionsByDate = computed(
             return acc;
         }, {});
     },
+);
+
+export const $comparableVersionsCount = computed($versionsByDate, (versionsByDate) =>
+    Object.values(versionsByDate).reduce(
+        (count, versions) => count + versions.filter(isVersionComparable).length,
+        0,
+    ),
 );
 
 //

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionSelectionToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionSelectionToolbar.tsx
@@ -43,7 +43,7 @@ export const VersionSelectionToolbar = ({
 
     return (
         <div
-            className='flex justify-center items-center gap-2.5 sticky top-0 bg-surface-neutral min-h-16 z-1'
+            className='flex justify-center items-center gap-2.5 sticky -top-5 bg-surface-neutral min-h-16 z-1'
             data-component={COMPONENT_NAME}
         >
             <Button

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionsListItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/VersionsListItem.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../store/context/versionPublishState';
 import {
     $activeVersionId,
+    $comparableVersionsCount,
     $selectedVersions,
     toggleVersionSelection,
 } from '../../../../store/context/versionStore';
@@ -49,13 +50,14 @@ type VersionsListItemProps = {
 const useVersionItemState = (version: ContentVersion) => {
     const selectedVersions = useStore($selectedVersions);
     const currentVersionId = useStore($activeVersionId);
+    const comparableVersionsCount = useStore($comparableVersionsCount);
     const {active, setActive} = useListbox();
 
     const versionId = version.getId();
     const isActive = active === versionId;
     const isSelected = useMemo(() => selectedVersions.has(versionId), [versionId, selectedVersions]);
     const isRevertable = version.getId() !== currentVersionId && isVersionRevertable(version);
-    const isComparable = isVersionComparable(version);
+    const isComparable = isVersionComparable(version) && comparableVersionsCount > 1;
 
     return {
         versionId,

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/hooks/useVersionsKeyboard.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/versions/hooks/useVersionsKeyboard.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../../../store/context/versionOperations';
 import {
     $activeVersionId,
+    $comparableVersionsCount,
     $versions,
     toggleVersionSelection,
 } from '../../../../../store/context/versionStore';
@@ -38,6 +39,7 @@ export const useVersionsKeyboard = ({
 }: UseVersionsKeyboardOptions) => {
     const versions = useStore($versions);
     const latestContentVersionId = useStore($activeVersionId);
+    const comparableVersionsCount = useStore($comparableVersionsCount);
     const revertActions = useRevertActions();
 
     const hasRestoreButton = useCallback((): boolean => {
@@ -97,7 +99,7 @@ export const useVersionsKeyboard = ({
             e.preventDefault();
             e.stopPropagation();
             const version = versions.find((item) => item.getId() === activeListItemId);
-            if (version && isVersionComparable(version)) {
+            if (version && isVersionComparable(version) && comparableVersionsCount > 1) {
                 toggleVersionSelection(activeListItemId);
             }
             return;
@@ -122,6 +124,7 @@ export const useVersionsKeyboard = ({
         onSetRestoreFocus,
         revertActions,
         versions,
+        comparableVersionsCount,
     ]);
 
     return {handleKeyDown};


### PR DESCRIPTION
- Not showing selection checkbox when there are less than 2 comparable versions in the list
- Correctly marking Online/Scheduled/Expired version item
- Shifting VersionSelectionToolbar higher to compensate widget padding to avoid seeing versions between the toolbar and widget border