### PR TITLE
Stop persisting zoomPosition in v6 image uploader #10616

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/lib/propertySet.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/lib/propertySet.ts
@@ -84,11 +84,8 @@ export function setCropInPropertySet(value: Value, crop: Crop, dimensions: Dimen
         set.setDoubleByPath('cropPosition.top', crop.y1 / dimensions.h);
         set.setDoubleByPath('cropPosition.right', crop.x2 / dimensions.w);
         set.setDoubleByPath('cropPosition.bottom', crop.y2 / dimensions.h);
-        set.setDoubleByPath('cropPosition.zoom', 1);
-        set.setDoubleByPath('zoomPosition.left', 0);
-        set.setDoubleByPath('zoomPosition.top', 0);
-        set.setDoubleByPath('zoomPosition.right', 1);
-        set.setDoubleByPath('zoomPosition.bottom', 1);
+        // zoomPosition is never read by XP nor by this input type; don't persist it (drops stale values too).
+        set.removeProperty('zoomPosition', 0);
     } else {
         set.removeProperty('cropPosition', 0);
         set.removeProperty('zoomPosition', 0);


### PR DESCRIPTION
Fixes part of #10616.

`setCropInPropertySet` wrote `cropPosition.zoom = 1` and a constant `zoomPosition` (`0,0,1,1`) on every crop save. Neither is read by anything:

- **XP** consumes only `cropPosition.{top,left,bottom,right}` and `focalPoint` (no reference to `zoomPosition`/`cropPosition.zoom` anywhere in the XP source).
- **This input type's own read path** (`readNormalizedCropFromPropertySet`) reads only the four `cropPosition` edges.

So they were write-only dead data. This drops the writes and removes any stale `zoomPosition` on save. `cropPosition` itself is unchanged — still image-space `crop / dimensions`, always in `[0,1]`.

### Not covered here
The legacy `app/inputtype/upload/ImageUploader.ts` path is the actual source of the out-of-range `cropPosition` behind enonic/xp#12082 — it stores zoomed-space edges plus `cropPosition.zoom`, and reads `zoomPosition` back to restore the zoom view on re-edit. Fixing it means storing image-space edges and reworking the load path (dropping zoom-restore, as v6 already does). Tracked in #10616 as a separate, editor-tested change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)