### PR TITLE
Fix focal point in content icons #10618

### DIFF
--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentIconUrlResolver.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentIconUrlResolver.java
@@ -2,28 +2,39 @@ package com.enonic.app.contentstudio.rest.resource.content;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import com.enonic.xp.app.ApplicationNotFoundException;
 import com.enonic.app.contentstudio.rest.resource.ResourceConstants;
 import com.enonic.app.contentstudio.rest.resource.schema.content.ContentTypeIconResolver;
 import com.enonic.app.contentstudio.rest.resource.schema.content.ContentTypeIconUrlResolver;
+import com.enonic.xp.app.ApplicationNotFoundException;
 import com.enonic.xp.attachment.AttachmentNames;
+import com.enonic.xp.branch.Branch;
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.Media;
 import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.portal.url.ImageUrlGeneratorParams;
+import com.enonic.xp.portal.url.PortalUrlGeneratorService;
 import com.enonic.xp.project.ProjectConstants;
+import com.enonic.xp.project.ProjectName;
 import com.enonic.xp.schema.content.ContentTypeService;
 import com.enonic.xp.web.servlet.ServletRequestUrlHelper;
 
 public final class ContentIconUrlResolver
 {
+    private static final String ICON_SCALE = "square(128)";
+
     private final ContentTypeIconUrlResolver contentTypeIconUrlResolver;
+
+    private final PortalUrlGeneratorService portalUrlGeneratorService;
 
     private final HttpServletRequest servletRequest;
 
-    public ContentIconUrlResolver( final ContentTypeService contentTypeService, final HttpServletRequest servletRequest )
+    public ContentIconUrlResolver( final ContentTypeService contentTypeService,
+                                   final PortalUrlGeneratorService portalUrlGeneratorService,
+                                   final HttpServletRequest servletRequest )
     {
         final ContentTypeIconResolver contentTypeIconResolver = new ContentTypeIconResolver( contentTypeService );
         this.contentTypeIconUrlResolver = new ContentTypeIconUrlResolver( contentTypeIconResolver, servletRequest );
+        this.portalUrlGeneratorService = portalUrlGeneratorService;
         this.servletRequest = servletRequest;
     }
 
@@ -31,12 +42,12 @@ public final class ContentIconUrlResolver
     {
         if ( content.getAttachments().byName( AttachmentNames.THUMBNAIL ) != null )
         {
-            return makeIconPath( content );
+            return makeLegacyThumbnailUrl( content );
         }
 
         if ( isImageWithAttachment( content ) )
         {
-            return makeIconPath( content );
+            return makeImageApiUrl( (Media) content );
         }
 
         try
@@ -51,25 +62,30 @@ public final class ContentIconUrlResolver
 
     private boolean isImageWithAttachment( final Content content )
     {
-        if ( !isImage( content ) )
-        {
-            return false;
-        }
-
-        return ( (Media) content ).getMediaAttachment() != null;
+        return isImage( content ) && ( (Media) content ).getMediaAttachment() != null;
     }
 
     private boolean isImage( final Content content )
     {
-        if ( !( content instanceof Media ) )
-        {
-            return false;
-        }
-
-        return ( (Media) content ).isImage();
+        return content instanceof Media && ( (Media) content ).isImage();
     }
 
-    private String makeIconPath( final Content content )
+    private String makeImageApiUrl( final Media media )
+    {
+        final ProjectName projectName = ProjectName.from( getProjectName() );
+        final Branch branch = ContextAccessor.current().getBranch();
+
+        final ImageUrlGeneratorParams params = ImageUrlGeneratorParams.create()
+            .setMedia( () -> media )
+            .setProjectName( () -> projectName )
+            .setBranch( () -> branch )
+            .setScale( ICON_SCALE )
+            .build();
+
+        return ServletRequestUrlHelper.createUri( servletRequest, portalUrlGeneratorService.imageUrl( params ) );
+    }
+
+    private String makeLegacyThumbnailUrl( final Content content )
     {
         return ServletRequestUrlHelper.createUri( servletRequest,
                                                   ResourceConstants.REST_ROOT + "cms/" + getProjectName() + "/" + getLayer() +
@@ -79,9 +95,7 @@ public final class ContentIconUrlResolver
 
     private String getProjectName()
     {
-        final String project =
-            ContextAccessor.current().getRepositoryId().toString().replace( ProjectConstants.PROJECT_REPO_ID_PREFIX, "" );
-        return project;
+        return ContextAccessor.current().getRepositoryId().toString().replace( ProjectConstants.PROJECT_REPO_ID_PREFIX, "" );
     }
 
     private String getLayer()

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentIconUrlResolver.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentIconUrlResolver.java
@@ -95,7 +95,7 @@ public final class ContentIconUrlResolver
 
     private String getProjectName()
     {
-        return ContextAccessor.current().getRepositoryId().toString().replace( ProjectConstants.PROJECT_REPO_ID_PREFIX, "" );
+        return ProjectName.from( ContextAccessor.current().getRepositoryId() ).toString();
     }
 
     private String getLayer()

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/JsonObjectsFactory.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/JsonObjectsFactory.java
@@ -29,6 +29,7 @@ import com.enonic.xp.content.FindContentByParentParams;
 import com.enonic.xp.content.ValidationErrors;
 import com.enonic.xp.i18n.LocaleService;
 import com.enonic.xp.page.PageDescriptor;
+import com.enonic.xp.portal.url.PortalUrlGeneratorService;
 import com.enonic.xp.region.LayoutDescriptor;
 import com.enonic.xp.region.PartDescriptor;
 import com.enonic.xp.schema.content.CmsFormFragmentService;
@@ -50,6 +51,8 @@ public class JsonObjectsFactory
     private ContentPrincipalsResolver principalsResolver;
 
     private ComponentDisplayNameResolver componentDisplayNameResolver;
+
+    private PortalUrlGeneratorService portalUrlGeneratorService;
 
     public JsonObjectsFactory()
     {
@@ -95,14 +98,14 @@ public class JsonObjectsFactory
                                                                                 request.getLocales() ) ) )
             .collect( Collectors.toList() );
 
-        return new ContentJson( content, hasChildren( content ), new ContentIconUrlResolver( contentTypeService, request ), principalsResolver,
+        return new ContentJson( content, hasChildren( content ), new ContentIconUrlResolver( contentTypeService, portalUrlGeneratorService, request ), principalsResolver,
                                 componentDisplayNameResolver, new ContentListTitleResolver( contentTypeService ),
                                 localizedValidationErrors );
     }
 
     public ContentSummaryJson createContentSummaryJson( final Content content, final HttpServletRequest request )
     {
-        return new ContentSummaryJson( content, hasChildren( content ), new ContentIconUrlResolver( contentTypeService, request ),
+        return new ContentSummaryJson( content, hasChildren( content ), new ContentIconUrlResolver( contentTypeService, portalUrlGeneratorService, request ),
                                        new ContentListTitleResolver( contentTypeService ) );
     }
 
@@ -148,5 +151,11 @@ public class JsonObjectsFactory
     public void setContentService( final ContentService contentService )
     {
         this.contentService = contentService;
+    }
+
+    @Reference
+    public void setPortalUrlGeneratorService( final PortalUrlGeneratorService portalUrlGeneratorService )
+    {
+        this.portalUrlGeneratorService = portalUrlGeneratorService;
     }
 }

--- a/modules/app/src/main/resources/admin/tools/main/main.yaml
+++ b/modules/app/src/main/resources/admin/tools/main/main.yaml
@@ -14,6 +14,7 @@ apis:
   - "events"
   - "export"
   - "import-content"
+  - "media:image"
   - "styles"
   - "admin:extension"
   - "admin:status"

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentIconUrlResolverTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentIconUrlResolverTest.java
@@ -1,0 +1,186 @@
+package com.enonic.app.contentstudio.rest.resource.content;
+
+import java.time.Instant;
+import java.util.function.Supplier;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.HttpHeaders;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.enonic.xp.attachment.Attachment;
+import com.enonic.xp.attachment.AttachmentNames;
+import com.enonic.xp.attachment.Attachments;
+import com.enonic.xp.branch.Branch;
+import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentId;
+import com.enonic.xp.content.ContentPath;
+import com.enonic.xp.content.Media;
+import com.enonic.xp.context.Context;
+import com.enonic.xp.context.ContextAccessorSupport;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.data.PropertyTree;
+import com.enonic.xp.portal.url.ImageUrlGeneratorParams;
+import com.enonic.xp.portal.url.PortalUrlGeneratorService;
+import com.enonic.xp.project.ProjectName;
+import com.enonic.xp.repository.RepositoryId;
+import com.enonic.xp.schema.content.ContentTypeName;
+import com.enonic.xp.schema.content.ContentTypeService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContentIconUrlResolverTest
+{
+    private static final String PROJECT_NAME = "test-project";
+
+    private static final RepositoryId REPO_ID = RepositoryId.from( "com.enonic.cms." + PROJECT_NAME );
+
+    private static final Branch BRANCH = Branch.from( "draft" );
+
+    private static final String GENERATED_IMAGE_URL = "/api/media:image/test-project:draft/abc:hash/square-128/photo.jpg";
+
+    private ContentTypeService contentTypeService;
+
+    private PortalUrlGeneratorService portalUrlGeneratorService;
+
+    private HttpServletRequest request;
+
+    private ContentIconUrlResolver resolver;
+
+    @BeforeEach
+    void setUp()
+    {
+        contentTypeService = mock( ContentTypeService.class );
+        portalUrlGeneratorService = mock( PortalUrlGeneratorService.class );
+        request = mock( HttpServletRequest.class );
+        when( request.getHeader( HttpHeaders.HOST ) ).thenReturn( "localhost" );
+        when( request.getRequestURL() ).thenReturn( new StringBuffer( "http://localhost/api/admin/contentstudio" ) );
+        when( request.getServerName() ).thenReturn( "localhost" );
+
+        when( portalUrlGeneratorService.imageUrl( any( ImageUrlGeneratorParams.class ) ) ).thenReturn( GENERATED_IMAGE_URL );
+
+        resolver = new ContentIconUrlResolver( contentTypeService, portalUrlGeneratorService, request );
+    }
+
+    @Test
+    void image_media_uses_media_image_api()
+    {
+        runInContext( () -> {
+            final Media image = newImageMedia( true );
+
+            final String url = resolver.resolve( image );
+
+            assertThat( url ).contains( GENERATED_IMAGE_URL );
+
+            final ArgumentCaptor<ImageUrlGeneratorParams> captor = ArgumentCaptor.forClass( ImageUrlGeneratorParams.class );
+            verify( portalUrlGeneratorService ).imageUrl( captor.capture() );
+
+            final ImageUrlGeneratorParams params = captor.getValue();
+            assertThat( params.getMedia().get() ).isSameAs( image );
+            assertThat( params.getProjectName().get() ).isEqualTo( ProjectName.from( PROJECT_NAME ) );
+            assertThat( params.getBranch().get() ).isEqualTo( BRANCH );
+            assertThat( params.getScale() ).isEqualTo( "square(128)" );
+            // No cache-buster query param: the media:image URL is content-hashed already.
+            assertThat( params.getQueryParams() ).isEmpty();
+        } );
+    }
+
+    @Test
+    void content_with_thumbnail_attachment_uses_legacy_icon_endpoint()
+    {
+        runInContext( () -> {
+            final Content content = newContentWithThumbnail();
+
+            final String url = resolver.resolve( content );
+
+            assertThat( url ).contains( "/content/icon/" + content.getId().toString() );
+            verify( portalUrlGeneratorService, never() ).imageUrl( any() );
+        } );
+    }
+
+    @Test
+    void image_media_without_attachment_falls_back_to_content_type_icon()
+    {
+        runInContext( () -> {
+            final Media image = newImageMedia( false );
+
+            resolver.resolve( image );
+
+            // No media:image URL generated because there is no media attachment.
+            verify( portalUrlGeneratorService, never() ).imageUrl( any() );
+        } );
+    }
+
+    private static <T> T runInContext( final Supplier<T> action )
+    {
+        final Context ctx = ContextBuilder.create().repositoryId( REPO_ID ).branch( BRANCH ).build();
+        return ctx.callWith( action::get );
+    }
+
+    private static void runInContext( final Runnable action )
+    {
+        runInContext( () -> {
+            action.run();
+            return null;
+        } );
+    }
+
+    private static PropertyTree buildImageData( final boolean withAttachment )
+    {
+        final PropertyTree data = new PropertyTree();
+        if ( withAttachment )
+        {
+            data.addSet( "media" ).setString( "attachment", "photo.jpg" );
+        }
+        return data;
+    }
+
+    private static Media newImageMedia( final boolean withAttachment )
+    {
+        final Attachments attachments = withAttachment
+            ? Attachments.from( Attachment.create()
+                                    .name( "photo.jpg" )
+                                    .mimeType( "image/jpeg" )
+                                    .label( "source" )
+                                    .build() )
+            : Attachments.empty();
+
+        return Media.create()
+            .id( ContentId.from( "abc" ) )
+            .path( ContentPath.from( "/photo.jpg" ) )
+            .name( "photo.jpg" )
+            .displayName( "photo" )
+            .type( ContentTypeName.imageMedia() )
+            .data( buildImageData( withAttachment ) )
+            .attachments( attachments )
+            .modifiedTime( Instant.parse( "2024-01-01T00:00:00Z" ) )
+            .build();
+    }
+
+    private static Content newContentWithThumbnail()
+    {
+        final Attachment thumbnail = Attachment.create()
+            .name( AttachmentNames.THUMBNAIL )
+            .mimeType( "image/png" )
+            .label( "thumbnail" )
+            .build();
+
+        return Content.create()
+            .id( ContentId.from( "xyz" ) )
+            .path( ContentPath.from( "/doc" ) )
+            .name( "doc" )
+            .displayName( "doc" )
+            .type( ContentTypeName.from( "myapp:doc" ) )
+            .data( new PropertyTree() )
+            .attachments( Attachments.from( thumbnail ) )
+            .modifiedTime( Instant.parse( "2024-01-01T00:00:00Z" ) )
+            .build();
+    }
+}

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentResourceTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentResourceTest.java
@@ -150,6 +150,7 @@ import com.enonic.xp.index.ChildOrder;
 import com.enonic.xp.jaxrs.impl.MockRestResponse;
 import com.enonic.xp.page.Page;
 import com.enonic.xp.page.PageTemplateKey;
+import com.enonic.xp.portal.url.PortalUrlGeneratorService;
 import com.enonic.xp.project.ProjectName;
 import com.enonic.xp.project.ProjectService;
 import com.enonic.xp.region.LayoutDescriptorService;
@@ -252,6 +253,8 @@ public class ContentResourceTest
 
     private ProjectService projectService;
 
+    private PortalUrlGeneratorService portalUrlGeneratorService;
+
     private HttpServletRequest request;
 
     @Override
@@ -297,11 +300,14 @@ public class ContentResourceTest
         componentNameResolver.setLayoutDescriptorService( layoutDescriptorService );
         componentNameResolver.setPartDescriptorService( partDescriptorService );
 
+        portalUrlGeneratorService = mock( PortalUrlGeneratorService.class );
+
         final JsonObjectsFactory jsonObjectsFactory = new JsonObjectsFactory();
         jsonObjectsFactory.setComponentNameResolver( componentNameResolver );
         jsonObjectsFactory.setSecurityService( securityService );
         jsonObjectsFactory.setContentTypeService( contentTypeService );
         jsonObjectsFactory.setContentService( contentService );
+        jsonObjectsFactory.setPortalUrlGeneratorService( portalUrlGeneratorService );
         resource.setJsonObjectsFactory( jsonObjectsFactory );
 
         config = mock( AdminRestConfig.class, invocation -> invocation.getMethod().getDefaultValue() );
@@ -1664,9 +1670,9 @@ public class ContentResourceTest
         assertEquals( 2L, result.getMetadata().getTotalHits() );
 
         assertEquals( 2, result.getContents().size() );
-        assertEquals( new ContentSummaryJson( content1, null, new ContentIconUrlResolver( contentTypeService, request ),
+        assertEquals( new ContentSummaryJson( content1, null, new ContentIconUrlResolver( contentTypeService, portalUrlGeneratorService, request ),
                                               new ContentListTitleResolver( contentTypeService ) ), result.getContents().get( 0 ) );
-        assertEquals( new ContentSummaryJson( content2, null, new ContentIconUrlResolver( contentTypeService, request ),
+        assertEquals( new ContentSummaryJson( content2, null, new ContentIconUrlResolver( contentTypeService, portalUrlGeneratorService, request ),
                                               new ContentListTitleResolver( contentTypeService ) ), result.getContents().get( 1 ) );
     }
 
@@ -1757,7 +1763,7 @@ public class ContentResourceTest
         componentNameResolver.setLayoutDescriptorService( layoutDescriptorService );
         componentNameResolver.setPartDescriptorService( partDescriptorService );
 
-        assertEquals( new ContentJson( site, false, new ContentIconUrlResolver( contentTypeService, request ),
+        assertEquals( new ContentJson( site, false, new ContentIconUrlResolver( contentTypeService, portalUrlGeneratorService, request ),
                                        new ContentPrincipalsResolver( securityService ), componentNameResolver,
                                        new ContentListTitleResolver( contentTypeService ), Collections.emptyList() ), result );
     }


### PR DESCRIPTION
## Summary

Icons for image media in Content Studio were served by the legacy
`/rest-v2/cs/<project>/<layer>/content/icon/<id>?size=128` endpoint,
which does not honor the Media's focal point — so an image with an
off-center focal point was cropped from the geometric center.

- `ContentIconUrlResolver` now builds icon URLs for image content via
  `PortalUrlGeneratorService.imageUrl(...)` using the universal
  `media:image` API at scale `block(128,128)` with a `ts` cache buster.
- `media:image` is added to the admin tool's `apis:` allowlist in
  `modules/app/src/main/resources/admin/tools/main/main.yaml`.
- `JsonObjectsFactory` injects `PortalUrlGeneratorService` and forwards
  it to the resolver; `ContentResourceTest` is updated for the new
  constructor signature.
- Custom thumbnail attachments still resolve via the legacy
  `ContentIconResource`, since `media:image` rejects non-image content
  types.

Closes #10618

## Test plan

- [ ] Build the app and deploy on a fresh XP install with Content Studio.
- [ ] Create or use a Media:image content and set a focal point off-center.
- [ ] Open the content browser and verify the icon thumbnail is cropped
      around the focal point (not the geometric center).
- [ ] In DevTools Network, confirm the icon URL is a `media:image` API
      URL (e.g. `/api/media:image/<project>:<branch>/<id>:<hash>/block-128-128/<name>?ts=...`)
      and returns 200 with the expected scaled image.

<sub>*Drafted with AI assistance*</sub>