### PR TITLE
Fix icon cropping in v6 (flags, application, content) #10621

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/locale/Flag.ts
+++ b/modules/lib/src/main/resources/assets/js/app/locale/Flag.ts
@@ -8,14 +8,13 @@ export interface FlagData {
     classCode: string;
 }
 
-export class Flag
-    extends DivEl {
-
+export class Flag extends DivEl {
     private static CODE_NONE: string = 'none';
 
     private static CODE_UNKNOWN: string = 'unknown';
 
     private static NONSTANDARD_CODES: NonstandardCodes = Object.freeze({
+        'ar-SA': 'sa',
         'ast-es': 'es',
         'af-na': 'na',
         'af-za': 'za',
@@ -110,7 +109,7 @@ export class Flag
         sr: 'rs',
         sv: 'se',
         uk: 'ua',
-        zh: 'cn'
+        zh: 'cn',
     });
 
     private countryCode: string;
@@ -125,7 +124,7 @@ export class Flag
 
     updateCountryCode(countryCode: string) {
         const oldCountryCode = this.countryCode || '';
-        const codeData = this.mapCode((countryCode || ''));
+        const codeData = this.mapCode(countryCode || '');
         const oldCodeData = this.mapCode(oldCountryCode);
         const countryClass = Flag.createCountryClass(codeData.classCode);
         const oldCountryClass = Flag.createCountryClass(oldCodeData.classCode);
@@ -136,7 +135,7 @@ export class Flag
     }
 
     getCountryClass(): string {
-        const codeData = this.mapCode((this.countryCode || ''));
+        const codeData = this.mapCode(this.countryCode || '');
         return Flag.createCountryClass(codeData.classCode);
     }
 
@@ -154,13 +153,13 @@ export class Flag
     }
 
     protected mapCode(countryCode: string): FlagData {
-        const codeMap = this.getCodeMap();
+        const codeMap = Flag.NONSTANDARD_CODES;
         const fullCode = countryCode.toLowerCase();
         const longCode = fullCode.slice(0, 3);
         const shortCode = fullCode.slice(0, 2);
 
         const classCode = codeMap[fullCode] || codeMap[longCode] || codeMap[shortCode] || shortCode;
-        const code = (this.hasNoFlag(classCode) || !this.isShortCode(classCode)) ? shortCode : classCode;
+        const code = this.hasNoFlag(classCode) || !this.isShortCode(classCode) ? shortCode : classCode;
 
         return {code, classCode};
     }
@@ -171,9 +170,5 @@ export class Flag
 
     protected isShortCode(classCode: string): boolean {
         return classCode.length === 2 || classCode.length === 1;
-    }
-
-    protected getCodeMap(): NonstandardCodes {
-        return Flag.NONSTANDARD_CODES;
     }
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/PreviewContextMenu.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/PreviewContextMenu.tsx
@@ -27,14 +27,16 @@ export const PreviewContextMenu = ({pageName, pageType, messages, showIcon}: Pre
     const handleClick = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
         if (event.button !== 0) return;
         event.preventDefault();
-        event.currentTarget.dispatchEvent(new MouseEvent('contextmenu', {
-            bubbles: true,
-            cancelable: true,
-            clientX: event.clientX,
-            clientY: event.clientY,
-            button: 2,
-            view: window,
-        }));
+        event.currentTarget.dispatchEvent(
+            new MouseEvent('contextmenu', {
+                bubbles: true,
+                cancelable: true,
+                clientX: event.clientX,
+                clientY: event.clientY,
+                button: 2,
+                view: window,
+            }),
+        );
     }, []);
 
     const handleInspect = useCallback(() => {
@@ -45,10 +47,7 @@ export const PreviewContextMenu = ({pageName, pageType, messages, showIcon}: Pre
 
     return (
         <ContextMenu data-component={PREVIEW_CONTEXT_MENU_NAME}>
-            <ContextMenu.Trigger
-                className="flex h-full w-full items-center justify-center"
-                onClick={handleClick}
-            >
+            <ContextMenu.Trigger className="flex h-full w-full items-center justify-center" onClick={handleClick}>
                 <PreviewLabel messages={messages} showIcon={showIcon} className="text-xl" />
             </ContextMenu.Trigger>
             <ContextMenu.Portal>
@@ -57,9 +56,7 @@ export const PreviewContextMenu = ({pageName, pageType, messages, showIcon}: Pre
                         <Globe className="size-4 shrink-0" aria-hidden />
                         <span className="truncate">{pageName || pageType}</span>
                     </div>
-                    <ContextMenu.Item onSelect={handleInspect}>
-                        {inspectLabel}
-                    </ContextMenu.Item>
+                    <ContextMenu.Item onSelect={handleInspect}>{inspectLabel}</ContextMenu.Item>
                 </ContextMenu.Content>
             </ContextMenu.Portal>
         </ContextMenu>
@@ -73,9 +70,7 @@ PreviewContextMenu.displayName = PREVIEW_CONTEXT_MENU_NAME;
 //
 
 export class PreviewContextMenuElement extends LegacyElement<typeof PreviewContextMenu> {
-
     constructor(props: PreviewContextMenuProps) {
         super(props, PreviewContextMenu);
-        this.addClass('size-full');
     }
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/ApplicationIcon.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/ApplicationIcon.tsx
@@ -13,10 +13,12 @@ export const ApplicationIcon = ({application, className}: ApplicationIconProps):
     const url = application.getIconUrl();
 
     if (url) {
-        return <img src={url} alt={name} draggable={false} className={cn('size-6 bg-center object-cover', className)} />;
+        return (
+            <img src={url} alt={name} draggable={false} className={cn('size-6 bg-center object-contain', className)} />
+        );
     }
 
-    return <Box className={cn('rounded-full bg-center object-cover', className)} />;
+    return <Box className={cn('rounded-full bg-center object-contain', className)} />;
 };
 
 ApplicationIcon.displayName = 'ApplicationIcon';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/ContentIcon.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/ContentIcon.tsx
@@ -77,7 +77,7 @@ const BuiltInIcon = ({contentType, ...props}: BuiltInIconProps): React.ReactElem
     return <Icon {...props} />;
 };
 
-export const ContentIcon = ({className, contentType, url, imageSize = 64, crop}: Props): React.ReactElement => {
+export const ContentIcon = ({className, contentType, url, imageSize = 64, crop = false}: Props): React.ReactElement => {
     const src = url ? createImageUrl(url, {size: imageSize * 2, crop}) : undefined;
 
     const [isImageBroken, setImageBroken] = useState(false);
@@ -96,10 +96,8 @@ export const ContentIcon = ({className, contentType, url, imageSize = 64, crop}:
         return (
             <Image
                 className={cn(
-                    'w-6 h-6 p-px',
-                    isImageType
-                        ? 'object-cover'
-                        : 'object-contain dark:invert-100 dark:brightness-75 dark:contrast-125',
+                    'size-6 p-px object-contain',
+                    isImageType && 'object-contain dark:invert-100 dark:brightness-75 dark:contrast-125',
                     className,
                 )}
                 alt={contentType}
@@ -109,7 +107,7 @@ export const ContentIcon = ({className, contentType, url, imageSize = 64, crop}:
         );
     }
 
-    return <BuiltInIcon className={cn('w-6 h-6', className)} contentType={contentType} strokeWidth={1.75} />;
+    return <BuiltInIcon className={cn('size-6', className)} contentType={contentType} strokeWidth={1.75} />;
 };
 
 ContentIcon.displayName = 'ContentIcon';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/FlagIcon.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/FlagIcon.tsx
@@ -11,11 +11,14 @@ export const FlagIcon = ({language, className}: {language: string; className?: s
     const initials = lang.slice(0, 2);
 
     return (
-        <div className={cn('relative size-6', className)} aria-hidden="true">
-            <div className="absolute inset-0 flex items-center justify-center rounded-full border-1 border-bdr-subtle text-xs font-semibold lowercase text-subtle">
+        <div className={cn('relative size-6', className)} aria-hidden='true'>
+            <div className='absolute inset-0 flex items-center justify-center rounded-full border border-bdr-subtle text-xs font-semibold lowercase text-subtle'>
                 {initials}
             </div>
-            <div className={cn('absolute inset-0 rounded-full flag bg-center', countryClass)} data-code={dataCode} />
+            <div
+                className={cn('absolute inset-0 rounded-full flag bg-center bg-no-repeat bg-cover', countryClass)}
+                data-code={dataCode}
+            />
         </div>
     );
 };


### PR DESCRIPTION
Fix icon rendering so flags fully cover their circle and content/application icons stop being cropped.

- Flag icon: added `bg-cover bg-no-repeat` so the flag fills the circle without tiling
- Application icon: switched to `object-contain` to stop cropping uploaded icons
- Content icon: unified to `object-contain` with default `crop=false` so images render without cropping or distortion
- `Flag.ts`: added `ar-SA` mapping and inlined `getCodeMap()` reference to `NONSTANDARD_CODES`
- `PreviewContextMenuElement`: dropped redundant `size-full` class

Closes #10621

<sub>*Drafted with AI assistance*</sub>
