### PR TITLE
Duplicate @enonic/ui in main.js bundle causes Toolbar context errors on app start #10623

### DIFF
--- a/modules/app/rspack.config.js
+++ b/modules/app/rspack.config.js
@@ -42,7 +42,12 @@ module.exports = {
             'react': path.resolve(__dirname, 'node_modules/preact/compat'),
             'react-dom': path.resolve(__dirname, 'node_modules/preact/compat'),
             'react/jsx-runtime': path.resolve(__dirname, 'node_modules/preact/jsx-runtime'),
-            'react/jsx-dev-runtime': path.resolve(__dirname, 'node_modules/preact/jsx-dev-runtime')
+            'react/jsx-dev-runtime': path.resolve(__dirname, 'node_modules/preact/jsx-dev-runtime'),
+            // ! Force a single @enonic/ui instance. lib-admin-ui's compiled JS imports
+            // ! @enonic/ui without a local copy and resolves to app's hoisted version,
+            // ! which is often a different beta than lib-contentstudio's. Two copies in
+            // ! the bundle means two ToolbarContext instances and a context lookup miss.
+            '@enonic/ui': path.resolve(__dirname, 'node_modules/@enonic/lib-contentstudio/node_modules/@enonic/ui')
         }
     },
     module: {

--- a/modules/lib/rspack.config.js
+++ b/modules/lib/rspack.config.js
@@ -41,7 +41,11 @@ module.exports = {
             'react': path.resolve(__dirname, 'node_modules/preact/compat'),
             'react-dom': path.resolve(__dirname, 'node_modules/preact/compat'),
             'react/jsx-runtime': path.resolve(__dirname, 'node_modules/preact/jsx-runtime'),
-            'react/jsx-dev-runtime': path.resolve(__dirname, 'node_modules/preact/jsx-dev-runtime')
+            'react/jsx-dev-runtime': path.resolve(__dirname, 'node_modules/preact/jsx-dev-runtime'),
+            // ? Defensive: matches the singleton pattern above. lib's entries do not
+            // ? import @enonic/ui in JS today (only CSS via tailwind), so this is a no-op,
+            // ? but keeps parity with modules/app and guards against future drift.
+            '@enonic/ui': path.resolve(__dirname, 'node_modules/@enonic/ui')
         }
     },
     module: {


### PR DESCRIPTION
Forced a single `@enonic/ui` instance via `resolve.alias` in `modules/app/rspack.config.js`, pointing at `lib-contentstudio`'s nested copy. Mirrored the alias in `modules/lib/rspack.config.js` for parity with the existing `preact`/`react` singletons (no-op today but guards against future drift).

Closes #10623

<sub>*Drafted with AI assistance*</sub>
