### PR TITLE
Restore lang, dir, and spellcheck on v6 form text inputs #10625

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormRenderer.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/FormRenderer.tsx
@@ -1,6 +1,7 @@
 import type {ApplicationKey} from '@enonic/lib-admin-ui/application/ApplicationKey';
 import type {Form} from '@enonic/lib-admin-ui/form/Form';
 import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
+import {LocaleProvider} from '@enonic/lib-admin-ui/form2';
 import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
 import {useStore} from '@nanostores/preact';
 import {type ReactElement, type ReactNode, useMemo} from 'react';
@@ -65,14 +66,16 @@ const HtmlAreaShell = ({children}: {children: ReactNode}): ReactElement => {
     const applicationKeys = useApplicationKeys();
 
     return (
-        <HtmlAreaProvider
-            contentSummary={contextContent ?? undefined}
-            project={activeProject}
-            applicationKeys={applicationKeys}
-            assetsUri={CONFIG.getString('assetsUri')}
-        >
-            {children}
-        </HtmlAreaProvider>
+        <LocaleProvider locale={contextContent?.getLanguage()}>
+            <HtmlAreaProvider
+                contentSummary={contextContent ?? undefined}
+                project={activeProject}
+                applicationKeys={applicationKeys}
+                assetsUri={CONFIG.getString('assetsUri')}
+            >
+                {children}
+            </HtmlAreaProvider>
+        </LocaleProvider>
     );
 };
 


### PR DESCRIPTION
Wrapped `HtmlAreaShell` in `FormRenderer.tsx` with `LocaleProvider` from `@enonic/lib-admin-ui/form2`, sourcing the locale from `$contextContent?.getLanguage()`. Mirrors the existing `HtmlAreaProvider` wiring, so every `FormRenderer` subtree — top-level and nested — inherits the active content's language via React context. Restores `lang`, `dir`, and `spellCheck` attributes on `TextLine`/`TextArea` inputs that were lost in the v6 form migration. Depends on enonic/lib-admin-ui#4506.

Closes #10625

<sub>*Drafted with AI assistance*</sub>
