### PR TITLE
Duplicate @enonic/ui in main.js bundle causes Toolbar context errors on app start #10623

### DIFF
--- a/modules/app/rspack.config.js
+++ b/modules/app/rspack.config.js
@@ -43,11 +43,11 @@ module.exports = {
             'react-dom': path.resolve(__dirname, 'node_modules/preact/compat'),
             'react/jsx-runtime': path.resolve(__dirname, 'node_modules/preact/jsx-runtime'),
             'react/jsx-dev-runtime': path.resolve(__dirname, 'node_modules/preact/jsx-dev-runtime'),
-            // ! Force a single @enonic/ui instance. lib-admin-ui's compiled JS imports
-            // ! @enonic/ui without a local copy and resolves to app's hoisted version,
-            // ! which is often a different beta than lib-contentstudio's. Two copies in
-            // ! the bundle means two ToolbarContext instances and a context lookup miss.
-            '@enonic/ui': path.resolve(__dirname, 'node_modules/@enonic/lib-contentstudio/node_modules/@enonic/ui')
+            // Force a single @enonic/ui instance. Both lib-admin-ui and lib-contentstudio
+            // currently resolve to the same hoisted copy, but pin the alias here so any
+            // future hoist/dedupe drift can't reintroduce two ToolbarContext instances
+            // in the bundle.
+            '@enonic/ui': path.resolve(__dirname, 'node_modules/@enonic/ui')
         }
     },
     module: {

--- a/modules/lib/rspack.config.js
+++ b/modules/lib/rspack.config.js
@@ -42,9 +42,8 @@ module.exports = {
             'react-dom': path.resolve(__dirname, 'node_modules/preact/compat'),
             'react/jsx-runtime': path.resolve(__dirname, 'node_modules/preact/jsx-runtime'),
             'react/jsx-dev-runtime': path.resolve(__dirname, 'node_modules/preact/jsx-dev-runtime'),
-            // ? Defensive: matches the singleton pattern above. lib's entries do not
-            // ? import @enonic/ui in JS today (only CSS via tailwind), so this is a no-op,
-            // ? but keeps parity with modules/app and guards against future drift.
+            // Parity with modules/app — lib's entries don't import @enonic/ui in JS today
+            // (only CSS via Tailwind), so this is a no-op now but guards against drift.
             '@enonic/ui': path.resolve(__dirname, 'node_modules/@enonic/ui')
         }
     },


### PR DESCRIPTION
Reverted `modules/app` alias to hoisted `node_modules/@enonic/ui` and updated comments in both `modules/app` and `modules/lib` rspack configs.