### PR TITLE
Lazy chunks fail with undefined module ID on app open #10632

### DIFF
--- a/modules/app/rspack.config.js
+++ b/modules/app/rspack.config.js
@@ -9,9 +9,9 @@ const {module: _module, exclude: _exclude, ...swcOptions} = swcConfig;
 const isProd = process.env.NODE_ENV === 'production';
 
 module.exports = {
-    cache: true,
+    cache: !isProd,
     experiments: {
-        cache: {
+        cache: isProd ? false : {
             type: 'persistent',
             buildDependencies: [__filename],
             storage: {
@@ -31,6 +31,7 @@ module.exports = {
     output: {
         path: path.join(__dirname, '/build/resources/main/assets'),
         filename: './[name].js',
+        chunkFilename: './[id].[contenthash:8].js',
         assetModuleFilename: './[file]'
     },
     resolve: {
@@ -86,6 +87,7 @@ module.exports = {
         ]
     },
     optimization: {
+        chunkIds: 'named',
         minimizer: [
             new rspack.SwcJsMinimizerRspackPlugin({
                 minimizerOptions: {

--- a/modules/lib/rspack.config.js
+++ b/modules/lib/rspack.config.js
@@ -9,9 +9,9 @@ const {module: _module, exclude: _exclude, ...swcOptions} = swcConfig;
 const isProd = process.env.NODE_ENV === 'production';
 
 module.exports = {
-    cache: true,
+    cache: !isProd,
     experiments: {
-        cache: {
+        cache: isProd ? false : {
             type: 'persistent',
             buildDependencies: [__filename],
             storage: {
@@ -30,7 +30,8 @@ module.exports = {
     },
     output: {
         path: path.join(__dirname, '/build/resources/main/assets'),
-        filename: './[name].js'
+        filename: './[name].js',
+        chunkFilename: './[id].[contenthash:8].js'
     },
     resolve: {
         extensions: ['.tsx', '.ts', '.jsx', '.js', '.less', '.css'],
@@ -103,6 +104,7 @@ module.exports = {
         ]
     },
     optimization: {
+        chunkIds: 'named',
         minimizer: [
             new rspack.SwcJsMinimizerRspackPlugin({
                 // Exclude pre-built CKEditor — already minified, re-minimizing


### PR DESCRIPTION
Disabled rspack's persistent filesystem cache in production builds and added content-hashed filenames to lazy chunks so the browser can't pair a stale chunk against a fresh `main.js` runtime. Set `optimization.chunkIds: 'named'` to keep readable chunk IDs in dev URLs.

Closes #10632

<sub>*Drafted with AI assistance*</sub>
