### PR TITLE
Enonic UI: Issue List modal dialog - Incorrect option selected in Assignee filter dropdown #9758

### DIFF
--- a/modules/app/src/main/resources/assets/js/main.ts
+++ b/modules/app/src/main/resources/assets/js/main.ts
@@ -377,8 +377,8 @@ async function startApplication() {
 
     CreateIssuePromptEvent.on((event) => IssueDialogsManager.get().openCreateDialog(event.getModels()));
 
-    ShowIssuesDialogEvent.on((event: ShowIssuesDialogEvent) =>
-        IssueDialogsManager.get().openListDialog(event.getAssignedToMe()));
+    ShowIssuesDialogEvent.on(() =>
+        IssueDialogsManager.get().openListDialog());
 
     ShowDependenciesEvent.on(ContentEventsProcessor.handleShowDependencies);
 

--- a/modules/lib/src/main/resources/assets/js/app/issue/IssueDialogsManager.ts
+++ b/modules/lib/src/main/resources/assets/js/app/issue/IssueDialogsManager.ts
@@ -169,9 +169,9 @@ export class IssueDialogsManager {
         openIssueDialogDetails(issue.getId());
     }
 
-    openListDialog(assignedToMe: boolean = false) {
+    openListDialog() {
         openIssueDialog();
-        setIssueDialogListFilter(assignedToMe ? 'assignedToMe' : 'all');
+        setIssueDialogListFilter('assignedToMe');
     }
 
     openCreateDialog(summaries?: ContentSummaryAndCompareStatus[]) {

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueDialogListContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueDialogListContent.tsx
@@ -8,6 +8,7 @@ import {
     $issueDialog,
     $issueDialogListFilteredIssues,
     $issueDialogListTabCounts,
+    ISSUE_DIALOG_FILTER_ORDER,
     openIssueDialogDetails,
     setIssueDialogListFilter,
     setIssueDialogListTab,
@@ -21,14 +22,7 @@ import type {IssueDialogFilter, IssueDialogTab} from './issueDialog.types';
 
 const ISSUE_DIALOG_LIST_CONTENT_NAME = 'IssueDialogListContent';
 
-const FILTER_ORDER: IssueDialogFilter[] = [
-    'all',
-    'assignedToMe',
-    'createdByMe',
-    'publishRequests',
-    'issues',
-];
-const FILTER_VALUES = new Set<string>(FILTER_ORDER);
+const FILTER_VALUES = new Set<string>(ISSUE_DIALOG_FILTER_ORDER);
 
 const isIssueDialogFilter = (value: string): value is IssueDialogFilter => {
     return FILTER_VALUES.has(value);
@@ -77,7 +71,7 @@ export const IssueDialogListContent = (): ReactElement => {
             return tab === 'open' ? counts.open ?? 0 : counts.closed ?? 0;
         };
 
-        const filterOptions = FILTER_ORDER.map(option => {
+        const filterOptions = ISSUE_DIALOG_FILTER_ORDER.map(option => {
             const count = getFilterCount(option);
             const baseLabel = filterLabels[option];
             return {

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueList.tsx
@@ -13,34 +13,21 @@ export type IssueListProps = {
 
 const ISSUE_LIST_NAME = 'IssueList';
 
-export const IssueList = ({
-    issues,
-    emptyLabel,
-    loading = false,
-    onSelect,
-}: IssueListProps): ReactElement => {
+export const IssueList = ({issues, emptyLabel, loading = false, onSelect}: IssueListProps): ReactElement => {
     const showLoading = loading && issues.length === 0;
     const showEmpty = issues.length === 0 && !loading && emptyLabel;
 
     return (
         <>
             {showLoading && (
-                <div className='flex items-center justify-center py-10'>
-                    <LoaderCircle className='size-7 animate-spin text-subtle' />
+                <div className="flex items-center justify-center py-10">
+                    <LoaderCircle className="size-7 animate-spin text-subtle" />
                 </div>
             )}
-            {showEmpty && (
-                <div className='text-sm text-subtle'>{emptyLabel}</div>
-            )}
-            <div
-                data-component={ISSUE_LIST_NAME}
-                className='flex flex-col gap-1.25 min-h-0 max-h-100 overflow-y-auto'>
+            {showEmpty && <div className="text-subtle italic px-2.5">{emptyLabel}</div>}
+            <div data-component={ISSUE_LIST_NAME} className="flex flex-col gap-1.25 min-h-0 max-h-100 overflow-y-auto">
                 {issues.map(issue => (
-                    <IssueListItem
-                        key={issue.getIssue().getId()}
-                        issue={issue}
-                        onSelect={onSelect}
-                    />
+                    <IssueListItem key={issue.getIssue().getId()} issue={issue} onSelect={onSelect} />
                 ))}
             </div>
         </>

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialog.store.ts
@@ -11,6 +11,7 @@ import {$activeProject} from '../activeProject.store';
 
 import type {
     IssueDialogFilter,
+    IssueDialogListCounts,
     IssueDialogListTotals,
     IssueDialogTab,
     IssueDialogView,
@@ -36,6 +37,14 @@ type IssueDialogStore = {
 
 const EMPTY_COUNTS = {open: 0, closed: 0};
 
+export const ISSUE_DIALOG_FILTER_ORDER: IssueDialogFilter[] = [
+    'all',
+    'assignedToMe',
+    'createdByMe',
+    'publishRequests',
+    'issues',
+];
+
 const createEmptyTotals = (): IssueDialogListTotals => ({
     all: {...EMPTY_COUNTS},
     assignedToMe: {...EMPTY_COUNTS},
@@ -48,7 +57,7 @@ const initialListState: Pick<IssueDialogStore, 'loading' | 'error' | 'issues' | 
     loading: false,
     error: false,
     issues: [],
-    filter: 'all',
+    filter: 'assignedToMe',
     tab: 'open',
     totals: createEmptyTotals(),
 };
@@ -173,7 +182,7 @@ export const loadIssueDialogList = async (): Promise<void> => {
             loading: false,
             error: false,
         });
-        syncTabWithTotals();
+        syncViewWithTotals();
     } catch (error) {
         console.error(error);
         $issueDialog.set({
@@ -236,18 +245,27 @@ const matchesFilter = (
     return false;
 };
 
-const syncTabWithTotals = (): void => {
-    const {filter, tab, totals} = $issueDialog.get();
-    const counts = totals[filter] ?? EMPTY_COUNTS;
-    const openCount = counts.open ?? 0;
-    const closedCount = counts.closed ?? 0;
+const getTabCount = (counts: IssueDialogListCounts | undefined, tab: IssueDialogTab): number => {
+    return (tab === 'open' ? counts?.open : counts?.closed) ?? 0;
+};
 
-    if (tab === 'open' && openCount === 0 && closedCount > 0) {
-        $issueDialog.setKey('tab', 'closed');
+// Keep the current view when it has issues; otherwise prefer the first filter with open
+// issues, and only fall back to closed issues when no filter has anything open.
+const syncViewWithTotals = (): void => {
+    const {filter, tab, totals} = $issueDialog.get();
+    if (getTabCount(totals[filter], tab) > 0) {
+        return;
     }
 
-    if (tab === 'closed' && closedCount === 0 && openCount > 0) {
-        $issueDialog.setKey('tab', 'open');
+    const openFilter = ISSUE_DIALOG_FILTER_ORDER.find(option => getTabCount(totals[option], 'open') > 0);
+    if (openFilter) {
+        $issueDialog.set({...$issueDialog.get(), filter: openFilter, tab: 'open'});
+        return;
+    }
+
+    const closedFilter = ISSUE_DIALOG_FILTER_ORDER.find(option => getTabCount(totals[option], 'closed') > 0);
+    if (closedFilter) {
+        $issueDialog.set({...$issueDialog.get(), filter: closedFilter, tab: 'closed'});
     }
 };
 


### PR DESCRIPTION
Defaulted the Issue List dialog filter to `assignedToMe` so the dropdown lands on a meaningful slice of data instead of the disabled `All` option when the user has limited visibility.

Simplified `IssueDialogsManager.openListDialog` and its `main.ts` caller — dropped the unused `assignedToMe` flag from `ShowIssuesDialogEvent`. Also tightened `IssueList` empty-state styling.

Closes #9758

<sub>*Drafted with AI assistance*</sub>
