### PR TITLE
Selected Issue status is not readable #10636

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/status/IssueStatusBadge.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/status/IssueStatusBadge.tsx
@@ -17,9 +17,12 @@ export function IssueStatusBadge({status, className}: IssueStatusBadgeProps): Re
 
     // TODO: Enonic UI - Replace bg-bdr-subtle once the closed status color is defined.
     return (
-        <span data-component={ISSUE_STATUS_BADGE_NAME} className={cn('inline-flex items-center gap-3', className)}>
+        <span
+            data-component={ISSUE_STATUS_BADGE_NAME}
+            className={cn(ISSUE_STATUS_BADGE_NAME, 'inline-flex items-center gap-3', className)}
+        >
             <span className={cn('size-4 rounded-full bg-success', isClosed && 'bg-surface-muted')} />
-            <span className={cn('text-lg font-semibold capitalize', isClosed && 'text-subtle')}>
+            <span className={cn('text-lg font-semibold capitalize', isClosed && 'group-data-[tone=inverse]:text-alt')}>
                 {label}
             </span>
         </span>


### PR DESCRIPTION
Used `group-data-[tone=inverse]:text-alt` for the closed status label so the text color follows the parent's `data-tone`, fixing readability when the row is selected (especially in light theme). Added `ISSUE_STATUS_BADGE_NAME` as a class on the outer span so the badge can be targeted by parent styling hooks.

Closes #10636

<sub>*Drafted with AI assistance*</sub>
