### PR TITLE
Browser freezes in ContentSelector #10214

### DIFF
--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentResource.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentResource.java
@@ -1384,15 +1384,22 @@ public final class ContentResource
             .filter( content -> layerPaths.contains( content.getPath() ) )
             .collect( Collectors.toList() );
 
-        final List<ContentTreeSelectorJson> resultItems = layersContents.stream()
+        final int totalLayerHits = layersContents.size();
+        final int fromIndex = from != null ? Math.min( Math.max( from, 0 ), totalLayerHits ) : 0;
+        final int toIndex = size == null || size < 0
+            ? totalLayerHits
+            : Math.min( fromIndex + size, totalLayerHits );
+        final List<Content> pagedContents = layersContents.subList( fromIndex, toIndex );
+
+        final List<ContentTreeSelectorJson> resultItems = pagedContents.stream()
             .map( content -> new ContentTreeSelectorJson( jsonObjectsFactory.createContentJson( content, request ),
                                                           targetContentPaths.contains( content.getPath() ), targetContentPaths.stream()
                                                               .anyMatch( path -> path.isChildOf( content.getPath() ) ) ) )
             .collect( Collectors.toList() );
 
         final ContentListMetaData metaData = ContentListMetaData.create()
-            .hits( findLayerContentsResult.getContents().getSize() )
-            .totalHits( findLayerContentsResult.getTotalHits() )
+            .hits( resultItems.size() )
+            .totalHits( totalLayerHits )
             .build();
 
         return new ContentTreeSelectorListJson( resultItems, metaData );

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentResourceTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentResourceTest.java
@@ -1459,6 +1459,63 @@ public class ContentResourceTest
     }
 
     @Test
+    public void treeSelectorQuery_paginated()
+    {
+        ContentResource contentResource = getResourceInstance();
+
+        Content child1 = createContent( "child-id1", "child-name1", "myapplication:content-type" );
+        Content child2 = createContent( "child-id2", "child-name2", "myapplication:content-type" );
+        Content child3 = createContent( "child-id3", "child-name3", "myapplication:content-type" );
+
+        when( this.contentService.findPaths( isA( ContentQuery.class ) ) ).thenReturn( FindContentPathsByQueryResult.create()
+                                                                                           .contentPaths( ContentPaths.from(
+                                                                                               child1.getPath(), child2.getPath(),
+                                                                                               child3.getPath() ) )
+                                                                                           .totalHits( 3 )
+                                                                                           .build() );
+
+        doReturn( FindContentByParentResult.create()
+                      .totalHits( 3L )
+                      .contents( Contents.from( child1, child2, child3 ) )
+                      .build() ).when( this.contentService ).findByParent( isA( FindContentByParentParams.class ) );
+        when( contentService.findIdsByParent( any() ) ).thenReturn( FindContentIdsByParentResult.create().build() );
+
+        ContentTreeSelectorQueryJson json = mock( ContentTreeSelectorQueryJson.class );
+        when( json.getQueryExprString() ).thenReturn( "" );
+        when( json.getContentTypeNames() ).thenReturn( Collections.emptyList() );
+        when( json.getParentPath() ).thenReturn( null );
+
+        when( json.getFrom() ).thenReturn( 0 );
+        when( json.getSize() ).thenReturn( 2 );
+        ContentTreeSelectorListJson firstPage = contentResource.treeSelectorQuery( json, request );
+        assertEquals( 2, firstPage.getItems().size() );
+        assertEquals( child1.getId().toString(), firstPage.getItems().get( 0 ).getContent().getId() );
+        assertEquals( child2.getId().toString(), firstPage.getItems().get( 1 ).getContent().getId() );
+        assertEquals( 3, firstPage.getMetadata().getTotalHits() );
+        assertEquals( 2, firstPage.getMetadata().getHits() );
+
+        when( json.getFrom() ).thenReturn( 2 );
+        when( json.getSize() ).thenReturn( 2 );
+        ContentTreeSelectorListJson secondPage = contentResource.treeSelectorQuery( json, request );
+        assertEquals( 1, secondPage.getItems().size() );
+        assertEquals( child3.getId().toString(), secondPage.getItems().get( 0 ).getContent().getId() );
+        assertEquals( 3, secondPage.getMetadata().getTotalHits() );
+        assertEquals( 1, secondPage.getMetadata().getHits() );
+
+        when( json.getFrom() ).thenReturn( 10 );
+        when( json.getSize() ).thenReturn( 2 );
+        ContentTreeSelectorListJson outOfRange = contentResource.treeSelectorQuery( json, request );
+        assertEquals( 0, outOfRange.getItems().size() );
+        assertEquals( 3, outOfRange.getMetadata().getTotalHits() );
+
+        when( json.getFrom() ).thenReturn( 0 );
+        when( json.getSize() ).thenReturn( -1 );
+        ContentTreeSelectorListJson unlimited = contentResource.treeSelectorQuery( json, request );
+        assertEquals( 3, unlimited.getItems().size() );
+        assertEquals( 3, unlimited.getMetadata().getTotalHits() );
+    }
+
+    @Test
     public void createMedia()
         throws Exception
     {

--- a/modules/lib/src/main/resources/assets/js/v6/features/hooks/useContentComboboxData.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/hooks/useContentComboboxData.ts
@@ -340,9 +340,9 @@ export function useContentComboboxData(options: UseContentComboboxDataOptions): 
             request.setFrom(0);
             request.setSize(BATCH_SIZE);
             request.setExpand(Expand.SUMMARY);
+            applyContentFilters(request, filtersRef.current);
             request.setParentPath(null);
             request.setChildOrder(createDefaultChildOrder());
-            applyContentFilters(request, filtersRef.current);
 
             const rawItems = await request.sendAndParse();
             const metadata = request.getMetadata();
@@ -389,9 +389,9 @@ export function useContentComboboxData(options: UseContentComboboxDataOptions): 
             request.setFrom(offset);
             request.setSize(BATCH_SIZE);
             request.setExpand(Expand.SUMMARY);
+            applyContentFilters(request, filtersRef.current);
             request.setParentPath(null);
             request.setChildOrder(createDefaultChildOrder());
-            applyContentFilters(request, filtersRef.current);
 
             const rawItems = await request.sendAndParse();
             const items = deduplicateById(rawItems);
@@ -441,12 +441,12 @@ export function useContentComboboxData(options: UseContentComboboxDataOptions): 
                 request.setSize(BATCH_SIZE);
                 request.setExpand(Expand.SUMMARY);
 
+                applyContentFilters(request, filtersRef.current);
+
                 if (parentContent) {
                     request.setParentPath(parentContent.getPath());
                     request.setChildOrder(parentContent.getChildOrder());
                 }
-
-                applyContentFilters(request, filtersRef.current);
 
                 const rawItems = await request.sendAndParse();
                 const metadata = request.getMetadata();
@@ -502,12 +502,12 @@ export function useContentComboboxData(options: UseContentComboboxDataOptions): 
                 request.setSize(BATCH_SIZE);
                 request.setExpand(Expand.SUMMARY);
 
+                applyContentFilters(request, filtersRef.current);
+
                 if (parentContent) {
                     request.setParentPath(parentContent.getPath());
                     request.setChildOrder(parentContent.getChildOrder());
                 }
-
-                applyContentFilters(request, filtersRef.current);
 
                 const rawItems = await request.sendAndParse();
                 const items = deduplicateById(rawItems);


### PR DESCRIPTION
- Fix: setting correct 'parentPath' in 'treeSelectorQuery' request (parent path was overridden by setContent call)
- Fixed pagination for tree requests