### PR TITLE
Error when inserting a layout #10657

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/page/region/DescriptorBasedComponent.ts
+++ b/modules/lib/src/main/resources/assets/js/app/page/region/DescriptorBasedComponent.ts
@@ -1,11 +1,9 @@
-import {FormState} from '@enonic/lib-admin-ui/app/wizard/WizardPanel';
 import {PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
 import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
 import {type Equitable} from '@enonic/lib-admin-ui/Equitable';
-import {FormContext} from '@enonic/lib-admin-ui/form/FormContext';
-import {FormView} from '@enonic/lib-admin-ui/form/FormView';
 import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
 import Q from 'q';
+import {seedFormDefaults} from '../../../v6/features/shared/form/seedFormDefaults';
 import {type Descriptor} from '../Descriptor';
 import {DescriptorKey} from '../DescriptorKey';
 import {ComponentDescriptorUpdatedEvent} from './ComponentDescriptorUpdatedEvent';
@@ -43,18 +41,24 @@ export abstract class DescriptorBasedComponent
 
         this.descriptorKey = descriptor?.getKey();
 
-        // populating config before saving with values from form view after layout
+        // Pre-seed config with the descriptor's defaults so it matches what the
+        // form2 FormRenderer produces on mount, avoiding a reload loop (#9085).
         const propertyTree = new PropertyTree();
-        const layoutPromise = descriptor ? new FormView(FormContext.create().setFormState(new FormState(true)).build(),
-            descriptor.getConfig(), propertyTree.getRoot()).layout(false) : Q.resolve(null);
+        const configForm = descriptor?.getConfig();
+        if (configForm) {
+            try {
+                seedFormDefaults(configForm, propertyTree.getRoot());
+            } catch (e) {
+                DefaultErrorHandler.handle(e);
+            }
+        }
 
-        return layoutPromise.catch(DefaultErrorHandler.handle).finally(() => {
-            this.config?.unChanged(this.configChangedHandler);
-            this.config = propertyTree;
-            this.config.onChanged(this.configChangedHandler);
-            this.notifyComponentUpdated(new ComponentDescriptorUpdatedEvent(this.getPath(), this.descriptorKey));
-            return Q.resolve();
-        });
+        this.config?.unChanged(this.configChangedHandler);
+        this.config = propertyTree;
+        this.config.onChanged(this.configChangedHandler);
+        this.notifyComponentUpdated(new ComponentDescriptorUpdatedEvent(this.getPath(), this.descriptorKey));
+
+        return Q.resolve();
     }
 
     doReset() {

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/seedFormDefaults.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/seedFormDefaults.test.ts
@@ -1,0 +1,175 @@
+import {PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
+import {FormBuilder} from '@enonic/lib-admin-ui/form/Form';
+import type {FormItem} from '@enonic/lib-admin-ui/form/FormItem';
+import {Input} from '@enonic/lib-admin-ui/form/Input';
+import {FieldSet} from '@enonic/lib-admin-ui/form/set/fieldset/FieldSet';
+import {FormItemSet} from '@enonic/lib-admin-ui/form/set/itemset/FormItemSet';
+import {FormOptionSet} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSet';
+import {FormOptionSetOption} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSetOption';
+import {initBuiltInTypes} from '@enonic/lib-admin-ui/form2';
+import {beforeAll, describe, expect, it} from 'vitest';
+import {seedFormDefaults} from './seedFormDefaults';
+
+type Json = Record<string, unknown>;
+
+// Recursive factory mirroring how the server JSON is materialized into a Form.
+const factory = {
+    createFormItem: (json: Json): FormItem => {
+        if (json.Input) return Input.fromJson(json.Input as Parameters<typeof Input.fromJson>[0]);
+        if (json.FieldSet) return new FieldSet(json.FieldSet as ConstructorParameters<typeof FieldSet>[0], factory);
+        if (json.FormItemSet) return new FormItemSet(json.FormItemSet as ConstructorParameters<typeof FormItemSet>[0], factory);
+        if (json.FormOptionSet) return new FormOptionSet(json.FormOptionSet as ConstructorParameters<typeof FormOptionSet>[0], factory);
+        if (json.FormOptionSetOption) {
+            return new FormOptionSetOption(json.FormOptionSetOption as ConstructorParameters<typeof FormOptionSetOption>[0], factory);
+        }
+        return null as never;
+    },
+};
+
+function inputJson(name: string, inputType: string, min: number, max: number, config: Json = {}): Json {
+    return {Input: {name, inputType, label: name, occurrences: {minimum: min, maximum: max}, config, helpText: ''}};
+}
+
+function formOf(...items: Json[]): ReturnType<FormBuilder['build']> {
+    const builder = new FormBuilder();
+    for (const item of items) {
+        builder.addFormItem(factory.createFormItem(item));
+    }
+    return builder.build();
+}
+
+function seed(...items: Json[]): PropertyTree {
+    const tree = new PropertyTree();
+    seedFormDefaults(formOf(...items), tree.getRoot());
+    return tree;
+}
+
+describe('seedFormDefaults', () => {
+    beforeAll(() => {
+        initBuiltInTypes();
+    });
+
+    it('does nothing for an empty form', () => {
+        const tree = new PropertyTree();
+        expect(() => seedFormDefaults(new FormBuilder().build(), tree.getRoot())).not.toThrow();
+    });
+
+    it('seeds a single Checkbox with its configured default', () => {
+        const tree = seed(inputJson('agree', 'Checkbox', 0, 1, {default: [{value: 'checked'}]}));
+
+        const arr = tree.getRoot().getPropertyArray('agree');
+        expect(arr?.getSize()).toBe(1);
+        expect(arr?.get(0)?.getValue().getBoolean()).toBe(true);
+    });
+
+    it('seeds a single input occurrence even without a default value', () => {
+        const tree = seed(inputJson('title', 'TextLine', 0, 1));
+
+        const arr = tree.getRoot().getPropertyArray('title');
+        // Single-occurrence input still materializes one (null) value.
+        expect(arr?.getSize()).toBe(1);
+        expect(arr?.get(0)?.getValue().isNull()).toBe(true);
+    });
+
+    it('seeds minimum occurrences for a list input', () => {
+        const tree = seed(inputJson('tags', 'TextLine', 3, 5));
+        expect(tree.getRoot().getPropertyArray('tags')?.getSize()).toBe(3);
+    });
+
+    it('does not add values for internal-mode inputs (selectors)', () => {
+        const tree = seed(inputJson('ref', 'ComboBox', 1, 1));
+        // Array is materialized but left empty — selectors aren't auto-seeded.
+        expect(tree.getRoot().getPropertyArray('ref')?.getSize()).toBe(0);
+    });
+
+    it('does not seed or crash on unregistered input types', () => {
+        const tree = new PropertyTree();
+        const form = formOf(inputJson('weird', 'NoSuchType', 1, 1));
+
+        expect(() => seedFormDefaults(form, tree.getRoot())).not.toThrow();
+        expect(tree.getRoot().getPropertyArray('weird') == null).toBe(true);
+    });
+
+    it('recurses into FieldSet children on the same property set', () => {
+        const tree = seed({
+            FieldSet: {name: 'fs', label: 'FS', items: [inputJson('agree', 'Checkbox', 0, 1, {default: [{value: 'checked'}]})]},
+        });
+
+        // FieldSet is a layout grouping — child lands on the root, not nested.
+        expect(tree.getRoot().getPropertyArray('agree')?.get(0)?.getValue().getBoolean()).toBe(true);
+    });
+
+    it('seeds minimum item-set occurrences and their child defaults', () => {
+        const tree = seed({
+            FormItemSet: {
+                name: 'items',
+                label: 'Items',
+                occurrences: {minimum: 2, maximum: 0},
+                helpText: '',
+                items: [inputJson('flag', 'Checkbox', 0, 1, {default: [{value: 'checked'}]})],
+            },
+        });
+
+        const arr = tree.getRoot().getPropertyArray('items');
+        expect(arr?.getSize()).toBe(2);
+        expect(arr?.getSet(0)?.getPropertyArray('flag')?.get(0)?.getValue().getBoolean()).toBe(true);
+        expect(arr?.getSet(1)?.getPropertyArray('flag')?.get(0)?.getValue().getBoolean()).toBe(true);
+    });
+
+    it('does not seed an optional item set (min 0)', () => {
+        const tree = seed({
+            FormItemSet: {name: 'items', label: 'Items', occurrences: {minimum: 0, maximum: 0}, helpText: '', items: []},
+        });
+
+        const arr = tree.getRoot().getPropertyArray('items');
+        expect(arr == null || arr.getSize() === 0).toBe(true);
+    });
+
+    it('seeds a locked-single radio option set: selects the default option and seeds its children', () => {
+        const tree = seed({
+            FormOptionSet: {
+                name: 'opts',
+                label: 'Options',
+                expanded: false,
+                occurrences: {minimum: 1, maximum: 1},
+                multiselection: {minimum: 1, maximum: 1},
+                helpText: '',
+                options: [
+                    {
+                        name: 'optA',
+                        label: 'Option A',
+                        defaultOption: true,
+                        items: [inputJson('flag', 'Checkbox', 0, 1, {default: [{value: 'checked'}]})],
+                    },
+                    {name: 'optB', label: 'Option B', defaultOption: false, items: []},
+                ],
+            },
+        });
+
+        const arr = tree.getRoot().getPropertyArray('opts');
+        expect(arr?.getSize()).toBe(1);
+
+        const occurrence = arr?.getSet(0);
+        expect(occurrence?.getPropertyArray('_selected')?.get(0)?.getValue().getString()).toBe('optA');
+        expect(occurrence?.getPropertyArray('optA')?.getSet(0)?.getPropertyArray('flag')?.get(0)?.getValue().getBoolean()).toBe(true);
+        // Non-selected option is not materialized.
+        expect(occurrence?.getPropertyArray('optB') == null).toBe(true);
+    });
+
+    it('does not seed occurrences for a non-locked radio option set', () => {
+        const tree = seed({
+            FormOptionSet: {
+                name: 'opts',
+                label: 'Options',
+                expanded: false,
+                occurrences: {minimum: 0, maximum: 0},
+                multiselection: {minimum: 1, maximum: 1},
+                helpText: '',
+                options: [{name: 'optA', label: 'A', defaultOption: true, items: []}],
+            },
+        });
+
+        const arr = tree.getRoot().getPropertyArray('opts');
+        expect(arr == null || arr.getSize() === 0).toBe(true);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/seedFormDefaults.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/seedFormDefaults.ts
@@ -1,0 +1,160 @@
+import {PropertyArray} from '@enonic/lib-admin-ui/data/PropertyArray';
+import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
+import type {Value} from '@enonic/lib-admin-ui/data/Value';
+import type {ValueType} from '@enonic/lib-admin-ui/data/ValueType';
+import {ValueTypes} from '@enonic/lib-admin-ui/data/ValueTypes';
+import type {Form} from '@enonic/lib-admin-ui/form/Form';
+import type {FormItem} from '@enonic/lib-admin-ui/form/FormItem';
+import {Input} from '@enonic/lib-admin-ui/form/Input';
+import {FieldSet} from '@enonic/lib-admin-ui/form/set/fieldset/FieldSet';
+import {FormItemSet} from '@enonic/lib-admin-ui/form/set/itemset/FormItemSet';
+import {FormOptionSet} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSet';
+import {getEffectiveOccurrences, InputTypeRegistry} from '@enonic/lib-admin-ui/form2';
+import type {InputTypeConfig} from '@enonic/lib-admin-ui/form2/descriptor/InputTypeConfig';
+import type {InputTypeDescriptor} from '@enonic/lib-admin-ui/form2/descriptor/InputTypeDescriptor';
+import {instanceOf} from '../../utils/object/instanceOf';
+import {seedOptionSetDefaults} from './sets/option-set/seedOptionSetDefaults';
+
+const SELECTED_NAME = '_selected';
+
+/**
+ * Populates `root` with a config form's default values, matching what the form2
+ * FormRenderer writes on mount (FormItemRenderer / InputField / ItemSetView /
+ * OptionSetView). Pre-seeding keeps the stored config in sync with the rendered
+ * form, avoiding a reload loop (#9085).
+ *
+ * Expects a fresh `root`; existing arrays are left as-is.
+ */
+export function seedFormDefaults(form: Form, root: PropertySet): void {
+    seedFormItems(form.getFormItems(), root);
+}
+
+function seedFormItems(items: FormItem[], propertySet: PropertySet): void {
+    for (const item of items) {
+        seedFormItem(item, propertySet);
+    }
+}
+
+// Dispatch order mirrors FormItemRenderer / validateForm.
+function seedFormItem(item: FormItem, propertySet: PropertySet): void {
+    if (instanceOf(item, Input)) {
+        seedInput(item, propertySet);
+        return;
+    }
+    if (instanceOf(item, FieldSet)) {
+        // Layout-only: children share the parent set.
+        seedFormItems(item.getFormItems(), propertySet);
+        return;
+    }
+    if (instanceOf(item, FormItemSet)) {
+        seedItemSet(item, propertySet);
+        return;
+    }
+    if (instanceOf(item, FormOptionSet)) {
+        seedOptionSet(item, propertySet);
+    }
+    // Unknown types hold no data.
+}
+
+function seedInput(input: Input, propertySet: PropertySet): void {
+    const definition = InputTypeRegistry.getDefinition(input.getInputType().getName());
+
+    // No component → rendered as UnsupportedInput, seeds nothing.
+    if (definition?.component == null) return;
+
+    const {descriptor, mode} = definition;
+    const config = descriptor.readConfig(input.getInputTypeConfig() ?? {});
+    const occurrences = getEffectiveOccurrences(mode, input.getOccurrences());
+    const propertyArray = getOrCreatePropertyArray(propertySet, input.getName(), descriptor.getValueType());
+
+    // internal-mode (selectors) aren't auto-seeded; cf. useOccurrenceManager minFill.
+    const minFill = mode === 'internal' ? 0 : Math.max(occurrences.getMinimum(), 1);
+    if (minFill === 0) return;
+
+    const defaultValue = computeDefaultValue(input, descriptor, config);
+
+    while (propertyArray.getSize() < minFill && !occurrences.maximumReached(propertyArray.getSize())) {
+        propertyArray.add(defaultValue);
+    }
+}
+
+function seedItemSet(itemSet: FormItemSet, propertySet: PropertySet): void {
+    const occurrences = itemSet.getOccurrences();
+    const propertyArray = getOrCreatePropertyArray(propertySet, itemSet.getName(), ValueTypes.DATA);
+    const items = itemSet.getFormItems();
+
+    // cf. useSetPropertyArray: fill to the minimum, then recurse into each occurrence.
+    while (propertyArray.getSize() < occurrences.getMinimum()) {
+        const occurrence = propertyArray.addSet();
+        seedFormItems(items, occurrence);
+    }
+}
+
+function seedOptionSet(optionSet: FormOptionSet, propertySet: PropertySet): void {
+    const occurrences = optionSet.getOccurrences();
+    const propertyArray = getOrCreatePropertyArray(propertySet, optionSet.getName(), ValueTypes.DATA);
+
+    const isRadio = optionSet.isRadioSelection();
+    const isLockedSingle = occurrences.getMinimum() === 1 && occurrences.getMaximum() === 1;
+
+    // cf. OptionSetView: radio seeds occurrences only when locked single (min=max=1).
+    if (isRadio && !isLockedSingle) return;
+
+    while (propertyArray.getSize() < occurrences.getMinimum()) {
+        const occurrence = propertyArray.addSet();
+        seedOptionSetDefaults(optionSet, occurrence);
+        seedSelectedOptionItems(optionSet, occurrence);
+    }
+}
+
+function seedSelectedOptionItems(optionSet: FormOptionSet, occurrence: PropertySet): void {
+    const selectedNames = readSelectedOptionNames(occurrence);
+    if (selectedNames.length === 0) return;
+
+    for (const option of optionSet.getOptions()) {
+        if (!selectedNames.includes(option.getName())) continue;
+
+        const items = option.getFormItems();
+        if (items.length === 0) continue;
+
+        // seedOptionSetDefaults created the selected option's set at index 0.
+        const optionDataSet = occurrence.getPropertyArray(option.getName())?.getSet(0);
+        if (optionDataSet == null) continue;
+
+        seedFormItems(items, optionDataSet);
+    }
+}
+
+function readSelectedOptionNames(occurrence: PropertySet): string[] {
+    const selectedArray = occurrence.getPropertyArray(SELECTED_NAME);
+    if (selectedArray == null) return [];
+
+    const names: string[] = [];
+    const size = selectedArray.getSize();
+    for (let i = 0; i < size; i++) {
+        const name = selectedArray.get(i)?.getValue().getString();
+        if (name != null) names.push(name);
+    }
+    return names;
+}
+
+// Mirrors the defaultValue memo in form2 InputField.tsx — keep in sync.
+function computeDefaultValue(input: Input, descriptor: InputTypeDescriptor, config: InputTypeConfig): Value {
+    const raw = input.getInputTypeConfig()?.['default']?.[0]?.value;
+    if (raw == null) return descriptor.getValueType().newNullValue();
+
+    const value = descriptor.createDefaultValue(raw);
+    if (value.isNull()) return descriptor.getValueType().newNullValue();
+    if (descriptor.validate(value, config).length > 0) return descriptor.getValueType().newNullValue();
+
+    return value;
+}
+
+function getOrCreatePropertyArray(propertySet: PropertySet, name: string, type: ValueType): PropertyArray {
+    const existing = propertySet.getPropertyArray(name);
+    if (existing != null) return existing;
+
+    const created = PropertyArray.create().setName(name).setType(type).setParent(propertySet).build();
+    propertySet.addPropertyArray(created);
+    return created;
+}


### PR DESCRIPTION
## Changes

- Replaced the legacy `FormView`/`InputTypeManager` config seeding in `DescriptorBasedComponent.setDescriptor` with a headless form2 seeder. Selecting a layout/part variant no longer hits the empty legacy `InputTypeManager` and throws `Input type [...] need to be registered first`.
- Added `seedFormDefaults`, which walks a descriptor's config form and populates the config `PropertyTree` with the same default values the form2 `FormRenderer` writes on mount (inputs, item sets, option sets, field sets), so the stored config already matches the rendered form and the inspect panel does not reload in a loop (#9085).
- Added unit tests for `seedFormDefaults` covering input defaults, list/min occurrences, internal selectors, unregistered types, field-set recursion, item sets, and option sets.

Closes #10657

<sub>*Drafted with AI assistance*</sub>
