### PR TITLE
Update @enonic/page-editor to 1.0.0-beta.6

### DIFF
--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@enonic/lib-admin-ui": "workspace:*",
     "@enonic/lib-contentstudio": "workspace:*",
-    "@enonic/page-editor": "1.0.0-beta.5",
+    "@enonic/page-editor": "1.0.0-beta.6",
     "@radix-ui/react-slot": "^1.2.3",
     "chart.js": "^4.5.1",
     "dompurify": "^3.3.1",

--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: workspace:*
         version: link:.xp/dev/lib-contentstudio
       '@enonic/page-editor':
-        specifier: 1.0.0-beta.5
-        version: 1.0.0-beta.5
+        specifier: 1.0.0-beta.6
+        version: 1.0.0-beta.6
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
@@ -221,7 +221,7 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@enonic/ui':
-        specifier: ~1.0.0-beta.7
+        specifier: ~1.0.0-beta.9
         version: 1.0.0-beta.9(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.16.0(react@19.2.4))(preact@10.29.2)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
@@ -644,8 +644,8 @@ packages:
       typescript: ^5.8.3
       typescript-eslint: ^8.39.0
 
-  '@enonic/page-editor@1.0.0-beta.5':
-    resolution: {integrity: sha512-c7rZbw1EtpUNmTHTcymEu8lYJjwww58YgNZkrlQ7ydvoKRdFtsgJAPrV+CM65BIforGwVtkEoQzqL91ptenrrw==}
+  '@enonic/page-editor@1.0.0-beta.6':
+    resolution: {integrity: sha512-01B1nN04pzcRaLv3/LS0AF40eCL1I/+QlNhsb++NfaplQCmM+uvZ0DD8YHDWPjhj0W2iL/ZkDk8nTnmBnPdEiw==}
     engines: {node: '>= 24.16.0', pnpm: '>= 10.33.4'}
 
   '@enonic/ui@1.0.0-beta.9':
@@ -5903,7 +5903,7 @@ snapshots:
       typescript: 5.9.3
       typescript-eslint: 8.57.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
 
-  '@enonic/page-editor@1.0.0-beta.5':
+  '@enonic/page-editor@1.0.0-beta.6':
     dependencies:
       jquery: 3.7.1
       jquery-simulate: 1.0.2

--- a/modules/lib/pnpm-lock.yaml
+++ b/modules/lib/pnpm-lock.yaml
@@ -230,7 +230,7 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@enonic/ui':
-        specifier: ~1.0.0-beta.7
+        specifier: ~1.0.0-beta.9
         version: 1.0.0-beta.9(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@1.16.0(react@19.2.4))(preact@10.29.2)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5


### PR DESCRIPTION
## Changes

- Updated `@enonic/page-editor` from `1.0.0-beta.5` to `1.0.0-beta.6`.
- Synced `pnpm-lock.yaml` files, aligning the `@enonic/ui` specifier to `~1.0.0-beta.9`.

<sub>*Drafted with AI assistance*</sub>
