### PR TITLE
Update @enonic/page-editor to 1.0.0-beta.7

### DIFF
--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@enonic/lib-admin-ui": "workspace:*",
     "@enonic/lib-contentstudio": "workspace:*",
-    "@enonic/page-editor": "1.0.0-beta.6",
+    "@enonic/page-editor": "1.0.0-beta.7",
     "@radix-ui/react-slot": "^1.2.3",
     "chart.js": "^4.5.1",
     "dompurify": "^3.3.1",

--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: workspace:*
         version: link:.xp/dev/lib-contentstudio
       '@enonic/page-editor':
-        specifier: 1.0.0-beta.6
-        version: 1.0.0-beta.6
+        specifier: 1.0.0-beta.7
+        version: 1.0.0-beta.7
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
@@ -644,8 +644,8 @@ packages:
       typescript: ^5.8.3
       typescript-eslint: ^8.39.0
 
-  '@enonic/page-editor@1.0.0-beta.6':
-    resolution: {integrity: sha512-01B1nN04pzcRaLv3/LS0AF40eCL1I/+QlNhsb++NfaplQCmM+uvZ0DD8YHDWPjhj0W2iL/ZkDk8nTnmBnPdEiw==}
+  '@enonic/page-editor@1.0.0-beta.7':
+    resolution: {integrity: sha512-GMhEbNgXBYrDIlv+iwlBzZX5hrnSa98oDnv0024LLROsNI8kXRzledQ2DuBhgBNbH4m7FI9TYPHwgV4zAH1NsQ==}
     engines: {node: '>= 24.16.0', pnpm: '>= 10.33.4'}
 
   '@enonic/ui@1.0.0-beta.9':
@@ -5903,7 +5903,7 @@ snapshots:
       typescript: 5.9.3
       typescript-eslint: 8.57.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
 
-  '@enonic/page-editor@1.0.0-beta.6':
+  '@enonic/page-editor@1.0.0-beta.7':
     dependencies:
       jquery: 3.7.1
       jquery-simulate: 1.0.2


### PR DESCRIPTION
Bumps `@enonic/page-editor` from `1.0.0-beta.6` to `1.0.0-beta.7`.

<sub>*Drafted with AI assistance*</sub>