### PR TITLE
Enonic UI: Delete Content dialog does not update after references are deleted #9756

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/deleteDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/deleteDialog.store.test.ts
@@ -1,0 +1,145 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {ContentId} from '../../../../app/content/ContentId';
+import {
+    emitContentArchived,
+    emitContentDeleted,
+    emitContentUpdated,
+} from '../socket.store';
+import {
+    $deleteInboundIds,
+    openDeleteDialog,
+    resetDeleteDialogContext,
+} from './deleteDialog.store';
+import {
+    createMockChangeItem,
+    createMockContent,
+    flushDebouncedReload as flushDelayedReload,
+    flushPromises,
+} from './dialog.store.test.utils';
+
+const {
+    mockFetchContentSummaries,
+    mockResolveForDelete,
+    mockArchiveContent,
+    mockCleanupTask,
+    mockTrackTask,
+} = vi.hoisted(() => ({
+    mockFetchContentSummaries: vi.fn(),
+    mockResolveForDelete: vi.fn(),
+    mockArchiveContent: vi.fn(),
+    mockCleanupTask: vi.fn(),
+    mockTrackTask: vi.fn(),
+}));
+
+vi.mock('../../api/content', () => ({
+    fetchContentSummaries: mockFetchContentSummaries,
+}));
+
+vi.mock('../../api/delete', () => ({
+    resolveForDelete: mockResolveForDelete,
+    archiveContent: mockArchiveContent,
+}));
+
+vi.mock('../../services/task.service', () => ({
+    cleanupTask: mockCleanupTask,
+    trackTask: mockTrackTask,
+}));
+
+type InboundSpec = {target: string; sources: string[]};
+
+// Mimics ContentWithRefsResult: getContentIds() + getInboundDependencies(),
+// where each inbound dependency carries the target id and its referencing source ids.
+function createDeleteResolveResult(contentIds: string[], inbound: InboundSpec[] = []) {
+    return {
+        getContentIds: () => contentIds.map(id => new ContentId(id)),
+        getInboundDependencies: () => inbound.map(({target, sources}) => ({
+            getId: () => new ContentId(target),
+            getInboundDependencies: () => sources.map(id => new ContentId(id)),
+        })),
+        hasInboundDependencies: () => inbound.length > 0,
+        hasInboundDependency: (id: string) => inbound.some(dep => dep.target === id),
+    };
+}
+
+async function flushInitialReload(): Promise<void> {
+    await flushPromises(10);
+}
+
+async function flushDebouncedReload(): Promise<void> {
+    await flushDelayedReload(100);
+}
+
+const referenceRemovalEventCases = [
+    {
+        name: 'updated',
+        emit: (ids: string[]) => emitContentUpdated(ids.map(id => createMockContent(id))),
+    },
+    {
+        name: 'deleted',
+        emit: (ids: string[]) => emitContentDeleted(ids.map(createMockChangeItem)),
+    },
+    {
+        name: 'archived',
+        emit: (ids: string[]) => emitContentArchived(ids.map(createMockChangeItem)),
+    },
+] as const;
+
+describe('deleteDialog.store', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        resetDeleteDialogContext();
+        mockFetchContentSummaries.mockReset().mockResolvedValue([]);
+        mockArchiveContent.mockReset();
+        mockCleanupTask.mockReset();
+        mockTrackTask.mockReset();
+        mockResolveForDelete.mockReset().mockResolvedValue(createDeleteResolveResult([]));
+    });
+
+    afterEach(() => {
+        resetDeleteDialogContext();
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+    });
+
+    it.each(referenceRemovalEventCases)(
+        'clears the inbound reference when the referencing content is $name externally',
+        async ({emit}) => {
+            const item = createMockContent('item-1');
+
+            mockResolveForDelete
+                .mockResolvedValueOnce(createDeleteResolveResult(['item-1'], [{target: 'item-1', sources: ['ref-1']}]))
+                .mockResolvedValueOnce(createDeleteResolveResult(['item-1'], []));
+
+            openDeleteDialog([item]);
+            await flushInitialReload();
+
+            expect($deleteInboundIds.get()).toEqual(['item-1']);
+
+            // The referencing content (not a dialog item or dependant) drops the reference.
+            emit(['ref-1']);
+            await flushDebouncedReload();
+
+            expect($deleteInboundIds.get()).toEqual([]);
+            expect(mockResolveForDelete).toHaveBeenCalledTimes(2);
+        },
+    );
+
+    it('does not reload when an unrelated content is updated externally', async () => {
+        const item = createMockContent('item-1');
+
+        mockResolveForDelete.mockResolvedValue(
+            createDeleteResolveResult(['item-1'], [{target: 'item-1', sources: ['ref-1']}]),
+        );
+
+        openDeleteDialog([item]);
+        await flushInitialReload();
+
+        expect(mockResolveForDelete).toHaveBeenCalledTimes(1);
+
+        emitContentUpdated([createMockContent('unrelated-1')]);
+        await flushDebouncedReload();
+
+        expect($deleteInboundIds.get()).toEqual(['item-1']);
+        expect(mockResolveForDelete).toHaveBeenCalledTimes(1);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/deleteDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/deleteDialog.store.ts
@@ -33,6 +33,8 @@ type DeleteDialogStore = {
     // Validation
     inboundTargets: ContentId[];
     inboundIgnored: boolean;
+    // IDs of content referencing the items (inbound sources); changes to these may add/remove references
+    inboundSourceIds: string[];
     // Pending operation (after dialog closes)
     submitting: boolean;
     pendingIds: string[];
@@ -50,6 +52,7 @@ const initialState: DeleteDialogStore = {
     archiveMessage: '',
     inboundTargets: [],
     inboundIgnored: false,
+    inboundSourceIds: [],
     submitting: false,
     pendingIds: [],
     pendingTotal: 0,
@@ -219,13 +222,17 @@ const reloadDeleteDialogData = async (): Promise<void> => {
 
         if (currentInstance !== instanceId) return;
 
-        const inboundTargets = result.getInboundDependencies().map(dep => dep.getId());
+        const inboundDependencies = result.getInboundDependencies();
+        const inboundTargets = inboundDependencies.map(dep => dep.getId());
+        const inboundSourceIds = inboundDependencies.flatMap(dep =>
+            dep.getInboundDependencies().map(id => id.toString()));
 
         $deleteDialog.set({
             ...$deleteDialog.get(),
             dependants: sortDependantsByInbound(dependants, inboundTargets),
             inboundTargets,
             inboundIgnored: inboundTargets.length === 0,
+            inboundSourceIds,
             loading: false,
             failed: false,
         });
@@ -277,6 +284,12 @@ const removeItemsByIds = (ids: Set<string>): {removedMain: boolean; removedDepen
     return {removedMain, removedDependant};
 };
 
+/** Whether any of the changed IDs is a content referencing the items (inbound source) */
+const hasInboundSourceChange = (changedIds: Set<string>): boolean => {
+    const {inboundSourceIds} = $deleteDialog.get();
+    return inboundSourceIds.some(id => changedIds.has(id));
+};
+
 //
 // * Completion Handling
 //
@@ -294,7 +307,8 @@ const handleExternalDeleteEvent = (changeItems: ContentServerChangeItem[]): void
             return;
         }
 
-        if (removedMain || removedDependant) {
+        // Removing a referencing content drops an inbound dependency: re-resolve to refresh references.
+        if (removedMain || removedDependant || hasInboundSourceChange(ids)) {
             reloadDeleteDialogDataDebounced();
         }
     }
@@ -339,9 +353,9 @@ $contentUpdated.subscribe((event) => {
     // Patch main items with updated data (display name, status, etc.)
     patchItemsWithUpdates(event.data);
 
-    // Reload when dependants change - dependency graph might have changed
+    // Reload when dependants change, or when a referencing content is edited to drop a reference.
     const hasDependantUpdates = dependants.some(item => updatedIds.has(item.getId()));
-    if (hasDependantUpdates) {
+    if (hasDependantUpdates || hasInboundSourceChange(updatedIds)) {
         reloadDeleteDialogDataDebounced();
     }
 });


### PR DESCRIPTION
The Delete Content dialog rendered "Show references" links from a single dependency resolve, so removing a reference elsewhere left the link stale. The store now tracks the inbound reference source IDs (previously discarded) and re-resolves on `$contentUpdated`, `$contentDeleted`, and `$contentArchived` when a referencing content changes, clearing the stale link. Added `deleteDialog.store.test.ts` covering reference removal via update/delete/archive plus an unrelated-update guard.

Closes #9756

<sub>*Drafted with AI assistance*</sub>
