### PR TITLE
Selector: Input focus is lost when selecting content #10689

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueDialogDetailsContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueDialogDetailsContent.tsx
@@ -295,6 +295,10 @@ export const IssueDialogDetailsContent = (): ReactElement => {
     const scheduleFromRef = useRef<Date | undefined>(issuePublishFrom);
     const scheduleToRef = useRef<Date | undefined>(issuePublishTo);
 
+    const focusBackButton = useCallback((): void => {
+        requestAnimationFrame(() => backButtonRef.current?.focus());
+    }, []);
+
     const {options: assigneeOptions, handleSearchChange} = useAssigneeSearch({
         publishableContentIds: publishTargetIds,
         useRootFallback: true,
@@ -365,19 +369,6 @@ export const IssueDialogDetailsContent = (): ReactElement => {
         [requiredDependantIds],
     );
     const itemsWithUnpublishedChildren = useItemsWithUnpublishedChildren(items);
-    const selectedItemKey = useMemo(
-        () => selectedItemIds.map(id => id.toString()).join('|'),
-        [selectedItemIds],
-    );
-    const selectedItemConfigKey = useMemo(() => {
-        const itemsConfig = issueData?.getPublishRequest()?.getItems() ?? [];
-        return itemsConfig
-            .map(item => `${item.getId().toString()}:${item.isIncludeChildren() ? 1 : 0}`)
-            .join('|');
-    }, [issueData]);
-    const excludedDependantKey = useMemo(() => {
-        return issueData?.getPublishRequest()?.getExcludeIds().map(id => id.toString()).join('|') ?? '';
-    }, [issueData]);
 
     const selectedAssigneeOptions = useAssigneeSelection({
         assigneeIds,
@@ -392,7 +383,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
             return;
         }
         void loadIssueDialogItems(issueData);
-    }, [issueDataId, selectedItemConfigKey, excludedDependantKey, loadIssueDialogItems]);
+    }, [issueDataId, loadIssueDialogItems]);
 
     const handleStatusChange = (next: string): void => {
         if (!isStatusOption(next)) {
@@ -441,12 +432,13 @@ export const IssueDialogDetailsContent = (): ReactElement => {
     useEffect(() => {
         return () => {
             debouncedUpdateItems.cancel();
+            pendingItemIdsRef.current = null;
         };
     }, [debouncedUpdateItems]);
 
     useEffect(() => {
         pendingItemIdsRef.current = null;
-    }, [selectedItemKey]);
+    }, [selectedItemIds]);
 
     const handleAssigneesChange = (next: readonly string[]): void => {
         debouncedUpdateAssignees([...next]);
@@ -460,6 +452,23 @@ export const IssueDialogDetailsContent = (): ReactElement => {
         pendingItemIdsRef.current = nextIds;
         debouncedUpdateItems(nextIds);
     }, [issueData, debouncedUpdateItems]);
+
+    const handleItemsApply = useCallback(async (nextSelection: readonly string[]): Promise<void> => {
+        if (!issueData) {
+            return;
+        }
+        debouncedUpdateItems.cancel();
+        const nextIds = nextSelection.map(id => new ContentId(id));
+        pendingItemIdsRef.current = null;
+        const updated = await updateIssueDialogItems(nextIds);
+        if (updated) {
+            focusBackButton();
+        }
+    }, [issueData, debouncedUpdateItems, focusBackButton]);
+
+    const handleItemsAppliedSelectionChange = useCallback((nextSelection: readonly string[]): void => {
+        void handleItemsApply(nextSelection);
+    }, [handleItemsApply]);
 
     const handleItemRemoved = useCallback((id: ContentId): void => {
         if (!issueData) {
@@ -538,7 +547,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
     const handleCommentSubmit = async (focusBackAfterSubmit = false): Promise<void> => {
         const submitted = await submitIssueDialogComment();
         if (submitted && focusBackAfterSubmit) {
-            requestAnimationFrame(() => backButtonRef.current?.focus());
+            focusBackButton();
         }
     };
 
@@ -775,6 +784,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
                                     label={itemsLabel}
                                     selection={selectedItemIdStrings}
                                     onSelectionChange={handleSelectionChange}
+                                    onAppliedSelectionChange={handleItemsAppliedSelectionChange}
                                     disabled={isItemsDisabled}
                                     closeOnBlur={true}
                                 />
@@ -896,6 +906,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
                                 searchPlaceholder={inviteUsersLabel}
                                 emptyLabel={noResultsLabel}
                                 onSelectionChange={handleAssigneesChange}
+                                onAppliedSelectionChange={focusBackButton}
                                 onSearchChange={handleSearchChange}
                                 disabled={isAssigneesDisabled}
                                 className='min-h-0 flex-1'

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueDialogDetailsContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueDialogDetailsContent.tsx
@@ -352,9 +352,15 @@ export const IssueDialogDetailsContent = (): ReactElement => {
         () => issueData?.getPublishRequest()?.getItemsIds() ?? [],
         [issueData],
     );
+    // Content-derived key keeps selection identity stable across unrelated
+    // issueData updates, so staged combobox edits are not reset mid-edit.
+    const selectedItemIdsKey = useMemo(
+        () => selectedItemIds.map(id => id.toString()).join('|'),
+        [selectedItemIds],
+    );
     const selectedItemIdStrings = useMemo(
         () => selectedItemIds.map(id => id.toString()),
-        [selectedItemIds],
+        [selectedItemIdsKey],
     );
     const excludeChildrenSet = useMemo(
         () => new Set(excludeChildrenIds.map(id => id.toString())),
@@ -438,7 +444,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
 
     useEffect(() => {
         pendingItemIdsRef.current = null;
-    }, [selectedItemIds]);
+    }, [selectedItemIdsKey]);
 
     const handleAssigneesChange = (next: readonly string[]): void => {
         debouncedUpdateAssignees([...next]);
@@ -452,23 +458,6 @@ export const IssueDialogDetailsContent = (): ReactElement => {
         pendingItemIdsRef.current = nextIds;
         debouncedUpdateItems(nextIds);
     }, [issueData, debouncedUpdateItems]);
-
-    const handleItemsApply = useCallback(async (nextSelection: readonly string[]): Promise<void> => {
-        if (!issueData) {
-            return;
-        }
-        debouncedUpdateItems.cancel();
-        const nextIds = nextSelection.map(id => new ContentId(id));
-        pendingItemIdsRef.current = null;
-        const updated = await updateIssueDialogItems(nextIds);
-        if (updated) {
-            focusBackButton();
-        }
-    }, [issueData, debouncedUpdateItems, focusBackButton]);
-
-    const handleItemsAppliedSelectionChange = useCallback((nextSelection: readonly string[]): void => {
-        void handleItemsApply(nextSelection);
-    }, [handleItemsApply]);
 
     const handleItemRemoved = useCallback((id: ContentId): void => {
         if (!issueData) {
@@ -784,7 +773,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
                                     label={itemsLabel}
                                     selection={selectedItemIdStrings}
                                     onSelectionChange={handleSelectionChange}
-                                    onAppliedSelectionChange={handleItemsAppliedSelectionChange}
+                                    onAppliedSelectionChange={focusBackButton}
                                     disabled={isItemsDisabled}
                                     closeOnBlur={true}
                                 />

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/assignee/AssigneeOptionsContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/assignee/AssigneeOptionsContent.tsx
@@ -6,7 +6,6 @@ export type AssigneeOptionsContentProps = {
     emptyLabel?: string;
     hasOptions: boolean;
     children: ReactNode;
-    onApply?: () => void;
 };
 
 const ASSIGNEE_OPTIONS_CONTENT_NAME = 'AssigneeOptionsContent';
@@ -16,7 +15,6 @@ export const AssigneeOptionsContent = ({
                                            emptyLabel,
                                            hasOptions,
                                            children,
-                                           onApply,
                                        }: AssigneeOptionsContentProps): ReactElement => {
     const {applyStagedSelection, stagingEnabled} = useCombobox();
 
@@ -30,7 +28,6 @@ export const AssigneeOptionsContent = ({
         if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
             event.preventDefault();
             event.stopPropagation();
-            onApply?.();
             applyStagedSelection();
         }
     };

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/assignee/AssigneeSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/assignee/AssigneeSelector.tsx
@@ -1,6 +1,6 @@
 import {Combobox, IconButton, ListItem, Listbox, cn} from '@enonic/ui';
 import {X} from 'lucide-react';
-import {useEffect, useMemo, useRef, useState, type ReactElement} from 'react';
+import {useEffect, useMemo, useState, type ReactElement} from 'react';
 import {createDebounce} from '../../../utils/timing/createDebounce';
 import {AssigneeOptionItem} from './AssigneeOptionItem';
 import {AssigneeOptionRow} from './AssigneeOptionRow';
@@ -12,6 +12,7 @@ export type AssigneeSelectorProps = {
     options: AssigneeSelectorOption[];
     selection: readonly string[];
     onSelectionChange: (selection: readonly string[]) => void;
+    onAppliedSelectionChange?: (selection: readonly string[]) => void;
     selectedOptions?: AssigneeSelectorOption[];
     selectedListClassName?: string;
     applyLabel?: string;
@@ -57,6 +58,7 @@ export const AssigneeSelector = ({
     options,
     selection,
     onSelectionChange,
+    onAppliedSelectionChange,
     selectedOptions,
     selectedListClassName,
     applyLabel,
@@ -72,10 +74,10 @@ export const AssigneeSelector = ({
     const [open, setOpen] = useState(false);
     const [inputValue, setInputValue] = useState('');
     const [activeItem, setActiveItem] = useState<string | null>(null);
-    const inputRef = useRef<HTMLInputElement>(null);
-    const restoreFocusRef = useRef(false);
 
     const selectedIds = selection ?? [];
+    const SELECTED_IDS_KEY_SEPARATOR = '\u0000';
+    const selectedIdsKey = selectedIds.join(SELECTED_IDS_KEY_SEPARATOR);
     const shouldFilter = filterOptions ?? !onSearchChange;
 
     const optionLookup = useMemo(() => {
@@ -103,7 +105,7 @@ export const AssigneeSelector = ({
         selectedIds.forEach(register);
 
         return {rawToSafe, safeToRaw};
-    }, [options, selectedOptions, selectedIds]);
+    }, [options, selectedOptions, selectedIdsKey]);
 
     const selectedOptionList = useMemo(() => {
         return selectedIds
@@ -165,40 +167,20 @@ export const AssigneeSelector = ({
     }, [debouncedSearch]);
 
     const showSelectedOptions = selectedOptionList.length > 0;
-    const safeSelection = selectedIds.map(id => valueMap.rawToSafe.get(id) ?? toSafeValue(id));
-    const selectionKey = useMemo(() => safeSelection.join('|'), [safeSelection]);
+    const safeSelection = useMemo(
+        () => selectedIds.map(toSafeValue),
+        [selectedIdsKey],
+    );
 
     const handleRemoveAssignee = (id: string): void => {
         onSelectionChange(selectedIds.filter(selectedId => selectedId !== id));
     };
-
-    const focusInput = (): void => {
-        requestAnimationFrame(() => {
-            inputRef.current?.focus();
-        });
-    };
-
-    const requestFocusRestore = (): void => {
-        restoreFocusRef.current = true;
-    };
-
-    useEffect(() => {
-        if (open) {
-            return;
-        }
-
-        if (restoreFocusRef.current) {
-            restoreFocusRef.current = false;
-            focusInput();
-        }
-    }, [open]);
 
     return (
         <div
             data-component={ASSIGNEE_SELECTOR_NAME}
             className={cn('flex min-h-0 flex-col gap-2', className)}>
             <Combobox.Root
-                key={selectionKey}
                 open={open}
                 onOpenChange={setOpen}
                 value={inputValue}
@@ -206,12 +188,13 @@ export const AssigneeSelector = ({
                 active={activeItem ?? ''}
                 setActive={setActiveItem}
                 selectionMode='staged'
-                defaultSelection={safeSelection}
+                selection={safeSelection}
                 onSelectionChange={(next) => {
                     const mapped = next
                         .map(value => valueMap.safeToRaw.get(value))
                         .filter((value): value is string => !!value);
                     onSelectionChange(mapped);
+                    onAppliedSelectionChange?.(mapped);
                 }}
                 disabled={disabled}
             >
@@ -220,11 +203,10 @@ export const AssigneeSelector = ({
                         <Combobox.Search>
                             <Combobox.SearchIcon />
                             <Combobox.Input
-                                ref={inputRef}
                                 placeholder={searchPlaceholder ?? placeholder}
                                 aria-label={label}
                             />
-                            <Combobox.Apply label={applyLabel} onPointerDown={requestFocusRestore} />
+                            <Combobox.Apply label={applyLabel} />
                             <Combobox.Toggle />
                         </Combobox.Search>
                     </Combobox.Control>
@@ -235,7 +217,6 @@ export const AssigneeSelector = ({
                                 label={label}
                                 emptyLabel={emptyLabel}
                                 hasOptions={visibleOptions.length > 0}
-                                onApply={requestFocusRestore}
                             >
                                 {visibleOptions.map(option => {
                                     const safeValue = valueMap.rawToSafe.get(option.id) ?? toSafeValue(option.id);

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/assignee/AssigneeSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/assignee/AssigneeSelector.tsx
@@ -12,6 +12,7 @@ export type AssigneeSelectorProps = {
     options: AssigneeSelectorOption[];
     selection: readonly string[];
     onSelectionChange: (selection: readonly string[]) => void;
+    /** Called alongside onSelectionChange when a staged selection is applied. */
     onAppliedSelectionChange?: (selection: readonly string[]) => void;
     selectedOptions?: AssigneeSelectorOption[];
     selectedListClassName?: string;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/combobox/ContentCombobox.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/combobox/ContentCombobox.tsx
@@ -21,6 +21,7 @@ const EMPTY_STRING_ARRAY: string[] = [];
 export type ContentComboboxProps = {
     'selection': readonly string[];
     'onSelectionChange': (selection: readonly string[]) => void;
+    /** Called alongside onSelectionChange when a staged selection is applied. */
     'onAppliedSelectionChange'?: (selection: readonly string[]) => void;
     'selectionMode'?: 'single' | 'multiple';
     'listMode'?: 'tree' | 'flat';
@@ -162,9 +163,12 @@ export const ContentCombobox = ({
 
     // Use staged selection mode for multiple selection
     const comboboxSelectionMode = selectionMode === 'multiple' ? 'staged' : 'single';
-    const handleSelectionChange = comboboxSelectionMode === 'staged' && onAppliedSelectionChange
-                                  ? onAppliedSelectionChange
-                                  : onSelectionChange;
+    const handleSelectionChange = (next: readonly string[]): void => {
+        onSelectionChange(next);
+        if (comboboxSelectionMode === 'staged') {
+            onAppliedSelectionChange?.(next);
+        }
+    };
 
     return (
         <div data-component={CONTENT_COMBOBOX_NAME} className={cn('flex flex-col gap-2.5', className)}>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/combobox/ContentCombobox.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/combobox/ContentCombobox.tsx
@@ -21,6 +21,7 @@ const EMPTY_STRING_ARRAY: string[] = [];
 export type ContentComboboxProps = {
     'selection': readonly string[];
     'onSelectionChange': (selection: readonly string[]) => void;
+    'onAppliedSelectionChange'?: (selection: readonly string[]) => void;
     'selectionMode'?: 'single' | 'multiple';
     'listMode'?: 'tree' | 'flat';
     'closeOnBlur'?: boolean;
@@ -69,6 +70,7 @@ const CONTENT_COMBOBOX_NAME = 'ContentCombobox';
 export const ContentCombobox = ({
     selection,
     onSelectionChange,
+    onAppliedSelectionChange,
     selectionMode = 'multiple',
     'listMode': externalListMode = 'tree',
     closeOnBlur = false,
@@ -160,6 +162,9 @@ export const ContentCombobox = ({
 
     // Use staged selection mode for multiple selection
     const comboboxSelectionMode = selectionMode === 'multiple' ? 'staged' : 'single';
+    const handleSelectionChange = comboboxSelectionMode === 'staged' && onAppliedSelectionChange
+                                  ? onAppliedSelectionChange
+                                  : onSelectionChange;
 
     return (
         <div data-component={CONTENT_COMBOBOX_NAME} className={cn('flex flex-col gap-2.5', className)}>
@@ -174,7 +179,7 @@ export const ContentCombobox = ({
                 value={inputValue}
                 onChange={setInputValue}
                 selection={selection}
-                onSelectionChange={onSelectionChange}
+                onSelectionChange={handleSelectionChange}
                 selectionMode={comboboxSelectionMode}
                 contentType="tree"
                 closeOnBlur={closeOnBlur}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/combobox/useContentComboboxController.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/combobox/useContentComboboxController.ts
@@ -97,7 +97,6 @@ export function useContentComboboxController(options: UseContentComboboxControll
     // Refs
     const virtuosoRef = useRef<VirtuosoHandle>(null);
     const inputRef = useRef<HTMLInputElement | null>(null);
-    const prevOpenRef = useRef(false);
 
     // View state
     const [open, setOpen] = useState(false);
@@ -167,16 +166,6 @@ export function useContentComboboxController(options: UseContentComboboxControll
         if (!open) {
             lastSearchedQueryRef.current = null;
         }
-    }, [open]);
-
-    // Focus restoration - return focus to input when dropdown closes
-    useEffect(() => {
-        if (prevOpenRef.current && !open) {
-            requestAnimationFrame(() => {
-                inputRef.current?.focus();
-            });
-        }
-        prevOpenRef.current = open;
     }, [open]);
 
     // Reset active item when list changes

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialogDetails.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialogDetails.store.ts
@@ -664,10 +664,10 @@ export const updateIssueDialogSchedule = async (
     }
 };
 
-export const updateIssueDialogItems = async (nextItemIds: ContentId[]): Promise<boolean> => {
+export const updateIssueDialogItems = async (nextItemIds: ContentId[]): Promise<void> => {
     const context = getIssueContext('itemsUpdating');
     if (!context) {
-        return false;
+        return;
     }
     const {issueId, dialogState, issueWithAssignees, issue} = context;
 
@@ -675,7 +675,7 @@ export const updateIssueDialogItems = async (nextItemIds: ContentId[]): Promise<
     const publishRequest = issue.getPublishRequest();
     const currentItemIds = publishRequest?.getItemsIds() ?? [];
     if (isIdsEqual(currentItemIds, nextUniqueIds)) {
-        return true;
+        return;
     }
 
     $issueDialogDetails.setKey('itemsUpdating', true);
@@ -695,12 +695,13 @@ export const updateIssueDialogItems = async (nextItemIds: ContentId[]): Promise<
         .setPublishRequestItems(nextItems)
         .build();
 
-    return !!await updateIssueWithPublishRequest({
+    await updateIssueWithPublishRequest({
         issueId,
         issue,
         dialogState,
         issueWithAssignees,
         nextPublishRequest,
+        forceReloadItems: true,
     });
 };
 
@@ -980,13 +981,15 @@ const updateIssueWithPublishRequest = async ({
     dialogState,
     issueWithAssignees,
     nextPublishRequest,
+    forceReloadItems = false,
 }: {
     issueId: string;
     issue: Issue;
     dialogState: IssueDialogState;
     issueWithAssignees?: IssueWithAssignees;
     nextPublishRequest: PublishRequest;
-}): Promise<Issue | undefined> => {
+    forceReloadItems?: boolean;
+}): Promise<void> => {
     try {
         const request = new UpdateIssueRequest(issueId)
             .setTitle(issue.getTitle())
@@ -998,7 +1001,7 @@ const updateIssueWithPublishRequest = async ({
         const updatedIssue = await request.sendAndParse();
 
         applyUpdatedIssue(updatedIssue, dialogState, issueWithAssignees, {});
-        await loadIssueDialogItems(updatedIssue, {forceReload: true});
+        await loadIssueDialogItems(updatedIssue, {forceReload: forceReloadItems});
         $issueDialogDetails.setKey('itemsUpdating', false);
 
         const prefix = updatedIssue.getType() === IssueType.PUBLISH_REQUEST
@@ -1006,12 +1009,10 @@ const updateIssueWithPublishRequest = async ({
                        : 'notify.issue.';
         showFeedback(i18n(`${prefix}updated`));
         void loadIssueDialogList();
-        return updatedIssue;
     } catch (error) {
         console.error(error);
         $issueDialogDetails.setKey('itemsUpdating', false);
         showError(error?.message ?? String(error));
-        return undefined;
     }
 };
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialogDetails.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialogDetails.store.ts
@@ -664,10 +664,10 @@ export const updateIssueDialogSchedule = async (
     }
 };
 
-export const updateIssueDialogItems = async (nextItemIds: ContentId[]): Promise<void> => {
+export const updateIssueDialogItems = async (nextItemIds: ContentId[]): Promise<boolean> => {
     const context = getIssueContext('itemsUpdating');
     if (!context) {
-        return;
+        return false;
     }
     const {issueId, dialogState, issueWithAssignees, issue} = context;
 
@@ -675,7 +675,7 @@ export const updateIssueDialogItems = async (nextItemIds: ContentId[]): Promise<
     const publishRequest = issue.getPublishRequest();
     const currentItemIds = publishRequest?.getItemsIds() ?? [];
     if (isIdsEqual(currentItemIds, nextUniqueIds)) {
-        return;
+        return true;
     }
 
     $issueDialogDetails.setKey('itemsUpdating', true);
@@ -695,7 +695,7 @@ export const updateIssueDialogItems = async (nextItemIds: ContentId[]): Promise<
         .setPublishRequestItems(nextItems)
         .build();
 
-    await updateIssueWithPublishRequest({
+    return !!await updateIssueWithPublishRequest({
         issueId,
         issue,
         dialogState,
@@ -986,7 +986,7 @@ const updateIssueWithPublishRequest = async ({
     dialogState: IssueDialogState;
     issueWithAssignees?: IssueWithAssignees;
     nextPublishRequest: PublishRequest;
-}): Promise<void> => {
+}): Promise<Issue | undefined> => {
     try {
         const request = new UpdateIssueRequest(issueId)
             .setTitle(issue.getTitle())
@@ -997,17 +997,21 @@ const updateIssueWithPublishRequest = async ({
         populateSchedule(request, issue);
         const updatedIssue = await request.sendAndParse();
 
-        applyUpdatedIssue(updatedIssue, dialogState, issueWithAssignees, {itemsUpdating: false});
+        applyUpdatedIssue(updatedIssue, dialogState, issueWithAssignees, {});
+        await loadIssueDialogItems(updatedIssue, {forceReload: true});
+        $issueDialogDetails.setKey('itemsUpdating', false);
 
         const prefix = updatedIssue.getType() === IssueType.PUBLISH_REQUEST
                        ? 'notify.publishRequest.'
                        : 'notify.issue.';
         showFeedback(i18n(`${prefix}updated`));
         void loadIssueDialogList();
+        return updatedIssue;
     } catch (error) {
         console.error(error);
         $issueDialogDetails.setKey('itemsUpdating', false);
         showError(error?.message ?? String(error));
+        return undefined;
     }
 };
 


### PR DESCRIPTION
Patch after npm-enonic-ui to fix closeOnBlur and restore focus after applying for combobox, contentcombobox for contentSelector assigneeSelector and itemSelector.

This pull request is in draft until new version of npm-enonic-ui is out.
Depending on:
https://github.com/enonic/npm-enonic-ui/pull/460