### PR TITLE
Update drag zone styles to match page editor placeholders #10690

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/DropZone.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/DropZone.tsx
@@ -103,9 +103,9 @@ export const DropZone = ({
                 htmlFor={inputId}
                 className={cn(
                     'relative flex flex-col gap-2.5 size-full items-center justify-center p-5',
-                    'border border-dashed border-info-rev hover:cursor-pointer transition-all',
+                    'dash-border hover:cursor-pointer transition-all',
                     'peer-focus-visible:outline-none peer-focus-visible:ring-3 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-3 peer-focus-visible:ring-offset-ring-offset',
-                    isDragging && 'bg-info-rev/10 border-solid',
+                    isDragging && 'dash-border-select bg-bdr-select/8',
                 )}
             >
                 {icon}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-image/ImageUploadZone.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-image/ImageUploadZone.tsx
@@ -45,7 +45,7 @@ export const ImageUploadZone = (): ReactElement => {
 
     if (uploading) {
         return (
-            <div className='flex flex-col items-center justify-center gap-2 rounded-md border border-dashed border-info-rev p-8'>
+            <div className='flex flex-col items-center justify-center gap-2 rounded-md dash-border p-8'>
                 <div className='text-sm text-subtle'>{uploadingLabel}</div>
                 <div className='w-full max-w-60 h-2 rounded-full bg-muted overflow-hidden'>
                     <div

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/attachment-uploader/AttachmentUploaderInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/attachment-uploader/AttachmentUploaderInput.tsx
@@ -91,7 +91,7 @@ export const AttachmentUploaderInput = ({
                 className="hidden"
             />
 
-            <div className={cn('w-full', !config.hideDropZone && canUpload && isDragging && 'border border-dashed rounded p-1')}>
+            <div className={cn('w-full', !config.hideDropZone && canUpload && isDragging && 'dash-border dash-border-select bg-bdr-select/8 rounded p-1')}>
                 <AttachmentUploaderList
                     names={attachmentNames}
                     contentId={contentId}

--- a/modules/lib/src/main/resources/assets/styles/tailwind.css
+++ b/modules/lib/src/main/resources/assets/styles/tailwind.css
@@ -50,6 +50,31 @@
   animation: text-shimmer-slide 1.5s ease-in-out infinite;
 }
 
+/*
+ * Decorative dashed border drawn as a background gradient, matching the page
+ * editor placeholders (16px dash period, 65% fill, 1px thick). The color comes
+ * from --dash-color, defaulting to the neutral decorative token; the -select
+ * variant switches it to the selection color for drag-over states.
+ */
+@utility dash-border {
+  background-image:
+    linear-gradient(90deg, var(--dash-color, var(--color-decorative)) 65%, transparent 0),
+    linear-gradient(90deg, var(--dash-color, var(--color-decorative)) 65%, transparent 0),
+    linear-gradient(0deg, var(--dash-color, var(--color-decorative)) 65%, transparent 0),
+    linear-gradient(0deg, var(--dash-color, var(--color-decorative)) 65%, transparent 0);
+  background-position: top, bottom, left, right;
+  background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
+  background-size:
+    16px 1px,
+    16px 1px,
+    1px 16px,
+    1px 16px;
+}
+
+@utility dash-border-select {
+  --dash-color: var(--color-bdr-select);
+}
+
 /* HACKS */
 @layer overrides {
   /* Hide launcher buttons that is injected from Launcher app */


### PR DESCRIPTION
## Changes

- Added `dash-border` / `dash-border-select` Tailwind utilities that port the page editor `.pe-dash` gradient (identical 16px dash period, 65% fill, 1px thickness), colored via `--dash-color` defaulting to `decorative`.
- `DropZone` now uses the neutral decorative dash when idle and switches to the selection color with a `bg-bdr-select/8` tint on drag-over, replacing the `info-rev` border that turned solid.
- Aligned the HTML-area uploading placeholder (`ImageUploadZone`) and the attachment uploader drag wrapper (`AttachmentUploaderInput`) to the same dash utility for consistency.

Closes #10690

<sub>*Drafted with AI assistance*</sub>
