### PR TITLE
Wizard auto-focuses the display name input even when it's already filled in #10709

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
@@ -844,6 +844,10 @@ export function requestDisplayNameInputFocus(): void {
         return;
     }
 
+    if ($displayName.get().trim().length > 0) {
+        return;
+    }
+
     $displayNameInputFocusRequested.set(true);
 }
 


### PR DESCRIPTION
Gated `requestDisplayNameInputFocus()` to skip the focus request when the display name is already set, so reopening saved content no longer steals focus into the name field. Auto-focus now only happens for an empty field on first creation, and `DisplayNameInput` stays a pure consumer of the request rather than owning the policy.

Closes #10709

<sub>*Drafted with AI assistance*</sub>
