### PR TITLE
Add missing ring offset to in-progress exclude button in SelectionStatusBar

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/status-bar/SelectionStatusBar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/status-bar/SelectionStatusBar.tsx
@@ -32,14 +32,20 @@ type Props = {
             disabled?: boolean;
             onExclude: () => void;
         };
-    },
+    };
 };
 
 type ErrorKind = keyof Props['errors'];
 
 type Status = 'loading' | 'failed' | 'editing' | 'ready' | 'errors' | 'none';
 
-function getStatus({loading, failed, editing, showReady, errors}: Omit<Props, 'className' | 'onApply' | 'onCancel'>): Status {
+function getStatus({
+    loading,
+    failed,
+    editing,
+    showReady,
+    errors,
+}: Omit<Props, 'className' | 'onApply' | 'onCancel'>): Status {
     if (loading) {
         return 'loading';
     }
@@ -83,53 +89,93 @@ export const SelectionStatusBar = ({className, onApply, onCancel, ...props}: Pro
 
     return (
         <div data-component={SELECTION_STATUS_BAR_NAME} className={cn('flex flex-col gap-2.5', className)}>
-            {status === 'loading' && <StatusBarEntry>
-                <LoaderCircle className="w-7 h-7 animate-spin text-subtle" />
-                <span className="text-sm font-semibold">{loadingText}</span>
-            </StatusBarEntry>}
+            {status === 'loading' && (
+                <StatusBarEntry>
+                    <LoaderCircle className="w-7 h-7 animate-spin text-subtle" />
+                    <span className="text-sm font-semibold">{loadingText}</span>
+                </StatusBarEntry>
+            )}
 
-            {status === 'failed' && <StatusBarEntry className="bg-surface-error">
-                <StatusIcon className="w-6 h-6" status='invalid' />
-                <span className="text-sm font-semibold">{failedText}</span>
-            </StatusBarEntry>}
+            {status === 'failed' && (
+                <StatusBarEntry className="bg-surface-error">
+                    <StatusIcon className="w-6 h-6" status="invalid" />
+                    <span className="text-sm font-semibold">{failedText}</span>
+                </StatusBarEntry>
+            )}
 
-            {status === 'editing' && <StatusBarEntry className="bg-surface-info">
-                <StatusIcon className="w-6 h-6" status='info' />
-                <span className="text-sm font-semibold">{editingText}</span>
-                <StatusBarEntryButton onClick={onApply} className='[--color-ring-offset:var(--color-surface-info)]'>
-                    {applyText}
-                </StatusBarEntryButton>
-                <StatusBarEntryButton onClick={onCancel} className='[--color-ring-offset:var(--color-surface-info)]'>
-                    {cancelText}
-                </StatusBarEntryButton>
-            </StatusBarEntry>}
+            {status === 'editing' && (
+                <StatusBarEntry className="bg-surface-info">
+                    <StatusIcon className="w-6 h-6" status="info" />
+                    <span className="text-sm font-semibold">{editingText}</span>
+                    <StatusBarEntryButton onClick={onApply} className="[--color-ring-offset:var(--color-surface-info)]">
+                        {applyText}
+                    </StatusBarEntryButton>
+                    <StatusBarEntryButton
+                        onClick={onCancel}
+                        className="[--color-ring-offset:var(--color-surface-info)]"
+                    >
+                        {cancelText}
+                    </StatusBarEntryButton>
+                </StatusBarEntry>
+            )}
 
-            {status === 'ready' && <StatusBarEntry className="bg-surface-success">
-                <StatusIcon className="w-6 h-6" status='ready' />
-                <span className="text-sm font-semibold">{readyText}</span>
-            </StatusBarEntry>}
+            {status === 'ready' && (
+                <StatusBarEntry className="bg-surface-success">
+                    <StatusIcon className="w-6 h-6" status="ready" />
+                    <span className="text-sm font-semibold">{readyText}</span>
+                </StatusBarEntry>
+            )}
 
-            {status === 'errors' && inProgress.count > 0 && <StatusBarErrorEntry status='in-progress' label={`${inProgressText} (${inProgress.count})`}>
-                {!inProgress.disabled && <StatusBarEntryButton onClick={inProgress.onExclude}>
-                    {excludeText}
-                </StatusBarEntryButton>}
-                {inProgress.onMarkAsReady && <StatusBarEntryButton onClick={inProgress.onMarkAsReady} className='[--color-ring-offset:var(--color-surface-warn)]'>
-                    {markAsReadyText}
-                </StatusBarEntryButton>}
-            </StatusBarErrorEntry>}
+            {status === 'errors' && inProgress.count > 0 && (
+                <StatusBarErrorEntry status="in-progress" label={`${inProgressText} (${inProgress.count})`}>
+                    {!inProgress.disabled && (
+                        <StatusBarEntryButton
+                            onClick={inProgress.onExclude}
+                            className="[--color-ring-offset:var(--color-surface-warn)]"
+                        >
+                            {excludeText}
+                        </StatusBarEntryButton>
+                    )}
+                    {inProgress.onMarkAsReady && (
+                        <StatusBarEntryButton
+                            onClick={inProgress.onMarkAsReady}
+                            className="[--color-ring-offset:var(--color-surface-warn)]"
+                        >
+                            {markAsReadyText}
+                        </StatusBarEntryButton>
+                    )}
+                </StatusBarErrorEntry>
+            )}
 
-            {status === 'errors' && invalid.count > 0 && <StatusBarErrorEntry status='invalid' label={`${invalidText} (${invalid.count})`} disabled={invalid.disabled}>
-                <StatusBarEntryButton onClick={invalid.onExclude} className='[--color-ring-offset:var(--color-surface-error)]'>
-                    {excludeText}
-                </StatusBarEntryButton>
-            </StatusBarErrorEntry>}
+            {status === 'errors' && invalid.count > 0 && (
+                <StatusBarErrorEntry
+                    status="invalid"
+                    label={`${invalidText} (${invalid.count})`}
+                    disabled={invalid.disabled}
+                >
+                    <StatusBarEntryButton
+                        onClick={invalid.onExclude}
+                        className="[--color-ring-offset:var(--color-surface-error)]"
+                    >
+                        {excludeText}
+                    </StatusBarEntryButton>
+                </StatusBarErrorEntry>
+            )}
 
-            {status === 'errors' && noPermissions.count > 0 && <StatusBarErrorEntry status='invalid' label={`${noPermissionsText} (${noPermissions.count})`} disabled={noPermissions.disabled}>
-                <StatusBarEntryButton onClick={noPermissions.onExclude} className='[--color-ring-offset:var(--color-surface-error)]'>
-                    {excludeText}
-                </StatusBarEntryButton>
-            </StatusBarErrorEntry>}
-
+            {status === 'errors' && noPermissions.count > 0 && (
+                <StatusBarErrorEntry
+                    status="invalid"
+                    label={`${noPermissionsText} (${noPermissions.count})`}
+                    disabled={noPermissions.disabled}
+                >
+                    <StatusBarEntryButton
+                        onClick={noPermissions.onExclude}
+                        className="[--color-ring-offset:var(--color-surface-error)]"
+                    >
+                        {excludeText}
+                    </StatusBarEntryButton>
+                </StatusBarErrorEntry>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## Changes

- Added `[--color-ring-offset:var(--color-surface-warn)]` to the in-progress exclude button so its focus ring offset matches the warn surface, aligning it with the mark-as-ready button.
- Reformatted the status JSX conditionals and `getStatus` destructuring, and normalized attribute quotes to double quotes.

<sub>*Drafted with AI assistance*</sub>
