### PR TITLE
Status icons should not expose tooltips on keyboard tab focus #10742

### DIFF
--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -25,6 +25,7 @@
     "@enonic/lib-admin-ui": "workspace:*",
     "@enonic/lib-contentstudio": "workspace:*",
     "@enonic/page-editor": "^1.0.0",
+    "@enonic/ui": "^1.0.1",
     "@radix-ui/react-slot": "^1.2.3",
     "chart.js": "^4.5.1",
     "dompurify": "^3.3.1",

--- a/modules/lib/package.json
+++ b/modules/lib/package.json
@@ -26,7 +26,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@enonic/ui": "^1.0.0",
+    "@enonic/ui": "^1.0.1",
     "@nanostores/preact": "^1.0.0",
     "ckeditor4-react": "4.3.0",
     "class-variance-authority": "^0.7.1",

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/ContentIcon.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/ContentIcon.tsx
@@ -19,7 +19,7 @@ import {
     FolderOpen,
     Globe,
     ImageIcon,
-    LucideIcon,
+    type LucideIcon,
     Presentation,
     Shapes,
     SplinePointer,
@@ -107,7 +107,7 @@ export const ContentIcon = ({className, contentType, url, imageSize = 64, crop =
         );
     }
 
-    return <BuiltInIcon className={cn('size-6', className)} contentType={contentType} strokeWidth={1.75} />;
+    return <BuiltInIcon className={cn('size-6', className)} contentType={contentType} strokeWidth={1.75}/>;
 };
 
 ContentIcon.displayName = 'ContentIcon';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/StatusIcon.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/icons/StatusIcon.tsx
@@ -78,12 +78,20 @@ export const StatusIcon = ({
     const classNames = cn(statusIconVariants({status}), className);
     const Icon = getIcon(status);
     const tooltip = useI18n(getTooltipKey(status));
-    const icon = <Icon data-component={componentName} className={classNames} aria-label={status} {...props} />;
+    const icon = (
+        <Icon
+            data-component={componentName}
+            className={classNames}
+            aria-label={status}
+            {...props}
+            focusable="false"
+        />
+    );
 
     if (!withTooltip) return icon;
 
     return (
-        <Tooltip side="top" delay={300} value={tooltip}>
+        <Tooltip side="top" delay={300} value={tooltip} trigger="hover">
             {icon}
         </Tooltip>
     );


### PR DESCRIPTION
This pr is dependant on: https://github.com/enonic/npm-enonic-ui/pull/466

Fix status icon tooltip focus