### PR TITLE
'Request publishing' is blocked for non-admin users #10707

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeActions.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentTreeActions.ts
@@ -18,6 +18,7 @@ import {GetContentTypeByNameRequest} from '../resource/GetContentTypeByNameReque
 import {GetPermittedActionsRequest} from '../resource/GetPermittedActionsRequest';
 import {HasUnpublishedChildrenRequest} from '../resource/HasUnpublishedChildrenRequest';
 import {type HasUnpublishedChildren, type HasUnpublishedChildrenResult} from '../resource/HasUnpublishedChildrenResult';
+import {ProjectHelper} from '../settings/data/project/ProjectHelper';
 import {ArchiveContentAction} from './action/ArchiveContentAction';
 import {type ContentTreeGridAction} from './action/ContentTreeGridAction';
 import {ContentTreeGridItemsState} from './action/ContentTreeGridItemsState';
@@ -51,6 +52,8 @@ export class ContentTreeActions implements TreeGridActions<ContentSummaryAndComp
     private actionsUnStashedListeners: (() => void)[] = [];
 
     private state: State = State.ENABLED;
+
+    private updateChildrenActionsRequestId: number = 0;
 
     constructor() {
         this.initActions();
@@ -212,7 +215,7 @@ export class ContentTreeActions implements TreeGridActions<ContentSummaryAndComp
             }
 
             this.toggleVisibility(state);
-            return this.updateDefaultActionsMultipleItemsSelected(items);
+            return this.updateDefaultActionsMultipleItemsSelected(items, state);
         });
     }
 
@@ -257,7 +260,7 @@ export class ContentTreeActions implements TreeGridActions<ContentSummaryAndComp
         this.showDefaultActions();
     }
 
-    private updateDefaultActionsMultipleItemsSelected(items: ContentSummary[]): Q.Promise<void> {
+    private updateDefaultActionsMultipleItemsSelected(items: ContentSummary[], state: ContentTreeGridItemsState): Q.Promise<void> {
         const promises: Q.Promise<void>[] = [];
 
         if (items.length === 1 &&
@@ -270,20 +273,48 @@ export class ContentTreeActions implements TreeGridActions<ContentSummaryAndComp
             }));
         }
 
-        if (this.getAction(ActionName.PUBLISH_TREE).isEnabled()) {
-            promises.push(this.updatePublishTreeAction(items));
+        if (this.shouldCheckUnpublishedChildren(state)) {
+            promises.push(this.updatePublishActionsByChildren(items, state));
         }
 
         return Q.all(promises).thenResolve(null);
     }
 
-    private updatePublishTreeAction(items: ContentSummary[]): Q.Promise<void> {
+    private shouldCheckUnpublishedChildren(state: ContentTreeGridItemsState): boolean {
+        if (state.hasAllLeafs()) {
+            return false;
+        }
+
+        if (this.getAction(ActionName.PUBLISH_TREE).isEnabled()) {
+            return true;
+        }
+
+        // Request Publishing: probe only when items are online themselves but may
+        // still have unpublished descendants.
+        return state.hasAllOnline() && state.hasAllValid() && ProjectHelper.canRequestPublish();
+    }
+
+    private updatePublishActionsByChildren(items: ContentSummary[], state: ContentTreeGridItemsState): Q.Promise<void> {
+        const requestId: number = ++this.updateChildrenActionsRequestId;
+
         return new HasUnpublishedChildrenRequest(items.map((item: ContentSummary) => item.getContentId()))
             .sendAndParse().then((hasUnpublishedChildrenResult: HasUnpublishedChildrenResult) => {
+                // Drop stale response superseded by a newer selection.
+                if (requestId !== this.updateChildrenActionsRequestId) {
+                    return;
+                }
+
                 const hasUnpublishedChildren: boolean =
                     hasUnpublishedChildrenResult.getResult().some((item: HasUnpublishedChildren) => item.getHasChildren());
 
-                this.getAction(ActionName.PUBLISH_TREE).setEnabled(hasUnpublishedChildren);
+                const publishTreeAction = this.getAction(ActionName.PUBLISH_TREE);
+                if (publishTreeAction.isEnabled()) {
+                    publishTreeAction.setEnabled(hasUnpublishedChildren);
+                }
+
+                if (hasUnpublishedChildren && state.hasAllValid() && ProjectHelper.canRequestPublish()) {
+                    this.getAction(ActionName.REQUEST_PUBLISH).setEnabled(true);
+                }
             }).catch(reason => DefaultErrorHandler.handle(reason));
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/browse/action/RequestPublishContentAction.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/action/RequestPublishContentAction.ts
@@ -1,5 +1,6 @@
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {getCurrentItemsAsCSCS} from '../../../v6/features/store/contentTreeSelection.store';
+import {ProjectHelper} from '../../settings/data/project/ProjectHelper';
 import {RequestContentPublishPromptEvent} from '../RequestContentPublishPromptEvent';
 import {ContentTreeGridAction} from './ContentTreeGridAction';
 import {type ContentTreeGridItemsState} from './ContentTreeGridItemsState';
@@ -18,6 +19,6 @@ export class RequestPublishContentAction
     }
 
     isToBeEnabled(state: ContentTreeGridItemsState): boolean {
-        return !state.isEmpty() && state.hasAllValid();
+        return !state.isEmpty() && state.hasAllValid() && !state.hasAllOnline() && ProjectHelper.canRequestPublish();
     }
 }

--- a/modules/lib/src/main/resources/assets/js/app/settings/data/project/ProjectHelper.test.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/data/project/ProjectHelper.test.ts
@@ -1,0 +1,94 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {AuthContext} from '@enonic/lib-admin-ui/auth/AuthContext';
+import {Principal} from '@enonic/lib-admin-ui/security/Principal';
+import {PrincipalKey} from '@enonic/lib-admin-ui/security/PrincipalKey';
+import {setActiveProject} from '../../../../v6/features/store/activeProject.store';
+import {Project} from './Project';
+import {ProjectHelper} from './ProjectHelper';
+
+const PROJECT_NAME = 'my-project';
+
+const USER = Principal.fromJson({
+    key: 'user:system:tester',
+    displayName: 'Tester',
+    modifiedTime: new Date().toISOString(),
+});
+
+function rolePrincipal(roleId: string): Principal {
+    return Principal.fromJson({
+        key: PrincipalKey.ofRole(roleId).toString(),
+        displayName: roleId,
+        modifiedTime: new Date().toISOString(),
+    });
+}
+
+function initPrincipals(principals: Principal[]): void {
+    AuthContext.init(USER, principals);
+}
+
+function projectRole(role: string): Principal {
+    return rolePrincipal(`cms.project.${PROJECT_NAME}.${role}`);
+}
+
+describe('ProjectHelper.canRequestPublish', () => {
+    beforeEach(() => {
+        setActiveProject(Project.create().setName(PROJECT_NAME).setDisplayName('My Project').build());
+    });
+
+    afterEach(() => {
+        setActiveProject(undefined);
+        vi.restoreAllMocks();
+    });
+
+    it('should allow a system admin', () => {
+        initPrincipals([rolePrincipal('system.admin')]);
+
+        expect(ProjectHelper.canRequestPublish()).toBe(true);
+    });
+
+    it('should allow a content admin', () => {
+        initPrincipals([rolePrincipal('cms.admin')]);
+
+        expect(ProjectHelper.canRequestPublish()).toBe(true);
+    });
+
+    it.each(['owner', 'editor', 'author', 'contributor'])(
+        'should allow a project %s',
+        (role) => {
+            initPrincipals([projectRole(role)]);
+
+            expect(ProjectHelper.canRequestPublish()).toBe(true);
+        });
+
+    it('should allow a role granted transitively via a group membership', () => {
+        // Group membership is resolved server-side into the user's principals.
+        initPrincipals([rolePrincipal('group:system:editors'), projectRole('contributor')]);
+
+        expect(ProjectHelper.canRequestPublish()).toBe(true);
+    });
+
+    it('should deny a viewer-only user', () => {
+        initPrincipals([projectRole('viewer')]);
+
+        expect(ProjectHelper.canRequestPublish()).toBe(false);
+    });
+
+    it('should deny a user with no project role', () => {
+        initPrincipals([rolePrincipal('system.authenticated')]);
+
+        expect(ProjectHelper.canRequestPublish()).toBe(false);
+    });
+
+    it('should deny a role that belongs to a different project', () => {
+        initPrincipals([rolePrincipal('cms.project.other-project.contributor')]);
+
+        expect(ProjectHelper.canRequestPublish()).toBe(false);
+    });
+
+    it('should deny a non-admin when no project is active', () => {
+        setActiveProject(undefined);
+        initPrincipals([projectRole('contributor')]);
+
+        expect(ProjectHelper.canRequestPublish()).toBe(false);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/app/settings/data/project/ProjectHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/settings/data/project/ProjectHelper.ts
@@ -1,12 +1,39 @@
 import {type Project} from './Project';
-import {type PrincipalKey} from '@enonic/lib-admin-ui/security/PrincipalKey';
+import {PrincipalKey} from '@enonic/lib-admin-ui/security/PrincipalKey';
 import {ProjectGetRequest} from '../../resource/ProjectGetRequest';
 import Q from 'q';
 import {type ProjectPermissions} from './ProjectPermissions';
 import {AuthContext} from '@enonic/lib-admin-ui/auth/AuthContext';
-import {getActiveProjectName} from '../../../../v6/features/store/activeProject.store';
+import {getActiveProjectName, isProjectInitialized} from '../../../../v6/features/store/activeProject.store';
+import {ProjectAccess} from '../../access/ProjectAccess';
+import {PermissionsHelper} from '../../../access/PermissionsHelper';
 
 export class ProjectHelper {
+
+    // Any project member except a viewer.
+    private static PUBLISH_REQUEST_ROLES: ProjectAccess[] = [
+        ProjectAccess.OWNER,
+        ProjectAccess.EDITOR,
+        ProjectAccess.AUTHOR,
+        ProjectAccess.CONTRIBUTOR,
+    ];
+
+    static canRequestPublish(): boolean {
+        if (PermissionsHelper.hasAdminPermissions()) {
+            return true;
+        }
+
+        if (!isProjectInitialized()) {
+            return false;
+        }
+
+        const projectName: string = getActiveProjectName();
+        const allowedRoleKeys: PrincipalKey[] = ProjectHelper.PUBLISH_REQUEST_ROLES.map(
+            (role: ProjectAccess) => PrincipalKey.ofRole(`cms.project.${projectName}.${role}`));
+
+        return AuthContext.get().getPrincipals().some(
+            principal => allowedRoleKeys.some((roleKey: PrincipalKey) => roleKey.equals(principal.getKey())));
+    }
 
     public static isUserProjectOwnerOrEditor(): Q.Promise<boolean> {
         return new ProjectGetRequest(getActiveProjectName()).sendAndParse().then((project: Project) => {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/action/ContentWizardActions.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/action/ContentWizardActions.ts
@@ -24,6 +24,7 @@ import {HasUnpublishedChildrenRequest} from '../../resource/HasUnpublishedChildr
 import {type HasUnpublishedChildren, type HasUnpublishedChildrenResult} from '../../resource/HasUnpublishedChildrenResult';
 import {type ContentWizardPanel} from '../ContentWizardPanel';
 import {AccessControlHelper} from '../AccessControlHelper';
+import {ProjectHelper} from '../../settings/data/project/ProjectHelper';
 import {ArchiveContentAction} from './ArchiveContentAction';
 import {ContentSaveAction} from './ContentSaveAction';
 import {CreateIssueAction} from './CreateIssueAction';
@@ -439,7 +440,7 @@ export class ContentWizardActions extends WizardActions<Content> {
         const canPublishTree: boolean = this.canPublishTree();
         const canBeUnpublished: boolean = isPublished(this.content.getContentSummary()) && this.userCanPublish;
         const canBeMarkedAsReady: boolean = this.contentCanBeMarkedAsReady && this.userCanModify;
-        const canBeRequestedPublish: boolean = this.isContentValid && !this.isOnline();
+        const canBeRequestedPublish: boolean = this.canBeRequestedPublish();
         const isInheritedItem: boolean = this.wizardPanel.isContentExistsInParentProject() && this.content.hasOriginProject();
         const canBeReset: boolean = isInheritedItem && !this.content.isFullyInherited();
         const canBeLocalized: boolean = isInheritedItem && this.content.isDataInherited();
@@ -460,7 +461,11 @@ export class ContentWizardActions extends WizardActions<Content> {
         this.actionsMap.RESET.setVisible(canBeReset);
         this.actionsMap.LOCALIZE.setVisible(canBeLocalized);
 
-        this.updatePublishTreeAction(canPublishTree);
+        this.updateActionsRequiringChildrenInfo(canPublishTree);
+    }
+
+    private canBeRequestedPublish(): boolean {
+        return ProjectHelper.canRequestPublish() && this.isContentValid && (!this.isOnline() || this.hasUnpublishedChildren);
     }
 
     canBePublished(): boolean {
@@ -503,8 +508,13 @@ export class ContentWizardActions extends WizardActions<Content> {
         return true;
     }
 
-    private updatePublishTreeAction(canPublishTree: boolean): void {
-        if (!canPublishTree || this.hasCheckedUnpublishedChildren) {
+    private updateActionsRequiringChildrenInfo(canPublishTree: boolean): void {
+        if (this.hasCheckedUnpublishedChildren || !this.content?.hasChildren()) {
+            return;
+        }
+
+        const isRelevantForRequestPublish = this.isContentValid && ProjectHelper.canRequestPublish();
+        if (!canPublishTree && !isRelevantForRequestPublish) {
             return;
         }
 
@@ -521,7 +531,10 @@ export class ContentWizardActions extends WizardActions<Content> {
                 this.hasUnpublishedChildren = hasUnpublishedChildrenResult
                     .getResult()
                     .some((item: HasUnpublishedChildren) => item.getHasChildren());
-                this.enableActions({PUBLISH_TREE: this.hasUnpublishedChildren});
+                this.enableActions({
+                    PUBLISH_TREE: canPublishTree && this.hasUnpublishedChildren,
+                    REQUEST_PUBLISH: this.canBeRequestedPublish(),
+                });
             })
             .catch((err: unknown) => {
                 this.hasCheckedUnpublishedChildren = false;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/requestPublish/RequestPublishDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/requestPublish/RequestPublishDialogContent.tsx
@@ -10,9 +10,9 @@ import {
     $requestPublishDialog,
     $requestPublishDialogCreateCount,
     $requestPublishDialogErrors,
+    $requestPublishPublishableCount,
     excludeInProgressRequestPublishItems,
     excludeInvalidRequestPublishItems,
-    excludeNotPublishableRequestPublishItems,
     markAllAsReadyInProgressRequestPublishItems,
     removeRequestPublishItem,
     setRequestPublishAssignees,
@@ -61,8 +61,9 @@ export const RequestPublishDialogContent = (): ReactElement => {
         ],
     });
     const createCount = useStore($requestPublishDialogCreateCount);
+    const publishableCount = useStore($requestPublishPublishableCount);
     const isPublishReady = useStore($isRequestPublishReady);
-    const {invalid, inProgress, noPermissions} = useStore($requestPublishDialogErrors);
+    const {invalid, inProgress} = useStore($requestPublishDialogErrors);
     const {allowContentUpdate} = useStore($config, {keys: ['allowContentUpdate']});
 
     const dialogTitle = useI18n('action.requestPublish');
@@ -75,6 +76,8 @@ export const RequestPublishDialogContent = (): ReactElement => {
     const applyLabel = useI18n('action.apply');
     const noResultsLabel = useI18n('dialog.search.result.noResults');
     const includeChildrenLabel = useI18n('dialog.includeChildren');
+    const nothingToPublishText = useI18n('dialog.publish.noItems');
+    const nothingToPublishWarning = createCount > 0 && publishableCount === 0 ? nothingToPublishText : undefined;
 
     const excludeChildrenSet = useMemo(
         () => new Set(excludeChildrenIds.map(id => id.toString())),
@@ -105,8 +108,8 @@ export const RequestPublishDialogContent = (): ReactElement => {
 
     const itemsWithUnpublishedChildren = useItemsWithUnpublishedChildren(items);
 
-    const createButtonLabel = createCount > 1
-        ? `${createLabel} (${createCount})`
+    const createButtonLabel = publishableCount > 1
+        ? `${createLabel} (${publishableCount})`
         : createLabel;
     const isCreateDisabled = submitting || loading || !isPublishReady || title.trim().length === 0;
 
@@ -141,6 +144,7 @@ export const RequestPublishDialogContent = (): ReactElement => {
                 loading={loading}
                 failed={failed}
                 showReady={isPublishReady}
+                warningText={nothingToPublishWarning}
                 editing={false}
                 onApply={() => undefined}
                 onCancel={() => undefined}
@@ -155,10 +159,6 @@ export const RequestPublishDialogContent = (): ReactElement => {
                     invalid: {
                         ...invalid,
                         onExclude: () => excludeInvalidRequestPublishItems(),
-                    },
-                    noPermissions: {
-                        ...noPermissions,
-                        onExclude: () => excludeNotPublishableRequestPublishItems(),
                     },
                 }}
             />

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/status-bar/SelectionStatusBar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/status-bar/SelectionStatusBar.tsx
@@ -13,6 +13,7 @@ type Props = {
     editing?: boolean;
     failed?: boolean;
     showReady?: boolean;
+    warningText?: string;
     onApply: () => void;
     onCancel: () => void;
     errors: {
@@ -27,7 +28,7 @@ type Props = {
             disabled?: boolean;
             onExclude: () => void;
         };
-        noPermissions: {
+        noPermissions?: {
             count: number;
             disabled?: boolean;
             onExclude: () => void;
@@ -37,13 +38,14 @@ type Props = {
 
 type ErrorKind = keyof Props['errors'];
 
-type Status = 'loading' | 'failed' | 'editing' | 'ready' | 'errors' | 'none';
+type Status = 'loading' | 'failed' | 'editing' | 'ready' | 'errors' | 'warning' | 'none';
 
 function getStatus({
     loading,
     failed,
     editing,
     showReady,
+    warningText,
     errors,
 }: Omit<Props, 'className' | 'onApply' | 'onCancel'>): Status {
     if (loading) {
@@ -55,8 +57,11 @@ function getStatus({
     if (editing) {
         return 'editing';
     }
-    if (Object.values(errors).some(({count}) => count > 0)) {
+    if (Object.values(errors).some(entry => (entry?.count ?? 0) > 0)) {
         return 'errors';
+    }
+    if (warningText) {
+        return 'warning';
     }
     if (showReady) {
         return 'ready';
@@ -126,6 +131,13 @@ export const SelectionStatusBar = ({className, onApply, onCancel, ...props}: Pro
                 </StatusBarEntry>
             )}
 
+            {status === 'warning' && (
+                <StatusBarEntry className="bg-surface-warn">
+                    <StatusIcon className="w-6 h-6" status="in-progress" />
+                    <span className="text-sm font-semibold">{props.warningText}</span>
+                </StatusBarEntry>
+            )}
+
             {status === 'errors' && inProgress.count > 0 && (
                 <StatusBarErrorEntry status="in-progress" label={`${inProgressText} (${inProgress.count})`}>
                     {!inProgress.disabled && (
@@ -162,7 +174,7 @@ export const SelectionStatusBar = ({className, onApply, onCancel, ...props}: Pro
                 </StatusBarErrorEntry>
             )}
 
-            {status === 'errors' && noPermissions.count > 0 && (
+            {status === 'errors' && noPermissions && noPermissions.count > 0 && (
                 <StatusBarErrorEntry
                     status="invalid"
                     label={`${noPermissionsText} (${noPermissions.count})`}

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.test.ts
@@ -12,6 +12,7 @@ import {
     $isRequestPublishReady,
     $requestPublishDialog,
     $requestPublishDialogErrors,
+    $requestPublishPublishableCount,
     openRequestPublishDialog,
     resetRequestPublishDialogContext,
     submitRequestPublishDialog,
@@ -155,6 +156,41 @@ describe('requestPublishDialog.store', () => {
         expect($requestPublishDialogErrors.get().inProgress.count).toBe(0);
         expect($isRequestPublishReady.get()).toBe(true);
         expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not block create-readiness when the user lacks publish permission', async () => {
+        const itemId = new ContentId('item-1');
+        const item = createMockContent('item-1');
+
+        // notPublishable must not block creating a publish request.
+        mockResolvePublishDependencies.mockResolvedValue(createResolveResult({notPublishable: [itemId]}));
+
+        openRequestPublishDialog([item]);
+        await flushRequestPublishReload();
+
+        expect($isRequestPublishReady.get()).toBe(true);
+    });
+
+    it('should block create-readiness when no selected item needs publishing', async () => {
+        // A purely online item has nothing to publish.
+        const item = createMockContent('online-1', {isOnline: true});
+
+        openRequestPublishDialog([item]);
+        await flushRequestPublishReload();
+
+        expect($requestPublishPublishableCount.get()).toBe(0);
+        expect($isRequestPublishReady.get()).toBe(false);
+    });
+
+    it('should allow create-readiness when at least one item needs publishing', async () => {
+        const onlineItem = createMockContent('online-1', {isOnline: true});
+        const offlineItem = createMockContent('offline-1');
+
+        openRequestPublishDialog([onlineItem, offlineItem]);
+        await flushRequestPublishReload();
+
+        expect($requestPublishPublishableCount.get()).toBe(1);
+        expect($isRequestPublishReady.get()).toBe(true);
     });
 
     it('patches renamed items without forcing a dependency reload', async () => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.ts
@@ -12,6 +12,7 @@ import {markAsReady, resolvePublishDependencies} from '../../api/publish';
 import {buildItems, dedupeItems, getItemIds} from '../../utils/cms/content/buildItems';
 import {hasContentIdInIds, uniqueIds} from '../../utils/cms/content/ids';
 import {findContentIdsWithCreatedDescendants} from '../../utils/cms/content/paths';
+import {isOnline} from '../../utils/cms/content/status';
 import {
     createContentIdSet,
     patchTrackedContentItems,
@@ -51,8 +52,6 @@ type RequestPublishChecksStore = {
     invalidExcludable: boolean;
     inProgressIds: ContentId[];
     inProgressExcludable: boolean;
-    notPublishableIds: ContentId[];
-    notPublishableExcludable: boolean;
 };
 
 const initialState: RequestPublishDialogStore = {
@@ -75,8 +74,6 @@ const initialChecksState: RequestPublishChecksStore = {
     invalidExcludable: false,
     inProgressIds: [],
     inProgressExcludable: false,
-    notPublishableIds: [],
-    notPublishableExcludable: false,
 };
 
 export const $requestPublishDialog = map<RequestPublishDialogStore>(structuredClone(initialState));
@@ -98,7 +95,6 @@ export const $requestPublishDialogErrors = computed(
         const excludedSet = new Set<string>(excludedDependantIds.map(id => id.toString()));
         const invalidCount = checks.invalidIds.filter(id => !excludedSet.has(id.toString())).length;
         const inProgressCount = checks.inProgressIds.filter(id => !excludedSet.has(id.toString())).length;
-        const noPermissionsCount = checks.notPublishableIds.filter(id => !excludedSet.has(id.toString())).length;
 
         return {
             invalid: {
@@ -109,24 +105,33 @@ export const $requestPublishDialogErrors = computed(
                 count: inProgressCount,
                 disabled: !checks.inProgressExcludable,
             },
-            noPermissions: {
-                count: noPermissionsCount,
-                disabled: !checks.notPublishableExcludable,
-            },
         };
     },
 );
 
+export const $requestPublishPublishableCount = computed(
+    $requestPublishDialog,
+    ({items, dependants, excludedDependantIds}) => {
+        const included = [
+            ...items,
+            ...dependants.filter(item => !hasContentIdInIds(item.getContentId(), excludedDependantIds)),
+        ];
+        return included.filter(item => !isOnline(item)).length;
+    },
+);
+
 export const $isRequestPublishReady = computed(
-    [$requestPublishDialog, $requestPublishDialogCreateCount, $requestPublishDialogErrors],
-    ({loading, failed}, total, errors): boolean => {
+    [$requestPublishDialog, $requestPublishDialogCreateCount, $requestPublishPublishableCount, $requestPublishDialogErrors],
+    ({loading, failed}, total, publishableCount, errors): boolean => {
         if (loading || failed) {
             return false;
         }
+        // Publish permission is intentionally not a gate: a publish request is how a
+        // user without publish rights asks someone else to publish.
         return total > 0 &&
+               publishableCount > 0 &&
                errors.invalid.count === 0 &&
-               errors.inProgress.count === 0 &&
-               errors.noPermissions.count === 0;
+               errors.inProgress.count === 0;
     },
 );
 
@@ -451,24 +456,6 @@ export const excludeInProgressRequestPublishItems = (): void => {
     );
 };
 
-export const excludeNotPublishableRequestPublishItems = (): void => {
-    const {dependants, excludedDependantIds, requiredDependantIds} = $requestPublishDialog.get();
-    const dependantIds = dependants.map(item => item.getContentId());
-    const notPublishableIds = $requestPublishChecks.get().notPublishableIds;
-    const idsToExclude = notPublishableIds
-        .filter(id => hasContentIdInIds(id, dependantIds))
-        .filter(id => !hasContentIdInIds(id, requiredDependantIds));
-
-    if (idsToExclude.length === 0) {
-        return;
-    }
-
-    $requestPublishDialog.setKey(
-        'excludedDependantIds',
-        uniqueIds([...excludedDependantIds, ...idsToExclude]),
-    );
-};
-
 export const markAllAsReadyInProgressRequestPublishItems = async (): Promise<void> => {
     const currentState = $requestPublishDialog.get();
     if (currentState.loading) {
@@ -598,7 +585,6 @@ const reloadRequestPublishDependencies = async (): Promise<void> => {
 
         const invalidIds = result.getInvalid();
         const inProgressIds = result.getInProgress().filter(id => !hasContentIdInIds(id, invalidIds));
-        const notPublishableIds = result.getNotPublishable();
 
         const isExcludable = (id: ContentId): boolean => {
             return !hasContentIdInIds(id, itemIds) &&
@@ -608,7 +594,6 @@ const reloadRequestPublishDependencies = async (): Promise<void> => {
 
         const invalidExcludable = invalidIds.length > 0 && invalidIds.every(id => isExcludable(id));
         const inProgressExcludable = inProgressIds.length > 0 && inProgressIds.every(id => isExcludable(id));
-        const notPublishableExcludable = notPublishableIds.length > 0 && notPublishableIds.every(id => isExcludable(id));
 
         $requestPublishDialog.set({
             ...latestState,
@@ -624,8 +609,6 @@ const reloadRequestPublishDependencies = async (): Promise<void> => {
             invalidExcludable,
             inProgressIds,
             inProgressExcludable,
-            notPublishableIds,
-            notPublishableExcludable,
         });
     } catch (error) {
         if (currentInstance !== instanceId) {

--- a/testing/specs/publish/browse.panel.publish.menu.spec.js
+++ b/testing/specs/publish/browse.panel.publish.menu.spec.js
@@ -34,7 +34,7 @@ describe('browse.panel.publish.menu.spec tests for Publish button in grid-toolba
         await studioUtils.doAddSite(SITE);
     });
 
-    it(`GIVEN browse panel is loaded WHEN no selected items THEN 'CREATE TASK...' button should appear in the browse-toolbar`, async () => {
+    it(`GIVEN browse panel is loaded WHEN no selected items THEN 'CREATE Issue' button should appear in the browse-toolbar`, async () => {
         let contentBrowsePanel = new ContentBrowsePanel();
         await contentBrowsePanel.waitForCreateIssueButtonDisplayed();
     });
@@ -64,7 +64,7 @@ describe('browse.panel.publish.menu.spec tests for Publish button in grid-toolba
             assert.equal(status, appConst.CONTENT_STATUS.ONLINE, 'The folder should be Online');
         });
 
-    it(`GIVEN existing 'published' folder WHEN publish menu has been expanded THEN 'Unpublish' and 'Create Task...' menu items should be enabled`,
+    it(`GIVEN existing 'online' folder WHEN publish menu has been expanded THEN only 'Create Issue' menu items should be enabled`,
         async () => {
             let contentBrowsePanel = new ContentBrowsePanel();
             // 1. Select the folder:
@@ -72,7 +72,7 @@ describe('browse.panel.publish.menu.spec tests for Publish button in grid-toolba
             // 2. Open Publish Menu and verify status of all menu items:
             await contentBrowsePanel.openPublishMenu();
             await studioUtils.saveScreenshot('publish_menu_Folder_published');
-            await contentBrowsePanel.waitForPublishMenuItemEnabled(appConst.PUBLISH_MENU.REQUEST_PUBLISH);
+            await contentBrowsePanel.waitForPublishMenuItemDisabled(appConst.PUBLISH_MENU.REQUEST_PUBLISH);
             await contentBrowsePanel.waitForPublishMenuItemEnabled(appConst.PUBLISH_MENU.CREATE_ISSUE);
             await contentBrowsePanel.waitForPublishMenuItemDisabled(appConst.PUBLISH_MENU.PUBLISH_TREE);
             await contentBrowsePanel.waitForPublishMenuItemDisabled(appConst.PUBLISH_MENU.MARK_AS_READY);
@@ -109,7 +109,7 @@ describe('browse.panel.publish.menu.spec tests for Publish button in grid-toolba
             await contentBrowsePanel.waitForPublishTreeButtonVisible();
         });
 
-    it(`GIVEN existing published site has been selected WHEN 'PUBLISH TREE...' button has been pressed THEN published dependent items should not be displayed in the dialog`,
+    it(`GIVEN existing published site has been selected WHEN 'PUBLISH TREE' button has been pressed THEN published dependent items should not be displayed in the dialog`,
         async () => {
             let contentBrowsePanel = new ContentBrowsePanel();
             let contentWizard = new ContentWizard();
@@ -137,7 +137,7 @@ describe('browse.panel.publish.menu.spec tests for Publish button in grid-toolba
         });
 
     //test verifies https://github.com/enonic/app-contentstudio/issues/493
-    it(`GIVEN existing published site has been selected WHEN 'PUBLISH TREE...' has been pressed THEN UNPUBLISH gets visible in the browse toolbar`,
+    it(`GIVEN existing published site has been selected WHEN 'PUBLISH TREE' has been pressed THEN UNPUBLISH gets visible in the browse toolbar`,
         async () => {
             let contentBrowsePanel = new ContentBrowsePanel();
             await studioUtils.findAndSelectItem(SITE.displayName);


### PR DESCRIPTION
# Request Publishing — aligned with legacy behavior

1. Replaced the wrong "needs publish permission" rule with the correct one: anyone who can act on the project (admin, or project role of contributor and above) may request publishing; only pure viewers cannot. Requesting publish is exactly for people who can't publish themselves, so publish permission must not be required.
2. The "Request Publishing" action is now disabled when the selection has nothing to publish (everything already online), instead of staying active.
3. Request Publishing now also turns on when a selected item is itself online but still has unpublished children, so a user can request publishing of the subtree — matching how Publish Tree already worked.
4. Made the children lookup robust against fast selection switching: a slow response for a previous selection can no longer flip the buttons for the current one.
5. Applied that single rule everywhere the action can be triggered — browse toolbar, the async children path, and the content wizard — so behavior is consistent.
6. Removed the false "Permissions" block in the dialog: lacking publish permission no longer disables the Create button (the backend that creates the request doesn't require it either).
7. Cleaned up the now-unused permission-blocking code left over from that old behavior.
8. The Create button is now disabled while the list contains nothing publishable (e.g. only an online parent with its children excluded); it enables once at least one item with actual changes is included.
9. When Create is blocked for that reason, a warning is shown at the top of the dialog explaining there's nothing to publish.
10. The count on the Create button now reflects only the items that will actually be published (online items are excluded), so it matches what really happens.