### PR TITLE
Content Operator: only set AI context while the dialog is open #10758

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.host.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.host.test.ts
@@ -1,7 +1,14 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import type {AiPlugin, AiPluginContext, AiPluginInstance} from './ai-protocol';
-import {__resetAiHostForTest, getAiHost, mountReadyPlugins} from './ai.host';
-import {$aiReady} from './ai.store';
+import {
+    __resetAiHostForTest,
+    captureOperatorSeed,
+    getAiHost,
+    handleDataActivePath,
+    mountReadyPlugins,
+    openOperatorWithSeed,
+} from './ai.host';
+import {$aiPluginDialogOpen, $aiReady} from './ai.store';
 
 function fakePlugin(overrides: Partial<AiPlugin> = {}): {plugin: AiPlugin; dispose: () => void; mount: ReturnType<typeof vi.fn>} {
     const dispose = vi.fn();
@@ -12,6 +19,23 @@ function fakePlugin(overrides: Partial<AiPlugin> = {}): {plugin: AiPlugin; dispo
         dispose,
         mount,
     };
+}
+
+// Mounts a fake Content Operator that records every context:set payload.
+function mountOperator(): {received: (string | null)[]} {
+    const received: (string | null)[] = [];
+    const mount = vi.fn((_c: HTMLElement, ctx: AiPluginContext) => {
+        ctx.api.on('context:set', payload => received.push(payload));
+        return {dispose: vi.fn()};
+    });
+    getAiHost().register({
+        id: 'ai.contentOperator',
+        version: '1.0.0',
+        commands: ['context:set', 'dialog:open'],
+        mount,
+    });
+    mountReadyPlugins();
+    return {received};
 }
 
 describe('AiHost', () => {
@@ -60,5 +84,83 @@ describe('AiHost', () => {
         getAiHost().register(plugin);
         mountReadyPlugins();
         expect(mount).not.toHaveBeenCalled();
+    });
+});
+
+describe('Content Operator context', () => {
+    beforeEach(() => {
+        __resetAiHostForTest();
+    });
+
+    it('does not push context on focus while the dialog is closed', () => {
+        const operator = mountOperator();
+        $aiPluginDialogOpen.setKey('ai.contentOperator', false);
+
+        handleDataActivePath('.title');
+
+        expect(operator.received).toEqual([]);
+    });
+
+    it('pushes context on focus while the dialog is open', () => {
+        const operator = mountOperator();
+        $aiPluginDialogOpen.setKey('ai.contentOperator', true);
+
+        handleDataActivePath('.title');
+
+        expect(operator.received).toEqual(['/title']);
+    });
+
+    it('seeds the dialog with the field focused at capture time on open', () => {
+        const operator = mountOperator();
+
+        // Focus while closed: remembered, not sent.
+        handleDataActivePath('.title');
+        expect(operator.received).toEqual([]);
+
+        captureOperatorSeed();
+        openOperatorWithSeed();
+
+        expect(operator.received).toEqual(['/title']);
+    });
+
+    it('does not seed when no field is focused at capture time', () => {
+        const operator = mountOperator();
+
+        // Focus then blur to a neutral element: live field cleared.
+        handleDataActivePath('.title');
+        handleDataActivePath(undefined);
+
+        captureOperatorSeed();
+        openOperatorWithSeed();
+
+        expect(operator.received).toEqual([]);
+    });
+
+    it('seeds the most recently focused field, not a stale one', () => {
+        const operator = mountOperator();
+
+        handleDataActivePath('.title');
+        handleDataActivePath('.body');
+
+        captureOperatorSeed();
+        openOperatorWithSeed();
+
+        expect(operator.received).toEqual(['/body']);
+    });
+
+    it('clears the pending seed after opening, so a later open does not re-seed', () => {
+        const operator = mountOperator();
+
+        handleDataActivePath('.title');
+        captureOperatorSeed();
+        openOperatorWithSeed();
+        expect(operator.received).toEqual(['/title']);
+
+        // No new capture: blur the field, then open again.
+        handleDataActivePath(undefined);
+        captureOperatorSeed();
+        openOperatorWithSeed();
+
+        expect(operator.received).toEqual(['/title']);
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.host.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.host.ts
@@ -24,6 +24,12 @@ type Registration = {
 const registry = new Map<AiPluginId, Registration>();
 let isInitialized = false;
 
+// Live context path of the focused data field, or null when none is focused.
+let activeDataContext: string | null = null;
+
+// Captured at toggle pointer-down, before the click blurs the focused field.
+let pendingOperatorSeed: string | null = null;
+
 function isKnownId(id: string): id is AiPluginId {
     return (KNOWN_IDS as readonly string[]).includes(id);
 }
@@ -167,6 +173,43 @@ export function sendPluginContext(id: AiPluginId, context: string | null): void 
 }
 
 //
+// * Content Operator context bridge
+//
+// Focused field is pushed as context only while the dialog is open; while
+// closed it is remembered as a seed for the next open.
+
+// Records the focused data field and, while the operator dialog is open, pushes
+// it as context. Blur (undefined) clears the live field but sends nothing — the
+// plugin keeps its last context until another field is focused.
+export function handleDataActivePath(activePath: string | undefined): void {
+    if (activePath == null) {
+        activeDataContext = null;
+        return;
+    }
+    // Drop the leading dot: ".itemSet[1].field" -> "itemSet[1].field".
+    const field = activePath.startsWith('.') ? activePath.slice(1) : activePath;
+    const context = field.length > 0 ? toPluginContextPath({kind: 'data', field}) : null;
+    activeDataContext = context;
+    if (context != null && $aiPluginDialogOpen.get()['ai.contentOperator']) {
+        sendPluginContext('ai.contentOperator', context);
+    }
+}
+
+// Snapshots the live focused field as the seed for the next operator open. Call
+// from the toolbar toggle's pointer-down, before the click blurs the field.
+export function captureOperatorSeed(): void {
+    pendingOperatorSeed = activeDataContext;
+}
+
+export function openOperatorWithSeed(): void {
+    openPluginDialog('ai.contentOperator');
+    if (pendingOperatorSeed != null) {
+        sendPluginContext('ai.contentOperator', pendingOperatorSeed);
+    }
+    pendingOperatorSeed = null;
+}
+
+//
 // * Signal fan-out
 //
 
@@ -222,30 +265,18 @@ export function initAiHost(): void {
         }
     });
 
-    $aiContent.subscribe(() => fanOutContent());
+    $aiContent.subscribe(() => {
+        // New content remounts the form; drop remembered focus and seed so the
+        // next open starts clean.
+        activeDataContext = null;
+        pendingOperatorSeed = null;
+        fanOutContent();
+    });
     $aiContentType.subscribe(() => fanOutSchema());
     $aiContentLanguage.subscribe(() => fanOutLanguage());
     $aiInstructions.subscribe(() => fanOutConfig());
 
-    // Push the focused field itself as context so it becomes the single mention
-    // target. Ignore the blur signal — context persists until another field is
-    // focused or the user clears it from the dialog.
-    getAiFieldRegistry('data').subscribeActivePath(activePath => {
-        if (activePath == null) {
-            return;
-        }
-        // Strip the leading dot from the absolute data path (e.g. ".itemSet[1].field" -> "itemSet[1].field").
-        const field = activePath.startsWith('.') ? activePath.slice(1) : activePath;
-        if (field.length === 0) {
-            return;
-        }
-
-        const context = toPluginContextPath({kind: 'data', field});
-        if (context == null) {
-            return;
-        }
-        sendPluginContext('ai.contentOperator', context);
-    });
+    getAiFieldRegistry('data').subscribeActivePath(handleDataActivePath);
 }
 
 // Test-only: clears the registry and mounted instances between specs.
@@ -254,4 +285,8 @@ export function __resetAiHostForTest(): void {
     registry.clear();
     $aiRegisteredPlugins.setKey('ai.translator', false);
     $aiRegisteredPlugins.setKey('ai.contentOperator', false);
+    $aiPluginDialogOpen.setKey('ai.translator', false);
+    $aiPluginDialogOpen.setKey('ai.contentOperator', false);
+    activeDataContext = null;
+    pendingOperatorSeed = null;
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/ai/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/ai/index.ts
@@ -16,7 +16,13 @@ export {clearAiTopicError} from './ai.commands';
 export {initAiHost} from './ai.host';
 
 // Write: AI plugin host commands
-export {closePluginDialog, openPluginDialog, sendPluginContext} from './ai.host';
+export {
+    captureOperatorSeed,
+    closePluginDialog,
+    openOperatorWithSeed,
+    openPluginDialog,
+    sendPluginContext,
+} from './ai.host';
 
 // Write: commands
 export {

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/toolbar/ContentWizardToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/toolbar/ContentWizardToolbar.tsx
@@ -10,7 +10,7 @@ import {LayerIndicator} from '../../../shared/icons/LayerIndicator';
 import {ProjectIcon} from '../../../shared/icons/ProjectIcon';
 import {StatusIcon} from '../../../shared/icons/StatusIcon';
 import {StatusBadge} from '../../../shared/status/StatusBadge';
-import {$aiPluginDialogOpen, $aiRegisteredPlugins, closePluginDialog, openPluginDialog} from '../../../store/ai';
+import {$aiPluginDialogOpen, $aiRegisteredPlugins, captureOperatorSeed, closePluginDialog, openOperatorWithSeed} from '../../../store/ai';
 import {setInspectSaveAction} from '../../../store/inspect-panel.store';
 import {$wizardToolbar} from '../../../store/wizardToolbar.store';
 import {formatContentFullPath} from '../../../utils/cms/content/paths';
@@ -149,9 +149,14 @@ export const ContentWizardToolbar = ({
     const [desktopPublishSplitRef, isDesktopPublishSplitVisible] = useElementVisibility<HTMLDivElement>();
     const [mobileActionsSplitRef, isMobileActionsSplitVisible] = useElementVisibility<HTMLDivElement>();
 
+    // Capture the focused field before this click blurs it; consumed on open.
+    const handleAiOperatorPointerDown = (): void => {
+        captureOperatorSeed();
+    };
+
     const handleAiOperatorToggle = (pressed: boolean): void => {
         if (pressed) {
-            openPluginDialog('ai.contentOperator');
+            openOperatorWithSeed();
         } else {
             closePluginDialog('ai.contentOperator');
         }
@@ -278,6 +283,7 @@ export const ContentWizardToolbar = ({
                                     startIcon={JukeIcon}
                                     startIconClassName="size-7"
                                     pressed={isOperatorDialogOpen}
+                                    onPointerDown={handleAiOperatorPointerDown}
                                     onPressedChange={handleAiOperatorToggle}
                                 />
                             </Toolbar.Item>


### PR DESCRIPTION
Stops Content Studio from pushing AI context to the Content Operator on every field focus. Context is now updated only while the operator dialog is open; while closed, the focused field is just remembered. On open, the dialog is seeded with the field captured at the toggle's pointer-down — before the click blurs the input — so a stale field is never shown. Clearing context on close stays the operator plugin's responsibility.

- Gated context updates on dialog-open state and added live focused-field tracking in `ai.host.ts`.
- Added `captureOperatorSeed`/`openOperatorWithSeed` and wired the toolbar toggle to capture focus on `onPointerDown`.
- Added host tests for gating, seeding, and pending-seed clearing.

Closes #10758

<sub>*Drafted with AI assistance*</sub>
