### PR TITLE
Content form doesn't respect server-side validation #10762

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -1434,7 +1434,10 @@ export class ContentWizardPanel
         // set the new property set to the form so that we receive change events
         // should happen before resetWizard which clears dirty state on inputs
         escalateVisibility('all');
-        setServerValidationErrors(this.getCurrentItem().getValidationErrors());
+        // Use the server-saved item — the update is re-validated server-side and
+        // carries fresh validationErrors. getCurrentItem() is the in-memory draft
+        // built from the form and has none, which would wipe the errors on save.
+        setServerValidationErrors(persistedItem.getValidationErrors());
 
         return Q.resolve(persistedItem);
     }

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/item-set/ItemSetView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/item-set/ItemSetView.tsx
@@ -1,7 +1,9 @@
+import {PropertyPath, PropertyPathElement} from '@enonic/lib-admin-ui/data/PropertyPath';
 import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
 import type {FormItemSet} from '@enonic/lib-admin-ui/form/set/itemset/FormItemSet';
 import {
     usePropertySetArray,
+    useServerErrors,
     useSetOccurrenceManager,
     useValidationVisibility,
     ValidationVisibilityProvider,
@@ -36,7 +38,16 @@ export const ItemSetView = ({itemSet, propertySet}: ItemSetViewProps): ReactElem
     const {propertySets} = usePropertySetArray(propertyArray);
     const propertySetKeys = usePropertySetKeys(propertySets);
     const {state, remove, move} = useSetOccurrenceManager(occurrences, propertySets);
+    const serverErrors = useServerErrors();
     const {setOccurrenceRef, scheduleScrollTo} = useScrollPanelToOccurrence(propertySets);
+
+    // Structural occurrence changes (add/remove/move) shift set positions, so the
+    // positional server errors under this set no longer align — drop them all
+    // (re-validated on the next save). Plain edits clear per-occurrence elsewhere.
+    const clearSetServerErrors = useCallback(() => {
+        const path = PropertyPath.fromParent(propertySet.getPropertyPath(), new PropertyPathElement(name, 0)).toString();
+        serverErrors?.clearField(path.startsWith('.') ? path.slice(1) : path);
+    }, [serverErrors, propertySet, name]);
     const lastAddedIndexRef = useRef<number | null>(null);
     const {expanded, isAllExpanded, handleExpandAll, handleCollapseAll, handleDragStart, handleToggleSingle} = useSetExpanded(
         propertyArray,
@@ -58,7 +69,8 @@ export const ItemSetView = ({itemSet, propertySet}: ItemSetViewProps): ReactElem
         lastAddedIndexRef.current = index;
         propertyArray.addSet();
         scheduleScrollTo(index);
-    }, [state.canAdd, propertyArray, scheduleScrollTo]);
+        clearSetServerErrors();
+    }, [state.canAdd, propertyArray, scheduleScrollTo, clearSetServerErrors]);
     const handleAddAbove = useCallback(
         (index: number) => {
             if (!state.canAdd) return;
@@ -67,8 +79,9 @@ export const ItemSetView = ({itemSet, propertySet}: ItemSetViewProps): ReactElem
             propertyArray.addSet();
             propertyArray.move(propertyArray.getSize() - 1, index);
             scheduleScrollTo(index);
+            clearSetServerErrors();
         },
-        [state.canAdd, propertyArray, scheduleScrollTo]
+        [state.canAdd, propertyArray, scheduleScrollTo, clearSetServerErrors]
     );
     const handleAddBelow = useCallback(
         (index: number) => {
@@ -78,8 +91,9 @@ export const ItemSetView = ({itemSet, propertySet}: ItemSetViewProps): ReactElem
             propertyArray.addSet();
             propertyArray.move(propertyArray.getSize() - 1, index + 1);
             scheduleScrollTo(index + 1);
+            clearSetServerErrors();
         },
-        [state.canAdd, propertyArray, scheduleScrollTo]
+        [state.canAdd, propertyArray, scheduleScrollTo, clearSetServerErrors]
     );
     const handleRemove = useCallback(
         (index: number) => {
@@ -87,17 +101,19 @@ export const ItemSetView = ({itemSet, propertySet}: ItemSetViewProps): ReactElem
 
             if (remove(index)) {
                 propertyArray.remove(index);
+                clearSetServerErrors();
             }
         },
-        [state.canRemove, remove, propertyArray]
+        [state.canRemove, remove, propertyArray, clearSetServerErrors]
     );
     const handleMove = useCallback(
         (fromIndex: number, toIndex: number) => {
             if (move(fromIndex, toIndex)) {
                 propertyArray.move(fromIndex, toIndex);
+                clearSetServerErrors();
             }
         },
-        [move, propertyArray]
+        [move, propertyArray, clearSetServerErrors]
     );
 
     return (

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/option-set/OptionSetView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/option-set/OptionSetView.tsx
@@ -1,7 +1,9 @@
+import {PropertyPath, PropertyPathElement} from '@enonic/lib-admin-ui/data/PropertyPath';
 import type {PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
 import type {FormOptionSet} from '@enonic/lib-admin-ui/form/set/optionset/FormOptionSet';
 import {
     usePropertySetArray,
+    useServerErrors,
     useSetOccurrenceManager,
     useValidationVisibility,
     ValidationVisibilityProvider,
@@ -56,8 +58,17 @@ export const OptionSetView = ({optionSet, propertySet}: OptionSetViewProps): Rea
     const {propertySets} = usePropertySetArray(propertyArray);
     const propertySetKeys = usePropertySetKeys(propertySets);
     const {state, remove, move} = useSetOccurrenceManager(occurrences, propertySets);
+    const serverErrors = useServerErrors();
     const {setOccurrenceRef, scheduleScrollTo} = useScrollPanelToOccurrence(propertySets);
     const lastAddedIndexRef = useRef<number | null>(null);
+
+    // Structural occurrence changes (add/remove/move/reset) shift set positions, so
+    // the positional server errors under this set no longer align — drop them all
+    // (re-validated on the next save). Plain edits clear per-occurrence elsewhere.
+    const clearSetServerErrors = useCallback(() => {
+        const path = PropertyPath.fromParent(propertySet.getPropertyPath(), new PropertyPathElement(name, 0)).toString();
+        serverErrors?.clearField(path.startsWith('.') ? path.slice(1) : path);
+    }, [serverErrors, propertySet, name]);
     const {expanded, isAllExpanded, handleExpandAll, handleCollapseAll, handleDragStart, handleToggleSingle} = useSetExpanded(
         propertyArray,
         state.count
@@ -79,11 +90,12 @@ export const OptionSetView = ({optionSet, propertySet}: OptionSetViewProps): Rea
             const newSet = propertyArray.addSet();
             seedDefaults(newSet);
             scheduleScrollTo(index);
+            clearSetServerErrors();
             return;
         }
 
         setConfirmingAdd(true);
-    }, [isRadio, state.canAdd, propertyArray, seedDefaults, scheduleScrollTo]);
+    }, [isRadio, state.canAdd, propertyArray, seedDefaults, scheduleScrollTo, clearSetServerErrors]);
     const handleConfirmAdd = useCallback(
         (selectedName: string) => {
             setConfirmingAdd(false);
@@ -95,8 +107,9 @@ export const OptionSetView = ({optionSet, propertySet}: OptionSetViewProps): Rea
             const newSet = propertyArray.addSet();
             selectOptionInPropertySet(newSet, optionSet, selectedName);
             scheduleScrollTo(index);
+            clearSetServerErrors();
         },
-        [state.canAdd, propertyArray, optionSet, scheduleScrollTo]
+        [state.canAdd, propertyArray, optionSet, scheduleScrollTo, clearSetServerErrors]
     );
     const handleCancelAdd = useCallback(() => {
         setConfirmingAdd(false);
@@ -114,8 +127,9 @@ export const OptionSetView = ({optionSet, propertySet}: OptionSetViewProps): Rea
                 seedDefaults(newSet);
             }
             scheduleScrollTo(index);
+            clearSetServerErrors();
         },
-        [state.canAdd, propertyArray, optionSet, seedDefaults, scheduleScrollTo]
+        [state.canAdd, propertyArray, optionSet, seedDefaults, scheduleScrollTo, clearSetServerErrors]
     );
     const handleAddBelow = useCallback(
         (index: number, selectedName?: string) => {
@@ -130,8 +144,9 @@ export const OptionSetView = ({optionSet, propertySet}: OptionSetViewProps): Rea
                 seedDefaults(newSet);
             }
             scheduleScrollTo(index + 1);
+            clearSetServerErrors();
         },
-        [state.canAdd, propertyArray, optionSet, seedDefaults, scheduleScrollTo]
+        [state.canAdd, propertyArray, optionSet, seedDefaults, scheduleScrollTo, clearSetServerErrors]
     );
     const handleRemove = useCallback(
         (index: number) => {
@@ -139,9 +154,10 @@ export const OptionSetView = ({optionSet, propertySet}: OptionSetViewProps): Rea
 
             if (remove(index)) {
                 propertyArray.remove(index);
+                clearSetServerErrors();
             }
         },
-        [state.canRemove, remove, propertyArray]
+        [state.canRemove, remove, propertyArray, clearSetServerErrors]
     );
     const handleReset = useCallback(
         (index: number) => {
@@ -156,16 +172,18 @@ export const OptionSetView = ({optionSet, propertySet}: OptionSetViewProps): Rea
             for (const option of optionSet.getOptions()) {
                 ps.removeProperty(option.getName(), 0);
             }
+            clearSetServerErrors();
         },
-        [propertySets, optionSet]
+        [propertySets, optionSet, clearSetServerErrors]
     );
     const handleMove = useCallback(
         (fromIndex: number, toIndex: number) => {
             if (move(fromIndex, toIndex)) {
                 propertyArray.move(fromIndex, toIndex);
+                clearSetServerErrors();
             }
         },
-        [move, propertyArray]
+        [move, propertyArray, clearSetServerErrors]
     );
 
     return (

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.test.ts
@@ -10,23 +10,36 @@ import {MixinName} from '../../../app/content/MixinName';
 import {Workflow} from '../../../app/content/Workflow';
 import {WorkflowState} from '../../../app/content/WorkflowState';
 import type {ContentType} from '../../../app/inputtype/schema/ContentType';
+import {ValidationError} from '@enonic/lib-admin-ui/ValidationError';
 import {
+    $wizardDataVersion,
     initializeWizardContentState,
     resetWizardContent,
     setDraftDisplayName,
 } from './wizardContent.store';
 import {
     $invalidTabs,
+    $serverErrorEntries,
     $validationVisibility,
+    clearServerErrorsAtPath,
+    clearServerErrorsForField,
     escalateVisibility,
     flushValidation,
     initializeValidation,
     resetValidation,
+    setServerValidationErrors,
 } from './wizardValidation.store';
 
-vi.mock('@enonic/lib-admin-ui/form2', () => {
+vi.mock('@enonic/lib-admin-ui/form2', async () => {
+    // Real (pure) path matchers — the clear commands rely on them; only validateForm
+    // is stubbed to keep form2's heavy React components out of the node test env.
+    const serverErrors = await vi.importActual<typeof import('@enonic/lib-admin-ui/form2/utils/serverErrors')>(
+        '@enonic/lib-admin-ui/form2/utils/serverErrors',
+    );
     return {
         validateForm: vi.fn(() => ({isValid: true, children: []})),
+        matchesFieldPath: serverErrors.matchesFieldPath,
+        matchesOccurrencePath: serverErrors.matchesOccurrencePath,
     };
 });
 
@@ -291,6 +304,69 @@ describe('wizardValidation.store', () => {
             flushValidation();
 
             expect($invalidTabs.get().has('content')).toBe(true);
+        });
+    });
+
+    describe('server validation errors', () => {
+        const serverError = (path: string, message: string) =>
+            ValidationError.create().setPropertyPath(path).setMessage(message).build();
+
+        it('should expose content server errors as path/message entries', () => {
+            setupWizard();
+
+            setServerValidationErrors([serverError('long[1]', 'The value is not allowed')]);
+
+            expect($serverErrorEntries.get()).toEqual([{path: 'long[1]', message: 'The value is not allowed'}]);
+        });
+
+        it('should ignore system errors (built-in) and keep custom-app errors', () => {
+            setupWizard();
+            const systemError = ValidationError.create()
+                .setPropertyPath('long')
+                .setMessage('System occurrence message')
+                .setErrorCode('system:cms.occurrencesInvalid')
+                .build();
+            const customError = ValidationError.create()
+                .setPropertyPath('long')
+                .setMessage('Custom app message')
+                .setErrorCode('com.acme.app:badValue')
+                .build();
+
+            setServerValidationErrors([systemError, customError]);
+
+            expect($serverErrorEntries.get()).toEqual([{path: 'long', message: 'Custom app message'}]);
+        });
+
+        it('should NOT clear server errors when the data version bumps (regression)', () => {
+            setupWizard();
+            setServerValidationErrors([serverError('long[1]', 'bad')]);
+
+            // Simulate any field edit bumping the data version.
+            $wizardDataVersion.set($wizardDataVersion.get() + 1);
+
+            expect($serverErrorEntries.get()).toEqual([{path: 'long[1]', message: 'bad'}]);
+        });
+
+        it('clearServerErrorsAtPath should drop only the matching occurrence', () => {
+            setupWizard();
+            setServerValidationErrors([serverError('mySet', 'a'), serverError('mySet[1].title', 'b')]);
+
+            clearServerErrorsAtPath('mySet[1].title');
+
+            expect($serverErrorEntries.get()).toEqual([{path: 'mySet', message: 'a'}]);
+        });
+
+        it('clearServerErrorsForField should drop every occurrence of the field only', () => {
+            setupWizard();
+            setServerValidationErrors([
+                serverError('mySet', 'a'),
+                serverError('mySet[1].title', 'b'),
+                serverError('other', 'c'),
+            ]);
+
+            clearServerErrorsForField('mySet');
+
+            expect($serverErrorEntries.get()).toEqual([{path: 'other', message: 'c'}]);
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.ts
@@ -1,7 +1,6 @@
 import {ComponentConfigValidationError, DataValidationError, MixinConfigValidationError, SiteConfigValidationError, type ValidationError} from '@enonic/lib-admin-ui/ValidationError';
-import {ValidationErrorHelper} from '@enonic/lib-admin-ui/ValidationErrorHelper';
-import {type RawValueMap, type ValidationVisibility, validateForm} from '@enonic/lib-admin-ui/form2';
-import {atom} from 'nanostores';
+import {matchesFieldPath, matchesOccurrencePath, type RawValueMap, type ServerErrorEntry, type ValidationVisibility, validateForm} from '@enonic/lib-admin-ui/form2';
+import {atom, computed} from 'nanostores';
 import type {PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
 import type {Descriptor} from '../../../app/page/Descriptor';
 import {DescriptorBasedComponent} from '../../../app/page/region/DescriptorBasedComponent';
@@ -34,6 +33,11 @@ export const $invalidTabs = atom<ReadonlySet<string>>(new Set());
 export const $invalidComponentPaths = atom<ReadonlySet<string>>(new Set());
 
 const $contentServerErrors = atom<DataValidationError[]>([]);
+
+// Server content errors flattened for the form fields to display by data path.
+export const $serverErrorEntries = computed($contentServerErrors, (errors): ServerErrorEntry[] =>
+    errors.map((e) => ({path: e.getPropertyPath(), message: e.getMessage()})),
+);
 
 const $componentConfigErrors = atom<ComponentConfigValidationError[]>([]);
 
@@ -213,9 +217,6 @@ let mixinTreeCleanups: Unsubscribe[] = [];
 function setupSubscriptions(): void {
     subscriptions.push(
         $wizardDataVersion.subscribe(() => {
-            if ($contentServerErrors.get().length > 0) {
-                $contentServerErrors.set([]);
-            }
             debouncedRunValidation();
         }),
     );
@@ -298,18 +299,28 @@ export function escalateVisibility(mode: ValidationVisibility): void {
     }
 }
 
+// Validation error codes are `<applicationKey>:<code>` (e.g. "system:cms.occurrencesInvalid").
+// Errors in the SYSTEM application are built-in occurrence/required checks that duplicate our
+// client-side validation; we ignore them and surface the (more readable) client messages instead.
+// Custom app validators carry their own application key (e.g. "com.acme.app:..") and are kept.
+const SYSTEM_ERROR_CODE_PREFIX = 'system:';
+
+function isSystemError(error: ValidationError): boolean {
+    return (error.getErrorCode() ?? '').startsWith(SYSTEM_ERROR_CODE_PREFIX);
+}
+
 export function setServerValidationErrors(errors: ValidationError[]): void {
     // ! Only DataValidationError has a propertyPath that validateForm can match
     // ! against content form fields. Base ValidationError and AttachmentValidationError
     // ! return null from getPropertyPath(), which would crash matchServerErrors.
-    // ! System errors (e.g. "system:required") are already handled by client-side
-    // ! validation; keeping them here would make them sticky after the user fixes
-    // ! the field, because $contentServerErrors is only refreshed on save.
+    // ! System (built-in) errors are dropped — client-side validation covers them with
+    // ! clearer messages; keeping them would also make them sticky until the next save.
     const contentErrors = errors.filter(
         (e): e is DataValidationError => e instanceof DataValidationError
             && !(e instanceof ComponentConfigValidationError)
             && !(e instanceof SiteConfigValidationError)
             && !(e instanceof MixinConfigValidationError)
+            && !isSystemError(e)
     );
 
     const componentErrors = errors.filter(
@@ -317,6 +328,28 @@ export function setServerValidationErrors(errors: ValidationError[]): void {
     );
     $contentServerErrors.set(contentErrors);
     $componentConfigErrors.set(componentErrors);
+    runValidation();
+}
+
+// Drop the server errors on an edited occurrence's data path (and its descendants).
+export function clearServerErrorsAtPath(occurrencePath: string): void {
+    const current = $contentServerErrors.get();
+    const next = current.filter((e) => !matchesOccurrencePath(e.getPropertyPath(), occurrencePath));
+    if (next.length === current.length) return;
+
+    $contentServerErrors.set(next);
+    runValidation();
+}
+
+// Drop every server error on a field (all occurrences). Used on structural
+// occurrence changes (add/remove/move), where positional alignment is lost;
+// fresh errors arrive on the next save.
+export function clearServerErrorsForField(fieldPath: string): void {
+    const current = $contentServerErrors.get();
+    const next = current.filter((e) => !matchesFieldPath(e.getPropertyPath(), fieldPath));
+    if (next.length === current.length) return;
+
+    $contentServerErrors.set(next);
     runValidation();
 }
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
@@ -1,11 +1,11 @@
-import {FieldRegistryProvider, RawValueProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
+import {FieldRegistryProvider, RawValueProvider, ServerErrorsProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
 import {useStore} from '@nanostores/preact';
 import {type ReactElement, useEffect, useMemo} from 'react';
 import {FormRenderer} from '../../../shared/form';
 import {useBreakpoints} from '../../../hooks/useBreakpoints';
 import {getAiFieldRegistry} from '../../../store/ai/ai.field-registry';
 import {$contentType, $wizardDraftData, $wizardReadOnly, notifyContentFormMounted} from '../../../store/wizardContent.store';
-import {$validationVisibility, getContentRawValueMap} from '../../../store/wizardValidation.store';
+import {$serverErrorEntries, $validationVisibility, clearServerErrorsAtPath, clearServerErrorsForField, getContentRawValueMap} from '../../../store/wizardValidation.store';
 import {DisplayNameInput} from './DisplayNameInput';
 import {ImageUploaderDescriptor} from '../../../shared/form/input-types/image-uploader';
 
@@ -15,6 +15,7 @@ export const ContentForm = (): ReactElement | null => {
     const contentType = useStore($contentType);
     const draftData = useStore($wizardDraftData);
     const visibility = useStore($validationVisibility);
+    const serverErrorEntries = useStore($serverErrorEntries);
     const readOnly = useStore($wizardReadOnly);
     const {lg} = useBreakpoints();
 
@@ -54,13 +55,19 @@ export const ContentForm = (): ReactElement | null => {
             <ValidationVisibilityProvider visibility={visibility}>
                 <RawValueProvider map={rawValueMap}>
                     <FieldRegistryProvider registry={fieldRegistry}>
-                        <FormRenderer
-                            form={contentType.getForm()}
-                            propertySet={draftData.getRoot()}
-                            enabled={!readOnly}
-                            applicationKey={applicationKey}
-                            excludeInputTypes={excludeInputTypes}
-                        />
+                        <ServerErrorsProvider
+                            entries={serverErrorEntries}
+                            clear={clearServerErrorsAtPath}
+                            clearField={clearServerErrorsForField}
+                        >
+                            <FormRenderer
+                                form={contentType.getForm()}
+                                propertySet={draftData.getRoot()}
+                                enabled={!readOnly}
+                                applicationKey={applicationKey}
+                                excludeInputTypes={excludeInputTypes}
+                            />
+                        </ServerErrorsProvider>
                     </FieldRegistryProvider>
                 </RawValueProvider>
             </ValidationVisibilityProvider>


### PR DESCRIPTION
- Feed content server validation errors into form2 via ServerErrorsProvider; drop built-in system errors (errorCode `system:*`) in favour of clearer client messages and keep custom app errors. Clear them per occurrence on edit and per field/set on occurrence add/remove/move, and refresh from the saved content after save (postUpdatePersistedItem now reads the server response).