### PR TITLE
redo cache-control #10693

### DIFF
--- a/modules/app/src/main/resources/admin/extensions/preview-json/preview-json.js
+++ b/modules/app/src/main/resources/admin/extensions/preview-json/preview-json.js
@@ -28,6 +28,7 @@ exports.get = function (req) {
             return {
                 contentType: 'text/html',
                 headers: {
+                    'Cache-Control': 'no-store',
                     'X-Frame-Options': 'SAMEORIGIN',
                     'Content-Security-Policy': "media-src 'self'"
                 },

--- a/modules/app/src/main/resources/admin/extensions/settings/settings.js
+++ b/modules/app/src/main/resources/admin/extensions/settings/settings.js
@@ -17,7 +17,7 @@ function handleGet() {
         contentType: 'text/html',
         body: mustache.render(view, params),
         headers: {
-            'Cache-Control': 'no-cache',
+            'Cache-Control': 'no-store',
         },
     };
 }

--- a/modules/app/src/main/resources/admin/extensions/stats/stats.js
+++ b/modules/app/src/main/resources/admin/extensions/stats/stats.js
@@ -39,6 +39,9 @@ router.get('', (req) => {
 
     return {
         contentType: 'text/html',
+        headers: {
+            'Cache-Control': 'no-store',
+        },
         body: mustache.render(view, params)
     };
 });

--- a/modules/app/src/main/resources/admin/tools/main/main.js
+++ b/modules/app/src/main/resources/admin/tools/main/main.js
@@ -16,9 +16,6 @@ exports.renderTemplate = function (params) {
     const response = {
         contentType: 'text/html',
         body: mustache.render(view, params),
-        headers: {
-            'Cache-Control': 'no-cache',
-        },
     };
 
     if (enableSecurityPolicy) {
@@ -29,7 +26,9 @@ exports.renderTemplate = function (params) {
         if (!securityPolicy) {
             securityPolicy = `default-src 'self'; connect-src 'self' ws: wss: ${baseMarketUrl}; script-src 'self' 'unsafe-inline'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:`;
         }
-        response.headers['Content-Security-Policy'] = securityPolicy;
+        response.headers = {
+            'Content-Security-Policy': securityPolicy,
+        };
     }
 
     return response;

--- a/modules/app/src/main/resources/apis/chartdata/chartdata.js
+++ b/modules/app/src/main/resources/apis/chartdata/chartdata.js
@@ -35,6 +35,9 @@ const handleGet = () => {
 
     return {
         contentType: 'application/json',
+        headers: {
+            'Cache-Control': 'no-store',
+        },
         body: activityMap
     };
 }

--- a/modules/app/src/main/resources/apis/content/content.js
+++ b/modules/app/src/main/resources/apis/content/content.js
@@ -17,6 +17,9 @@ exports.get = function (req) {
     return {
         status: 200,
         contentType: 'application/json',
+        headers: {
+            'Cache-Control': 'no-store',
+        },
         body: getContent(contentId, req.params.versionId, req.params.repositoryId)
     };
 };

--- a/modules/app/src/main/resources/apis/export/export.js
+++ b/modules/app/src/main/resources/apis/export/export.js
@@ -7,6 +7,9 @@ exports.get = function (req) {
     return {
         contentType: `text/${type}`,
         status: report ? 200 : 404,
+        headers: {
+            'Cache-Control': 'no-store',
+        },
         body: report ? report : 'Not found'
     };
 };

--- a/modules/app/src/main/resources/apis/import-content/import-content.js
+++ b/modules/app/src/main/resources/apis/import-content/import-content.js
@@ -11,6 +11,9 @@ function jsonResponse(status, data) {
     return {
         status,
         contentType: 'application/json',
+        headers: {
+            'Cache-Control': 'no-store',
+        },
         body: JSON.stringify(data || {})
     };
 }

--- a/modules/app/src/main/resources/apis/styles/styles.js
+++ b/modules/app/src/main/resources/apis/styles/styles.js
@@ -31,6 +31,9 @@ exports.GET = function (req) {
     return {
         status: 200,
         contentType: 'application/json',
+        headers: {
+            'Cache-Control': 'no-store',
+        },
         body: styles
     };
 };

--- a/modules/app/src/main/resources/lib/export/widget.js
+++ b/modules/app/src/main/resources/lib/export/widget.js
@@ -29,7 +29,10 @@ function validateParams(params) {
 function widgetResponse(status, data) {
     const response = {
         status,
-        contentType: 'application/json'
+        contentType: 'application/json',
+        headers: {
+            'Cache-Control': 'no-store',
+        }
     }
 
     if (data) {
@@ -42,7 +45,10 @@ function widgetResponse(status, data) {
 function redirectResponse(url, data) {
     const response = {
         redirect: encodeURI(url),
-        contentType: 'text/html'
+        contentType: 'text/html',
+        headers: {
+            'Cache-Control': 'no-store',
+        }
     }
 
     if (data) {


### PR DESCRIPTION
Sets `Cache-Control` deliberately across Content Studio's admin responses.

The admin HTML page (`main.js`) drops its redundant `no-cache` and relies on XP's `NoCacheAdminFilter`, which already forces `private, no-cache` — keeping the document bfcache-eligible while still revalidating after a redeploy. Dynamic API and extension responses that should never be stored by any cache now send `no-store` (XP prepends `private`): the `settings`, `stats` and `preview-json` widgets; the `chartdata`, `content`, `styles`, `import-content` and `export` APIs; and the shared `widgetResponse`/`redirectResponse` builders the preview widgets use.

Left unchanged by design: `events.js` (WebSocket upgrade), `preview-media.js` (cacheable media binary), `stats.js` static assets (fingerprinted), and the page itself (`no-cache`).

Deferred follow-ups: `dismiss-notification` (POST), `style.js` (stylesheet — keep revalidating), `preview-automatic` (410 stub), and removing the `t=Date.now()` cache-buster in `ExtensionItemView`.

Closes #10693

<sub>*Drafted with AI assistance*</sub>