### PR TITLE
Combobox search does not display 'No matching items' message #10749

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/SelectorPopup.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/SelectorPopup.tsx
@@ -1,0 +1,36 @@
+import {Combobox, Listbox} from '@enonic/ui';
+import type {ReactElement, ReactNode} from 'react';
+
+const SELECTOR_POPUP_NAME = 'SelectorPopup';
+
+type SelectorOption = {
+    key: string;
+};
+
+type SelectorPopupProps<T extends SelectorOption> = {
+    options: T[];
+    emptyLabel: string;
+    children: (option: T) => ReactNode;
+};
+
+export const SelectorPopup = <T extends SelectorOption>({
+    options,
+    emptyLabel,
+    children,
+}: SelectorPopupProps<T>): ReactElement => (
+    <Combobox.Popup>
+        {options.length === 0 ? (
+            <div className="p-4 text-subtle">{emptyLabel}</div>
+        ) : (
+            <Listbox.Content className="max-h-60 rounded-sm">
+                {options.map(option => (
+                    <Listbox.Item key={option.key} value={option.key}>
+                        {children(option)}
+                    </Listbox.Item>
+                ))}
+            </Listbox.Content>
+        )}
+    </Combobox.Popup>
+);
+
+SelectorPopup.displayName = SELECTOR_POPUP_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/component/ComponentDescriptorSelector.test.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/component/ComponentDescriptorSelector.test.tsx
@@ -1,0 +1,129 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import type {ComponentOption} from './hooks/useComponentDescriptorSelector';
+
+// Mock @enonic/ui — render structural slots so popup content is observable
+vi.mock('@enonic/ui', () => {
+    const passthrough = (name: string) =>
+        Object.assign(
+            ({children, ...props}: {children?: React.ReactNode;[key: string]: unknown}) => (
+                <div data-testid={name} {...props}>{children}</div>
+            ),
+            {displayName: name},
+        );
+
+    const MockCombobox = {
+        Root: passthrough('combobox-root'),
+        Content: passthrough('combobox-content'),
+        Control: passthrough('combobox-control'),
+        Search: passthrough('combobox-search'),
+        Input: ({placeholder, ...props}: {placeholder?: string;[key: string]: unknown}) => (
+            <input role='combobox' placeholder={placeholder} {...props} />
+        ),
+        Toggle: passthrough('combobox-toggle'),
+        Value: passthrough('combobox-value'),
+        Popup: passthrough('combobox-popup'),
+    };
+
+    const MockListbox = {
+        Content: passthrough('listbox-content'),
+        Item: passthrough('listbox-item'),
+    };
+
+    return {
+        cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+        Combobox: MockCombobox,
+        Listbox: MockListbox,
+    };
+});
+
+// Mock lucide-react icons used by the component type map
+vi.mock('lucide-react', () => ({
+    Box: () => <span data-testid='icon-box' />,
+    Columns2: () => <span data-testid='icon-columns' />,
+}));
+
+// Mock useI18n — return readable English strings for asserted keys
+vi.mock('../../../../../../hooks/useI18n', () => ({
+    useI18n: vi.fn((key: string) => {
+        const translations: Record<string, string> = {
+            'field.part': 'Part',
+            'field.layout': 'Layout',
+            'field.option.placeholder': 'Type to search...',
+            'field.descriptors.notFound': 'No descriptors found',
+            'field.option.noitems': 'No matching items',
+        };
+        return translations[key] ?? key;
+    }),
+}));
+
+// Mock the selector hook so component state is fully controllable
+let mockSelectorState: {
+    filteredOptions: ComponentOption[];
+    selectedOption: ComponentOption | undefined;
+    searchValue: string | undefined;
+    setSearchValue: (value: string | undefined) => void;
+    selection: string[];
+    handleSelectionChange: (selection: readonly string[]) => void;
+    isLoading: boolean;
+    isEmpty: boolean;
+};
+
+vi.mock('./hooks/useComponentDescriptorSelector', () => ({
+    useComponentDescriptorSelector: () => mockSelectorState,
+}));
+
+import {render, screen} from '@testing-library/preact';
+import {ComponentDescriptorSelector} from './ComponentDescriptorSelector';
+
+const buildOption = (key: string, label: string): ComponentOption => ({
+    key,
+    label,
+    description: `${label} description`,
+});
+
+describe('ComponentDescriptorSelector', () => {
+    beforeEach(() => {
+        mockSelectorState = {
+            filteredOptions: [buildOption('app:part-1', 'Hero Part')],
+            selectedOption: undefined,
+            searchValue: undefined,
+            setSearchValue: vi.fn(),
+            selection: [],
+            handleSelectionChange: vi.fn(),
+            isLoading: false,
+            isEmpty: false,
+        };
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should display "No matching items" when the search filters out all options', () => {
+        mockSelectorState.filteredOptions = [];
+        mockSelectorState.searchValue = 'zzz';
+
+        render(<ComponentDescriptorSelector componentType='part' />);
+
+        expect(screen.getByText('No matching items')).toBeDefined();
+        expect(screen.queryAllByTestId('listbox-item')).toHaveLength(0);
+    });
+
+    it('should render the options instead of the empty message when results match', () => {
+        render(<ComponentDescriptorSelector componentType='part' />);
+
+        expect(screen.getByText('Hero Part')).toBeDefined();
+        expect(screen.queryByText('No matching items')).toBeNull();
+    });
+
+    it('should show the not-found label and no popup when there are no descriptors at all', () => {
+        mockSelectorState.filteredOptions = [];
+        mockSelectorState.isEmpty = true;
+
+        render(<ComponentDescriptorSelector componentType='part' />);
+
+        expect(screen.getByText('No descriptors found')).toBeDefined();
+        expect(screen.queryByText('No matching items')).toBeNull();
+        expect(screen.queryByTestId('combobox-popup')).toBeNull();
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/component/ComponentDescriptorSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/component/ComponentDescriptorSelector.tsx
@@ -1,7 +1,8 @@
-import {cn, Combobox, Listbox} from '@enonic/ui';
+import {cn, Combobox} from '@enonic/ui';
 import {Box, Columns2} from 'lucide-react';
 import type {ReactElement} from 'react';
 import {useI18n} from '../../../../../../hooks/useI18n';
+import {SelectorPopup} from '../SelectorPopup';
 import {useComponentDescriptorSelector} from './hooks/useComponentDescriptorSelector';
 
 const COMPONENT_TYPE_ICON = {
@@ -30,6 +31,7 @@ export const ComponentDescriptorSelector = ({componentType}: ComponentDescriptor
     const label = useI18n(componentType === 'part' ? 'field.part' : 'field.layout');
     const searchPlaceholder = useI18n('field.option.placeholder');
     const notFoundLabel = useI18n('field.descriptors.notFound');
+    const noMatchingLabel = useI18n('field.option.noitems');
 
     const Icon = COMPONENT_TYPE_ICON[componentType];
 
@@ -77,27 +79,23 @@ export const ComponentDescriptorSelector = ({componentType}: ComponentDescriptor
                             <Combobox.Toggle />
                         </Combobox.Search>
                     </Combobox.Control>
-                    <Combobox.Popup>
-                        <Listbox.Content className="max-h-60 rounded-sm">
-                            {filteredOptions.map(option => (
-                                <Listbox.Item key={option.key} value={option.key}>
-                                    <div className="flex flex-col overflow-hidden">
-                                        <span className="leading-5.5 font-semibold truncate group-data-[tone=inverse]:text-alt">
-                                            {option.label}
-                                        </span>
-                                        <small
-                                            className={cn(
-                                                'leading-4.5 text-sm truncate group-data-[tone=inverse]:text-alt',
-                                                option.isInvalid ? 'text-error' : 'text-subtle',
-                                            )}
-                                        >
-                                            {option.description}
-                                        </small>
-                                    </div>
-                                </Listbox.Item>
-                            ))}
-                        </Listbox.Content>
-                    </Combobox.Popup>
+                    <SelectorPopup options={filteredOptions} emptyLabel={noMatchingLabel}>
+                        {option => (
+                            <div className="flex flex-col overflow-hidden">
+                                <span className="leading-5.5 font-semibold truncate group-data-[tone=inverse]:text-alt">
+                                    {option.label}
+                                </span>
+                                <small
+                                    className={cn(
+                                        'leading-4.5 text-sm truncate group-data-[tone=inverse]:text-alt',
+                                        option.isInvalid ? 'text-error' : 'text-subtle',
+                                    )}
+                                >
+                                    {option.description}
+                                </small>
+                            </div>
+                        )}
+                    </SelectorPopup>
                 </Combobox.Content>
             </Combobox.Root>
         </div>

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/fragment/FragmentContentSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/fragment/FragmentContentSelector.tsx
@@ -1,7 +1,8 @@
-import {Combobox, Listbox} from '@enonic/ui';
+import {Combobox} from '@enonic/ui';
 import {FileChartPie} from 'lucide-react';
 import type {ReactElement} from 'react';
 import {useI18n} from '../../../../../../hooks/useI18n';
+import {SelectorPopup} from '../SelectorPopup';
 import {useFragmentContentSelector} from './hooks/useFragmentContentSelector';
 
 const FRAGMENT_CONTENT_SELECTOR_NAME = 'FragmentContentSelector';
@@ -22,6 +23,7 @@ export const FragmentContentSelector = (): ReactElement | null => {
     const label = useI18n('field.fragment');
     const searchPlaceholder = useI18n('field.option.placeholder');
     const notFoundLabel = useI18n('field.fragments.notFound');
+    const noMatchingLabel = useI18n('field.option.noitems');
 
     if (isLoading) return null;
 
@@ -61,22 +63,18 @@ export const FragmentContentSelector = (): ReactElement | null => {
                             <Combobox.Toggle />
                         </Combobox.Search>
                     </Combobox.Control>
-                    <Combobox.Popup>
-                        <Listbox.Content className="max-h-60 rounded-sm">
-                            {filteredOptions.map(option => (
-                                <Listbox.Item key={option.key} value={option.key}>
-                                    <div className="flex flex-col overflow-hidden">
-                                        <span className="leading-5.5 font-semibold truncate group-data-[tone=inverse]:text-alt">
-                                            {option.label}
-                                        </span>
-                                        <small className="leading-4.5 text-sm text-subtle truncate group-data-[tone=inverse]:text-alt">
-                                            {option.description}
-                                        </small>
-                                    </div>
-                                </Listbox.Item>
-                            ))}
-                        </Listbox.Content>
-                    </Combobox.Popup>
+                    <SelectorPopup options={filteredOptions} emptyLabel={noMatchingLabel}>
+                        {option => (
+                            <div className="flex flex-col overflow-hidden">
+                                <span className="leading-5.5 font-semibold truncate group-data-[tone=inverse]:text-alt">
+                                    {option.label}
+                                </span>
+                                <small className="leading-4.5 text-sm text-subtle truncate group-data-[tone=inverse]:text-alt">
+                                    {option.description}
+                                </small>
+                            </div>
+                        )}
+                    </SelectorPopup>
                 </Combobox.Content>
             </Combobox.Root>
         </div>

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageControllerSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageControllerSelector.tsx
@@ -1,7 +1,8 @@
-import {Combobox, Listbox} from '@enonic/ui';
+import {Combobox} from '@enonic/ui';
 import type {ReactElement} from 'react';
 import {useI18n} from '../../../../../../hooks/useI18n';
 import {ConfirmationDialog} from '../../../../../../shared/dialogs/ConfirmationDialog';
+import {SelectorPopup} from '../SelectorPopup';
 import {usePageControllerSelector} from './hooks/usePageControllerSelector';
 
 const PAGE_CONTROLLER_SELECTOR_NAME = 'PageControllerSelector';
@@ -21,6 +22,7 @@ export const PageControllerSelector = (): ReactElement | null => {
 
     const templateLabel = useI18n('field.page.template');
     const searchPlaceholder = useI18n('field.option.placeholder');
+    const noMatchingLabel = useI18n('field.option.noitems');
 
     // ? Keep mounted on background refetch (after a controller change reloads the
     // ? descriptor list) — only bail on the initial load with nothing to render.
@@ -53,23 +55,21 @@ export const PageControllerSelector = (): ReactElement | null => {
                                 <Combobox.Toggle />
                             </Combobox.Search>
                         </Combobox.Control>
-                        <Combobox.Popup>
-                            <Listbox.Content className="max-h-60 rounded-sm">
-                                {filteredOptions.map(option => (
-                                    <Listbox.Item key={option.key} value={option.key}>
-                                        <option.icon className="size-6 shrink-0" />
-                                        <div className="flex flex-col overflow-hidden">
-                                            <span className="leading-5.5 font-semibold truncate group-data-[tone=inverse]:text-alt">
-                                                {option.label}
-                                            </span>
-                                            <small className="leading-4.5 text-sm text-subtle truncate group-data-[tone=inverse]:text-alt">
-                                                {option.description}
-                                            </small>
-                                        </div>
-                                    </Listbox.Item>
-                                ))}
-                            </Listbox.Content>
-                        </Combobox.Popup>
+                        <SelectorPopup options={filteredOptions} emptyLabel={noMatchingLabel}>
+                            {option => (
+                                <>
+                                    <option.icon className="size-6 shrink-0" />
+                                    <div className="flex flex-col overflow-hidden">
+                                        <span className="leading-5.5 font-semibold truncate group-data-[tone=inverse]:text-alt">
+                                            {option.label}
+                                        </span>
+                                        <small className="leading-4.5 text-sm text-subtle truncate group-data-[tone=inverse]:text-alt">
+                                            {option.description}
+                                        </small>
+                                    </div>
+                                </>
+                            )}
+                        </SelectorPopup>
                     </Combobox.Content>
                 </Combobox.Root>
             </div>


### PR DESCRIPTION
## Changes

- Show the "No matching items" label (`field.option.noitems`) in the selector popup when a search filters out all options — previously the dropdown rendered an empty popup.
- Applied the empty-state fallback to all three Inspect Panel selectors: `ComponentDescriptorSelector` (the reported case), `PageControllerSelector`, and `FragmentContentSelector`, which share the identical pattern.
- Added render tests for `ComponentDescriptorSelector` covering the no-match search, populated results, and no-descriptors-at-all states.

Closes #10749

<sub>*Drafted with AI assistance*</sub>
