### PR TITLE
Export/Import via Content Studio reassigns content IDs and breaks all references #10784

### DIFF
--- a/modules/app/src/main/resources/apis/import-content/import-content.js
+++ b/modules/app/src/main/resources/apis/import-content/import-content.js
@@ -116,6 +116,7 @@ function handleImport(req) {
             return exportLib.importNodes({
                 source: exportName,
                 targetNodePath: targetPath,
+                includeNodeIds: true,
                 xslt: resolve('./import-content.xslt'),
                 xsltParams: {keepPublishFirst: keepPublishFirst ? 'true' : 'false'},
                 versionAttributes: {


### PR DESCRIPTION
The import controller now passes `includeNodeIds: true` to XP's `importNodes`. Imported content keeps its original node IDs instead of being reassigned new ones, so references (image and content references) stay intact after export/import.

The default of `includeNodeIds: false` generated fresh IDs on import while references kept pointing at the original IDs, breaking every reference. This was a regression introduced with the CS6 import widget.

Closes #10784

<sub>*Drafted with AI assistance*</sub>