### PR TITLE
Components rendering errors are not displayed in the PCV #10675

### DIFF
--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@enonic/lib-admin-ui": "workspace:*",
     "@enonic/lib-contentstudio": "workspace:*",
-    "@enonic/page-editor": "2.0.0-beta.0",
+    "@enonic/page-editor": "2.0.0-beta.1",
     "@enonic/ui": "^1.0.5",
     "@radix-ui/react-slot": "^1.2.3",
     "chart.js": "^4.5.1",

--- a/modules/app/pnpm-lock.yaml
+++ b/modules/app/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: workspace:*
         version: link:.xp/dev/lib-contentstudio
       '@enonic/page-editor':
-        specifier: 2.0.0-beta.0
-        version: 2.0.0-beta.0
+        specifier: 2.0.0-beta.1
+        version: 2.0.0-beta.1
       '@enonic/ui':
         specifier: ^1.0.5
         version: 1.0.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.545.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
@@ -639,6 +639,10 @@ packages:
 
   '@enonic/page-editor@2.0.0-beta.0':
     resolution: {integrity: sha512-c2Ea3zO2vOpl3u9/si30+4iCq37Elc6LtLm9q7Lv55kUuk3SCj3qjvig+kh67JtZzx34wl/u3RrEHl0UYdZmGA==}
+    engines: {node: '>= 24.16.0', pnpm: '>= 11.4.0'}
+
+  '@enonic/page-editor@2.0.0-beta.1':
+    resolution: {integrity: sha512-tzku+6fJaZLz1v9JIGKO3L9zPbVPQgs0BxCX8nM7APp+0Wbouu/Uxcx5xtQ06U3lMUDt2EOKK0lrxZ8QYBGNEQ==}
     engines: {node: '>= 24.16.0', pnpm: '>= 11.4.0'}
 
   '@enonic/ui@1.0.5':
@@ -5940,6 +5944,10 @@ snapshots:
   '@enonic-types/lib-websocket@8.0.0': {}
 
   '@enonic/page-editor@2.0.0-beta.0':
+    dependencies:
+      nanostores: 1.4.0
+
+  '@enonic/page-editor@2.0.0-beta.1':
     dependencies:
       nanostores: 1.4.0
 

--- a/modules/lib/package.json
+++ b/modules/lib/package.json
@@ -27,7 +27,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@enonic/page-editor": "2.0.0-beta.0",
+    "@enonic/page-editor": "2.0.0-beta.1",
     "@enonic/ui": "^1.0.5",
     "@nanostores/preact": "^1.0.0",
     "ckeditor4-react": "4.3.0",

--- a/modules/lib/pnpm-lock.yaml
+++ b/modules/lib/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   .:
     dependencies:
       '@enonic/page-editor':
-        specifier: 2.0.0-beta.0
-        version: 2.0.0-beta.0
+        specifier: 2.0.0-beta.1
+        version: 2.0.0-beta.1
       '@enonic/ui':
         specifier: ^1.0.5
         version: 1.0.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
@@ -450,8 +450,8 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@enonic/page-editor@2.0.0-beta.0':
-    resolution: {integrity: sha512-c2Ea3zO2vOpl3u9/si30+4iCq37Elc6LtLm9q7Lv55kUuk3SCj3qjvig+kh67JtZzx34wl/u3RrEHl0UYdZmGA==}
+  '@enonic/page-editor@2.0.0-beta.1':
+    resolution: {integrity: sha512-tzku+6fJaZLz1v9JIGKO3L9zPbVPQgs0BxCX8nM7APp+0Wbouu/Uxcx5xtQ06U3lMUDt2EOKK0lrxZ8QYBGNEQ==}
     engines: {node: '>= 24.16.0', pnpm: '>= 11.4.0'}
 
   '@enonic/ui@1.0.5':
@@ -5383,7 +5383,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@enonic/page-editor@2.0.0-beta.0':
+  '@enonic/page-editor@2.0.0-beta.1':
     dependencies:
       nanostores: 1.4.0
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/PageEventsManager.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/PageEventsManager.ts
@@ -53,6 +53,8 @@ export class PageEventsManager {
 
     private componentLoadFailedListeners: ((path: ComponentPath, error: unknown) => void)[] = [];
 
+    private pageRenderErrorsListeners: ((paths: ComponentPath[]) => void)[] = [];
+
     private liveEditPageViewReadyListeners: ((event: LiveEditPageViewReadyEvent) => void)[] = [];
 
     private liveEditPageInitErrorListeners: ((event: LiveEditPageInitializationErrorEvent) => void)[] = [];
@@ -238,6 +240,18 @@ export class PageEventsManager {
 
     notifyComponentLoadFailed(path: ComponentPath, error: unknown) {
         this.componentLoadFailedListeners.forEach((listener) => listener(path, error));
+    }
+
+    onPageRenderErrors(listener: ((paths: ComponentPath[]) => void)) {
+        this.pageRenderErrorsListeners.push(listener);
+    }
+
+    unPageRenderErrors(listener: ((paths: ComponentPath[]) => void)) {
+        this.pageRenderErrorsListeners = this.pageRenderErrorsListeners.filter((curr) => (curr !== listener));
+    }
+
+    notifyPageRenderErrors(paths: ComponentPath[]) {
+        this.pageRenderErrorsListeners.forEach((listener) => listener(paths));
     }
 
     onLiveEditPageViewReady(listener: ((event: LiveEditPageViewReadyEvent) => void)) {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/LiveEditPageProxy.ts
@@ -426,7 +426,10 @@ export class LiveEditPageProxy implements PageNavigationHandler {
         );
 
         cleanups.push(
-            bus.on('ready', () => {
+            bus.on('ready', (payload) => {
+                eventsManager.notifyPageRenderErrors(
+                    (payload.errorPaths ?? []).map((path) => ComponentPath.fromString(path)),
+                );
                 eventsManager.notifyLiveEditPageViewReady(new LiveEditPageViewReadyEvent());
             }),
         );

--- a/modules/lib/src/main/resources/assets/js/page-editor/event/LiveEditPageViewReadyEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/event/LiveEditPageViewReadyEvent.ts
@@ -1,33 +1,11 @@
 import {ClassHelper} from '@enonic/lib-admin-ui/ClassHelper';
-import {type ComponentPath} from '../../app/page/region/ComponentPath';
 import {IframeEvent} from '@enonic/lib-admin-ui/event/IframeEvent';
-
-export interface LiveEditComponentRecord {
-    path: ComponentPath;
-    type: string;
-    parentPath?: string;
-    children: readonly string[];
-    empty: boolean;
-    error: boolean;
-    descriptor?: string;
-    loading: boolean;
-}
 
 export class LiveEditPageViewReadyEvent
     extends IframeEvent {
 
     constructor() {
         super();
-    }
-
-    getComponents(): LiveEditComponentRecord[] {
-        const data = this.getData();
-        if (data == null || !('components' in data)) {
-            return [];
-        }
-
-        const {components} = data;
-        return Array.isArray(components) ? components : [];
     }
 
     static on(handler: (event: LiveEditPageViewReadyEvent) => void, contextWindow: Window = window) {

--- a/modules/lib/src/main/resources/assets/js/page-editor/event/LiveEditPageViewReadyEvent.ts
+++ b/modules/lib/src/main/resources/assets/js/page-editor/event/LiveEditPageViewReadyEvent.ts
@@ -1,11 +1,33 @@
 import {ClassHelper} from '@enonic/lib-admin-ui/ClassHelper';
+import {type ComponentPath} from '../../app/page/region/ComponentPath';
 import {IframeEvent} from '@enonic/lib-admin-ui/event/IframeEvent';
+
+export interface LiveEditComponentRecord {
+    path: ComponentPath;
+    type: string;
+    parentPath?: string;
+    children: readonly string[];
+    empty: boolean;
+    error: boolean;
+    descriptor?: string;
+    loading: boolean;
+}
 
 export class LiveEditPageViewReadyEvent
     extends IframeEvent {
 
     constructor() {
         super();
+    }
+
+    getComponents(): LiveEditComponentRecord[] {
+        const data = this.getData();
+        if (data == null || !('components' in data)) {
+            return [];
+        }
+
+        const {components} = data;
+        return Array.isArray(components) ? components : [];
     }
 
     static on(handler: (event: LiveEditPageViewReadyEvent) => void, contextWindow: Window = window) {

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -29,7 +29,7 @@ import {
     $partDescriptorOptions,
     isComponentReferenceMissing,
 } from '../../../../../widgets/inspectors/model/component-inspection.store';
-import { $inspectedPath, $page, $pageVersion } from '../../../../../widgets/inspectors/model/page-editor/store';
+import { $inspectedPath, $page, $pageVersion, $renderErrorComponentPaths } from '../../../../../widgets/inspectors/model/page-editor/store';
 import { $wizardReadOnly } from '../../../model/wizardContent.store';
 import { $invalidComponentPaths, $validationVisibility } from '../../../model/wizardValidation.store';
 import { EditLockOverlay } from '../../../../../shared/ui/EditLockOverlay';
@@ -71,6 +71,7 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
     const layoutDescriptorOptions = useStore($layoutDescriptorOptions);
     const isComponentLoading = useStore($isComponentInspectionLoading);
     const invalidComponentPaths = useStore($invalidComponentPaths);
+    const renderErrorComponentPaths = useStore($renderErrorComponentPaths);
     const validationVisibility = useStore($validationVisibility);
     const readOnly = useStore($wizardReadOnly);
     const showErrors = validationVisibility === 'all';
@@ -229,7 +230,10 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
                 descriptors,
                 referenceLoading,
             );
-            const isInvalid = showErrors && (invalidComponentPaths.has(context.item.id) || referenceMissing);
+            // Render errors are always shown (a real failure), unlike form validation
+            // which respects validation visibility.
+            const isInvalid = renderErrorComponentPaths.has(context.item.id)
+                || (showErrors && (invalidComponentPaths.has(context.item.id) || referenceMissing));
 
             return (
                 <PageComponentsContextMenu node={context.item}>
@@ -250,6 +254,7 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
             pageMetadata,
             showErrors,
             invalidComponentPaths,
+            renderErrorComponentPaths,
             page,
             fragmentOptions,
             descriptors,

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/model/page-editor/bridge.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/model/page-editor/bridge.ts
@@ -1,3 +1,4 @@
+import type { ComponentPath } from '../../../../../app/page/region/ComponentPath';
 import { PageEventsManager } from '../../../../../app/wizard/PageEventsManager';
 import type { PageNavigationEvent } from '../../../../../app/wizard/PageNavigationEvent';
 import { PageNavigationEventType } from '../../../../../app/wizard/PageNavigationEventType';
@@ -14,8 +15,11 @@ import {
     $pageEditorLifecycle,
     $pageVersion,
     $selectionEventNonce,
+    addRenderErrorComponentPath,
     bumpPageVersion,
     bumpSelectionEventNonce,
+    removeRenderErrorComponentPath,
+    setRenderErrorComponentPaths,
     syncPageFromState,
 } from './store';
 import type { InitPageEditorBridgeOptions } from './types';
@@ -55,9 +59,28 @@ export function initPageEditorBridge(options?: InitPageEditorBridgeOptions): voi
     mgr.onLiveEditPageViewReady(onReady);
     cleanups.push(() => mgr.unLiveEditPageViewReady(onReady));
 
-    const onBeforeLoad = () => $pageEditorLifecycle.setKey('isPageReady', false);
+    const onBeforeLoad = () => {
+        $pageEditorLifecycle.setKey('isPageReady', false);
+        // Drop stale render-error marks while the page reloads; the iframe
+        // re-reports them on the next ready.
+        setRenderErrorComponentPaths([]);
+    };
     mgr.onBeforeLoad(onBeforeLoad);
     cleanups.push(() => mgr.unBeforeLoad(onBeforeLoad));
+
+    const onRenderErrors = (paths: ComponentPath[]) => {
+        setRenderErrorComponentPaths(paths.map((path) => path.toString()));
+    };
+    mgr.onPageRenderErrors(onRenderErrors);
+    cleanups.push(() => mgr.unPageRenderErrors(onRenderErrors));
+
+    const onComponentLoaded = (path: ComponentPath) => removeRenderErrorComponentPath(path.toString());
+    mgr.onComponentLoaded(onComponentLoaded);
+    cleanups.push(() => mgr.unComponentLoaded(onComponentLoaded));
+
+    const onComponentLoadFailed = (path: ComponentPath) => addRenderErrorComponentPath(path.toString());
+    mgr.onComponentLoadFailed(onComponentLoadFailed);
+    cleanups.push(() => mgr.unComponentLoadFailed(onComponentLoadFailed));
 
     // Page model events from PageState.getEvents()
 
@@ -72,11 +95,20 @@ export function initPageEditorBridge(options?: InitPageEditorBridgeOptions): voi
     events.onPageReset(onPageReset);
     cleanups.push(() => events.unPageReset(onPageReset));
 
-    const onComponentAdded = () => bumpPageVersion();
+    // Render-error marks are positional snapshots from the last render; add /
+    // remove / move shift sibling indices, so drop them on structural changes.
+    // They are re-reported on the next page render.
+    const onComponentAdded = () => {
+        setRenderErrorComponentPaths([]);
+        bumpPageVersion();
+    };
     events.onComponentAdded(onComponentAdded);
     cleanups.push(() => events.unComponentAdded(onComponentAdded));
 
-    const onComponentRemoved = () => bumpPageVersion();
+    const onComponentRemoved = () => {
+        setRenderErrorComponentPaths([]);
+        bumpPageVersion();
+    };
     events.onComponentRemoved(onComponentRemoved);
     cleanups.push(() => events.unComponentRemoved(onComponentRemoved));
 
@@ -149,4 +181,5 @@ export function cleanupPageEditorBridge(): void {
     $contentContext.set(null);
     $inspectedPath.set(null);
     $selectionEventNonce.set(0);
+    setRenderErrorComponentPaths([]);
 }

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/model/page-editor/store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/model/page-editor/store.ts
@@ -37,6 +37,9 @@ export const $selectionEventNonce = atom<number>(0);
 
 export const $insertTabActivateNonce = atom<number>(0);
 
+// Visual-only marks for failed-to-render components; does not affect form validity.
+export const $renderErrorComponentPaths = atom<ReadonlySet<string>>(new Set());
+
 //
 // * Computed
 //
@@ -92,6 +95,24 @@ export function bumpSelectionEventNonce(): void {
 
 export function bumpInsertTabActivateNonce(): void {
     $insertTabActivateNonce.set($insertTabActivateNonce.get() + 1);
+}
+
+export function setRenderErrorComponentPaths(paths: string[]): void {
+    $renderErrorComponentPaths.set(new Set(paths));
+}
+
+export function addRenderErrorComponentPath(path: string): void {
+    const current = $renderErrorComponentPaths.get();
+    if (current.has(path)) return;
+    $renderErrorComponentPaths.set(new Set(current).add(path));
+}
+
+export function removeRenderErrorComponentPath(path: string): void {
+    const current = $renderErrorComponentPaths.get();
+    if (!current.has(path)) return;
+    const next = new Set(current);
+    next.delete(path);
+    $renderErrorComponentPaths.set(next);
 }
 
 export function syncPageFromState(): void {


### PR DESCRIPTION
## Summary

Components that fail to render in the live edit are now marked as invalid in the v6 page components tree, so a broken part/layout/fragment is visible in the outline even though it does not affect form validity.

## What changed

- `LiveEditPageProxy` reads the render-error snapshot from the page editor protocol's `ready` message (`errorPaths`) and forwards the paths via `PageEventsManager.notifyPageRenderErrors`.
- The page editor bridge stores them in a dedicated `$renderErrorComponentPaths` fact store; `PageComponentsView` merges them into each node's visual `invalid` flag.
- Incremental tracking supplements the snapshot: `component-loaded` clears a mark, `component-load-failed` adds one.
- Render-error marks are cleared on page reload and on component add/remove/move.
- Bumped `@enonic/page-editor` to 2.0.0-beta.1 (`modules/lib` and `modules/app`), which introduces the `ready.errorPaths` payload.

## Why / how it works

```
editor posts ready{errorPaths} -> LiveEditPageProxy -> PageEventsManager.notifyPageRenderErrors -> bridge -> $renderErrorComponentPaths -> PageComponentsView -> OctagonAlert on the node
```

The marker reuses the existing invalid visual but is kept separate from form validation: render errors are a real render failure, so they show regardless of validation visibility and never feed `$invalidComponentPaths` / `setWizardFormValidation`.

## Notable findings / decisions

- **Positional paths drift.** Node ids are positional (`/main/0`). The error set is a snapshot taken at render time; add/remove/move shift sibling indices, and most edits are partial reloads (no fresh snapshot), so the marks would stick to the wrong position. A full positional remap would duplicate the tree's index-shift logic (especially for move) at notable risk, and is overkill for an edge case. We clear the marks on structural changes instead; they are re-reported on the next full render. Move is covered because it fires both component-removed and component-added; config updates do not shift positions and are left untouched.
- **The wire contract carries only error paths, not full component records.** The host already owns the page model; the editor reports just the DOM-derived render-error state. See enonic/npm-page-editor#86.

Closes #10675

Requires `@enonic/page-editor` >= 2.0.0-beta.1 (enonic/npm-page-editor#86)

<sub>*Drafted with AI assistance*</sub>