### PR TITLE
Delete dialog - incorrect layout when items have references #10729

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/ContentReferencesLink.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/ContentReferencesLink.tsx
@@ -40,7 +40,7 @@ export const ContentReferencesLink = forwardRef<HTMLAnchorElement, ContentRefere
             ref={ref}
             className={cn(
                 className,
-                'visited:text-main h-12 px-2 active:bg-transparent data-[active=true]:bg-transparent',
+                'self-stretch px-2 visited:text-main active:bg-transparent data-[active=true]:bg-transparent',
             )}
             href={href}
             newTab

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/items/ContentListItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/items/ContentListItem.tsx
@@ -66,7 +66,7 @@ export const ContentListItem = ({
                     <ContentLabel content={content} variant={variant}/>
                 </Button>
             </ListItem.Content>
-            <ListItem.Right>
+            <ListItem.Right className='self-stretch'>
                 {rightSlotOrder === 'before-status' && children}
                 <DiffStatusBadge contentSummary={content}/>
                 {rightSlotOrder === 'after-status' && children}


### PR DESCRIPTION
Set height of show references dynamically to maintain correct focus-ring height without affecting item height in delete and unpublish dialog.