### PR TITLE
Remove text-alt from focused Content #10800

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ContentReferenceList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ContentReferenceList.tsx
@@ -56,7 +56,7 @@ const ACTIVE_ACTION_CLASS = [
 ].join(' ');
 const ACTIVE_REFERENCE_LINK_CLASS = cn(
     'rounded-sm',
-    'data-[active=true]:bg-btn-active data-[active=true]:text-alt',
+    'data-[active=true]:bg-btn-active',
     ACTIVE_ACTION_CLASS,
 );
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/items/ContentListItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/items/ContentListItem.tsx
@@ -57,7 +57,7 @@ export const ContentListItem = ({
                     onClick={handleClick}
                     className={cn(
                         'box-content justify-start flex-1 px-2.5 py-1',
-                        'active:bg-transparent data-[active=true]:bg-transparent',
+                        'active:bg-transparent data-[active=true]:bg-transparent data-[active=true]:text-unset',
                         isCompact && 'h-6',
                         contentButtonClassName,
                     )}


### PR DESCRIPTION
Removed text-alt from ContentReferenceList.tsx, added text-unset to ContentListItem.tsx to avoid "white on white text" in light-mode for delete dialog and others.