### PR TITLE
Disable inherited non-localized content editing #10728

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/hooks/useInheritedNonLocalized.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/hooks/useInheritedNonLocalized.ts
@@ -1,0 +1,10 @@
+import {useStore} from '@nanostores/preact';
+import {$wizardToolbar} from '../store/wizardToolbar.store';
+
+export function useInheritedNonLocalized(): boolean {
+    const {isContentInherited, isContentDataInherited} = useStore($wizardToolbar, {
+        keys: ['isContentInherited', 'isContentDataInherited'],
+    });
+
+    return isContentInherited && isContentDataInherited;
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageControllerSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageControllerSelector.tsx
@@ -1,5 +1,6 @@
 import {Combobox} from '@enonic/ui';
 import type {ReactElement} from 'react';
+import {useInheritedNonLocalized} from '../../../../../../hooks/useInheritedNonLocalized';
 import {useI18n} from '../../../../../../hooks/useI18n';
 import {ConfirmationDialog} from '../../../../../../shared/dialogs/ConfirmationDialog';
 import {SelectorPopup} from '../SelectorPopup';
@@ -20,6 +21,8 @@ export const PageControllerSelector = (): ReactElement | null => {
         isLoading,
     } = usePageControllerSelector();
 
+    const isInheritedNonLocalized = useInheritedNonLocalized();
+
     const templateLabel = useI18n('field.page.template');
     const searchPlaceholder = useI18n('field.option.placeholder');
     const noMatchingLabel = useI18n('field.option.noitems');
@@ -35,6 +38,7 @@ export const PageControllerSelector = (): ReactElement | null => {
             <div className="flex flex-col gap-2.5">
                 <span className="font-semibold">{templateLabel}</span>
                 <Combobox.Root
+                    disabled={isInheritedNonLocalized}
                     value={searchValue}
                     onChange={setSearchValue}
                     selection={selection}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageInspectionPanel.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageInspectionPanel.tsx
@@ -2,9 +2,10 @@ import {FieldRegistryProvider} from '@enonic/lib-admin-ui/form2';
 import {Button} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
 import {type ReactElement, useCallback, useMemo, useState} from 'react';
+import {useInheritedNonLocalized} from '../../../../../../hooks/useInheritedNonLocalized';
 import {useI18n} from '../../../../../../hooks/useI18n';
 import {ConfirmationDialog} from '../../../../../../shared/dialogs/ConfirmationDialog';
-import {FormRenderer} from '../../../../../../shared/form/FormRenderer';
+import {FormRenderer} from '../../../../../../shared/form';
 import {getAiFieldRegistry} from '../../../../../../store/ai/ai.field-registry';
 import {
     $contentContext,
@@ -31,6 +32,7 @@ export const PageInspectionPanel = (): ReactElement => {
     const descriptor = useStore($pageConfigDescriptor);
     const isCustomizeVisible = useStore($isCustomizeVisible);
     const isEmpty = useStore($isPageInspectionEmpty);
+    const isInheritedNonLocalized = useInheritedNonLocalized();
 
     const customizeLabel = useI18n("action.page.customize");
     const customizeQuestion = useI18n("dialog.page.customize.confirmation");
@@ -73,6 +75,7 @@ export const PageInspectionPanel = (): ReactElement => {
                         label={customizeLabel}
                         variant="outline"
                         onClick={handleCustomize}
+                        disabled={isInheritedNonLocalized}
                         className="w-full"
                     />
                 )}
@@ -83,7 +86,7 @@ export const PageInspectionPanel = (): ReactElement => {
                     <FormRenderer
                         form={configForm}
                         propertySet={configRoot}
-                        enabled={!lifecycle.isPageLocked}
+                        enabled={!lifecycle.isPageLocked && !isInheritedNonLocalized}
                         applicationKey={ctx?.applicationKey ?? undefined}
                     />
                 </FieldRegistryProvider>

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentWizardTabs.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentWizardTabs.tsx
@@ -1,6 +1,7 @@
 import {Tab} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
 import {type ReactElement, useEffect, useState} from 'react';
+import {useInheritedNonLocalized} from '../../../hooks/useInheritedNonLocalized';
 import {useI18n} from '../../../hooks/useI18n';
 import {
     $contentTypeDisplayName,
@@ -30,9 +31,11 @@ export const ContentWizardTabs = ({tabListAction}: ContentWizardTabsProps): Reac
     const xDataTabs = useStore($mixinsTabs);
     const invalidTabs = useStore($invalidTabs);
     const validationVisibility = useStore($validationVisibility);
+    const isInheritedNonLocalized = useInheritedNonLocalized();
     const pageTabLabel = useI18n('field.page');
     const [activeTab, setActiveTab] = useState('content');
     const showErrors = validationVisibility === 'all';
+    const inheritedContentClassName = isInheritedNonLocalized ? 'opacity-30' : undefined;
 
     useEffect(() => {
         const validTabs = ['content', ...(hasPage ? ['page'] : []), ...xDataTabs.map((tab) => tab.name)];
@@ -42,16 +45,19 @@ export const ContentWizardTabs = ({tabListAction}: ContentWizardTabsProps): Reac
     }, [hasPage, xDataTabs, activeTab]);
 
     if (!isExpanded) {
-        return <CollapsedFormPanel data-component={CONTENT_WIZARD_TABS_NAME} displayName={displayName || contentTypeDisplayName} />;
+        return <CollapsedFormPanel data-component={CONTENT_WIZARD_TABS_NAME} displayName={displayName || contentTypeDisplayName}/>;
     }
 
     return (
-        <Tab.Root data-component={CONTENT_WIZARD_TABS_NAME} value={activeTab} onValueChange={setActiveTab} className="flex flex-col gap-7.5">
+        <Tab.Root data-component={CONTENT_WIZARD_TABS_NAME} value={activeTab} onValueChange={setActiveTab}
+                  className="flex flex-col gap-7.5">
             <div className="flex items-center gap-1.5">
                 <Tab.ListOverflow className="min-w-0 flex-1">
                     <Tab.List>
-                        <Tab.DefaultTrigger value="content" error={showErrors && invalidTabs.has('content')}>{contentTypeDisplayName}</Tab.DefaultTrigger>
-                        {hasPage && <Tab.DefaultTrigger value="page" error={showErrors && invalidTabs.has('page')}>{pageTabLabel}</Tab.DefaultTrigger>}
+                        <Tab.DefaultTrigger value="content"
+                                            error={showErrors && invalidTabs.has('content')}>{contentTypeDisplayName}</Tab.DefaultTrigger>
+                        {hasPage &&
+                         <Tab.DefaultTrigger value="page" error={showErrors && invalidTabs.has('page')}>{pageTabLabel}</Tab.DefaultTrigger>}
                         {xDataTabs.map((tab) => (
                             <Tab.DefaultTrigger
                                 key={tab.name}
@@ -67,19 +73,19 @@ export const ContentWizardTabs = ({tabListAction}: ContentWizardTabsProps): Reac
                 <ToggleFormButton/>
             </div>
 
-            <Tab.Content value="content">
-                <ContentForm />
+            <Tab.Content className={inheritedContentClassName} value="content">
+                <ContentForm/>
             </Tab.Content>
 
             {hasPage && (
-                <Tab.Content value="page">
-                    <PageComponentsView showTitle />
+                <Tab.Content className={inheritedContentClassName} value="page">
+                    <PageComponentsView showTitle disabled={isInheritedNonLocalized}/>
                 </Tab.Content>
             )}
 
             {xDataTabs.map((tab) => (
-                <Tab.Content key={tab.name} value={tab.name}>
-                    <MixinView mixinName={tab.name} />
+                <Tab.Content className={inheritedContentClassName} key={tab.name} value={tab.name}>
+                    <MixinView mixinName={tab.name}/>
                 </Tab.Content>
             ))}
         </Tab.Root>

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsItem.tsx
@@ -14,6 +14,7 @@ export type PageComponentsItemProps = {
     pageMetadata?: PageComponentPageMetadata;
     selected?: boolean;
     invalid?: boolean;
+    disabled?: boolean;
     onToggle: (id: string) => void;
     onSelect: (id: string) => void;
 };
@@ -54,6 +55,7 @@ export const PageComponentsItem = ({
     pageMetadata,
     selected,
     invalid,
+    disabled,
     onToggle,
     onSelect,
 }: PageComponentsItemProps): ReactElement | null => {
@@ -73,10 +75,18 @@ export const PageComponentsItem = ({
 
     const handleToggleClick = (e: MouseEvent<HTMLButtonElement>): void => {
         e.stopPropagation();
+        if (disabled) {
+            return;
+        }
+
         onToggle(node.id);
     };
 
     const handleClick = (): void => {
+        if (disabled) {
+            return;
+        }
+
         onSelect(node.id);
     };
 
@@ -84,6 +94,7 @@ export const PageComponentsItem = ({
         <div
             className="flex flex-1 min-w-0 items-center gap-1 py-1"
             data-node-id={node.id}
+            aria-disabled={disabled}
             onClick={handleClick}
         >
             {!context.isMovable && <span className="size-5 shrink-0" />}
@@ -96,8 +107,10 @@ export const PageComponentsItem = ({
                 <button
                     type="button"
                     tabIndex={-1}
+                    disabled={disabled}
                     className={cn(
-                        'flex items-center justify-center size-5 shrink-0 cursor-pointer hover:text-main',
+                        'flex items-center justify-center size-5 shrink-0',
+                        disabled ? 'cursor-default' : 'cursor-pointer hover:text-main',
                         selected ? 'text-alt' : 'text-subtle',
                     )}
                     onClick={handleToggleClick}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -46,9 +46,10 @@ const animateLayoutChanges = ({isSorting}: {isSorting: boolean}): boolean => isS
 
 export type PageComponentsViewProps = {
     showTitle?: boolean;
+    disabled?: boolean;
 };
 
-export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps = {}): ReactElement => {
+export const PageComponentsView = ({showTitle = false, disabled = false}: PageComponentsViewProps = {}): ReactElement => {
     const containerRef = useRef<HTMLDivElement>(null);
     const componentsLabel = useI18n('field.components');
     const pageVersion = useStore($pageVersion);
@@ -160,45 +161,65 @@ export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps 
     }, [flatNodes]);
 
     const handleSelect = useCallback((nodeId: string): void => {
+        if (disabled) {
+            return;
+        }
+
         const path = ComponentPath.fromString(nodeId);
         inspectItem(path);
         PageNavigationMediator.get().notify(
             new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)),
         );
-    }, []);
+    }, [disabled]);
 
     const isItemMovable = useCallback((node: FlatNode<PageComponentNodeData>): boolean => {
+        if (disabled) {
+            return false;
+        }
+
         return node.data?.draggable ?? false;
-    }, []);
+    }, [disabled]);
 
     const itemClassName = useCallback((
         context: SortableListItemContext<FlatNode<PageComponentNodeData>>,
     ): string => {
         const isSelected = context.item.id === inspectedPath;
         return cn(
-            'w-full px-2.5 select-none cursor-pointer',
-            isSelected ? 'bg-surface-selected text-alt [&>button]:text-alt' : 'hover:bg-surface-neutral-hover',
+            'w-full px-2.5 select-none',
+            disabled ? 'pointer-events-none cursor-default' : 'cursor-pointer',
+            isSelected
+                ? 'bg-surface-selected text-alt [&>button]:text-alt'
+                : !disabled && 'hover:bg-surface-neutral-hover',
         );
-    }, [inspectedPath]);
+    }, [inspectedPath, disabled]);
 
     const renderItem = useCallback((
         context: SortableListItemContext<FlatNode<PageComponentNodeData>>,
     ): ReactElement | null => {
         const isSelected = context.item.id === inspectedPath;
         const isInvalid = showErrors && invalidComponentPaths.has(context.item.id);
+        const item = (
+            <PageComponentsItem
+                context={context}
+                pageMetadata={pageMetadata}
+                selected={isSelected}
+                invalid={isInvalid}
+                disabled={disabled}
+                onToggle={toggleComponentExpand}
+                onSelect={handleSelect}
+            />
+        );
+
+        if (disabled) {
+            return item;
+        }
+
         return (
             <PageComponentsContextMenu node={context.item}>
-                <PageComponentsItem
-                    context={context}
-                    pageMetadata={pageMetadata}
-                    selected={isSelected}
-                    invalid={isInvalid}
-                    onToggle={toggleComponentExpand}
-                    onSelect={handleSelect}
-                />
+                {item}
             </PageComponentsContextMenu>
         );
-    }, [handleSelect, inspectedPath, pageMetadata, showErrors, invalidComponentPaths]);
+    }, [handleSelect, inspectedPath, disabled, pageMetadata, showErrors, invalidComponentPaths]);
 
     return (
         <div ref={containerRef} data-component={PAGE_COMPONENTS_VIEW_NAME} className="flex flex-col gap-1 py-2">
@@ -208,7 +229,7 @@ export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps 
                 keyExtractor={(node) => node.id}
                 onDragStart={handleDragStart}
                 onMove={handleMove}
-                enabled={flatNodes.length > 1}
+                enabled={!disabled && flatNodes.length > 1}
                 fullRowDraggable
                 isItemMovable={isItemMovable}
                 resolveDrop={resolveDrop}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/layout/DetachedPageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/layout/DetachedPageComponentsView.tsx
@@ -2,6 +2,7 @@ import {cn, IconButton} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
 import {ChevronLeft, ChevronRight} from 'lucide-react';
 import {createPortal, type CSSProperties, type PointerEvent as ReactPointerEvent, useCallback, useEffect, useRef, useState, type ReactElement} from 'react';
+import {useInheritedNonLocalized} from '../../../hooks/useInheritedNonLocalized';
 import {useI18n} from '../../../hooks/useI18n';
 import {$app, setPageComponentsViewCollapsed} from '../../../store/app.store';
 import {$hasPage, $isContentFormExpanded} from '../../../store/wizardContent.store';
@@ -27,6 +28,7 @@ export const DetachedPageComponentsView = (): ReactElement | null => {
     const isExpanded = useStore($isContentFormExpanded);
     const hasPage = useStore($hasPage);
     const {pageComponentsViewCollapsed: collapsed} = useStore($app, {keys: ['pageComponentsViewCollapsed']});
+    const isInheritedNonLocalized = useInheritedNonLocalized();
     const showLabel = useI18n('field.showComponent');
     const hideLabel = useI18n('field.hideComponent');
     const componentsLabel = useI18n('field.components');
@@ -153,7 +155,7 @@ export const DetachedPageComponentsView = (): ReactElement | null => {
                 />
             </div>
             <div className="overflow-auto px-3 pb-2">
-                <PageComponentsView />
+                <PageComponentsView disabled={isInheritedNonLocalized} />
             </div>
         </div>,
         document.body,


### PR DESCRIPTION
Updates inherited non-localized handling across wizard tabs and page inspection.

Adds shared `useInheritedNonLocalized()` hook and applies it to content tabs, detached page components, page controller selector, customize button, and page config form.

The page components list now disables drag, click, toggle, hover affordance, and context menu when content is inherited and data-inherited.

Keeps existing opacity treatment on tab contents while blocking editing/actions in page-specific controls.