### PR TITLE
Lazy-load publish deps and resolve publish status server-side #10796

### DIFF
--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentResource.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentResource.java
@@ -2,6 +2,7 @@ package com.enonic.app.contentstudio.rest.resource.content;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -156,10 +157,6 @@ import com.enonic.xp.content.GetActiveContentVersionsResult;
 import com.enonic.xp.content.GetContentVersionsParams;
 import com.enonic.xp.content.GetContentVersionsResult;
 import com.enonic.xp.content.GetContentByIdsParams;
-import com.enonic.xp.content.GetContentVersionsParams;
-import com.enonic.xp.content.GetContentVersionsResult;
-import com.enonic.xp.content.GetPublishStatusesParams;
-import com.enonic.xp.content.GetPublishStatusesResult;
 import com.enonic.xp.content.HasUnpublishedChildrenParams;
 import com.enonic.xp.content.MoveContentParams;
 import com.enonic.xp.content.MoveContentsResult;
@@ -702,7 +699,7 @@ public final class ContentResource
     {
         final ArrayList<ContentId> childrenIds = new ArrayList<>();
         ids.getContentIds().stream().forEach( id -> {
-            FindContentByParentParams params = FindContentByParentParams.create().parentId( id ).recursive( true ).build();
+            FindContentByParentParams params = FindContentByParentParams.create().parentId( id ).recursive( true ).size( -1 ).build();
             childrenIds.addAll( this.contentService.findIdsByParent( params ).getContentIds().getSet() );
         } );
 
@@ -767,6 +764,13 @@ public final class ContentResource
         final ContentIds notValidContentIds = contentValidity.getNotValidContentIds();
         final ContentIds notReadyContentIds = contentValidity.getNotReadyContentIds();
 
+        final ContentIds publishableContentIds = compareResults.stream()
+            .filter( result -> result.getCompareStatus() != CompareStatus.EQUAL )
+            .map( CompareContentResult::getContentId )
+            .collect( ContentIds.collector() );
+
+        final boolean schedulable = isSchedulable( compareResults, fullPublishList );
+
         //sort all dependant content ids
         final ContentIds sortedDependentContentIds = sortContentIds( dependentContentIds, "_path" );
 
@@ -781,6 +785,8 @@ public final class ContentResource
             .setRequiredContents( requiredDependantIds )
             .setNotPublishableContents( notPublishableContentIds )
             .setSomePublishable( isSomePublishable )
+            .setPublishableContents( publishableContentIds )
+            .setSchedulable( schedulable )
             .setContainsInvalid( !notValidContentIds.isEmpty() )
             .setInvalidContents( notValidContentIds )
             .setContainsNotReady( !notReadyContentIds.isEmpty() )
@@ -828,6 +834,30 @@ public final class ContentResource
         return this.contentService.find(
                 ContentQuery.create().filterContentIds( contentIds ).queryExpr( QueryParser.parse( "order by " + field ) ).size( -1 ).build() )
             .getContentIds();
+    }
+
+    private boolean isSchedulable( final CompareContentResults compareResults, final ContentIds fullPublishList )
+    {
+        // Offline content (never published, or unpublished) shows up as NEW in the compare results.
+        final boolean hasOffline = compareResults.stream().anyMatch( result -> result.getCompareStatus() == CompareStatus.NEW );
+        if ( hasOffline )
+        {
+            return true;
+        }
+
+        if ( fullPublishList.isEmpty() )
+        {
+            return false;
+        }
+
+        // Expired content has a publish-to date in the past, which implies it was already online.
+        final long expiredCount = this.contentService.find( ContentQuery.create()
+            .filterContentIds( fullPublishList )
+            .queryExpr( QueryParser.parse( ContentIndexPath.PUBLISH_TO.getPath() + " < instant('" + Instant.now() + "')" ) )
+            .size( 1 )
+            .build() ).getTotalHits();
+
+        return expiredCount > 0;
     }
 
     private ContentIds problematicDependantsOnTop( final ContentIds dependentContentIdList, final ContentIds requestedContentIds,

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/json/ResolvePublishContentResultJson.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/json/ResolvePublishContentResultJson.java
@@ -16,11 +16,15 @@ public class ResolvePublishContentResultJson
 
     private final List<ContentIdJson> nextDependentContents;
 
+    private final List<ContentIdJson> publishableContents;
+
     private final Boolean containsInvalid;
 
     private final List<ContentIdJson> notPublishableContents;
 
     private final Boolean somePublishable;
+
+    private final Boolean schedulable;
 
     private final Boolean containsNotReady;
 
@@ -38,6 +42,8 @@ public class ResolvePublishContentResultJson
         containsInvalid = builder.containsInvalid;
         notPublishableContents = builder.notPublishableContents.stream().map( ContentIdJson::new ).collect( Collectors.toList() );
         somePublishable = builder.somePublishable;
+        schedulable = builder.schedulable;
+        publishableContents = builder.publishableContents.stream().map( ContentIdJson::new ).collect( Collectors.toList() );
         containsNotReady = builder.containsNotReady;
         invalidContents = builder.invalidContents.stream().map( ContentIdJson::new ).collect( Collectors.toList() );
         notReadyContents = builder.notReadyContents.stream().map( ContentIdJson::new ).collect( Collectors.toList() );
@@ -83,6 +89,17 @@ public class ResolvePublishContentResultJson
         return somePublishable;
     }
 
+    public Boolean isSchedulable()
+    {
+        return schedulable;
+    }
+
+    @SuppressWarnings("unused")
+    public List<ContentIdJson> getPublishableContents()
+    {
+        return publishableContents;
+    }
+
     public Boolean getContainsNotReady()
     {
         return containsNotReady;
@@ -122,6 +139,10 @@ public class ResolvePublishContentResultJson
         private ContentIds notPublishableContents;
 
         private Boolean somePublishable;
+
+        private Boolean schedulable;
+
+        private ContentIds publishableContents;
 
         private Boolean containsNotReady;
 
@@ -170,6 +191,18 @@ public class ResolvePublishContentResultJson
         public Builder setSomePublishable( final Boolean somePublishable )
         {
             this.somePublishable = somePublishable;
+            return this;
+        }
+
+        public Builder setSchedulable( final Boolean schedulable )
+        {
+            this.schedulable = schedulable;
+            return this;
+        }
+
+        public Builder setPublishableContents( final ContentIds publishableContents )
+        {
+            this.publishableContents = publishableContents;
             return this;
         }
 

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentResourceTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentResourceTest.java
@@ -72,6 +72,8 @@ import com.enonic.app.contentstudio.rest.resource.content.json.LocalizeContentsJ
 import com.enonic.app.contentstudio.rest.resource.content.json.MoveContentJson;
 import com.enonic.app.contentstudio.rest.resource.content.json.PublishContentJson;
 import com.enonic.app.contentstudio.rest.resource.content.json.ResetContentInheritJson;
+import com.enonic.app.contentstudio.rest.resource.content.json.ResolvePublishContentResultJson;
+import com.enonic.app.contentstudio.rest.resource.content.json.ResolvePublishDependenciesJson;
 import com.enonic.app.contentstudio.rest.resource.content.json.RevertContentJson;
 import com.enonic.app.contentstudio.rest.resource.content.json.UnpublishContentJson;
 import com.enonic.xp.aggregation.Aggregation;
@@ -1190,6 +1192,103 @@ public class ContentResourceTest
             .getAsString();
 
         assertJson( "resolve_publish_content.json", jsonString );
+    }
+
+    @Test
+    public void resolve_publish_content_excludes_equal_from_publishable()
+    {
+        final ContentResource contentResource = getResourceInstance();
+
+        final ContentId requestedId = ContentId.from( "requested-content-id" );
+        final ContentId dependantId = ContentId.from( "dependant-content-id" );
+
+        final Content content = mock( Content.class );
+        when( content.getPermissions() ).thenReturn( AccessControlList.empty() );
+
+        // requested is in sync (EQUAL), dependant has changes (NEWER)
+        when( contentService.resolvePublishDependencies( isA( ResolvePublishDependenciesParams.class ) ) ).thenReturn(
+            CompareContentResults.create()
+                .add( new CompareContentResult( CompareStatus.EQUAL, requestedId ) )
+                .add( new CompareContentResult( CompareStatus.NEWER, dependantId ) )
+                .build() );
+        when( contentService.resolveRequiredDependencies( isA( ResolveRequiredDependenciesParams.class ) ) ).thenReturn(
+            ContentIds.empty() );
+        when( contentService.compare( isA( CompareContentsParams.class ) ) ).thenReturn( CompareContentResults.create().build() );
+        when( contentService.getById( isA( ContentId.class ) ) ).thenReturn( content );
+        when( contentService.getOutboundDependencies( isA( ContentId.class ) ) ).thenReturn( ContentIds.empty() );
+        // No NEW items -> schedulable falls back to the expired query, which finds nothing here
+        when( contentService.find( isA( ContentQuery.class ) ) ).thenReturn(
+            FindContentIdsByQueryResult.create().contents( ContentIds.from( dependantId ) ).totalHits( 0L ).build() );
+        doReturn( ContentValidityResult.create().build() ).when( this.contentService ).getContentValidity(
+            isA( ContentValidityParams.class ) );
+
+        final ResolvePublishContentResultJson result = contentResource.resolvePublishContent(
+            createResolveParams( requestedId.toString() ) );
+
+        final List<String> publishable = result.getPublishableContents().stream().map( ContentIdJson::getId ).toList();
+        assertTrue( publishable.contains( dependantId.toString() ) );
+        assertFalse( publishable.contains( requestedId.toString() ) );
+        assertFalse( result.isSchedulable() );
+    }
+
+    @Test
+    public void resolve_publish_content_schedulable_when_expired()
+    {
+        final ContentResource contentResource = getResourceInstance();
+
+        final ContentId requestedId = ContentId.from( "requested-content-id" );
+        final ContentId dependantId = ContentId.from( "dependant-content-id" );
+
+        final Content content = mock( Content.class );
+        when( content.getPermissions() ).thenReturn( AccessControlList.empty() );
+
+        // No NEW items (so the offline shortcut does not apply)
+        when( contentService.resolvePublishDependencies( isA( ResolvePublishDependenciesParams.class ) ) ).thenReturn(
+            CompareContentResults.create()
+                .add( new CompareContentResult( CompareStatus.NEWER, requestedId ) )
+                .add( new CompareContentResult( CompareStatus.NEWER, dependantId ) )
+                .build() );
+        when( contentService.resolveRequiredDependencies( isA( ResolveRequiredDependenciesParams.class ) ) ).thenReturn(
+            ContentIds.empty() );
+        when( contentService.compare( isA( CompareContentsParams.class ) ) ).thenReturn( CompareContentResults.create().build() );
+        when( contentService.getById( isA( ContentId.class ) ) ).thenReturn( content );
+        when( contentService.getOutboundDependencies( isA( ContentId.class ) ) ).thenReturn( ContentIds.empty() );
+        // The expired query (publish.to < now) matches at least one content
+        when( contentService.find( isA( ContentQuery.class ) ) ).thenReturn(
+            FindContentIdsByQueryResult.create().contents( ContentIds.from( dependantId ) ).totalHits( 1L ).build() );
+        doReturn( ContentValidityResult.create().build() ).when( this.contentService ).getContentValidity(
+            isA( ContentValidityParams.class ) );
+
+        final ResolvePublishContentResultJson result = contentResource.resolvePublishContent(
+            createResolveParams( requestedId.toString() ) );
+
+        assertTrue( result.isSchedulable() );
+    }
+
+    @Test
+    public void find_ids_by_parents_resolves_all_descendants_recursively()
+    {
+        final ContentResource contentResource = getResourceInstance();
+
+        final ArgumentCaptor<FindContentByParentParams> captor = ArgumentCaptor.forClass( FindContentByParentParams.class );
+        when( contentService.findIdsByParent( captor.capture() ) ).thenReturn(
+            FindContentIdsByParentResult.create().contentIds( ContentIds.empty() ).build() );
+
+        contentResource.findIdsByParents( new ContentIdsJson( List.of( "parent-id" ) ) );
+
+        final FindContentByParentParams params = captor.getValue();
+        assertTrue( params.isRecursive() );
+        // size(-1) returns all descendants instead of the default page of 500
+        assertEquals( -1, params.getSize().intValue() );
+    }
+
+    private static ResolvePublishDependenciesJson createResolveParams( final String... ids )
+    {
+        final ResolvePublishDependenciesJson params = new ResolvePublishDependenciesJson();
+        params.setIds( Set.of( ids ) );
+        params.setExcludedIds( Set.of() );
+        params.setExcludeChildrenIds( Set.of() );
+        return params;
     }
 
     @Test

--- a/modules/app/src/test/resources/com/enonic/app/contentstudio/rest/resource/content/resolve_publish_content.json
+++ b/modules/app/src/test/resources/com/enonic/app/contentstudio/rest/resource/content/resolve_publish_content.json
@@ -30,6 +30,14 @@
     }
   ],
   "notReadyContents": [],
+  "publishableContents": [
+    {
+      "id": "requested-content-id"
+    },
+    {
+      "id": "dependant-content-id"
+    }
+  ],
   "requestedContents": [
     {
       "id": "requested-content-id"
@@ -40,5 +48,6 @@
       "id": "required-content-id"
     }
   ],
+    "schedulable": true,
     "somePublishable": true
 }

--- a/modules/lib/src/main/resources/assets/js/app/resource/ResolvePublishDependenciesResult.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/ResolvePublishDependenciesResult.ts
@@ -6,9 +6,11 @@ export class ResolvePublishDependenciesResult {
     dependentContents: ContentId[];
     requestedContents: ContentId[];
     requiredContents: ContentId[];
+    publishableContents: ContentId[];
     containsInvalid: boolean;
     notPublishableContents: ContentId[];
     somePublishable: boolean;
+    schedulable: boolean;
     invalidContents: ContentId[];
     notReadyContents: ContentId[];
     nextDependentContents: ContentId[];
@@ -18,9 +20,11 @@ export class ResolvePublishDependenciesResult {
         this.dependentContents = builder.dependentContents;
         this.requestedContents = builder.requestedContents;
         this.requiredContents = builder.requiredContents;
+        this.publishableContents = builder.publishableContents;
         this.containsInvalid = builder.containsInvalid;
         this.notPublishableContents = builder.notPublishableContents;
         this.somePublishable = builder.somePublishable;
+        this.schedulable = builder.schedulable;
         this.invalidContents = builder.invalidContents;
         this.notReadyContents = builder.notReadyContents;
         this.nextDependentContents = builder.nextDependentContents;
@@ -37,6 +41,14 @@ export class ResolvePublishDependenciesResult {
 
     getRequired(): ContentId[] {
         return this.requiredContents;
+    }
+
+    getPublishable(): ContentId[] {
+        return this.publishableContents;
+    }
+
+    isSchedulable(): boolean {
+        return this.schedulable;
     }
 
     isContainsInvalid(): boolean {
@@ -74,9 +86,11 @@ export class ResolvePublishDependenciesResult {
                                         : [];
         const requested: ContentId[] = json.requestedContents?.map(dependant => new ContentId(dependant.id)) ?? [];
         const required: ContentId[] = json.requiredContents?.map(dependant => new ContentId(dependant.id)) ?? [];
+        const publishable: ContentId[] = json.publishableContents?.map(dependant => new ContentId(dependant.id)) ?? [];
         const containsInvalid: boolean = json.containsInvalid;
         const notPublishableIds: ContentId[] = json.notPublishableContents?.map(dependant => new ContentId(dependant.id)) ?? [];
         const somePublishable: boolean = json.somePublishable;
+        const schedulable: boolean = json.schedulable ?? false;
         const invalidIds: ContentId[] = json.invalidContents?.map(dependant => new ContentId(dependant.id)) ?? [];
         const notReadyIds: ContentId[] = json.notReadyContents?.map(dependant => new ContentId(dependant.id)) ?? [];
         const nextDependentContents: ContentId[] = json.nextDependentContents?.map(dependant => new ContentId(dependant.id)) ?? [];
@@ -85,9 +99,11 @@ export class ResolvePublishDependenciesResult {
         return ResolvePublishDependenciesResult.create().setDependentContents(dependants).setRequestedContents(
             requested)
             .setRequiredContents(required)
+            .setPublishableContents(publishable)
             .setContainsInvalid(containsInvalid)
             .setNotPublishableContents(notPublishableIds)
             .setSomePublishable(somePublishable)
+            .setSchedulable(schedulable)
             .setInvalidContents(invalidIds)
             .setNotReadyContents(notReadyIds)
             .setNextDependentContents(nextDependentContents)
@@ -104,9 +120,11 @@ export class Builder {
     dependentContents: ContentId[];
     requestedContents: ContentId[];
     requiredContents: ContentId[];
+    publishableContents: ContentId[];
     containsInvalid: boolean;
     notPublishableContents: ContentId[];
     somePublishable: boolean;
+    schedulable: boolean;
     invalidContents: ContentId[];
     notReadyContents: ContentId[];
     nextDependentContents: ContentId[];
@@ -127,6 +145,11 @@ export class Builder {
         return this;
     }
 
+    setPublishableContents(value: ContentId[]): Builder {
+        this.publishableContents = value;
+        return this;
+    }
+
     setContainsInvalid(value: boolean): Builder {
         this.containsInvalid = value;
         return this;
@@ -139,6 +162,11 @@ export class Builder {
 
     setSomePublishable(value: boolean): Builder {
         this.somePublishable = value;
+        return this;
+    }
+
+    setSchedulable(value: boolean): Builder {
+        this.schedulable = value;
         return this;
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/resource/json/ResolvePublishContentResultJson.ts
+++ b/modules/lib/src/main/resources/assets/js/app/resource/json/ResolvePublishContentResultJson.ts
@@ -4,9 +4,11 @@ export interface ResolvePublishContentResultJson {
     dependentContents: ContentIdBaseItemJson[];
     requestedContents: ContentIdBaseItemJson[];
     requiredContents: ContentIdBaseItemJson[];
+    publishableContents: ContentIdBaseItemJson[];
     containsInvalid: boolean;
     notPublishableContents: ContentIdBaseItemJson[];
     somePublishable: boolean;
+    schedulable: boolean;
     invalidContents: ContentIdBaseItemJson[];
     notReadyContents: ContentIdBaseItemJson[];
     nextDependentContents: ContentIdBaseItemJson[];

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialogMainContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialogMainContent.tsx
@@ -7,6 +7,7 @@ import {$config} from '../../../store/config.store';
 import {
     $dependantPublishItems,
     $hasExcludedDependantItems,
+    $hasMoreDependants,
     $hasSchedulableItems,
     $isPublishChecking,
     $isPublishReady,
@@ -21,6 +22,7 @@ import {
     excludeInProgressPublishItems,
     excludeInvalidPublishItems,
     excludeNotPublishablePublishItems,
+    loadMoreDependants,
     markAllAsReadyInProgressPublishItems,
     removePublishDialogItem,
     setPublishDialogDependantItemSelected,
@@ -50,6 +52,7 @@ export const PublishDialogMainContent = ({
     const {allowContentUpdate, defaultPublishFromTime} = useStore($config, {keys: ['allowContentUpdate', 'defaultPublishFromTime']});
     const mainItems = useStore($mainPublishItems);
     const dependantItems = useStore($dependantPublishItems);
+    const hasMoreDependants = useStore($hasMoreDependants);
     const publishCount = useStore($totalPublishableItems);
     const hasSchedulableItems = useStore($hasSchedulableItems);
     const hasExcludedItems = useStore($hasExcludedDependantItems);
@@ -225,6 +228,8 @@ export const PublishDialogMainContent = ({
                         getItemId={(item) => item.id}
                         emptyMessage={hasExcludedItems ? allExcludedMessage : undefined}
                         disabled={loading}
+                        hasMore={hasMoreDependants}
+                        onEndReached={loadMoreDependants}
                         renderRow={(item) => (
                             <ContentRow
                                 key={item.id}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/split-list/SplitList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/split-list/SplitList.tsx
@@ -1,6 +1,7 @@
 import {cn, GridList, Separator} from '@enonic/ui';
 import type {ReactElement, ReactNode} from 'react';
 import {useI18n} from '../../../hooks/useI18n';
+import {useInfiniteScroll} from '../../../hooks/useInfiniteScroll';
 import {InlineButton} from '../../InlineButton';
 import type {
     SplitListPrimaryProps,
@@ -130,14 +131,26 @@ SplitListSeparatorButton.displayName = SPLIT_LIST_SEPARATOR_BUTTON_NAME;
 
 const SPLIT_LIST_SECONDARY_NAME = 'SplitList.Secondary';
 
+const NOOP = (): void => undefined;
+
 function SplitListSecondary<T>({
     items,
     renderRow,
     emptyMessage,
     className,
     disabled = false,
+    hasMore = false,
+    onEndReached,
 }: SplitListSecondaryProps<T>): ReactElement | null {
     const secondaryLabel = useI18n('field.split.secondary');
+
+    // IntersectionObserver clips against the scrolling Dialog.Body anyway, so the
+    // hook's default viewport root is correct here.
+    const sentinelRef = useInfiniteScroll<HTMLDivElement>({
+        hasMore,
+        isLoading: disabled,
+        onLoadMore: onEndReached ?? NOOP,
+    });
 
     if (items.length === 0) {
         if (!emptyMessage) {
@@ -151,14 +164,17 @@ function SplitListSecondary<T>({
     }
 
     return (
-        <GridList
-            data-component={SPLIT_LIST_SECONDARY_NAME}
-            className={cn('flex flex-col gap-y-1.5 py-2 rounded-md', className)}
-            label={secondaryLabel}
-            disabled={disabled}
-        >
-            {items.map((item, index) => renderRow(item, index))}
-        </GridList>
+        <>
+            <GridList
+                data-component={SPLIT_LIST_SECONDARY_NAME}
+                className={cn('flex flex-col gap-y-1.5 py-2 rounded-md', className)}
+                label={secondaryLabel}
+                disabled={disabled}
+            >
+                {items.map((item, index) => renderRow(item, index))}
+            </GridList>
+            {hasMore && <div ref={sentinelRef} aria-hidden className="h-px w-full" />}
+        </>
     );
 }
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/split-list/types.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/split-list/types.ts
@@ -42,4 +42,8 @@ export type SplitListSecondaryProps<T> = {
     emptyMessage?: string;
     className?: string;
     disabled?: boolean;
+    /** When true, more items can be lazy-loaded as the user scrolls to the end. */
+    hasMore?: boolean;
+    /** Invoked when the end of the list is scrolled into view (lazy-load trigger). */
+    onEndReached?: () => void;
 };

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/dialog.store.test.utils.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/dialog.store.test.utils.ts
@@ -11,6 +11,8 @@ type ResolveResultOptions = {
     inProgress?: ContentId[];
     notPublishable?: ContentId[];
     next?: ContentId[];
+    publishable?: ContentId[];
+    schedulable?: boolean;
 };
 
 type MockContentOptions = {
@@ -70,6 +72,8 @@ export function createResolveResult({
     inProgress = [],
     notPublishable = [],
     next = [],
+    publishable = [],
+    schedulable = false,
 }: ResolveResultOptions) {
     return {
         getDependants: () => dependants,
@@ -78,6 +82,8 @@ export function createResolveResult({
         getInProgress: () => inProgress,
         getNotPublishable: () => notPublishable,
         getNextDependants: () => next,
+        getPublishable: () => publishable,
+        isSchedulable: () => schedulable,
     };
 }
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.test.ts
@@ -12,6 +12,7 @@ import {$config} from '../config.store';
 import {
     $dependantPublishItems,
     $hasExcludedDependantItems,
+    $hasMoreDependants,
     $hasSchedulableItems,
     $isPublishReady,
     $isScheduleValid,
@@ -19,7 +20,9 @@ import {
     $publishDialog,
     $publishDialogPending,
     $scheduleFromError,
+    $totalPublishableItems,
     applyDraftPublishDialogSelection,
+    loadMoreDependants,
     openPublishDialog,
     resetPublishDialogContext,
     setPublishDialogDependantItemSelected,
@@ -109,7 +112,10 @@ describe('publishDialog.store', () => {
         mockFindIdsByParents.mockReset().mockResolvedValue([]);
         mockMarkAsReady.mockReset();
         mockPublishContent.mockReset();
-        mockResolvePublishDependencies.mockReset().mockResolvedValue(createResolveResult({}));
+        // By default treat the requested (main) items as publishable, mirroring the
+        // server's publishableContents (status != EQUAL) for typical scenarios.
+        mockResolvePublishDependencies.mockReset().mockImplementation(
+            (params: {ids?: ContentId[]}) => createResolveResult({publishable: params?.ids ?? []}));
     });
 
     afterEach(() => {
@@ -123,11 +129,11 @@ describe('publishDialog.store', () => {
         const original = createMockContent('item-1', {displayName: 'Original name'});
         const updated = createMockContent('item-1', {displayName: 'Updated name'});
 
+        // No dependants, so each reload makes a single resolve call (the duplicate is skipped):
+        // open consumes the first result, the external-update reload the second.
         mockResolvePublishDependencies
-            .mockResolvedValueOnce(createResolveResult({inProgress: [itemId]}))
-            .mockResolvedValueOnce(createResolveResult({inProgress: [itemId]}))
-            .mockResolvedValueOnce(createResolveResult({}))
-            .mockResolvedValueOnce(createResolveResult({}));
+            .mockResolvedValueOnce(createResolveResult({inProgress: [itemId], publishable: [itemId]}))
+            .mockResolvedValueOnce(createResolveResult({publishable: [itemId]}));
 
         openPublishDialog([original]);
         await flushInitialReload();
@@ -143,7 +149,7 @@ describe('publishDialog.store', () => {
 
         expect($publishCheckErrors.get().inProgress.count).toBe(0);
         expect($isPublishReady.get()).toBe(true);
-        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(4);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
     });
 
     it('patches renamed tracked items without forcing a dependency reload', async () => {
@@ -188,14 +194,15 @@ describe('publishDialog.store', () => {
         emitContentCreated([unrelated]);
         await flushDebouncedReload();
 
-        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+        // The unrelated content is not below a selected path, so no reload happens.
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(1);
         expect($publishDialog.get().items[0].hasChildren()).toBe(false);
 
         emitContentCreated([child]);
         await flushDebouncedReload();
 
         expect($publishDialog.get().items[0].hasChildren()).toBe(true);
-        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(4);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
     });
 
     it.each(publishRemovalEventCases)(
@@ -212,7 +219,7 @@ describe('publishDialog.store', () => {
 
             expect($publishDialog.get().open).toBe(true);
             expect($publishDialog.get().items.map(item => item.getId())).toEqual(['item-2']);
-            expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(4);
+            expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
         },
     );
 
@@ -228,7 +235,7 @@ describe('publishDialog.store', () => {
 
         expect($publishDialog.get().open).toBe(true);
         expect($publishDialog.get().items.map(item => item.getId())).toEqual(['item-1', 'item-2']);
-        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(4);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
     });
 
     it.each([
@@ -250,7 +257,7 @@ describe('publishDialog.store', () => {
 
             expect($publishDialog.get().open).toBe(false);
             expect($publishDialog.get().items).toEqual([]);
-            expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+            expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(1);
         },
     );
 
@@ -258,6 +265,8 @@ describe('publishDialog.store', () => {
         it('should be true when at least one main item is offline', async () => {
             const offline = createMockContent('item-1', {isOnline: false});
             const online = createMockContent('item-2', {isOnline: true});
+
+            mockResolvePublishDependencies.mockResolvedValue(createResolveResult({schedulable: true}));
 
             openPublishDialog([offline, online]);
             await flushInitialReload();
@@ -284,6 +293,8 @@ describe('publishDialog.store', () => {
             });
             const online = createMockContent('item-2', {isOnline: true});
 
+            mockResolvePublishDependencies.mockResolvedValue(createResolveResult({schedulable: true}));
+
             openPublishDialog([expired, online]);
             await flushInitialReload();
 
@@ -295,7 +306,7 @@ describe('publishDialog.store', () => {
             const dependantId = new ContentId('dep-1');
             const dependant = createMockContent('dep-1', {isOnline: false});
 
-            mockResolvePublishDependencies.mockResolvedValue(createResolveResult({dependants: [dependantId]}));
+            mockResolvePublishDependencies.mockResolvedValue(createResolveResult({dependants: [dependantId], schedulable: true}));
             mockFetchContentSummaries.mockResolvedValue([dependant]);
 
             openPublishDialog([main]);
@@ -322,7 +333,7 @@ describe('publishDialog.store', () => {
         expect($publishDialog.get().open).toBe(true);
         expect($publishDialog.get().items.map(currentItem => currentItem.getId())).toEqual(['item-1']);
         expect($publishDialogPending.get().submitting).toBe(true);
-        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(1);
     });
 
     describe('requiredPublishFrom', () => {
@@ -453,6 +464,44 @@ describe('publishDialog.store', () => {
             expect(dependant.hidden).toBe(false);
             expect($publishDialog.get().excludedDependantItemsIds).toHaveLength(0);
             expect($hasExcludedDependantItems.get()).toBe(false);
+        });
+    });
+
+    describe('windowed dependant loading', () => {
+        afterEach(() => {
+            $config.setKey('excludeDependencies', true);
+        });
+
+        it('loads dependant summaries in windows while counting all by id', async () => {
+            // Auto-exclude off so every dependant stays included; this isolates windowing.
+            $config.setKey('excludeDependencies', false);
+
+            const mainId = new ContentId('main-1');
+            const dependantIds = Array.from({length: 40}, (_, index) => new ContentId(`dep-${index}`));
+
+            mockResolvePublishDependencies.mockResolvedValue(createResolveResult({
+                dependants: dependantIds,
+                publishable: [mainId, ...dependantIds],
+            }));
+            mockFetchContentSummaries.mockImplementation((ids: ContentId[]) =>
+                Promise.resolve(ids.map(id => createMockContent(id.toString()))));
+
+            openPublishDialog([createMockContent('main-1')]);
+            await flushInitialReload();
+
+            // Only the first window of summaries is loaded...
+            expect($dependantPublishItems.get()).toHaveLength(36);
+            expect($hasMoreDependants.get()).toBe(true);
+
+            // ...but the count is id-based, so it includes all dependants plus the main item.
+            expect($totalPublishableItems.get()).toBe(41);
+
+            await loadMoreDependants();
+            await flushPromises();
+
+            expect($dependantPublishItems.get()).toHaveLength(40);
+            expect($hasMoreDependants.get()).toBe(false);
+            expect($totalPublishableItems.get()).toBe(41);
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
@@ -6,7 +6,6 @@ import {type ContentId} from '../../../../app/content/ContentId';
 import type {ContentSummary} from '../../../../app/content/ContentSummary';
 import {fetchContentSummaries} from '../../api/content';
 import {type CompareResult, compareContent} from '../../api/compare';
-import {PublishStatus} from '../../../../app/publish/PublishStatus';
 import {calcSecondaryStatus, calcTreePublishStatus} from '../../utils/cms/content/status';
 import {hasUnpublishedChildren} from '../../api/hasUnpublishedChildren';
 import {findIdsByParents, markAsReady, publishContent, resolvePublishDependencies as resolvePublishDeps} from '../../api/publish';
@@ -90,6 +89,7 @@ type PublishChecksStore = {
     inProgressExcludable: boolean;
     notPublishableIds: ContentId[];
     notPublishableExcludable: boolean;
+    schedulable: boolean;
 }
 
 type PublishCheckError = {
@@ -139,6 +139,7 @@ const initialChecksState: PublishChecksStore = {
     inProgressExcludable: false,
     notPublishableIds: [],
     notPublishableExcludable: false,
+    schedulable: false,
 };
 
 const initialPendingState: PublishDialogPendingStore = {
@@ -155,11 +156,20 @@ export const $draftPublishDialogSelection = map<PublishDialogSelectionStore>(str
 
 const $publishChecks = map<PublishChecksStore>(structuredClone(initialChecksState));
 
-// Store for resolved dependencies (output of reloadPublishDialogData)
+const DEPENDANT_LOAD_SIZE = 36;
+
+// Full ordered dependant id list; summaries load lazily, a window at a time.
+const $dependantIds = atom<ContentId[]>([]);
+
 const $publishDialogDependants = atom<ContentSummary[]>([]);
 
 // Dependant ids visible in the dialog (legacy `calcVisibleIds`): min dependants, direct excluded deps, included children
 const $visibleDependantIds = atom<ContentId[]>([]);
+
+const $dependantWindow = atom<number>(0);
+
+// Publishable ids (status != EQUAL) resolved by the server, across the full set
+const $publishableContentIds = atom<ContentId[]>([]);
 
 export const $publishDialogPending = map<PublishDialogPendingStore>(initialPendingState);
 
@@ -233,27 +243,26 @@ export const $hasExcludedDependantItems = computed($dependantPublishItems, (item
     return items.some(item => item.excludedByDefault && !item.hidden && !item.required);
 });
 
-export const $publishableIds = computed([$mainPublishItems, $dependantPublishItems], (mainItems, dependantItems): ContentId[] => {
-    return [...mainItems, ...dependantItems].filter(item => {
-        return item.included && calcSecondaryStatus(calcTreePublishStatus(item.content), item.content) != null;
-    }).map(item => item.content.getContentId());
-});
+// Filter the server's publishable set by the draft selection so the count stays live
+// while the user toggles checkboxes, without re-resolving or loading summaries.
+export const $publishableIds = computed(
+    [$publishableContentIds, $draftPublishDialogSelection],
+    (publishableIds, {excludedItemsIds, excludedDependantItemsIds}): ContentId[] => {
+        const excludedIds = uniqueIds([...excludedItemsIds, ...excludedDependantItemsIds]);
+        return publishableIds.filter(id => !hasContentIdInIds(id, excludedIds));
+    }
+);
 
 export const $totalPublishableItems = computed($publishableIds, (publishableIds): number => {
     return publishableIds.length;
 });
 
-// Scheduling only makes sense when at least one item is not currently online.
-// Mirrors legacy `hasSchedulable`: hide when all items are Published, Modified, or Scheduled.
-export const $hasSchedulableItems = computed(
-    [$publishDialog, $publishDialogDependants],
-    ({items}, dependants): boolean => {
-        return [...items, ...dependants].some(item => {
-            const status = calcTreePublishStatus(item);
-            return status === PublishStatus.OFFLINE || status === PublishStatus.EXPIRED;
-        });
-    },
-);
+export const $hasMoreDependants = computed([$dependantIds, $dependantWindow], (ids, loaded): boolean => {
+    return loaded < ids.length;
+});
+
+// Scheduling makes sense only when something is offline or expired (resolved server-side).
+export const $hasSchedulableItems = computed($publishChecks, ({schedulable}): boolean => schedulable);
 
 export const $publishCheckErrors = computed([$publishChecks], (state): PublishCheckErrorsStore => {
     return {
@@ -395,9 +404,8 @@ export const openPublishDialog = (items: ContentSummary[], includeChildItems = f
         excludedDependantItemsIds: [...excludedIds],
     });
 
-    // Reset dependants store
-    $publishDialogDependants.set([]);
-    $visibleDependantIds.set([]);
+    // Reset dependants stores
+    resetDependantsState();
 
     // TODO: Sync after updates to $publishDialog
     $draftPublishDialogSelection.set({
@@ -426,8 +434,7 @@ export const resetPublishDialogContext = () => {
     $publishDialog.set(structuredClone(initialPublishDialogState));
     $draftPublishDialogSelection.set(structuredClone(initialSelectionState));
     $publishChecks.set(structuredClone(initialChecksState));
-    $publishDialogDependants.set([]);
-    $visibleDependantIds.set([]);
+    resetDependantsState();
     $publishDialogPending.set(initialPendingState);
     $hasUnpublishedChildrenIds.set(new Set());
     $compareStatuses.set(new Map());
@@ -615,6 +622,54 @@ export const removePublishDialogItem = (id: ContentId): void => {
 
 // DATA
 
+let loadingMore = false;
+
+const orderSummariesByIds = (summaries: ContentSummary[], orderIds: ContentId[]): ContentSummary[] => {
+    const indexById = new Map<string, number>();
+    orderIds.forEach((id, index) => indexById.set(id.toString(), index));
+    const indexOf = (item: ContentSummary): number =>
+        indexById.get(item.getContentId().toString()) ?? orderIds.length;
+    return [...summaries].sort((a, b) => indexOf(a) - indexOf(b));
+};
+
+// Loads the next slice into the window, preserving server order. Returns null if a
+// newer reload superseded this one (guardId no longer matches the current instanceId).
+async function loadDependantWindow(allIds: ContentId[], start: number, guardId: number): Promise<ContentSummary[] | null> {
+    const sliceIds = allIds.slice(start, start + DEPENDANT_LOAD_SIZE);
+    const summaries = sliceIds.length > 0 ? await fetchContentSummaries(sliceIds) : [];
+
+    if (guardId !== instanceId) return null;
+
+    if (sliceIds.length > 0 && summaries.length === 0) {
+        return $publishDialogDependants.get();
+    }
+
+    const base = start === 0 ? [] : $publishDialogDependants.get();
+    const merged = orderSummariesByIds([...base, ...summaries], allIds);
+
+    $publishDialogDependants.set(merged);
+    $dependantWindow.set(Math.min(start + DEPENDANT_LOAD_SIZE, allIds.length));
+
+    return merged;
+}
+
+/** Lazy-load the next window of dependant summaries (triggered by list scroll). */
+export const loadMoreDependants = async (): Promise<void> => {
+    if (loadingMore) return;
+
+    const allIds = $dependantIds.get();
+    const loaded = $dependantWindow.get();
+    if (loaded >= allIds.length) return;
+
+    loadingMore = true;
+    const guardId = instanceId;
+    try {
+        await loadDependantWindow(allIds, loaded, guardId);
+    } finally {
+        loadingMore = false;
+    }
+};
+
 async function reloadPublishDialogData(): Promise<void> {
     $compareStatuses.set(new Map());
     $compareStatusesLoading.set(false);
@@ -625,10 +680,10 @@ async function reloadPublishDialogData(): Promise<void> {
         const result = await resolvePublishDependencies();
         if (!result) return;
 
-        const {dependantItems, visibleDependantIds, excludedItemsIds, excludedDependantItemsIds, ...checks} = result;
+        const {publishableContentIds, visibleDependantIds, excludedItemsIds, excludedDependantItemsIds, ...checks} = result;
 
-        // Write dependantItems to separate store
-        $publishDialogDependants.set(dependantItems);
+        // Dependant summaries are managed (windowed) inside resolvePublishDependencies
+        $publishableContentIds.set(publishableContentIds);
         $visibleDependantIds.set(visibleDependantIds);
 
         // Only update exclusion IDs in $publishDialog
@@ -654,7 +709,7 @@ async function reloadPublishDialogData(): Promise<void> {
         await fetchHasUnpublishedChildren(items);
 
         // Verify compare status for online+modified items (non-blocking)
-        void fetchCompareStatuses([...items, ...dependantItems]);
+        void fetchCompareStatuses([...items, ...$publishDialogDependants.get()]);
     } catch (error) {
         $publishDialog.setKey('failed', true);
         // TODO: Notify error
@@ -682,8 +737,7 @@ export const markAllAsReadyInProgressPublishItems = async (): Promise<void> => {
 
 export const excludeInProgressPublishItems = (): ContentId[] => {
     const {excludedDependantItemsIds} = $publishDialog.get();
-    const dependantItems = $publishDialogDependants.get();
-    const dependantItemsIds = dependantItems.map(item => item.getContentId());
+    const dependantItemsIds = $dependantIds.get();
     const inProgressDependantIds = $publishChecks.get().inProgressIds.filter(id => hasContentIdInIds(id, dependantItemsIds));
     const newExcludedDependantItemsIds = uniqueIds([...excludedDependantItemsIds, ...inProgressDependantIds]);
 
@@ -695,8 +749,7 @@ export const excludeInProgressPublishItems = (): ContentId[] => {
 
 export const excludeInvalidPublishItems = (): ContentId[] => {
     const {excludedDependantItemsIds} = $publishDialog.get();
-    const dependantItems = $publishDialogDependants.get();
-    const dependantItemsIds = dependantItems.map(item => item.getContentId());
+    const dependantItemsIds = $dependantIds.get();
     const invalidDependantIds = $publishChecks.get().invalidIds.filter(id => hasContentIdInIds(id, dependantItemsIds));
     const newExcludedDependantItemsIds = uniqueIds([...excludedDependantItemsIds, ...invalidDependantIds]);
 
@@ -708,8 +761,7 @@ export const excludeInvalidPublishItems = (): ContentId[] => {
 
 export const excludeNotPublishablePublishItems = (): ContentId[] => {
     const {excludedDependantItemsIds} = $publishDialog.get();
-    const dependantItems = $publishDialogDependants.get();
-    const dependantItemsIds = dependantItems.map(item => item.getContentId());
+    const dependantItemsIds = $dependantIds.get();
     const notPublishableDependantIds = $publishChecks.get().notPublishableIds.filter(id => hasContentIdInIds(id, dependantItemsIds));
     const newExcludedDependantItemsIds = uniqueIds([...excludedDependantItemsIds, ...notPublishableDependantIds]);
 
@@ -778,6 +830,15 @@ const filterItemsWithChildren = (items: ContentSummary[]): ContentSummary[] => {
     return items.filter(item => item.hasChildren());
 };
 
+/** Clears all dependant-related state (full IDs, loaded window, publishable set). */
+function resetDependantsState(): void {
+    $publishDialogDependants.set([]);
+    $dependantIds.set([]);
+    $dependantWindow.set(0);
+    $visibleDependantIds.set([]);
+    $publishableContentIds.set([]);
+}
+
 //
 // * Internal Helpers
 //
@@ -814,6 +875,17 @@ const removeItemsByIds = (idsToRemove: Set<string>): {removedMain: boolean; remo
     }
     if (removedDependant) {
         $publishDialogDependants.set(nextDependantItems.items);
+    }
+
+    // Keep the full ID list and publishable set in sync until the follow-up reload.
+    const nextDependantIds = $dependantIds.get().filter(id => !idsToRemove.has(id.toString()));
+    if (nextDependantIds.length !== $dependantIds.get().length) {
+        $dependantIds.set(nextDependantIds);
+        $dependantWindow.set(Math.min($dependantWindow.get(), nextDependantIds.length));
+    }
+    const nextPublishableIds = $publishableContentIds.get().filter(id => !idsToRemove.has(id.toString()));
+    if (nextPublishableIds.length !== $publishableContentIds.get().length) {
+        $publishableContentIds.set(nextPublishableIds);
     }
 
     return {removedMain, removedDependant};
@@ -982,7 +1054,8 @@ $contentPublished.subscribe(onIdlePublishSocketEvent((event) => {
 // TODO: Use AbortController to cancel the request if the instanceId changes
 
 type ResolvePublishDependenciesResult = {
-    dependantItems: ContentSummary[];
+    publishableContentIds: ContentId[];
+    schedulable: boolean;
     visibleDependantIds: ContentId[];
     excludedItemsIds: ContentId[];
     excludedDependantItemsIds: ContentId[];
@@ -1022,7 +1095,12 @@ async function resolvePublishDependencies(): Promise<ResolvePublishDependenciesR
                 !hasContentIdInIds(id, childrenIds) && !hasContentIdInIds(id, itemsIds)),
         ])
         : initialExcludedIds;
-    const minResult = await resolvePublishDeps({ids: itemsIds, excludedIds: minExcludedIds, excludeChildrenIds: allExcludedItemsWithChildrenIds});
+
+    // Skip the second request when its parameters match the first: maxResult
+    // and minResult only differ when non-required dependencies are excluded.
+    const minResult = isIdsEqual(minExcludedIds, excludedItemsIds)
+        ? maxResult
+        : await resolvePublishDeps({ids: itemsIds, excludedIds: minExcludedIds, excludeChildrenIds: allExcludedItemsWithChildrenIds});
 
     if (currentInstanceId !== instanceId) return;
 
@@ -1059,20 +1137,21 @@ async function resolvePublishDependencies(): Promise<ResolvePublishDependenciesR
         // TODO: notify 'dialog.publish.notAllExcluded'
     }
 
-    // TODO: Cache dependant items
-    const dependantItems = await fetchContentSummaries(allDependantIds);
-
-    if (currentInstanceId !== instanceId) return;
+    // Store all ids; load only the first window of summaries (rest load on scroll).
+    $dependantIds.set(allDependantIds);
+    const loaded = await loadDependantWindow(allDependantIds, 0, currentInstanceId);
+    if (loaded == null) return;
 
     const newExcludedItemsIds = items.filter(item =>
         hasContentIdInIds(item.getContentId(), excludedIds) ||
         hasContentIdInIds(item.getContentId(), excludedItemsIds)
     ).map(item => item.getContentId());
 
-    const newExcludedDependantItemsIds = dependantItems.filter(item =>
-        hasContentIdInIds(item.getContentId(), excludedIds) ||
-        hasContentIdInIds(item.getContentId(), baseExcludedDependantIds)
-    ).map(item => item.getContentId());
+    // Exclusions are computed from IDs (the full set), not from loaded summaries.
+    const newExcludedDependantItemsIds = allDependantIds.filter(id =>
+        hasContentIdInIds(id, excludedIds) ||
+        hasContentIdInIds(id, baseExcludedDependantIds)
+    );
 
     const isExcludableFromIds = (id: ContentId): boolean => {
         return !hasContentIdInIds(id, newExcludedItemsIds) &&
@@ -1090,7 +1169,8 @@ async function resolvePublishDependencies(): Promise<ResolvePublishDependenciesR
     const notPublishableExcludable = excludableNotPublishableIds.length === notPublishableIds.length && notPublishableIds.length > 0;
 
     return {
-        dependantItems,
+        publishableContentIds: maxResult.getPublishable(),
+        schedulable: maxResult.isSchedulable(),
         visibleDependantIds,
         excludedItemsIds: newExcludedItemsIds,
         excludedDependantItemsIds: newExcludedDependantItemsIds,


### PR DESCRIPTION
Lazy-load publish dialog dependants and resolve publish status server-side #10796

The publish dialog loaded every dependency summary in one request and computed publish status on the client from those summaries. For large trees this meant an unpaginated fetch and, combined with a truncated children lookup, wrongly auto-excluded children. This windows the dependant loading, moves status computation to the server, and fixes the child-exclusion bug.

### Backend

- `resolvePublishContent` now returns `publishableContents` (resolved items with `CompareStatus != EQUAL`) and `schedulable` (any item offline (`NEW`) or expired (`publish.to < now`)).
- `findIdsByParents` resolves all descendants (`size(-1)`); it previously capped at 500, so large trees returned an incomplete child set.

### Frontend

- Dependant summaries load in windows of 36: `$dependantIds` holds the full ordered id list, `$publishDialogDependants` the loaded window; more load on scroll via a `useInfiniteScroll` sentinel in `SplitList.Secondary`.
- `$publishableIds` / `$totalPublishableItems` derive from the server's `publishableContents` intersected with the draft selection — id-based, so the count is correct regardless of how many summaries are loaded and stays live as checkboxes toggle.
- `$hasSchedulableItems` reads the server `schedulable` flag.
- Exclude-by-category commands operate over the full id set, not the loaded window.
- The second (`min`) `resolvePublishContent` request is skipped when its exclusions match the first.

### Why

- A root with 500+ descendants produced a huge `excludedIds`, unchecked children, and a wrong count: the `findIdsByParents` cap left children out of the auto-exclude guard. Resolving all descendants restores correct handling; windowing bounds the request size.
- Publish status is authoritative on the server (draft↔master compare) and no longer requires every summary to be loaded on the client.

### Tests

- Backend: `publishableContents` excludes `EQUAL`; `schedulable` via the expired path; `findIdsByParents` uses `recursive(true)` + `size(-1)`.
- Frontend: windowed loading — first window loads 36, the count is id-based across all 40, `loadMoreDependants` loads the rest and clears `hasMore`.

### Notes

- Row rendering is not virtualized (lazy-load only); "Show excluded" reflects the loaded window for very large dependency sets.

### Follow-up (not in this PR)

- #10264: compute publish status from each content's `publishInfo` instead of calling `resolvePublishDependencies`. Blocked — that call also resolves the reference graph (linked unpublished content to co-publish), which publish fields can't provide.

Closes #10796

<sub>*Drafted with AI assistance*</sub>
