### PR TITLE
Incorrect progress reporting in Publish, Unpublish and Archive dialogs

### DIFF
--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/archive/ArchiveContentProgressListener.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/archive/ArchiveContentProgressListener.java
@@ -1,10 +1,11 @@
 package com.enonic.app.contentstudio.rest.resource.archive;
 
 import com.enonic.xp.archive.ArchiveContentListener;
+import com.enonic.xp.content.PushContentListener;
 import com.enonic.xp.task.ProgressReporter;
 
 public final class ArchiveContentProgressListener
-    implements ArchiveContentListener
+    implements ArchiveContentListener, PushContentListener
 {
     private final ProgressReporter progressReporter;
 
@@ -20,10 +21,28 @@ public final class ArchiveContentProgressListener
     public void setTotal( final int count )
     {
         total = count;
+        progressReporter.progress( progressCount, total );
     }
 
     @Override
     public void contentArchived( final int count )
+    {
+        advance( count );
+    }
+
+    @Override
+    public void contentPushed( final int count )
+    {
+        advance( count );
+    }
+
+    @Override
+    public void contentResolved( final int count )
+    {
+        // Total spans both the unpublish and archive phases and is set via setTotal
+    }
+
+    private void advance( final int count )
     {
         progressCount = progressCount + count;
         progressReporter.progress( progressCount, total );

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/DeleteContentProgressListener.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/DeleteContentProgressListener.java
@@ -1,5 +1,6 @@
 package com.enonic.app.contentstudio.rest.resource.content;
 
+import com.enonic.app.contentstudio.rest.resource.content.task.TaskPhases;
 import com.enonic.xp.content.DeleteContentListener;
 import com.enonic.xp.task.ProgressReporter;
 
@@ -11,6 +12,8 @@ public final class DeleteContentProgressListener
     private int total = 0;
 
     private int progressCount = 0;
+
+    private boolean started = false;
 
     public DeleteContentProgressListener( final ProgressReporter progressReporter )
     {
@@ -25,6 +28,12 @@ public final class DeleteContentProgressListener
     @Override
     public void contentDeleted( final int count )
     {
+        if ( !started )
+        {
+            started = true;
+            progressReporter.info( TaskPhases.phaseInfo( "delete", total ) );
+        }
+
         progressCount = progressCount + count;
         progressReporter.progress( progressCount, total );
     }

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/PublishContentProgressListener.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/PublishContentProgressListener.java
@@ -1,5 +1,6 @@
 package com.enonic.app.contentstudio.rest.resource.content;
 
+import com.enonic.app.contentstudio.rest.resource.content.task.TaskPhases;
 import com.enonic.xp.content.PushContentListener;
 import com.enonic.xp.task.ProgressReporter;
 
@@ -13,6 +14,8 @@ public final class PublishContentProgressListener
 
     private int progressCount = 0;
 
+    private boolean started = false;
+
     public PublishContentProgressListener( final ProgressReporter progressReporter )
     {
         this.progressReporter = progressReporter;
@@ -21,6 +24,12 @@ public final class PublishContentProgressListener
     @Override
     public void contentPushed( final int count )
     {
+        if ( !started )
+        {
+            started = true;
+            progressReporter.info( TaskPhases.phaseInfo( "publish", total ) );
+        }
+
         progressCount = progressCount + count;
         progressReporter.progress( progressCount, total );
     }
@@ -28,7 +37,6 @@ public final class PublishContentProgressListener
     @Override
     public void contentResolved( final int count )
     {
-        total = count; // x2 previously for resolving + copying
-        progressReporter.progress( progressCount, total );
+        total = count;
     }
 }

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/task/ArchiveRunnableTask.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/task/ArchiveRunnableTask.java
@@ -1,18 +1,30 @@
 package com.enonic.app.contentstudio.rest.resource.content.task;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.enonic.app.contentstudio.rest.resource.archive.ArchiveContentProgressListener;
 import com.enonic.app.contentstudio.rest.resource.archive.json.ArchiveContentJson;
+import com.enonic.app.contentstudio.rest.resource.content.query.ContentQueryWithChildren;
 import com.enonic.xp.archive.ArchiveContentException;
 import com.enonic.xp.archive.ArchiveContentParams;
 import com.enonic.xp.archive.ArchiveContentsResult;
+import com.enonic.xp.content.CompareContentResult;
+import com.enonic.xp.content.CompareContentResults;
+import com.enonic.xp.content.CompareContentsParams;
+import com.enonic.xp.content.CompareStatus;
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentIds;
 import com.enonic.xp.content.ContentService;
 import com.enonic.xp.content.Contents;
 import com.enonic.xp.content.GetContentByIdsParams;
+import com.enonic.xp.content.UnpublishContentParams;
 import com.enonic.app.contentstudio.json.task.AbstractRunnableTask;
 import com.enonic.xp.task.ProgressReporter;
 import com.enonic.xp.task.TaskId;
@@ -21,6 +33,11 @@ import com.enonic.xp.task.TaskService;
 public class ArchiveRunnableTask
     extends AbstractRunnableTask
 {
+    private static final Set<CompareStatus> ONLINE_STATUSES =
+        EnumSet.of( CompareStatus.EQUAL, CompareStatus.NEWER, CompareStatus.OLDER, CompareStatus.MOVED );
+
+    private static final int UNPUBLISH_BATCH_SIZE = 50;
+
     private final ArchiveContentJson params;
 
     private ArchiveRunnableTask( Builder builder )
@@ -38,13 +55,49 @@ public class ArchiveRunnableTask
     public void run( final TaskId id, final ProgressReporter progressReporter )
     {
         final ContentIds contentToArchiveIds = params.getContentIds().stream().map( ContentId::from ).collect( ContentIds.collector() );
-        progressReporter.info( "Archiving content" );
-
-        final ArchiveContentProgressListener listener = new ArchiveContentProgressListener( progressReporter );
-        listener.setTotal( contentToArchiveIds.getSize() );
 
         final Contents contentsToArchive =
             contentService.getByIds( GetContentByIdsParams.create().contentIds( contentToArchiveIds ).build() );
+
+        final ContentIds childrenIds = ContentQueryWithChildren.create()
+            .contentService( this.contentService )
+            .contentsPaths( contentsToArchive.getPaths() )
+            .size( -1 )
+            .build()
+            .find()
+            .getContentIds();
+
+        final ContentIds allIds = ContentIds.create().addAll( contentToArchiveIds ).addAll( childrenIds ).build();
+
+        final ContentIds publishedIds = filterPublished( allIds );
+
+        final List<ContentId> orderedChildrenIds = new ArrayList<>( childrenIds.getSet() );
+        Collections.reverse( orderedChildrenIds );
+
+        final List<ContentId> idsToUnpublish = Stream.concat( orderedChildrenIds.stream(), contentsToArchive.stream()
+                .sorted( ( a, b ) -> b.getPath().elementCount() - a.getPath().elementCount() )
+                .map( Content::getId ) )
+            .filter( publishedIds::contains )
+            .collect( Collectors.toList() );
+
+        final ArchiveContentProgressListener listener = new ArchiveContentProgressListener( progressReporter );
+        listener.setTotal( idsToUnpublish.size() + allIds.getSize() );
+
+        if ( !idsToUnpublish.isEmpty() )
+        {
+            progressReporter.info( TaskPhases.phaseInfo( "unpublish", idsToUnpublish.size() ) );
+
+            for ( int from = 0; from < idsToUnpublish.size(); from += UNPUBLISH_BATCH_SIZE )
+            {
+                final List<ContentId> batch =
+                    idsToUnpublish.subList( from, Math.min( from + UNPUBLISH_BATCH_SIZE, idsToUnpublish.size() ) );
+
+                contentService.unpublish(
+                    UnpublishContentParams.create().contentIds( ContentIds.from( batch ) ).pushListener( listener ).build() );
+            }
+        }
+
+        progressReporter.info( TaskPhases.phaseInfo( "archive", allIds.getSize() ) );
 
         ArchiveRunnableTaskResult.Builder result = ArchiveRunnableTaskResult.create();
 
@@ -69,6 +122,16 @@ public class ArchiveRunnableTask
         }
 
         progressReporter.info( result.build().toJson() );
+    }
+
+    private ContentIds filterPublished( final ContentIds ids )
+    {
+        final CompareContentResults compareResults = contentService.compare( CompareContentsParams.create().contentIds( ids ).build() );
+
+        return compareResults.stream()
+            .filter( entry -> ONLINE_STATUSES.contains( entry.getCompareStatus() ) )
+            .map( CompareContentResult::getContentId )
+            .collect( ContentIds.collector() );
     }
 
     public static class Builder

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/task/RestoreContentProgressListener.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/task/RestoreContentProgressListener.java
@@ -12,6 +12,8 @@ public final class RestoreContentProgressListener
 
     private int progressCount = 0;
 
+    private boolean started = false;
+
     public RestoreContentProgressListener( final ProgressReporter progressReporter )
     {
         this.progressReporter = progressReporter;
@@ -25,6 +27,12 @@ public final class RestoreContentProgressListener
     @Override
     public void contentRestored( final int count )
     {
+        if ( !started )
+        {
+            started = true;
+            progressReporter.info( TaskPhases.phaseInfo( "restore", total ) );
+        }
+
         progressCount = progressCount + count;
         progressReporter.progress( progressCount, total );
     }

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/task/RestoreRunnableTask.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/task/RestoreRunnableTask.java
@@ -6,16 +6,21 @@ import java.util.stream.Collectors;
 import com.google.common.base.Strings;
 
 import com.enonic.app.contentstudio.rest.resource.archive.json.RestoreContentJson;
+import com.enonic.app.contentstudio.rest.resource.content.query.ContentQueryWithChildren;
+import com.enonic.xp.archive.ArchiveConstants;
 import com.enonic.xp.archive.RestoreContentException;
 import com.enonic.xp.archive.RestoreContentParams;
 import com.enonic.xp.archive.RestoreContentsResult;
 import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentIds;
 import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.content.ContentService;
 import com.enonic.xp.content.Contents;
 import com.enonic.xp.content.GetContentByIdsParams;
+import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.context.ContextBuilder;
 import com.enonic.app.contentstudio.json.task.AbstractRunnableTask;
 import com.enonic.xp.task.ProgressReporter;
 import com.enonic.xp.task.TaskId;
@@ -43,11 +48,22 @@ public class RestoreRunnableTask
         final ContentIds contentToRestoreIds = params.getContentIds().stream().map( ContentId::from ).collect( ContentIds.collector() );
         progressReporter.info( "Restoring content" );
 
-        final RestoreContentProgressListener listener = new RestoreContentProgressListener( progressReporter );
-        listener.setTotal( contentToRestoreIds.getSize() );
-
         final Contents contentsToRestore =
             contentService.getByIds( GetContentByIdsParams.create().contentIds( contentToRestoreIds ).build() );
+
+        final ContentIds childrenIds = ContextBuilder.from( ContextAccessor.current() )
+            .attribute( ContentConstants.CONTENT_ROOT_PATH_ATTRIBUTE, ArchiveConstants.ARCHIVE_ROOT_PATH )
+            .build()
+            .callWith( () -> ContentQueryWithChildren.create()
+                .contentService( this.contentService )
+                .contentsPaths( contentsToRestore.getPaths() )
+                .size( -1 )
+                .build()
+                .find()
+                .getContentIds() );
+
+        final RestoreContentProgressListener listener = new RestoreContentProgressListener( progressReporter );
+        listener.setTotal( contentToRestoreIds.getSize() + childrenIds.getSize() );
 
         RestoreRunnableTaskResult.Builder result = RestoreRunnableTaskResult.create();
 

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/task/TaskPhases.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/task/TaskPhases.java
@@ -1,0 +1,13 @@
+package com.enonic.app.contentstudio.rest.resource.content.task;
+
+public final class TaskPhases
+{
+    private TaskPhases()
+    {
+    }
+
+    public static String phaseInfo( final String phase, final int count )
+    {
+        return String.format( "{\"phase\":\"%s\",\"count\":%d}", phase, count );
+    }
+}

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/task/UnpublishRunnableTask.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/task/UnpublishRunnableTask.java
@@ -9,13 +9,20 @@ import com.enonic.xp.task.ProgressReporter;
 import com.enonic.xp.task.TaskId;
 import com.enonic.xp.task.TaskService;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class UnpublishRunnableTask
     extends AbstractRunnableTask
 {
     public static final Set<CompareStatus> IGNORE_STATUES = EnumSet.of( CompareStatus.EQUAL, CompareStatus.NEWER );
+
+    private static final int UNPUBLISH_BATCH_SIZE = 50;
 
     private final UnpublishContentJson params;
 
@@ -44,9 +51,11 @@ public class UnpublishRunnableTask
 
         final PushContentListener listener = new UnpublishContentProgressListener( progressReporter );
 
+        final Contents contents = contentService.getByIds( GetContentByIdsParams.create().contentIds( contentIds ).build() );
+
         final ContentIds childrenIds = ContentQueryWithChildren.create()
             .contentService( this.contentService )
-            .contentsPaths( contentService.getByIds( GetContentByIdsParams.create().contentIds( contentIds ).build() ).getPaths() )
+            .contentsPaths( contents.getPaths() )
             .size( -1 )
             .build()
             .find()
@@ -54,18 +63,37 @@ public class UnpublishRunnableTask
 
         final ContentIds filteredChildrenIds = this.filterIdsByStatus( childrenIds );
 
-        listener.contentResolved( filteredChildrenIds.getSize() + contentIds.getSize() );
+        final List<ContentId> orderedChildrenIds = new ArrayList<>( childrenIds.getSet() );
+        Collections.reverse( orderedChildrenIds );
+
+        final List<ContentId> idsToUnpublish = Stream.concat(
+                orderedChildrenIds.stream().filter( filteredChildrenIds::contains ),
+                contents.stream()
+                    .sorted( ( a, b ) -> b.getPath().elementCount() - a.getPath().elementCount() )
+                    .map( Content::getId ) )
+            .collect( Collectors.toList() );
+
+        if ( !idsToUnpublish.isEmpty() )
+        {
+            progressReporter.info( TaskPhases.phaseInfo( "unpublish", idsToUnpublish.size() ) );
+
+            listener.contentResolved( idsToUnpublish.size() );
+        }
 
         final UnpublishRunnableTaskResult.Builder resultBuilder = UnpublishRunnableTaskResult.create();
 
         try
         {
-            final UnpublishContentsResult result = this.contentService.unpublish( UnpublishContentParams.create().
-                contentIds( contentIds ).
-                pushListener( listener ).
-                build() );
+            for ( int from = 0; from < idsToUnpublish.size(); from += UNPUBLISH_BATCH_SIZE )
+            {
+                final List<ContentId> batch =
+                    idsToUnpublish.subList( from, Math.min( from + UNPUBLISH_BATCH_SIZE, idsToUnpublish.size() ) );
 
-            resultBuilder.succeeded( result.getUnpublishedContents() );
+                final UnpublishContentsResult result = this.contentService.unpublish(
+                    UnpublishContentParams.create().contentIds( ContentIds.from( batch ) ).pushListener( listener ).build() );
+
+                resultBuilder.succeeded( result.getUnpublishedContents() );
+            }
         }
         catch ( Exception e )
         {

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/task/UnpublishRunnableTaskTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/task/UnpublishRunnableTaskTest.java
@@ -79,14 +79,14 @@ class UnpublishRunnableTaskTest
         final UnpublishRunnableTask task = createAndRunTask();
         task.createTaskResult();
 
-        Mockito.verify( progressReporter, Mockito.times( 2 ) ).info( contentQueryArgumentCaptor.capture() );
+        Mockito.verify( progressReporter, Mockito.times( 3 ) ).info( contentQueryArgumentCaptor.capture() );
         Mockito.verify( progressReporter, Mockito.times( 1 ) ).progress( Mockito.anyInt(), progressArgumentCaptor.capture() );
         Mockito.verify( taskService, Mockito.times( 1 ) )
             .submitLocalTask( any( SubmitLocalTaskParams.class ) );
 
-        final String resultMessage = contentQueryArgumentCaptor.getAllValues().get( 1 );
+        final String resultMessage = contentQueryArgumentCaptor.getAllValues().get( 2 );
 
-        assertEquals( 4, progressArgumentCaptor.getValue().intValue() );
+        assertEquals( 3, progressArgumentCaptor.getValue().intValue() );
         assertEquals( "{\"state\":\"SUCCESS\",\"message\":\"3 items have been unpublished\"}", resultMessage );
     }
 
@@ -109,9 +109,9 @@ class UnpublishRunnableTaskTest
 
         createAndRunTask();
 
-        Mockito.verify( progressReporter, Mockito.times( 2 ) ).info( contentQueryArgumentCaptor.capture() );
+        Mockito.verify( progressReporter, Mockito.times( 3 ) ).info( contentQueryArgumentCaptor.capture() );
 
-        final String resultMessage = contentQueryArgumentCaptor.getAllValues().get( 1 );
+        final String resultMessage = contentQueryArgumentCaptor.getAllValues().get( 2 );
 
         assertEquals( "{\"state\":\"SUCCESS\",\"message\":\"Item \\\"id1\\\" has been unpublished.\"}", resultMessage );
     }
@@ -124,7 +124,7 @@ class UnpublishRunnableTaskTest
         Set<String> ids = Collections.emptySet();
 
         Mockito.when( params.getIds() ).thenReturn( ids );
-        Mockito.when( contentService.getByIds( Mockito.isA( GetContentByIdsParams.class ) ) ).thenReturn( Contents.from( contents ) );
+        Mockito.when( contentService.getByIds( Mockito.isA( GetContentByIdsParams.class ) ) ).thenReturn( Contents.empty() );
         Mockito.when( contentService.find( Mockito.isA( ContentQuery.class ) ) )
             .thenReturn( FindContentIdsByQueryResult.create().contents( ids.stream().map( ContentId::from ).collect( ContentIds.collector() ) ).build() );
         Mockito.when( contentService.unpublish( Mockito.isA( UnpublishContentParams.class ) ) ).thenReturn( result );

--- a/modules/lib/src/main/resources/assets/js/v6/features/hooks/useAnimatedEllipsis.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/hooks/useAnimatedEllipsis.ts
@@ -1,0 +1,22 @@
+import {useEffect, useState} from 'react';
+
+const ELLIPSIS_INTERVAL_MS = 400;
+
+export const useAnimatedEllipsis = (text: string, active = true): string => {
+    const [step, setStep] = useState(1);
+
+    useEffect(() => {
+        if (!active) {
+            return;
+        }
+
+        const id = setInterval(() => setStep(prev => prev % 3 + 1), ELLIPSIS_INTERVAL_MS);
+        return () => clearInterval(id);
+    }, [active]);
+
+    if (!active) {
+        return text;
+    }
+
+    return text.replace(/[.…]+$/, '') + '.'.repeat(step);
+};

--- a/modules/lib/src/main/resources/assets/js/v6/features/hooks/useTaskProgress.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/hooks/useTaskProgress.ts
@@ -1,7 +1,13 @@
 import type {TaskId} from '@enonic/lib-admin-ui/task/TaskId';
 import {useStore} from '@nanostores/preact';
 import {useEffect, useRef} from 'react';
-import {cleanupTask as cleanupTaskService, trackTask as trackTaskService, type TaskTrackerConfig} from '../services/task.service';
+import {
+    cleanupTask as cleanupTaskService,
+    getTaskPhaseInfo,
+    trackTask as trackTaskService,
+    type TaskPhase,
+    type TaskTrackerConfig,
+} from '../services/task.service';
 import {$taskStore, type TaskProgressState, type TaskResultState} from '../store/task.store';
 import {clampProgress} from '../utils/cms/content/progress';
 
@@ -18,6 +24,10 @@ export type UseTaskProgressResult = {
     resultMessage?: string;
     /** Result state (SUCCESS, ERROR, WARNING) */
     resultState?: TaskResultState;
+    /** Current phase reported by a multi-phase task while running */
+    phase?: TaskPhase;
+    /** Number of items covered by the current phase */
+    phaseTotal?: number;
 };
 
 /**
@@ -77,6 +87,8 @@ export const useTaskProgress = (
         };
     }
 
+    const phaseInfo = getTaskPhaseInfo(taskState.taskInfo);
+
     return {
         progress: clampProgress(taskState.progress),
         state: taskState.state,
@@ -84,6 +96,8 @@ export const useTaskProgress = (
         isError: taskState.state === 'failed',
         resultMessage: taskState.resultMessage,
         resultState: taskState.resultState,
+        phase: phaseInfo?.phase,
+        phaseTotal: phaseInfo?.count,
     };
 };
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/services/task.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/services/task.service.ts
@@ -21,6 +21,13 @@ type ProgressInfoJson = {
     message: string;
 };
 
+export type TaskPhase = 'unpublish' | 'archive' | 'publish' | 'restore' | 'delete';
+
+export type TaskPhaseInfo = {
+    phase: TaskPhase;
+    count?: number;
+};
+
 export type TaskTrackerConfig = {
     /** Callback when task completes (success, error, or warning) */
     onComplete?: (state: TaskResultState, message: string) => void;
@@ -109,6 +116,25 @@ const handleTaskInfo = (taskIdStr: string, taskInfo: TaskInfo, config: TaskTrack
 //
 // * Public API
 //
+
+/**
+ * Parse the phase marker from a running task's progress info.
+ * Multi-phase tasks report the current phase and the number of items it covers
+ * as JSON: {"phase":"unpublish","count":123}.
+ */
+export const getTaskPhaseInfo = (taskInfo: TaskInfo | undefined): TaskPhaseInfo | undefined => {
+    const info = taskInfo?.getProgress()?.getInfo();
+    if (!info) {
+        return undefined;
+    }
+
+    try {
+        const {phase, count} = JSON.parse(info) as {phase?: TaskPhase; count?: number};
+        return phase ? {phase, count} : undefined;
+    } catch {
+        return undefined;
+    }
+};
 
 /**
  * Start tracking a task's progress.

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProgressDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/ProgressDialogContent.tsx
@@ -5,7 +5,7 @@ import {ProgressBar} from '../primitives/ProgressBar';
 type ProgressDialogProps = {
     title: string;
     description?: string;
-    progress: number;
+    progress?: number;
     className?: string;
     'data-component'?: string;
 } & DialogContentProps;
@@ -33,7 +33,7 @@ export const ProgressDialogContent = ({
         >
             <Dialog.DefaultHeader title={title} description={description} />
             <Dialog.Body className='flex flex-col pb-10'>
-                <ProgressBar value={progress} />
+                {progress != null && <ProgressBar value={progress} />}
             </Dialog.Body>
         </Dialog.Content>
     );

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/delete/DeleteDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/delete/DeleteDialog.tsx
@@ -27,7 +27,7 @@ export const DeleteDialog = (): ReactElement => {
     const total = useStore($deleteItemsCount);
     const hasSite = useStore($isDeleteTargetSite);
     const taskId = useStore($deleteTaskId);
-    const {progress} = useTaskProgress(taskId);
+    const {progress, phase, phaseTotal} = useTaskProgress(taskId);
 
     const [view, setView] = useState<View>('main');
 
@@ -97,8 +97,9 @@ export const DeleteDialog = (): ReactElement => {
                 />}
                 {view === 'progress' && (
                     <DeleteDialogProgressContent
-                        total={progressTotal}
+                        total={phaseTotal ?? progressTotal}
                         progress={progress}
+                        phase={phase}
                     />
                 )}
             </Dialog.Portal>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/delete/DeleteDialogProgressContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/delete/DeleteDialogProgressContent.tsx
@@ -1,10 +1,13 @@
 import {type ReactElement} from 'react';
+import {useAnimatedEllipsis} from '../../../hooks/useAnimatedEllipsis';
 import {useI18n} from '../../../hooks/useI18n';
+import {type TaskPhase} from '../../../services/task.service';
 import {ProgressDialogContent} from '../ProgressDialogContent';
 
 type DeleteDialogProgressContentProps = {
     total: number;
     progress: number;
+    phase?: TaskPhase;
     'data-component'?: string;
 };
 
@@ -13,16 +16,24 @@ const DELETE_DIALOG_PROGRESS_CONTENT_NAME = 'DeleteDialogProgressContent';
 export const DeleteDialogProgressContent = ({
     total,
     progress,
+    phase,
     'data-component': componentName = DELETE_DIALOG_PROGRESS_CONTENT_NAME,
 }: DeleteDialogProgressContentProps): ReactElement => {
     const archiveTitle = useI18n('dialog.archive.progress.title');
+    const resolvingDescription = useAnimatedEllipsis(useI18n('dialog.statusBar.loading'), phase == null);
+    const unpublishDescription = useI18n('dialog.unpublish.beingUnpublished', total);
     const archiveDescription = useI18n('dialog.archiving', total);
+
+    const descriptionByPhase: Partial<Record<TaskPhase, string>> = {
+        unpublish: unpublishDescription,
+        archive: archiveDescription,
+    };
 
     return (
         <ProgressDialogContent
             title={archiveTitle}
-            description={archiveDescription}
-            progress={progress}
+            description={phase ? descriptionByPhase[phase] : resolvingDescription}
+            progress={phase ? progress : undefined}
             data-component={componentName}
             className="w-full h-full gap-10 sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
         />

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialog.tsx
@@ -20,7 +20,7 @@ export const PublishDialog = (): ReactElement => {
     const {open, items} = useStore($publishDialog, {keys: ['open', 'items']});
     const publishCount = useStore($totalPublishableItems);
     const taskId = useStore($publishTaskId);
-    const {progress} = useTaskProgress(taskId);
+    const {progress, phase, phaseTotal} = useTaskProgress(taskId);
 
     const [view, setView] = useState<View>('main');
 
@@ -57,7 +57,11 @@ export const PublishDialog = (): ReactElement => {
                     <PublishDialogMainContent onPublish={() => void handlePublish()} />
                 )}
                 {view === 'progress' && (
-                    <PublishDialogProgressContent total={progressTotal} progress={progress} />
+                    <PublishDialogProgressContent
+                        total={phaseTotal ?? progressTotal}
+                        progress={progress}
+                        resolving={phase == null}
+                    />
                 )}
             </Dialog.Portal>
         </Dialog.Root>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialogProgressContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialogProgressContent.tsx
@@ -1,10 +1,12 @@
 import {type ReactElement} from 'react';
+import {useAnimatedEllipsis} from '../../../hooks/useAnimatedEllipsis';
 import {useI18n} from '../../../hooks/useI18n';
 import {ProgressDialogContent} from '../ProgressDialogContent';
 
 type PublishDialogProgressContentProps = {
     total: number;
     progress: number;
+    resolving?: boolean;
     'data-component'?: string;
 };
 
@@ -13,16 +15,18 @@ const PUBLISH_DIALOG_PROGRESS_CONTENT_NAME = 'PublishDialogProgressContent';
 export const PublishDialogProgressContent = ({
     total,
     progress,
+    resolving = false,
     'data-component': componentName = PUBLISH_DIALOG_PROGRESS_CONTENT_NAME,
 }: PublishDialogProgressContentProps): ReactElement => {
     const title = useI18n('dialog.publish');
-    const description = useI18n('dialog.publish.beingPublished', total);
+    const resolvingDescription = useAnimatedEllipsis(useI18n('dialog.statusBar.loading'), resolving);
+    const publishDescription = useI18n('dialog.publish.beingPublished', total);
 
     return (
         <ProgressDialogContent
             title={title}
-            description={description}
-            progress={progress}
+            description={resolving ? resolvingDescription : publishDescription}
+            progress={resolving ? undefined : progress}
             data-component={componentName}
         />
     );

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/unpublish/UnpublishDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/unpublish/UnpublishDialog.tsx
@@ -24,7 +24,7 @@ export const UnpublishDialog = (): ReactElement => {
     const total = useStore($unpublishItemsCount);
     const hasSite = useStore($isUnpublishTargetSite);
     const taskId = useStore($unpublishTaskId);
-    const {progress} = useTaskProgress(taskId);
+    const {progress, phase, phaseTotal} = useTaskProgress(taskId);
 
     const [view, setView] = useState<View>('main');
 
@@ -82,8 +82,9 @@ export const UnpublishDialog = (): ReactElement => {
                 />}
                 {view === 'progress' &&
                     <UnpublishDialogProgressContent
-                        total={total || items.length || 1}
+                        total={phaseTotal ?? (total || items.length || 1)}
                         progress={progress}
+                        resolving={phase == null}
                     />
                 }
             </Dialog.Portal>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/unpublish/UnpublishDialogProgressContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/unpublish/UnpublishDialogProgressContent.tsx
@@ -1,10 +1,12 @@
 import {type ReactElement} from 'react';
+import {useAnimatedEllipsis} from '../../../hooks/useAnimatedEllipsis';
 import {useI18n} from '../../../hooks/useI18n';
 import {ProgressDialogContent} from '../ProgressDialogContent';
 
 type UnpublishDialogProgressContentProps = {
     total: number;
     progress: number;
+    resolving?: boolean;
     'data-component'?: string;
 };
 
@@ -13,16 +15,18 @@ const UNPUBLISH_DIALOG_PROGRESS_CONTENT_NAME = 'UnpublishDialogProgressContent';
 export const UnpublishDialogProgressContent = ({
     total,
     progress,
+    resolving = false,
     'data-component': componentName = UNPUBLISH_DIALOG_PROGRESS_CONTENT_NAME,
 }: UnpublishDialogProgressContentProps): ReactElement => {
     const title = useI18n('dialog.unpublish');
-    const description = useI18n('dialog.unpublish.beingUnpublished', total);
+    const resolvingDescription = useAnimatedEllipsis(useI18n('dialog.statusBar.loading'), resolving);
+    const unpublishDescription = useI18n('dialog.unpublish.beingUnpublished', total);
 
     return (
         <ProgressDialogContent
             title={title}
-            description={description}
-            progress={progress}
+            description={resolving ? resolvingDescription : unpublishDescription}
+            progress={resolving ? undefined : progress}
             data-component={componentName}
         />
     );

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/deleteDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/deleteDialog.store.ts
@@ -414,8 +414,8 @@ $deleteDialog.subscribe(({open, loading}, oldState) => {
 
 /** Check if dialog is open and has items */
 const isDialogActive = (): boolean => {
-    const {open, items} = $deleteDialog.get();
-    return open && items.length > 0;
+    const {open, items, submitting} = $deleteDialog.get();
+    return open && !submitting && items.length > 0;
 };
 
 // Handle content created: reload dependencies as new content might be a child or dependency

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
@@ -851,7 +851,7 @@ const reloadPublishDialogDataDebounced = createDebounce(() => {
 /** Check if dialog is open and has items */
 const isDialogActive = (): boolean => {
     const {open, items} = $publishDialog.get();
-    return open && items.length > 0;
+    return open && items.length > 0 && !$publishDialogPending.get().submitting;
 };
 
 const onPublishSocketEvent = createGuardedSocketHandler(isDialogActive);

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/unpublishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/unpublishDialog.store.ts
@@ -307,7 +307,7 @@ const patchItemsWithUpdates = (updates: ContentSummary[]): {patchedMain: boolean
 
 const isDialogActive = (): boolean => {
     const {open, items} = $unpublishDialog.get();
-    return open && items.length > 0;
+    return open && items.length > 0 && !$unpublishDialogPending.get().submitting;
 };
 
 //

--- a/modules/lib/src/main/resources/i18n/cs-plus.properties
+++ b/modules/lib/src/main/resources/i18n/cs-plus.properties
@@ -17,6 +17,7 @@ dialog.confirmRestore.subtitle=Selected items will be moved from the Archive bac
 dialog.restore.archive.title=Restore from Archive
 dialog.restore.archive.subtitle=Restore selected content items to the root of the Content grid
 dialog.restore.archive.items.subtitle=Other content items that will be restored
+dialog.restoring=Restoring {0} item(s)...
 dialog.archive.license.missing=No valid license found
 
 #


### PR DESCRIPTION
Reworked progress reporting for the Archive, Unpublish and Publish operations and the corresponding dialogs.

  - Tasks now report the current phase through the task progress info as a machine-readable marker (`{"phase":"unpublish","count":N}`), with all user-facing texts localized client-side. A shared `TaskPhases` helper produces the markers, and `useTaskProgress` exposes `phase` and `phaseTotal` to the dialogs.
  - The archive task resolves the full descendant tree up front, explicitly unpublishes the published items first and then archives, reporting both operations on a single cumulative progress scale. The dialog shows "Unpublishing N item(s)..." followed by "Archiving N item(s)..." with a continuously filling bar.
  - Unpublishing (both standalone and within archive) processes items deepest-first in batches of 50, so every item produces its own progress callback and the server-side post-processing is spread across the operation instead of running silently after the bar is full.
  - The publish task emits its phase marker at the first actual push callback, so the silent stretch (dependency resolution, validity checks, version preparation) is reported as a resolving state.
  - Until the first phase marker arrives, dialogs show "Resolving items..." with an animated ellipsis and no progress bar; the bar appears when real progress starts. `ProgressDialogContent` hides the bar when `progress` is undefined.
  - Dialog stores no longer reload their resolved dependency lists in response to content events caused by their own running task.

  <sub>*Drafted with AI assistance*</sub>