### PR TITLE
Duplicate preview requests #10838

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/view/ExtensionRenderingHandler.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/ExtensionRenderingHandler.ts
@@ -46,6 +46,8 @@ export class ExtensionRenderingHandler {
 
     private summary: ContentSummary;
 
+    private lastRenderKey: string;
+
     protected mode: RenderingMode;
 
     protected renderableChangedListeners: ((isRenderable: boolean, wasRenderable: boolean) => void)[] = [];
@@ -74,6 +76,7 @@ export class ExtensionRenderingHandler {
         }
 
         this.summary = summary;
+        this.lastRenderKey = this.getRenderKey(summary, extension);
 
         this.showMask();
         this.renderer.getPreviewAction()?.setEnabled(false);
@@ -314,7 +317,18 @@ export class ExtensionRenderingHandler {
             return;
         }
 
-        void this.render(this.summary, event.getExtension());
+        const extension = event.getExtension();
+
+        // Skip re-render already done by the selection path (#10838).
+        if (this.getRenderKey(this.summary, extension) === this.lastRenderKey) {
+            return;
+        }
+
+        void this.render(this.summary, extension);
+    }
+
+    private getRenderKey(summary?: ContentSummary, extension?: Extension): string {
+        return `${summary?.getId() ?? ''}:${extension?.getDescriptorKey().toString() ?? ''}`;
     }
 
     protected handleEmulatorEvent(device: EmulatorDevice) {


### PR DESCRIPTION
Selecting a content with preview in the grid fired the preview widget request twice. The selection path (`doSetItem` → `update`) and `PreviewToolbarWidgetSelector`'s initial `ViewExtensionEvent` both rendered the same content with the same widget, and `ExtensionRenderingHandler.render()` had no dedup, so two identical HEAD requests (and the full auto-mode flow behind them) went out on the first selection.

Guarded `handleExtensionEvent` to skip the redundant re-render when the event's widget matches what was just rendered for the current item, tracked via a new `lastRenderKey`. A genuine widget switch passes a different widget and still re-renders.

Reproduced live before and traced to the dual trigger; the redundant render is event-driven and fires after the selection render, so the guard reliably drops it.

Closes #10838

<sub>*Drafted with AI assistance*</sub>
