### PR TITLE
Edit/Delete icons in the Site configurator should be hidden for non-admin users #10828

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/site-configurator/SiteConfiguratorInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/site-configurator/SiteConfiguratorInput.tsx
@@ -332,7 +332,7 @@ const SiteConfiguratorRow = ({context, applications, errors, disabled, onEdit, o
                 />
             </div>
             <div className="flex items-center gap-1.5 ml-auto shrink-0">
-                {hasForm && (
+                {hasForm && !disabled && (
                     <IconButton
                         variant="text"
                         icon={Pencil}


### PR DESCRIPTION
## Changes

- Gated the edit (pencil) icon in `SiteConfiguratorRow` by `!disabled`, mirroring the delete (×) icon. Read-only users (non content-admin, non project-owner) no longer see the edit affordance in the Site configurator, matching the legacy `setEnabled(!readonly)` behavior that hid both icons.

Closes #10828

<sub>*Drafted with AI assistance*</sub>
