### PR TITLE
Placeholder text in the preview panel is not shown until first unselect #10745

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/view/ExtensionRenderingHandler.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/ExtensionRenderingHandler.ts
@@ -59,6 +59,7 @@ export class ExtensionRenderingHandler {
         this.previewHelper = previewHelper || new PreviewActionHelper();
         this.emptyView = this.createEmptyView();
         this.messageView = this.createErrorView();
+        this.setPreviewType(PREVIEW_TYPE.EMPTY);
     }
 
 


### PR DESCRIPTION
<img width="1246" height="924" alt="image" src="https://github.com/user-attachments/assets/5a497939-2997-418c-8dd1-e00aa1a188bb" />

Set the preview panel empty on first load instead of after unselecting content.