### PR TITLE
Disable inherited non-localized content editing #10728

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/EditLockOverlay.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/EditLockOverlay.tsx
@@ -11,7 +11,7 @@ const EDIT_LOCK_OVERLAY_NAME = 'EditLockOverlay';
 
 export const EditLockOverlay = ({locked, contentClassName, className, children, ...rest}: EditLockOverlayProps): ReactElement => {
     return (
-        <div data-component={EDIT_LOCK_OVERLAY_NAME} className={cn('relative isolate', className)} {...rest}>
+        <div className={cn('relative isolate', className)} {...rest} data-component={EDIT_LOCK_OVERLAY_NAME}>
             <div className={contentClassName} inert={locked}>
                 {children}
             </div>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/EditLockOverlay.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/EditLockOverlay.tsx
@@ -1,0 +1,23 @@
+import {cn} from '@enonic/ui';
+import {type ComponentPropsWithoutRef, type ReactElement, type ReactNode} from 'react';
+
+export type EditLockOverlayProps = {
+    locked: boolean;
+    contentClassName?: string;
+    children: ReactNode;
+} & ComponentPropsWithoutRef<'div'>;
+
+const EDIT_LOCK_OVERLAY_NAME = 'EditLockOverlay';
+
+export const EditLockOverlay = ({locked, contentClassName, className, children, ...rest}: EditLockOverlayProps): ReactElement => {
+    return (
+        <div data-component={EDIT_LOCK_OVERLAY_NAME} className={cn('relative isolate', className)} {...rest}>
+            <div className={contentClassName} inert={locked}>
+                {children}
+            </div>
+            {locked && <div className="pointer-events-none absolute inset-0 z-20 bg-surface-neutral/70" aria-hidden="true" />}
+        </div>
+    );
+};
+
+EditLockOverlay.displayName = EDIT_LOCK_OVERLAY_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/toolbar/ContentWizardToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/toolbar/ContentWizardToolbar.tsx
@@ -19,7 +19,7 @@ import {useElementVisibility} from '../../../utils/hooks/useElementVisibility';
 import {ContextToggle} from './ContextToggle';
 import {OverflowActionRow, type OverflowActionRowItem} from './OverflowActionRow';
 import {SplitActionButton} from './SplitActionButton';
-import {$wizardContentPathExists} from '../../../store/wizardContent.store';
+import {$wizardContentPathExists, $wizardReadOnly} from '../../../store/wizardContent.store';
 
 export type ContentWizardToolbarProps = {
     onProjectBack?: () => void;
@@ -98,6 +98,7 @@ export const ContentWizardToolbar = ({
     const {'ai.contentOperator': isOperatorRegistered} = useStore($aiRegisteredPlugins, {keys: ['ai.contentOperator']});
     const {'ai.contentOperator': isOperatorDialogOpen} = useStore($aiPluginDialogOpen, {keys: ['ai.contentOperator']});
     const {exists: contentPathExists, fetching: isPathFetching} = useStore($wizardContentPathExists);
+    const readOnly = useStore($wizardReadOnly);
 
     // Delay disabling the split buttons until the fetch has been in-flight for 200ms.
     // Most path-exists responses are faster than that, so the buttons never visually
@@ -122,7 +123,8 @@ export const ContentWizardToolbar = ({
     const projectViewLabel = projectLabel || projectRoot;
     const unnamedPathLabel = `<${unnamedFieldLabel}>`;
     const contentNameLabel = contentName || `<${nameFieldLabel}>`;
-    const contentFullPath = canRenameContentPath
+    const canRename = canRenameContentPath && !readOnly;
+    const contentFullPath = canRename
         ? formatContentFullPath(contentParentPath, contentName || unnamedPathLabel, unnamedPathLabel)
         : contentNameLabel;
     const pathTitle = contentPathExists ? pathExistsLabel : contentFullPath;
@@ -242,7 +244,7 @@ export const ContentWizardToolbar = ({
                                     size="sm"
                                     variant="text"
                                     className="min-w-0 max-w-full px-1.5 md:px-2.75"
-                                    disabled={!canRenameContentPath}
+                                    disabled={!canRename}
                                     onClick={onContentPathClick}
                                 >
                                     <span
@@ -264,7 +266,7 @@ export const ContentWizardToolbar = ({
                                     size="md"
                                     icon={Link2}
                                     aria-label={contentNameLabel}
-                                    disabled={!canRenameContentPath}
+                                    disabled={!canRename}
                                     onClick={onContentPathClick}
                                     className="shrink-0 size-8"
                                 />

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageInspectionPanel.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageInspectionPanel.tsx
@@ -4,6 +4,7 @@ import {useStore} from '@nanostores/preact';
 import {type ReactElement, useCallback, useMemo, useState} from 'react';
 import {useI18n} from '../../../../../../hooks/useI18n';
 import {ConfirmationDialog} from '../../../../../../shared/dialogs/ConfirmationDialog';
+import {EditLockOverlay} from '../../../../../../shared/EditLockOverlay';
 import {FormRenderer} from '../../../../../../shared/form/FormRenderer';
 import {getAiFieldRegistry} from '../../../../../../store/ai/ai.field-registry';
 import {
@@ -15,16 +16,15 @@ import {
 } from '../../../../../../store/page-editor';
 import {$isCustomizeVisible, $isPageInspectionEmpty, $pageConfigDescriptor} from '../../../../../../store/page-inspection.store';
 import {$wizardReadOnly} from '../../../../../../store/wizardContent.store';
-import {EditLockOverlay} from '../../../../../../shared/EditLockOverlay';
 import {useInspectFormTracking} from '../useInspectFormTracking';
-import {PageControllerSelector} from "./PageControllerSelector";
+import {PageControllerSelector} from './PageControllerSelector';
 
 type ConfirmDialogState = {
     question: string;
     onConfirm: () => void;
 };
 
-const PAGE_INSPECTION_PANEL_NAME = "PageInspectionPanel";
+const PAGE_INSPECTION_PANEL_NAME = 'PageInspectionPanel';
 
 export const PageInspectionPanel = (): ReactElement => {
     const page = usePageState();
@@ -35,8 +35,8 @@ export const PageInspectionPanel = (): ReactElement => {
     const isEmpty = useStore($isPageInspectionEmpty);
     const readOnly = useStore($wizardReadOnly);
 
-    const customizeLabel = useI18n("action.page.customize");
-    const customizeQuestion = useI18n("dialog.page.customize.confirmation");
+    const customizeLabel = useI18n('action.page.customize');
+    const customizeQuestion = useI18n('dialog.page.customize.confirmation');
     const noTemplatesLabel = useI18n('text.notemplatesorblocks');
 
     const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogState | null>(null);

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageInspectionPanel.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/context/widget/page-editor/inspect/page/PageInspectionPanel.tsx
@@ -14,6 +14,8 @@ import {
     usePageState,
 } from '../../../../../../store/page-editor';
 import {$isCustomizeVisible, $isPageInspectionEmpty, $pageConfigDescriptor} from '../../../../../../store/page-inspection.store';
+import {$wizardReadOnly} from '../../../../../../store/wizardContent.store';
+import {EditLockOverlay} from '../../../../../../shared/EditLockOverlay';
 import {useInspectFormTracking} from '../useInspectFormTracking';
 import {PageControllerSelector} from "./PageControllerSelector";
 
@@ -31,6 +33,7 @@ export const PageInspectionPanel = (): ReactElement => {
     const descriptor = useStore($pageConfigDescriptor);
     const isCustomizeVisible = useStore($isCustomizeVisible);
     const isEmpty = useStore($isPageInspectionEmpty);
+    const readOnly = useStore($wizardReadOnly);
 
     const customizeLabel = useI18n("action.page.customize");
     const customizeQuestion = useI18n("dialog.page.customize.confirmation");
@@ -65,29 +68,31 @@ export const PageInspectionPanel = (): ReactElement => {
 
     return (
         <div data-component={PAGE_INSPECTION_PANEL_NAME} className="flex flex-col gap-5">
-            <div className="flex flex-col -mx-5 p-5 bg-surface-primary gap-5">
-                <PageControllerSelector />
+            <EditLockOverlay locked={readOnly} contentClassName="flex flex-col gap-5">
+                <div className="flex flex-col -mx-5 p-5 bg-surface-primary gap-5">
+                    <PageControllerSelector />
 
-                {isCustomizeVisible && (
-                    <Button
-                        label={customizeLabel}
-                        variant="outline"
-                        onClick={handleCustomize}
-                        className="w-full"
-                    />
+                    {isCustomizeVisible && (
+                        <Button
+                            label={customizeLabel}
+                            variant="outline"
+                            onClick={handleCustomize}
+                            className="w-full"
+                        />
+                    )}
+                </div>
+
+                {hasController && configForm && configRoot && (
+                    <FieldRegistryProvider registry={fieldRegistry}>
+                        <FormRenderer
+                            form={configForm}
+                            propertySet={configRoot}
+                            enabled={!lifecycle.isPageLocked}
+                            applicationKey={ctx?.applicationKey ?? undefined}
+                        />
+                    </FieldRegistryProvider>
                 )}
-            </div>
-
-            {hasController && configForm && configRoot && (
-                <FieldRegistryProvider registry={fieldRegistry}>
-                    <FormRenderer
-                        form={configForm}
-                        propertySet={configRoot}
-                        enabled={!lifecycle.isPageLocked}
-                        applicationKey={ctx?.applicationKey ?? undefined}
-                    />
-                </FieldRegistryProvider>
-            )}
+            </EditLockOverlay>
 
             <ConfirmationDialog.Root
                 open={confirmDialog != null}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
@@ -51,7 +51,7 @@ export const ContentForm = (): ReactElement | null => {
     }
 
     return (
-        <EditLockOverlay locked={readOnly} contentClassName="flex flex-col gap-7.5 pb-10" data-component={CONTENT_FORM_NAME}>
+        <EditLockOverlay locked={readOnly} contentClassName="flex flex-col gap-7.5 pb-10">
             <DisplayNameInput />
             <ValidationVisibilityProvider visibility={visibility}>
                 <RawValueProvider map={rawValueMap}>

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
@@ -1,6 +1,7 @@
 import {FieldRegistryProvider, RawValueProvider, ServerErrorsProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
 import {useStore} from '@nanostores/preact';
 import {type ReactElement, useEffect, useMemo} from 'react';
+import {EditLockOverlay} from '../../../shared/EditLockOverlay';
 import {FormRenderer} from '../../../shared/form';
 import {useBreakpoints} from '../../../hooks/useBreakpoints';
 import {getAiFieldRegistry} from '../../../store/ai/ai.field-registry';
@@ -50,7 +51,7 @@ export const ContentForm = (): ReactElement | null => {
     }
 
     return (
-        <div data-component={CONTENT_FORM_NAME} className="flex flex-col gap-7.5 pb-10">
+        <EditLockOverlay locked={readOnly} contentClassName="flex flex-col gap-7.5 pb-10" data-component={CONTENT_FORM_NAME}>
             <DisplayNameInput />
             <ValidationVisibilityProvider visibility={visibility}>
                 <RawValueProvider map={rawValueMap}>
@@ -63,7 +64,6 @@ export const ContentForm = (): ReactElement | null => {
                             <FormRenderer
                                 form={contentType.getForm()}
                                 propertySet={draftData.getRoot()}
-                                enabled={!readOnly}
                                 applicationKey={applicationKey}
                                 excludeInputTypes={excludeInputTypes}
                             />
@@ -71,7 +71,7 @@ export const ContentForm = (): ReactElement | null => {
                     </FieldRegistryProvider>
                 </RawValueProvider>
             </ValidationVisibilityProvider>
-        </div>
+        </EditLockOverlay>
     );
 };
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
@@ -218,7 +218,7 @@ export const DisplayNameInput = (): ReactElement => {
                         'block w-full min-w-64 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent',
                         'border-0 border-l-1 text-[2rem] font-semibold px-2.5 py-1 pl-4.5',
                         '[&:hover,&:focus]:border-l-4 [&:hover,&:focus]:pl-3.75 placeholder:text-subtle/50 rounded-none',
-                        'transition-highlight focus:outline-none disabled:select-none disabled:cursor-not-allowed disabled:opacity-50',
+                        'transition-highlight focus:outline-none disabled:select-none disabled:cursor-not-allowed',
                         'focus:ring-0 focus:ring-offset-0 focus:border-transparent',
                         showErrorBorder ? 'border-l-error focus:border-l-error' : 'border-l-bdr-subtle focus:border-l-ring',
                     )}

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
@@ -189,7 +189,6 @@ export const DisplayNameInput = (): ReactElement => {
                         'hover:not-disabled:border-l-4 hover:not-disabled:pl-3.75',
                         'focus:outline-none focus:ring-0 focus:ring-offset-0',
                         'disabled:select-none disabled:cursor-not-allowed',
-                        !aiProcessing && 'disabled:opacity-50',
                         aiProcessing && 'cursor-progress animate-text-shimmer',
                         touched ? 'whitespace-pre-wrap break-words' : 'truncate',
                         !aiProcessing && isShowingPlaceholder && 'text-subtle/50',

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/MixinView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/MixinView.tsx
@@ -13,6 +13,7 @@ import {
     setDraftMixinEnabled,
 } from '../../../store/wizardContent.store';
 import {$validationVisibility, getMixinRawValueMap} from '../../../store/wizardValidation.store';
+import {EditLockOverlay} from '../../../shared/EditLockOverlay';
 import {FormRenderer} from '../../../shared/form';
 
 type MixinViewProps = {
@@ -80,18 +81,19 @@ export const MixinView = ({mixinName}: MixinViewProps): ReactElement | null => {
     if (!form || !mixinData) return null;
 
     return (
-        <ValidationVisibilityProvider visibility={visibility}>
-            <RawValueProvider map={rawValueMap}>
-                <FieldRegistryProvider registry={fieldRegistry}>
-                    <FormRenderer
-                        form={form}
-                        propertySet={mixinData.getRoot()}
-                        enabled={!readOnly}
-                        applicationKey={applicationKey}
-                    />
-                </FieldRegistryProvider>
-            </RawValueProvider>
-        </ValidationVisibilityProvider>
+        <EditLockOverlay locked={readOnly}>
+            <ValidationVisibilityProvider visibility={visibility}>
+                <RawValueProvider map={rawValueMap}>
+                    <FieldRegistryProvider registry={fieldRegistry}>
+                        <FormRenderer
+                            form={form}
+                            propertySet={mixinData.getRoot()}
+                            applicationKey={applicationKey}
+                        />
+                    </FieldRegistryProvider>
+                </RawValueProvider>
+            </ValidationVisibilityProvider>
+        </EditLockOverlay>
     );
 };
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/MixinView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/MixinView.tsx
@@ -1,8 +1,8 @@
+import {FieldRegistryProvider, RawValueProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
 import {Button} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
 import {OctagonAlert} from 'lucide-react';
 import {type ReactElement, useCallback, useEffect, useMemo} from 'react';
-import {FieldRegistryProvider, RawValueProvider, ValidationVisibilityProvider} from '@enonic/lib-admin-ui/form2';
 import {useI18n} from '../../../hooks/useI18n';
 import {getAiFieldRegistry} from '../../../store/ai/ai.field-registry';
 import {
@@ -19,6 +19,8 @@ import {FormRenderer} from '../../../shared/form';
 type MixinViewProps = {
     mixinName: string;
 };
+
+const MIXIN_VIEW_NAME = 'MixinView';
 
 export const MixinView = ({mixinName}: MixinViewProps): ReactElement | null => {
     const descriptors = useStore($mixinsDescriptors);
@@ -97,4 +99,4 @@ export const MixinView = ({mixinName}: MixinViewProps): ReactElement | null => {
     );
 };
 
-MixinView.displayName = 'MixinView';
+MixinView.displayName = MIXIN_VIEW_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -20,7 +20,9 @@ import {useSelectedPageOption} from '../../../../hooks/usePageOptions';
 import type {FlatNode} from '../../../../lib/tree-store';
 import {inspectItem, requestComponentMove} from '../../../../store/page-editor';
 import {$inspectedPath, $pageVersion} from '../../../../store/page-editor/store';
+import {$wizardReadOnly} from '../../../../store/wizardContent.store';
 import {$invalidComponentPaths, $validationVisibility} from '../../../../store/wizardValidation.store';
+import {EditLockOverlay} from '../../../../shared/EditLockOverlay';
 import {PageComponentsContextMenu} from './PageComponentsContextMenu';
 import {calcSpacerWidth, PageComponentsItem, type PageComponentPageMetadata} from './PageComponentsItem';
 import {
@@ -54,6 +56,7 @@ export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps 
     const pageVersion = useStore($pageVersion);
     const invalidComponentPaths = useStore($invalidComponentPaths);
     const validationVisibility = useStore($validationVisibility);
+    const readOnly = useStore($wizardReadOnly);
     const showErrors = validationVisibility === 'all';
     const inspectedPath = useStore($inspectedPath);
     const [flatNodes, setFlatNodes] = useState(() => [...$componentsFlatNodes.get()]);
@@ -201,23 +204,25 @@ export const PageComponentsView = ({showTitle = false}: PageComponentsViewProps 
     }, [handleSelect, inspectedPath, pageMetadata, showErrors, invalidComponentPaths]);
 
     return (
-        <div ref={containerRef} data-component={PAGE_COMPONENTS_VIEW_NAME} className="flex flex-col gap-1 py-2">
-            {showTitle && <h3 className="text-base font-semibold">{componentsLabel}</h3>}
-            <SortableList
-                items={flatNodes}
-                keyExtractor={(node) => node.id}
-                onDragStart={handleDragStart}
-                onMove={handleMove}
-                enabled={flatNodes.length > 1}
-                fullRowDraggable
-                isItemMovable={isItemMovable}
-                resolveDrop={resolveDrop}
-                animateLayoutChanges={animateLayoutChanges}
-                itemClassName={itemClassName}
-                renderItem={renderItem}
-                className="flex flex-col gap-1.5"
-            />
-        </div>
+        <EditLockOverlay locked={readOnly}>
+            <div ref={containerRef} data-component={PAGE_COMPONENTS_VIEW_NAME} className="flex flex-col gap-1 py-2">
+                {showTitle && <h3 className="text-base font-semibold">{componentsLabel}</h3>}
+                <SortableList
+                    items={flatNodes}
+                    keyExtractor={(node) => node.id}
+                    onDragStart={handleDragStart}
+                    onMove={handleMove}
+                    enabled={flatNodes.length > 1}
+                    fullRowDraggable
+                    isItemMovable={isItemMovable}
+                    resolveDrop={resolveDrop}
+                    animateLayoutChanges={animateLayoutChanges}
+                    itemClassName={itemClassName}
+                    renderItem={renderItem}
+                    className="flex flex-col gap-1.5"
+                />
+            </div>
+        </EditLockOverlay>
     );
 };
 


### PR DESCRIPTION
# EditLockOverlay — read-only locking

## What
Added a shared `EditLockOverlay` and used it to lock the wizard's editable surfaces when the content is read-only (`$wizardReadOnly`): ContentForm, mixin tabs (MixinView), the page tab tree (PageComponentsView, incl. detached), and the page inspect panel (PageInspectionPanel). The rename button in the toolbar is disabled in the same state.

## How
- `EditLockOverlay` wraps content in a `relative isolate` container, applies `inert` to the children when `locked`, and paints a single veil (`bg-surface-neutral/70`) on top.
- `inert` blocks all interaction (focus/click/input); the veil is the only visual dimming layer.
- Removed per-input dimming under the mask: dropped `enabled={!readOnly}` from the wrapped `FormRenderer`s and `disabled:opacity-50` from DisplayNameInput.
- `isolate` scopes the mask's z-index so it can't cover sibling panels (e.g. the context panel).
- Rename: `canRename = canRenameContentPath && !readOnly` gates the toolbar path button.

## Why
- One veil instead of per-input `disabled` styling — avoids double-dimming (mask opacity stacking on already-dimmed inputs) and gives a uniform, theme-aware read-only look.
- Single reusable component keeps the behavior consistent across all surfaces and driven by one source of truth (`$wizardReadOnly`).

## Concerns
- `inert` fully freezes the content: no scrolling, expanding sets, text selection, and it drops the form from the a11y tree — read-only is "frozen", not "viewable".