### PR TITLE
Publishing dialog is missing checkbox for batch selecting dependencies #10868

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/InlineButton.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/InlineButton.tsx
@@ -11,7 +11,7 @@ export const InlineButton = ({className, ...props}: InlineButtonProps): ReactEle
             data-component={INLINE_BUTTON_NAME}
             {...props}
             size="sm"
-            className={cn(`h-8 px-1.5 -my-0.75 focus-visible:ring-offset-0`, className)}
+            className={cn(`h-8 px-1.5 -my-1 focus-visible:ring-offset-0`, className)}
         />
     );
 };

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/dependants/DependantsSelectAll.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/dependants/DependantsSelectAll.tsx
@@ -1,0 +1,35 @@
+import {Checkbox, type CheckboxChecked} from '@enonic/ui';
+import {type ReactElement} from 'react';
+import {useI18n} from '../../../hooks/useI18n';
+import {type DependantsSelection, type DependantsSelectionType} from '../../../utils/cms/content/dependantsSelection';
+
+const DEPENDANTS_SELECT_ALL_NAME = 'DependantsSelectAll';
+
+const CHECKED_BY_TYPE = {
+    all: true,
+    none: false,
+    partial: 'indeterminate',
+} as const satisfies Record<DependantsSelectionType, CheckboxChecked>;
+
+export type DependantsSelectAllProps = {
+    selection: DependantsSelection;
+    onToggle: () => void;
+    disabled?: boolean;
+};
+
+export const DependantsSelectAll = ({selection, onToggle, disabled}: DependantsSelectAllProps): ReactElement => {
+    const label = useI18n('dialog.select.all', selection.count);
+
+    return (
+        <Checkbox
+            data-component={DEPENDANTS_SELECT_ALL_NAME}
+            className="py-2 ps-2.5 font-semibold"
+            label={label}
+            checked={CHECKED_BY_TYPE[selection.selectionType]}
+            onCheckedChange={onToggle}
+            disabled={selection.disabled || disabled}
+        />
+    );
+};
+
+DependantsSelectAll.displayName = DEPENDANTS_SELECT_ALL_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueDialogDetailsContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/issue/IssueDialogDetailsContent.tsx
@@ -25,6 +25,7 @@ import {
     $isIssueDialogDetailsClosed,
     $isIssueDialogDetailsPublishRequest,
     $issueDialogDetails,
+    $issueDialogDetailsDependantsSelection,
     $issueDialogDetailsHasMoreDependants,
     loadIssueDialogItems,
     loadMoreIssueDialogDependants,
@@ -32,6 +33,7 @@ import {
     setIssueDialogCommentText,
     setIssueDialogDetailsTab,
     submitIssueDialogComment,
+    toggleIssueDialogDetailsDependantsSelection,
     updateIssueDialogAssignees,
     updateIssueDialogComment,
     updateIssueDialogDependencyIncluded,
@@ -65,6 +67,7 @@ import {AssigneeSelector} from '../../selectors/assignee/AssigneeSelector';
 import {useAssigneeSearch, useAssigneeSelection} from '../../selectors/assignee/hooks/useAssigneeSearch';
 import {ContentCombobox} from '../../selectors/content';
 import {IssueStatusBadge} from '../../status/IssueStatusBadge';
+import {DependantsSelectAll} from '../dependants/DependantsSelectAll';
 import {PublishDialogProgressContent} from '../publish/PublishDialogProgressContent';
 import {SelectionStatusBar} from '../status-bar/SelectionStatusBar';
 import {IssueDialogSelector} from './IssueDialogSelector';
@@ -202,6 +205,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
     const canShowSelectionStatusBar = useStore($canIssueDialogDetailsShowSelectionStatusBar);
     const canPublish = useStore($canIssueDialogDetailsPublish);
     const hasMoreDependants = useStore($issueDialogDetailsHasMoreDependants);
+    const dependantsSelection = useStore($issueDialogDetailsDependantsSelection);
     const publishCount = useStore($totalPublishableItems);
     const isPublishReady = useStore($isPublishReady);
     const isPublishChecking = useStore($isPublishChecking);
@@ -837,38 +841,50 @@ export const IssueDialogDetailsContent = (): ReactElement => {
                                             <SplitList.SeparatorLabel>{dependenciesLabel}</SplitList.SeparatorLabel>
                                         </SplitList.Separator>
 
-                                        <SplitList.Secondary
-                                            items={dependants}
-                                            getItemId={(item) => item.getId()}
-                                            disabled={isItemsDisabled || itemsLoading}
-                                            loading={itemsLoading}
-                                            hasMore={hasMoreDependants}
-                                            onEndReached={loadMoreIssueDialogDependants}
-                                            renderRow={(item) => {
-                                                const id = item.getContentId();
-                                                const isRequired = requiredDependantSet.has(id.toString());
-                                                const included = !excludedDependantSet.has(id.toString());
-
-                                                return (
-                                                    <ContentRow
-                                                        key={item.getId()}
-                                                        content={item}
-                                                        id={item.getId()}
+                                        {dependants.length > 0 && (
+                                            <div>
+                                                {dependantsSelection.count > 0 && (
+                                                    <DependantsSelectAll
+                                                        selection={dependantsSelection}
+                                                        onToggle={toggleIssueDialogDetailsDependantsSelection}
                                                         disabled={isItemsDisabled || itemsLoading}
-                                                    >
-                                                        <ContentRow.Checkbox
-                                                            checked={included}
-                                                            onCheckedChange={(checked) =>
-                                                                handleDependencyChange(id, checked)
-                                                            }
-                                                            disabled={isRequired || isItemsDisabled || itemsLoading}
-                                                        />
-                                                        <ContentRow.Label action="edit" />
-                                                        <ContentRow.Status />
-                                                    </ContentRow>
-                                                );
-                                            }}
-                                        />
+                                                    />
+                                                )}
+
+                                                <SplitList.Secondary
+                                                    items={dependants}
+                                                    getItemId={(item) => item.getId()}
+                                                    disabled={isItemsDisabled || itemsLoading}
+                                                    loading={itemsLoading}
+                                                    hasMore={hasMoreDependants}
+                                                    onEndReached={loadMoreIssueDialogDependants}
+                                                    renderRow={(item) => {
+                                                        const id = item.getContentId();
+                                                        const isRequired = requiredDependantSet.has(id.toString());
+                                                        const included = !excludedDependantSet.has(id.toString());
+
+                                                        return (
+                                                            <ContentRow
+                                                                key={item.getId()}
+                                                                content={item}
+                                                                id={item.getId()}
+                                                                disabled={isItemsDisabled || itemsLoading}
+                                                            >
+                                                                <ContentRow.Checkbox
+                                                                    checked={included}
+                                                                    onCheckedChange={(checked) =>
+                                                                        handleDependencyChange(id, checked)
+                                                                    }
+                                                                    disabled={isRequired || isItemsDisabled || itemsLoading}
+                                                                />
+                                                                <ContentRow.Label action="edit" />
+                                                                <ContentRow.Status />
+                                                            </ContentRow>
+                                                        );
+                                                    }}
+                                                />
+                                            </div>
+                                        )}
                                     </SplitList>
                                 </div>
                                 {isPublishRequest && scheduleMode && (

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/new-issue/NewIssueDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/new-issue/NewIssueDialogContent.tsx
@@ -7,6 +7,7 @@ import {ContentId} from '../../../../../app/content/ContentId';
 import {IssueType} from '../../../../../app/issue/IssueType';
 import {useI18n} from '../../../hooks/useI18n';
 import {
+    $newIssueDependantsSelection,
     $newIssueDialog,
     $newIssueDialogCreateCount,
     $newIssueDialogHasMoreDependants,
@@ -19,12 +20,14 @@ import {
     setNewIssueItemIncludeChildren,
     setNewIssueTitle,
     submitNewIssueDialog,
+    toggleNewIssueDependantsSelection,
 } from '../../../store/dialogs/newIssueDialog.store';
 import {useItemsWithUnpublishedChildren} from '../../../utils/cms/content/useItemsWithUnpublishedChildren';
 import {ContentRow, SplitList} from '../../lists';
 import {AssigneeSelector} from '../../selectors/assignee/AssigneeSelector';
 import {useAssigneeSearch, useAssigneeSelection} from '../../selectors/assignee/hooks/useAssigneeSearch';
 import {ContentCombobox} from '../../selectors/content';
+import {DependantsSelectAll} from '../dependants/DependantsSelectAll';
 import {IssueIcon} from '../issue/IssueIcon';
 
 const NEW_ISSUE_DIALOG_CONTENT_NAME = 'NewIssueDialogContent';
@@ -58,6 +61,7 @@ export const NewIssueDialogContent = (): ReactElement => {
 
     const createCount = useStore($newIssueDialogCreateCount);
     const hasMoreDependants = useStore($newIssueDialogHasMoreDependants);
+    const dependantsSelection = useStore($newIssueDependantsSelection);
 
     const titleLabel = useI18n('field.title');
     const descriptionLabel = useI18n('field.description');
@@ -242,38 +246,50 @@ export const NewIssueDialogContent = (): ReactElement => {
                                 <SplitList.SeparatorLabel>{dependenciesLabel}</SplitList.SeparatorLabel>
                             </SplitList.Separator>
 
-                            <SplitList.Secondary
-                                items={dependants}
-                                getItemId={(item) => item.getId()}
-                                disabled={isItemsDisabled}
-                                loading={loading}
-                                hasMore={hasMoreDependants}
-                                onEndReached={loadMoreNewIssueDependants}
-                                renderRow={(item) => {
-                                    const id = item.getContentId();
-                                    const isRequired = requiredDependantSet.has(id.toString());
-                                    const included = !excludedDependantSet.has(id.toString());
-
-                                    return (
-                                        <ContentRow
-                                            key={item.getId()}
-                                            content={item}
-                                            id={item.getId()}
+                            {dependants.length > 0 && (
+                                <div>
+                                    {dependantsSelection.count > 0 && (
+                                        <DependantsSelectAll
+                                            selection={dependantsSelection}
+                                            onToggle={toggleNewIssueDependantsSelection}
                                             disabled={isItemsDisabled}
-                                        >
-                                            <ContentRow.Checkbox
-                                                checked={included}
-                                                onCheckedChange={(checked) =>
-                                                    setNewIssueDependantIncluded(id, checked)
-                                                }
-                                                disabled={isRequired || isItemsDisabled}
-                                            />
-                                            <ContentRow.Label action="edit" />
-                                            <ContentRow.Status />
-                                        </ContentRow>
-                                    );
-                                }}
-                            />
+                                        />
+                                    )}
+
+                                    <SplitList.Secondary
+                                        items={dependants}
+                                        getItemId={(item) => item.getId()}
+                                        disabled={isItemsDisabled}
+                                        loading={loading}
+                                        hasMore={hasMoreDependants}
+                                        onEndReached={loadMoreNewIssueDependants}
+                                        renderRow={(item) => {
+                                            const id = item.getContentId();
+                                            const isRequired = requiredDependantSet.has(id.toString());
+                                            const included = !excludedDependantSet.has(id.toString());
+
+                                            return (
+                                                <ContentRow
+                                                    key={item.getId()}
+                                                    content={item}
+                                                    id={item.getId()}
+                                                    disabled={isItemsDisabled}
+                                                >
+                                                    <ContentRow.Checkbox
+                                                        checked={included}
+                                                        onCheckedChange={(checked) =>
+                                                            setNewIssueDependantIncluded(id, checked)
+                                                        }
+                                                        disabled={isRequired || isItemsDisabled}
+                                                    />
+                                                    <ContentRow.Label action="edit" />
+                                                    <ContentRow.Status />
+                                                </ContentRow>
+                                            );
+                                        }}
+                                    />
+                                </div>
+                            )}
                         </SplitList>
                     </div>
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/project/steps/ProjectDialogRoleStep.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/project/steps/ProjectDialogRoleStep.tsx
@@ -6,10 +6,13 @@ import {CircleUserRound, X} from 'lucide-react';
 import {ReactElement, useCallback, useEffect, useMemo, useState} from 'react';
 import {ProjectAccess} from '../../../../../../app/settings/access/ProjectAccess';
 import {useI18n} from '../../../../hooks/useI18n';
-import {$projectDialog, setProjectDialogRolePrincipals, setProjectDialogRoles} from '../../../../store/dialogs/projectDialog.store';
+import {
+    $projectDialog,
+    setProjectDialogRolePrincipals,
+    setProjectDialogRoles,
+} from '../../../../store/dialogs/projectDialog.store';
 import {$principals} from '../../../../store/principals.store';
 import {InlineButton} from '../../../InlineButton';
-import {ItemLabel} from '../../../ItemLabel';
 import {PrincipalSelector} from '../../../selectors/PrincipalSelector';
 import {getProjectDetailedPermissions} from '../../../../utils/url/projects';
 import {PrincipalLabel} from '../../../PrincipalLabel';
@@ -41,25 +44,27 @@ export type ProjectDialogRoleStepContentProps = {
 export const ProjectDialogRoleStepContent = ({locked = false}: ProjectDialogRoleStepContentProps): ReactElement => {
     // Hooks
     const {principals} = useStore($principals);
-    const {parentProjects, roles, rolePrincipals} = useStore($projectDialog, {keys: ['parentProjects', 'roles', 'rolePrincipals']});
+    const {parentProjects, roles} = useStore($projectDialog, {
+        keys: ['parentProjects', 'roles'],
+    });
     const [selection, setSelection] = useState<string[]>(Object.keys(roles));
     const selectedPrincipals = useMemo(
-        () => principals.filter((principal) => selection.includes(principal.getKey().toString())),
-        [principals, selection]
+        () => principals.filter(principal => selection.includes(principal.getKey().toString())),
+        [principals, selection],
     );
     const [selectedRoles, setSelectedRoles] = useState<Record<string, ProjectAccess>>(roles);
 
     // Set contributor role of the selected principals.
     // If not set, fallback to contributor role.
     useEffect(() => {
-        setSelectedRoles((prevRoles) =>
+        setSelectedRoles(prevRoles =>
             Object.fromEntries(
-                selectedPrincipals.map((principal) => {
+                selectedPrincipals.map(principal => {
                     const principalKey = principal.getKey().toString();
                     const role = prevRoles[principalKey] || ProjectAccess.CONTRIBUTOR;
                     return [principalKey, role];
-                })
-            )
+                }),
+            ),
         );
     }, [selectedPrincipals]);
 
@@ -81,9 +86,11 @@ export const ProjectDialogRoleStepContent = ({locked = false}: ProjectDialogRole
         const {principalKeys, roles} = getProjectDetailedPermissions(parentProjects[0]);
 
         const isParentProjectPrincipalsDifferent =
-            principalKeys.length !== selection.length || principalKeys.some((p) => !selection.includes(p));
+            principalKeys.length !== selection.length || principalKeys.some(p => !selection.includes(p));
 
-        const isParentProjectPermissionsRolesDifferent = Object.entries(roles).some(([key, value]) => selectedRoles[key] !== value);
+        const isParentProjectPermissionsRolesDifferent = Object.entries(roles).some(
+            ([key, value]) => selectedRoles[key] !== value,
+        );
 
         return isParentProjectPrincipalsDifferent || isParentProjectPermissionsRolesDifferent;
     }, [parentProjects, selection, selectedRoles, parentProjectName]);
@@ -103,7 +110,7 @@ export const ProjectDialogRoleStepContent = ({locked = false}: ProjectDialogRole
             {role: ProjectAccess.CONTRIBUTOR, label: contributorLabel},
             {role: ProjectAccess.AUTHOR, label: authorLabel},
         ],
-        [ownerLabel, editorLabel, contributorLabel, authorLabel]
+        [ownerLabel, editorLabel, contributorLabel, authorLabel],
     );
     const copyFromParentLabel = useI18n('settings.wizard.project.copy', parentProjectName);
 
@@ -119,9 +126,9 @@ export const ProjectDialogRoleStepContent = ({locked = false}: ProjectDialogRole
 
     const handleUnselect = useCallback(
         (principalKey: string): void => {
-            setSelection(selection.filter((id) => id !== principalKey));
+            setSelection(selection.filter(id => id !== principalKey));
         },
-        [setSelection, selection]
+        [setSelection, selection],
     );
 
     const handleSelectRole = useCallback(
@@ -129,14 +136,16 @@ export const ProjectDialogRoleStepContent = ({locked = false}: ProjectDialogRole
             const key = principal.getKey().toString();
             setSelectedRoles({...selectedRoles, [key]: role});
         },
-        [setSelectedRoles, selectedRoles]
+        [setSelectedRoles, selectedRoles],
     );
 
     return (
         <Dialog.StepContent step="step-role" locked={locked}>
             <div className="flex justify-between gap-3 mb-2">
                 <label className="font-semibold">{label}</label>
-                {canCopyFromParentProject && <InlineButton onClick={handleCopyFromParentProject} label={copyFromParentLabel} />}
+                {canCopyFromParentProject && (
+                    <InlineButton onClick={handleCopyFromParentProject} label={copyFromParentLabel} />
+                )}
             </div>
 
             <PrincipalSelector
@@ -152,10 +161,10 @@ export const ProjectDialogRoleStepContent = ({locked = false}: ProjectDialogRole
 
             {selection.length > 0 && (
                 <GridList className="rounded-md mb-2.5 py-2.5 pl-4 pr-1">
-                    {selectedPrincipals.map((principal) => {
+                    {selectedPrincipals.map(principal => {
                         const key = principal.getKey().toString();
                         const principalRole = selectedRoles[principal.getKey().toString()];
-                        const principalRoleLabel = roleOptions.find((role) => role.role === principalRole)?.label;
+                        const principalRoleLabel = roleOptions.find(role => role.role === principalRole)?.label;
 
                         return (
                             <GridList.Row key={key} id={key} className="p-1 gap-1.5">
@@ -169,7 +178,7 @@ export const ProjectDialogRoleStepContent = ({locked = false}: ProjectDialogRole
                                 <GridList.Cell>
                                     <Selector.Root
                                         value={principalRole}
-                                        onValueChange={(value) => handleSelectRole(principal, value as ProjectAccess)}
+                                        onValueChange={value => handleSelectRole(principal, value as ProjectAccess)}
                                     >
                                         <GridList.Action>
                                             <Selector.Trigger className="border-none text-sm h-10">
@@ -192,7 +201,11 @@ export const ProjectDialogRoleStepContent = ({locked = false}: ProjectDialogRole
                                 {/* Unselect principal */}
                                 <GridList.Cell>
                                     <GridList.Action>
-                                        <IconButton variant="text" icon={X} onClick={() => handleUnselect(principal.getKey().toString())} />
+                                        <IconButton
+                                            variant="text"
+                                            icon={X}
+                                            onClick={() => handleUnselect(principal.getKey().toString())}
+                                        />
                                     </GridList.Action>
                                 </GridList.Cell>
                             </GridList.Row>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialogMainContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/publish/PublishDialogMainContent.tsx
@@ -14,7 +14,9 @@ import {
     $isPublishSelectionSynced,
     $mainPublishItems,
     $publishCheckErrors,
+    $publishDependantsSelection,
     $publishDialog,
+    $showPublishDependantsExcluded,
     $totalPublishableItems,
     applyDraftPublishDialogSelection,
     cancelDraftPublishDialogSelection,
@@ -29,8 +31,11 @@ import {
     setPublishDialogItemWithChildrenSelected,
     setPublishDialogMessage,
     setPublishSchedule,
+    togglePublishDialogDependantsSelection,
+    togglePublishDialogShowExcluded,
 } from '../../../store/dialogs/publishDialog.store';
 import {ContentRow, SplitList} from '../../lists';
+import {DependantsSelectAll} from '../dependants/DependantsSelectAll';
 import {SelectionStatusBar} from '../status-bar/SelectionStatusBar';
 import {PublishDialogItemStatus} from './PublishDialogItemStatus';
 import {PublishScheduleForm} from './PublishScheduleForm';
@@ -56,6 +61,8 @@ export const PublishDialogMainContent = ({
     const publishCount = useStore($totalPublishableItems);
     const hasSchedulableItems = useStore($hasSchedulableItems);
     const hasExcludedItems = useStore($hasExcludedDependantItems);
+    const showExcluded = useStore($showPublishDependantsExcluded);
+    const dependantsSelection = useStore($publishDependantsSelection);
 
     const isSelectionSynced = useStore($isPublishSelectionSynced);
 
@@ -66,7 +73,6 @@ export const PublishDialogMainContent = ({
     const firstScheduleInputRef = useRef<HTMLInputElement>(null);
     const wasScheduleMode = useRef(scheduleMode);
 
-    const [showExcluded, setShowExcluded] = useState(true);
     const scheduleKeyboardActivation = useRef(false);
     const [showComment, setShowComment] = useState(false);
     const commentTextareaRef = useRef<HTMLTextAreaElement>(null);
@@ -77,12 +83,6 @@ export const PublishDialogMainContent = ({
     const showExcludedLabel = useI18n('dialog.publish.excluded.show');
     const hideExcludedLabel = useI18n('dialog.publish.excluded.hide');
     const toggleExcludedLabel = showExcluded ? hideExcludedLabel : showExcludedLabel;
-
-    useEffect(() => {
-        if (!hasExcludedItems) {
-            setShowExcluded(true);
-        }
-    }, [hasExcludedItems]);
 
     useEffect(() => {
         if (scheduleMode && !wasScheduleMode.current && scheduleKeyboardActivation.current) {
@@ -107,7 +107,7 @@ export const PublishDialogMainContent = ({
     };
 
     const title = useI18n('dialog.publish');
-    const separatorLabel = useI18n('dialog.publish.dependants');
+    const separatorLabel = useI18n('dialog.dependencies');
     const allExcludedMessage = useI18n('dialog.dependencies.allExcluded');
     const scheduleLabel = useI18n('action.schedule');
     const confirmScheduleLabel = useI18n('action.schedule.confirm');
@@ -217,37 +217,49 @@ export const PublishDialogMainContent = ({
                         {hasExcludedItems && isSelectionSynced && (
                             <SplitList.SeparatorButton
                                 label={toggleExcludedLabel}
-                                onClick={() => setShowExcluded(prev => !prev)}
+                                onClick={togglePublishDialogShowExcluded}
                                 disabled={loading}
                             />
                         )}
                     </SplitList.Separator>
 
-                    <SplitList.Secondary
-                        items={visibleDependantItems}
-                        getItemId={(item) => item.id}
-                        emptyMessage={hasExcludedItems ? allExcludedMessage : undefined}
-                        disabled={loading}
-                        loading={loading}
-                        hasMore={hasMoreDependants}
-                        onEndReached={loadMoreDependants}
-                        renderRow={(item) => (
-                            <ContentRow
-                                key={item.id}
-                                content={item.content}
-                                id={item.id}
-                                disabled={loading}
-                            >
-                                <ContentRow.Checkbox
-                                    checked={item.included}
-                                    onCheckedChange={(checked) => setPublishDialogDependantItemSelected(item.content.getContentId(), checked)}
-                                    disabled={item.required || loading}
+                    {(hasVisibleDependantItems || hasExcludedItems) && (
+                        <div>
+                            {dependantsSelection.count > 0 && (
+                                <DependantsSelectAll
+                                    selection={dependantsSelection}
+                                    onToggle={togglePublishDialogDependantsSelection}
+                                    disabled={loading}
                                 />
-                                <ContentRow.Label action="edit" />
-                                <PublishDialogItemStatus />
-                            </ContentRow>
-                        )}
-                    />
+                            )}
+
+                            <SplitList.Secondary
+                                items={visibleDependantItems}
+                                getItemId={(item) => item.id}
+                                emptyMessage={hasExcludedItems ? allExcludedMessage : undefined}
+                                disabled={loading}
+                                loading={loading}
+                                hasMore={hasMoreDependants}
+                                onEndReached={loadMoreDependants}
+                                renderRow={(item) => (
+                                    <ContentRow
+                                        key={item.id}
+                                        content={item.content}
+                                        id={item.id}
+                                        disabled={loading}
+                                    >
+                                        <ContentRow.Checkbox
+                                            checked={item.included}
+                                            onCheckedChange={(checked) => setPublishDialogDependantItemSelected(item.content.getContentId(), checked)}
+                                            disabled={item.required || loading}
+                                        />
+                                        <ContentRow.Label action="edit" />
+                                        <PublishDialogItemStatus />
+                                    </ContentRow>
+                                )}
+                            />
+                        </div>
+                    )}
                 </SplitList>
 
                 {showComment && (

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/requestPublish/RequestPublishDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/requestPublish/RequestPublishDialogContent.tsx
@@ -7,6 +7,7 @@ import {useI18n} from '../../../hooks/useI18n';
 import {$config} from '../../../store/config.store';
 import {
     $isRequestPublishReady,
+    $requestPublishDependantsSelection,
     $requestPublishDialog,
     $requestPublishDialogCreateCount,
     $requestPublishDialogErrors,
@@ -23,11 +24,13 @@ import {
     setRequestPublishItemIncludeChildren,
     setRequestPublishTitle,
     submitRequestPublishDialog,
+    toggleRequestPublishDependantsSelection,
 } from '../../../store/dialogs/requestPublishDialog.store';
 import {useItemsWithUnpublishedChildren} from '../../../utils/cms/content/useItemsWithUnpublishedChildren';
 import {ContentRow, SplitList} from '../../lists';
 import {AssigneeSelector} from '../../selectors/assignee/AssigneeSelector';
 import {useAssigneeSearch, useAssigneeSelection} from '../../selectors/assignee/hooks/useAssigneeSearch';
+import {DependantsSelectAll} from '../dependants/DependantsSelectAll';
 import {IssueIcon} from '../issue/IssueIcon';
 import {SelectionStatusBar} from '../status-bar/SelectionStatusBar';
 
@@ -64,6 +67,7 @@ export const RequestPublishDialogContent = (): ReactElement => {
     const createCount = useStore($requestPublishDialogCreateCount);
     const publishableCount = useStore($requestPublishPublishableCount);
     const hasMoreDependants = useStore($requestPublishHasMoreDependants);
+    const dependantsSelection = useStore($requestPublishDependantsSelection);
     const isPublishReady = useStore($isRequestPublishReady);
     const {invalid, inProgress} = useStore($requestPublishDialogErrors);
     const {allowContentUpdate} = useStore($config, {keys: ['allowContentUpdate']});
@@ -250,38 +254,50 @@ export const RequestPublishDialogContent = (): ReactElement => {
                             <SplitList.SeparatorLabel>{dependenciesLabel}</SplitList.SeparatorLabel>
                         </SplitList.Separator>
 
-                        <SplitList.Secondary
-                            items={dependants}
-                            getItemId={(item) => item.getId()}
-                            disabled={isItemsDisabled}
-                            loading={loading}
-                            hasMore={hasMoreDependants}
-                            onEndReached={loadMoreRequestPublishDependants}
-                            renderRow={(item) => {
-                                const id = item.getContentId();
-                                const isRequired = requiredDependantSet.has(id.toString());
-                                const included = !excludedDependantSet.has(id.toString());
-
-                                return (
-                                    <ContentRow
-                                        key={item.getId()}
-                                        content={item}
-                                        id={item.getId()}
+                        {dependants.length > 0 && (
+                            <div>
+                                {dependantsSelection.count > 0 && (
+                                    <DependantsSelectAll
+                                        selection={dependantsSelection}
+                                        onToggle={toggleRequestPublishDependantsSelection}
                                         disabled={isItemsDisabled}
-                                    >
-                                        <ContentRow.Checkbox
-                                            checked={included}
-                                            onCheckedChange={(checked) =>
-                                                setRequestPublishDependantIncluded(id, checked)
-                                            }
-                                            disabled={isRequired || isItemsDisabled}
-                                        />
-                                        <ContentRow.Label action="edit" />
-                                        <ContentRow.Status />
-                                    </ContentRow>
-                                );
-                            }}
-                        />
+                                    />
+                                )}
+
+                                <SplitList.Secondary
+                                    items={dependants}
+                                    getItemId={(item) => item.getId()}
+                                    disabled={isItemsDisabled}
+                                    loading={loading}
+                                    hasMore={hasMoreDependants}
+                                    onEndReached={loadMoreRequestPublishDependants}
+                                    renderRow={(item) => {
+                                        const id = item.getContentId();
+                                        const isRequired = requiredDependantSet.has(id.toString());
+                                        const included = !excludedDependantSet.has(id.toString());
+
+                                        return (
+                                            <ContentRow
+                                                key={item.getId()}
+                                                content={item}
+                                                id={item.getId()}
+                                                disabled={isItemsDisabled}
+                                            >
+                                                <ContentRow.Checkbox
+                                                    checked={included}
+                                                    onCheckedChange={(checked) =>
+                                                        setRequestPublishDependantIncluded(id, checked)
+                                                    }
+                                                    disabled={isRequired || isItemsDisabled}
+                                                />
+                                                <ContentRow.Label action="edit" />
+                                                <ContentRow.Status />
+                                            </ContentRow>
+                                        );
+                                    }}
+                                />
+                            </div>
+                        )}
                     </SplitList>
                 </div>
             </Dialog.Body>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/split-list/SplitList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/split-list/SplitList.tsx
@@ -18,10 +18,7 @@ import type {
 
 const SPLIT_LIST_NAME = 'SplitList';
 
-const SplitListRoot = ({
-    className,
-    children,
-}: SplitListProps): ReactElement => {
+const SplitListRoot = ({className, children}: SplitListProps): ReactElement => {
     return (
         <div className={cn('flex flex-col gap-y-8', className)} tabIndex={-1}>
             {children}
@@ -66,20 +63,12 @@ SplitListPrimary.displayName = SPLIT_LIST_PRIMARY_NAME;
 
 const SPLIT_LIST_SEPARATOR_NAME = 'SplitList.Separator';
 
-const SplitListSeparator = ({
-    children,
-    hidden = false,
-    className,
-}: SplitListSeparatorProps): ReactElement | null => {
+const SplitListSeparator = ({children, hidden = false, className}: SplitListSeparatorProps): ReactElement | null => {
     if (hidden) {
         return null;
     }
 
-    return (
-        <div className={cn('flex items-center gap-2.5 -mt-2.5 -mb-7.5 pr-1', className)}>
-            {children}
-        </div>
-    );
+    return <div className={cn('flex items-center gap-2.5 -mt-2.5 -mb-7.5 pr-1', className)}>{children}</div>;
 };
 
 SplitListSeparator.displayName = SPLIT_LIST_SEPARATOR_NAME;
@@ -90,12 +79,12 @@ SplitListSeparator.displayName = SPLIT_LIST_SEPARATOR_NAME;
 
 const SPLIT_LIST_SEPARATOR_LABEL_NAME = 'SplitList.SeparatorLabel';
 
-const SplitListSeparatorLabel = ({
-    children,
-    className,
-}: SplitListSeparatorLabelProps): ReactElement => {
+const SplitListSeparatorLabel = ({children, className}: SplitListSeparatorLabelProps): ReactElement => {
     return (
-        <Separator className={cn('text-sm flex-1', className)} label={typeof children === 'string' ? children : undefined} />
+        <Separator
+            className={cn('text-sm flex-1', className)}
+            label={typeof children === 'string' ? children : undefined}
+        />
     );
 };
 
@@ -113,14 +102,7 @@ const SplitListSeparatorButton = ({
     disabled = false,
     className,
 }: SplitListSeparatorButtonProps): ReactElement => {
-    return (
-        <InlineButton
-            label={label}
-            onClick={onClick}
-            disabled={disabled}
-            className={className}
-        />
-    );
+    return <InlineButton label={label} onClick={onClick} disabled={disabled} className={cn('-my-1.5', className)} />;
 };
 
 SplitListSeparatorButton.displayName = SPLIT_LIST_SEPARATOR_BUTTON_NAME;
@@ -159,7 +141,10 @@ function SplitListSecondary<T>({
             return null;
         }
         return (
-            <div data-component={SPLIT_LIST_SECONDARY_NAME} className={cn('text-sm text-subtle italic', className)}>
+            <div
+                data-component={SPLIT_LIST_SECONDARY_NAME}
+                className={cn('py-2 text-sm text-subtle italic', className)}
+            >
                 {emptyMessage}
             </div>
         );

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialogDetails.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialogDetails.store.test.ts
@@ -15,6 +15,7 @@ import {
 import {$issueDialog, closeIssueDialog, openIssueDialogDetails} from './issueDialog.store';
 import {
     $issueDialogDetails,
+    $issueDialogDetailsDependantsSelection,
     $issueDialogDetailsHasMoreDependants,
     loadIssueDialogItems,
     loadMoreIssueDialogDependants,
@@ -377,6 +378,29 @@ describe('issueDialogDetails.store', () => {
             expect(mockGetIssueSend).not.toHaveBeenCalled();
 
             unsubscribe();
+        });
+    });
+
+    describe('batch dependant selection', () => {
+        it('derives the tri-state from required and excluded dependants', () => {
+            $issueDialogDetails.setKey('dependantIds', [new ContentId('req'), new ContentId('a'), new ContentId('b')]);
+            $issueDialogDetails.setKey('requiredDependantIds', [new ContentId('req')]);
+            $issueDialogDetails.setKey('excludedDependantIds', [new ContentId('a')]);
+
+            const selection = $issueDialogDetailsDependantsSelection.get();
+            expect(selection.count).toBe(3);
+            expect(selection.selectionType).toBe('partial');
+            expect(selection.disabled).toBe(false);
+        });
+
+        it('is checked and disabled when every dependant is required', () => {
+            $issueDialogDetails.setKey('dependantIds', [new ContentId('a'), new ContentId('b')]);
+            $issueDialogDetails.setKey('requiredDependantIds', [new ContentId('a'), new ContentId('b')]);
+            $issueDialogDetails.setKey('excludedDependantIds', []);
+
+            const selection = $issueDialogDetailsDependantsSelection.get();
+            expect(selection.selectionType).toBe('all');
+            expect(selection.disabled).toBe(true);
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialogDetails.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/issueDialogDetails.store.ts
@@ -28,6 +28,7 @@ import {
     orderSummariesByIds,
     pruneDependantWindow,
 } from '../../utils/cms/content/dependantWindow';
+import {calcDependantsSelection, nextDependantExclusions} from '../../utils/cms/content/dependantsSelection';
 import {hasContentIdInIds, isIdsEqual, uniqueIds} from '../../utils/cms/content/ids';
 import {findContentIdsWithCreatedDescendants} from '../../utils/cms/content/paths';
 import {
@@ -160,6 +161,12 @@ export const $canIssueDialogDetailsPublish = computed(
 export const $issueDialogDetailsHasMoreDependants = computed(
     $issueDialogDetails,
     ({dependantIds, dependantWindow}) => dependantWindow < dependantIds.length,
+);
+
+export const $issueDialogDetailsDependantsSelection = computed(
+    $issueDialogDetails,
+    ({dependantIds, requiredDependantIds, excludedDependantIds}) =>
+        calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds),
 );
 
 //
@@ -864,6 +871,16 @@ export const updateIssueDialogExcludedDependants = async (nextExcludedIds: Conte
         issueWithAssignees,
         nextPublishRequest,
     });
+};
+
+export const toggleIssueDialogDetailsDependantsSelection = (): void => {
+    const {dependantIds, requiredDependantIds, excludedDependantIds} = $issueDialogDetails.get();
+    const selection = calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds);
+    if (selection.selectableIds.length === 0) {
+        return;
+    }
+
+    void updateIssueDialogExcludedDependants(nextDependantExclusions(selection, excludedDependantIds));
 };
 
 export const openDeleteCommentConfirmation = (commentId: string): void => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/newIssueDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/newIssueDialog.store.test.ts
@@ -9,12 +9,14 @@ import {
     emitContentUpdated,
 } from '../socket.store';
 import {
+    $newIssueDependantsSelection,
     $newIssueDialog,
     $newIssueDialogCreateCount,
     $newIssueDialogHasMoreDependants,
     loadMoreNewIssueDependants,
     openNewIssueDialog,
     resetNewIssueDialogContext,
+    toggleNewIssueDependantsSelection,
 } from './newIssueDialog.store';
 import {
     createMockChangeItem,
@@ -216,5 +218,55 @@ describe('newIssueDialog.store', () => {
         await flushNewIssueReload();
 
         expect($newIssueDialog.get().items[0].getDisplayName()).toBe('Item');
+    });
+
+    describe('batch dependant selection', () => {
+        it('derives the tri-state from required and excluded dependants', () => {
+            $newIssueDialog.setKey('dependantIds', [new ContentId('req'), new ContentId('a'), new ContentId('b')]);
+            $newIssueDialog.setKey('requiredDependantIds', [new ContentId('req')]);
+            $newIssueDialog.setKey('excludedDependantIds', [new ContentId('a')]);
+
+            const selection = $newIssueDependantsSelection.get();
+            expect(selection.count).toBe(3);
+            expect(selection.selectionType).toBe('partial');
+            expect(selection.disabled).toBe(false);
+        });
+
+        it('deselects every dependant when toggled from a full selection', () => {
+            $newIssueDialog.setKey('dependantIds', [new ContentId('a'), new ContentId('b')]);
+            $newIssueDialog.setKey('excludedDependantIds', []);
+
+            expect($newIssueDependantsSelection.get().selectionType).toBe('all');
+
+            toggleNewIssueDependantsSelection();
+
+            const excluded = $newIssueDialog.get().excludedDependantIds.map(id => id.toString()).sort();
+            expect(excluded).toEqual(['a', 'b']);
+            expect($newIssueDependantsSelection.get().selectionType).toBe('none');
+        });
+
+        it('keeps required dependants selected when deselecting all, staying partial', () => {
+            $newIssueDialog.setKey('dependantIds', [new ContentId('req'), new ContentId('a')]);
+            $newIssueDialog.setKey('requiredDependantIds', [new ContentId('req')]);
+            $newIssueDialog.setKey('excludedDependantIds', []);
+
+            toggleNewIssueDependantsSelection();
+
+            const excluded = $newIssueDialog.get().excludedDependantIds.map(id => id.toString());
+            expect(excluded).toEqual(['a']);
+            expect($newIssueDependantsSelection.get().selectionType).toBe('partial');
+        });
+
+        it('selects every dependant when toggled from an empty selection', () => {
+            $newIssueDialog.setKey('dependantIds', [new ContentId('a'), new ContentId('b')]);
+            $newIssueDialog.setKey('excludedDependantIds', [new ContentId('a'), new ContentId('b')]);
+
+            expect($newIssueDependantsSelection.get().selectionType).toBe('none');
+
+            toggleNewIssueDependantsSelection();
+
+            expect($newIssueDialog.get().excludedDependantIds).toHaveLength(0);
+            expect($newIssueDependantsSelection.get().selectionType).toBe('all');
+        });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/newIssueDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/newIssueDialog.store.ts
@@ -16,6 +16,7 @@ import {
     orderSummariesByIds,
     pruneDependantWindow,
 } from '../../utils/cms/content/dependantWindow';
+import {calcDependantsSelection, nextDependantExclusions} from '../../utils/cms/content/dependantsSelection';
 import {hasContentIdInIds, uniqueIds} from '../../utils/cms/content/ids';
 import {findContentIdsWithCreatedDescendants} from '../../utils/cms/content/paths';
 import {
@@ -86,6 +87,12 @@ export const $newIssueDialogCreateCount = computed(
 export const $newIssueDialogHasMoreDependants = computed(
     $newIssueDialog,
     ({dependantIds, dependantWindow}) => dependantWindow < dependantIds.length,
+);
+
+export const $newIssueDependantsSelection = computed(
+    $newIssueDialog,
+    ({dependantIds, requiredDependantIds, excludedDependantIds}) =>
+        calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds),
 );
 
 let instanceId = 0;
@@ -265,6 +272,16 @@ export const setNewIssueDependantIncluded = (id: ContentId, included: boolean): 
     if (!included && !isExcluded) {
         $newIssueDialog.setKey('excludedDependantIds', [...state.excludedDependantIds, id]);
     }
+};
+
+export const toggleNewIssueDependantsSelection = (): void => {
+    const {dependantIds, requiredDependantIds, excludedDependantIds} = $newIssueDialog.get();
+    const selection = calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds);
+    if (selection.selectableIds.length === 0) {
+        return;
+    }
+
+    $newIssueDialog.setKey('excludedDependantIds', nextDependantExclusions(selection, excludedDependantIds));
 };
 
 export const submitNewIssueDialog = async (): Promise<void> => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.test.ts
@@ -11,15 +11,18 @@ import {
 import {$config} from '../config.store';
 import {
     $dependantPublishItems,
+    $draftPublishDialogSelection,
     $hasExcludedDependantItems,
     $hasMoreDependants,
     $hasSchedulableItems,
     $isPublishReady,
     $isScheduleValid,
     $publishCheckErrors,
+    $publishDependantsSelection,
     $publishDialog,
     $publishDialogPending,
     $scheduleFromError,
+    $showPublishDependantsExcluded,
     $totalPublishableItems,
     applyDraftPublishDialogSelection,
     loadMoreDependants,
@@ -28,6 +31,8 @@ import {
     setPublishDialogDependantItemSelected,
     setPublishDialogItemWithChildrenSelected,
     setPublishSchedule,
+    togglePublishDialogDependantsSelection,
+    togglePublishDialogShowExcluded,
 } from './publishDialog.store';
 import {
     createMockChangeItem,
@@ -502,6 +507,124 @@ describe('publishDialog.store', () => {
             expect($dependantPublishItems.get()).toHaveLength(40);
             expect($hasMoreDependants.get()).toBe(false);
             expect($totalPublishableItems.get()).toBe(41);
+        });
+    });
+
+    describe('batch dependant selection', () => {
+        const reqId = new ContentId('req-1');
+        const depId = new ContentId('dep-1');
+
+        afterEach(() => {
+            $config.setKey('excludeDependencies', true);
+        });
+
+        // Min resolve excludes every non-required dependant; the server keeps required ones and
+        // reports the rest as "next" (auto-excluded, shown unchecked).
+        function mockResolve(allIds: ContentId[], requiredIds: ContentId[] = []): void {
+            mockResolvePublishDependencies.mockImplementation(({excludedIds = []}: {excludedIds?: ContentId[]}) => {
+                const isMinResolve = excludedIds.some(excludedId => allIds.some(id => id.equals(excludedId)));
+                const nextIds = allIds.filter(id => !requiredIds.some(req => req.equals(id)));
+                return Promise.resolve(isMinResolve
+                    ? createResolveResult({dependants: requiredIds, required: requiredIds, next: nextIds})
+                    : createResolveResult({dependants: allIds}));
+            });
+            mockFetchContentSummaries.mockResolvedValue(allIds.map(id => createMockContent(id.toString())));
+        }
+
+        it('reports all selected when no dependants are excluded', async () => {
+            $config.setKey('excludeDependencies', false);
+            mockResolve([reqId, depId]);
+
+            openPublishDialog([createMockContent('item-1')]);
+            await flushInitialReload();
+
+            const selection = $publishDependantsSelection.get();
+            expect(selection.count).toBe(2);
+            expect(selection.selectionType).toBe('all');
+            expect(selection.disabled).toBe(false);
+        });
+
+        it('reports none selected when every dependant is auto-excluded', async () => {
+            mockResolve([depId]);
+
+            openPublishDialog([createMockContent('item-1')]);
+            await flushInitialReload();
+
+            const selection = $publishDependantsSelection.get();
+            expect(selection.count).toBe(1);
+            expect(selection.selectionType).toBe('none');
+            expect(selection.disabled).toBe(false);
+        });
+
+        it('reports partial selection when a required dependant is mixed with an excluded one', async () => {
+            mockResolve([reqId, depId], [reqId]);
+
+            openPublishDialog([createMockContent('item-1')]);
+            await flushInitialReload();
+
+            const selection = $publishDependantsSelection.get();
+            expect(selection.count).toBe(2);
+            expect(selection.selectionType).toBe('partial');
+            expect(selection.disabled).toBe(false);
+        });
+
+        it('is checked and disabled when every dependant is mandatory', async () => {
+            mockResolve([reqId], [reqId]);
+
+            openPublishDialog([createMockContent('item-1')]);
+            await flushInitialReload();
+
+            const selection = $publishDependantsSelection.get();
+            expect(selection.count).toBe(1);
+            expect(selection.selectionType).toBe('all');
+            expect(selection.disabled).toBe(true);
+        });
+
+        it('drops auto-excluded dependants from the count when excluded are hidden', async () => {
+            mockResolve([reqId, depId], [reqId]);
+
+            openPublishDialog([createMockContent('item-1')]);
+            await flushInitialReload();
+
+            expect($publishDependantsSelection.get().count).toBe(2);
+
+            togglePublishDialogShowExcluded();
+
+            expect($showPublishDependantsExcluded.get()).toBe(false);
+            const selection = $publishDependantsSelection.get();
+            expect(selection.count).toBe(1);
+            expect(selection.selectionType).toBe('all');
+            expect(selection.disabled).toBe(true);
+        });
+
+        it('selects every dependant when toggled from a partial or empty selection', async () => {
+            mockResolve([depId]);
+
+            openPublishDialog([createMockContent('item-1')]);
+            await flushInitialReload();
+
+            expect($publishDependantsSelection.get().selectionType).toBe('none');
+
+            togglePublishDialogDependantsSelection();
+
+            expect($draftPublishDialogSelection.get().excludedDependantItemsIds).toHaveLength(0);
+            expect($publishDependantsSelection.get().selectionType).toBe('all');
+        });
+
+        it('deselects every selectable dependant when toggled from a full selection', async () => {
+            $config.setKey('excludeDependencies', false);
+            const otherId = new ContentId('dep-2');
+            mockResolve([depId, otherId]);
+
+            openPublishDialog([createMockContent('item-1')]);
+            await flushInitialReload();
+
+            expect($publishDependantsSelection.get().selectionType).toBe('all');
+
+            togglePublishDialogDependantsSelection();
+
+            expect($draftPublishDialogSelection.get().excludedDependantItemsIds).toHaveLength(2);
+            expect($publishDependantsSelection.get().selectionType).toBe('none');
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
@@ -10,6 +10,11 @@ import {calcSecondaryStatus, calcTreePublishStatus} from '../../utils/cms/conten
 import {hasUnpublishedChildren} from '../../api/hasUnpublishedChildren';
 import {findIdsByParents, markAsReady, publishContent, resolvePublishDependencies as resolvePublishDeps} from '../../api/publish';
 import {cleanupTask, trackTask} from '../../services/task.service';
+import {
+    calcDependantsSelection,
+    type DependantsSelection,
+    nextDependantExclusions,
+} from '../../utils/cms/content/dependantsSelection';
 import {hasContentById, hasContentIdInIds, isIdsEqual, uniqueIds} from '../../utils/cms/content/ids';
 import {findContentIdsWithCreatedDescendants} from '../../utils/cms/content/paths';
 import {
@@ -44,6 +49,7 @@ type DependantItem = {
     excludedByDefault: boolean;
     hidden: boolean;
 };
+
 
 type PublishDialogSelectionStore = {
     excludedItemsIds: ContentId[];
@@ -166,6 +172,9 @@ const $publishDialogDependants = atom<ContentSummary[]>([]);
 // Dependant ids visible in the dialog (legacy `calcVisibleIds`): min dependants, direct excluded deps, included children
 const $visibleDependantIds = atom<ContentId[]>([]);
 
+// Whether auto-excluded dependants are shown in the list (legacy "Hide/Show excluded" toggle).
+const $showExcludedDependants = atom<boolean>(true);
+
 const $dependantWindow = atom<number>(0);
 
 // Publishable ids (status != EQUAL) resolved by the server, across the full set
@@ -242,6 +251,21 @@ export const $dependantPublishItems = computed(
 export const $hasExcludedDependantItems = computed($dependantPublishItems, (items): boolean => {
     return items.some(item => item.excludedByDefault && !item.hidden && !item.required);
 });
+
+export const $showPublishDependantsExcluded = computed($showExcludedDependants, (show): boolean => show);
+
+export const $publishDependantsSelection = computed(
+    [$dependantIds, $visibleDependantIds, $publishChecks, $publishDialog, $draftPublishDialogSelection, $showExcludedDependants],
+    (allIds, visibleIds, {requiredIds}, {excludedDependantItemsIds}, {excludedDependantItemsIds: draftExcludedIds}, showExcluded): DependantsSelection => {
+        // From the full id set, not the loaded window, so the count is right before summaries
+        // lazy-load; respects the "show excluded" toggle to match the visible rows.
+        const shownIds = allIds.filter(id =>
+            hasContentIdInIds(id, visibleIds) &&
+            (showExcluded || !hasContentIdInIds(id, excludedDependantItemsIds)));
+
+        return calcDependantsSelection(shownIds, requiredIds, draftExcludedIds);
+    }
+);
 
 // Filter the server's publishable set by the draft selection so the count stays live
 // while the user toggles checkboxes, without re-resolving or loading summaries.
@@ -434,6 +458,7 @@ export const resetPublishDialogContext = () => {
     $publishDialog.set(structuredClone(initialPublishDialogState));
     $draftPublishDialogSelection.set(structuredClone(initialSelectionState));
     $publishChecks.set(structuredClone(initialChecksState));
+    $showExcludedDependants.set(true);
     resetDependantsState();
     $publishDialogPending.set(initialPendingState);
     $hasUnpublishedChildrenIds.set(new Set());
@@ -518,6 +543,22 @@ export const setPublishDialogDependantItemSelected = (id: ContentId, selected: b
         ...rest,
         excludedDependantItemsIds: newExcludedDependantItemsIds,
     });
+}
+
+export const togglePublishDialogDependantsSelection = () => {
+    const selection = $publishDependantsSelection.get();
+    if (selection.selectableIds.length === 0) return;
+
+    const {excludedDependantItemsIds, ...rest} = $draftPublishDialogSelection.get();
+
+    $draftPublishDialogSelection.set({
+        ...rest,
+        excludedDependantItemsIds: nextDependantExclusions(selection, excludedDependantItemsIds),
+    });
+}
+
+export const togglePublishDialogShowExcluded = () => {
+    $showExcludedDependants.set(!$showExcludedDependants.get());
 }
 
 export const setPublishDialogMessage = (message: string | undefined) => {
@@ -989,6 +1030,14 @@ $publishDialog.subscribe((state, oldState) => {
 
     if (exclusionsChanged) {
         reloadPublishDialogDataDebounced();
+    }
+});
+
+// Snap back to "show excluded" once there are no toggleable excluded dependants left,
+// so the toggle never lingers in the hidden state with nothing to reveal.
+$hasExcludedDependantItems.subscribe((hasExcluded) => {
+    if (!hasExcluded) {
+        $showExcludedDependants.set(true);
     }
 });
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../socket.store';
 import {
     $isRequestPublishReady,
+    $requestPublishDependantsSelection,
     $requestPublishDialog,
     $requestPublishDialogCreateCount,
     $requestPublishDialogErrors,
@@ -19,6 +20,7 @@ import {
     openRequestPublishDialog,
     resetRequestPublishDialogContext,
     submitRequestPublishDialog,
+    toggleRequestPublishDependantsSelection,
 } from './requestPublishDialog.store';
 import {
     createDeferredPromise,
@@ -419,5 +421,55 @@ describe('requestPublishDialog.store', () => {
         expect($requestPublishDialog.get().submitting).toBe(false);
         expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
         expect(mockShowError).toHaveBeenCalledWith('Request failed');
+    });
+
+    describe('batch dependant selection', () => {
+        it('derives the tri-state from required and excluded dependants', () => {
+            $requestPublishDialog.setKey('dependantIds', [new ContentId('req'), new ContentId('a'), new ContentId('b')]);
+            $requestPublishDialog.setKey('requiredDependantIds', [new ContentId('req')]);
+            $requestPublishDialog.setKey('excludedDependantIds', [new ContentId('a')]);
+
+            const selection = $requestPublishDependantsSelection.get();
+            expect(selection.count).toBe(3);
+            expect(selection.selectionType).toBe('partial');
+            expect(selection.disabled).toBe(false);
+        });
+
+        it('deselects every dependant when toggled from a full selection', () => {
+            $requestPublishDialog.setKey('dependantIds', [new ContentId('a'), new ContentId('b')]);
+            $requestPublishDialog.setKey('excludedDependantIds', []);
+
+            expect($requestPublishDependantsSelection.get().selectionType).toBe('all');
+
+            toggleRequestPublishDependantsSelection();
+
+            const excluded = $requestPublishDialog.get().excludedDependantIds.map(id => id.toString()).sort();
+            expect(excluded).toEqual(['a', 'b']);
+            expect($requestPublishDependantsSelection.get().selectionType).toBe('none');
+        });
+
+        it('keeps required dependants selected when deselecting all, staying partial', () => {
+            $requestPublishDialog.setKey('dependantIds', [new ContentId('req'), new ContentId('a')]);
+            $requestPublishDialog.setKey('requiredDependantIds', [new ContentId('req')]);
+            $requestPublishDialog.setKey('excludedDependantIds', []);
+
+            toggleRequestPublishDependantsSelection();
+
+            const excluded = $requestPublishDialog.get().excludedDependantIds.map(id => id.toString());
+            expect(excluded).toEqual(['a']);
+            expect($requestPublishDependantsSelection.get().selectionType).toBe('partial');
+        });
+
+        it('selects every dependant when toggled from an empty selection', () => {
+            $requestPublishDialog.setKey('dependantIds', [new ContentId('a'), new ContentId('b')]);
+            $requestPublishDialog.setKey('excludedDependantIds', [new ContentId('a'), new ContentId('b')]);
+
+            expect($requestPublishDependantsSelection.get().selectionType).toBe('none');
+
+            toggleRequestPublishDependantsSelection();
+
+            expect($requestPublishDialog.get().excludedDependantIds).toHaveLength(0);
+            expect($requestPublishDependantsSelection.get().selectionType).toBe('all');
+        });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/requestPublishDialog.store.ts
@@ -17,6 +17,7 @@ import {
     orderSummariesByIds,
     pruneDependantWindow,
 } from '../../utils/cms/content/dependantWindow';
+import {calcDependantsSelection, nextDependantExclusions} from '../../utils/cms/content/dependantsSelection';
 import {hasContentIdInIds, uniqueIds} from '../../utils/cms/content/ids';
 import {findContentIdsWithCreatedDescendants} from '../../utils/cms/content/paths';
 import {
@@ -104,6 +105,12 @@ export const $requestPublishDialogCreateCount = computed(
 export const $requestPublishHasMoreDependants = computed(
     $requestPublishDialog,
     ({dependantIds, dependantWindow}) => dependantWindow < dependantIds.length,
+);
+
+export const $requestPublishDependantsSelection = computed(
+    $requestPublishDialog,
+    ({dependantIds, requiredDependantIds, excludedDependantIds}) =>
+        calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds),
 );
 
 export const $requestPublishDialogErrors = computed(
@@ -444,6 +451,16 @@ export const setRequestPublishDependantIncluded = (id: ContentId, included: bool
     if (!included && !isExcluded) {
         $requestPublishDialog.setKey('excludedDependantIds', [...state.excludedDependantIds, id]);
     }
+};
+
+export const toggleRequestPublishDependantsSelection = (): void => {
+    const {dependantIds, requiredDependantIds, excludedDependantIds} = $requestPublishDialog.get();
+    const selection = calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds);
+    if (selection.selectableIds.length === 0) {
+        return;
+    }
+
+    $requestPublishDialog.setKey('excludedDependantIds', nextDependantExclusions(selection, excludedDependantIds));
 };
 
 export const excludeInvalidRequestPublishItems = (): void => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/dependantsSelection.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/dependantsSelection.test.ts
@@ -1,0 +1,102 @@
+import {describe, expect, it} from 'vitest';
+import {ContentId} from '../../../../../app/content/ContentId';
+import {calcDependantsSelection, nextDependantExclusions} from './dependantsSelection';
+
+const id = (value: string): ContentId => new ContentId(value);
+const ids = (...values: string[]): ContentId[] => values.map(id);
+const toStrings = (list: ContentId[]): string[] => list.map(item => item.toString()).sort();
+
+describe('dependantsSelection', () => {
+    describe('calcDependantsSelection', () => {
+        it('reports all selected when nothing is excluded or required', () => {
+            const result = calcDependantsSelection(ids('a', 'b', 'c'), [], []);
+
+            expect(result.count).toBe(3);
+            expect(result.selectionType).toBe('all');
+            expect(result.disabled).toBe(false);
+            expect(toStrings(result.selectableIds)).toEqual(['a', 'b', 'c']);
+        });
+
+        it('reports none selected when every dependant is excluded', () => {
+            const result = calcDependantsSelection(ids('a', 'b'), [], ids('a', 'b'));
+
+            expect(result.selectionType).toBe('none');
+            expect(result.disabled).toBe(false);
+        });
+
+        it('reports partial selection when some dependants are excluded', () => {
+            const result = calcDependantsSelection(ids('a', 'b', 'c'), [], ids('a'));
+
+            expect(result.count).toBe(3);
+            expect(result.selectionType).toBe('partial');
+            expect(result.disabled).toBe(false);
+        });
+
+        it('counts required dependants as selected, yielding partial when others are excluded', () => {
+            const result = calcDependantsSelection(ids('req', 'dep'), ids('req'), ids('dep'));
+
+            expect(result.selectionType).toBe('partial');
+            expect(result.disabled).toBe(false);
+            expect(toStrings(result.selectableIds)).toEqual(['dep']);
+        });
+
+        it('is checked and disabled when every dependant is required', () => {
+            const result = calcDependantsSelection(ids('a', 'b'), ids('a', 'b'), []);
+
+            expect(result.count).toBe(2);
+            expect(result.selectionType).toBe('all');
+            expect(result.disabled).toBe(true);
+            expect(result.selectableIds).toHaveLength(0);
+        });
+
+        it('is checked and disabled for an empty list', () => {
+            const result = calcDependantsSelection([], [], []);
+
+            expect(result.count).toBe(0);
+            expect(result.selectionType).toBe('all');
+            expect(result.disabled).toBe(true);
+        });
+    });
+
+    describe('nextDependantExclusions', () => {
+        it('excludes every selectable dependant when all are currently selected', () => {
+            const selection = calcDependantsSelection(ids('a', 'b'), [], []);
+
+            const next = nextDependantExclusions(selection, []);
+
+            expect(toStrings(next)).toEqual(['a', 'b']);
+        });
+
+        it('keeps required dependants out of the exclusion set when deselecting all', () => {
+            const selection = calcDependantsSelection(ids('req', 'a'), ids('req'), []);
+
+            const next = nextDependantExclusions(selection, []);
+
+            expect(toStrings(next)).toEqual(['a']);
+        });
+
+        it('clears selectable exclusions when selecting all from a partial state', () => {
+            const selection = calcDependantsSelection(ids('a', 'b', 'c'), [], ids('a'));
+
+            const next = nextDependantExclusions(selection, ids('a'));
+
+            expect(next).toHaveLength(0);
+        });
+
+        it('clears selectable exclusions when selecting all from an empty selection', () => {
+            const selection = calcDependantsSelection(ids('a', 'b'), [], ids('a', 'b'));
+
+            const next = nextDependantExclusions(selection, ids('a', 'b'));
+
+            expect(next).toHaveLength(0);
+        });
+
+        it('preserves unrelated exclusions and adds selectable ids when deselecting all', () => {
+            const selection = calcDependantsSelection(ids('a', 'b'), [], []);
+
+            const next = nextDependantExclusions(selection, ids('x'));
+
+            expect(toStrings(next)).toEqual(['a', 'b', 'x']);
+        });
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/dependantsSelection.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/cms/content/dependantsSelection.ts
@@ -1,0 +1,65 @@
+import {type ContentId} from '../../../../../app/content/ContentId';
+import {hasContentIdInIds, uniqueIds} from './ids';
+
+// Tri-state of a dependants list's batch "select all" checkbox (legacy `SelectionType`).
+export type DependantsSelectionType = 'all' | 'none' | 'partial';
+
+export type DependantsSelection = {
+    count: number;
+    selectionType: DependantsSelectionType;
+    disabled: boolean;
+    selectableIds: ContentId[];
+};
+
+/**
+ * Derive the batch "select all" state for a dependants list.
+ *
+ * @param shownIds  every dependant currently shown in the list (full id set, not just loaded)
+ * @param requiredIds  dependants that cannot be deselected
+ * @param excludedIds  dependants the user has deselected
+ *
+ * When no dependant is excludable (all mandatory) the checkbox is `all` and disabled.
+ */
+export const calcDependantsSelection = (
+    shownIds: readonly ContentId[],
+    requiredIds: readonly ContentId[],
+    excludedIds: readonly ContentId[],
+): DependantsSelection => {
+    const selectableIds = shownIds.filter(id => !hasContentIdInIds(id, requiredIds));
+    const selectedCount = shownIds.filter(id => !hasContentIdInIds(id, excludedIds)).length;
+
+    return {
+        count: shownIds.length,
+        selectionType: calcSelectionType(selectableIds.length, selectedCount, shownIds.length),
+        disabled: selectableIds.length === 0,
+        selectableIds,
+    };
+};
+
+/**
+ * Next exclusion set for a batch toggle: deselect every selectable dependant when all are
+ * selected, otherwise select them all (clear their exclusions). Required dependants are never
+ * touched because they are not part of `selection.selectableIds`.
+ */
+export const nextDependantExclusions = (
+    selection: DependantsSelection,
+    currentExcludedIds: readonly ContentId[],
+): ContentId[] => {
+    return selection.selectionType === 'all'
+        ? uniqueIds([...currentExcludedIds, ...selection.selectableIds])
+        : currentExcludedIds.filter(id => !hasContentIdInIds(id, selection.selectableIds));
+};
+
+const calcSelectionType = (
+    selectableCount: number,
+    selectedCount: number,
+    shownCount: number,
+): DependantsSelectionType => {
+    if (selectableCount === 0 || selectedCount === shownCount) {
+        return 'all';
+    }
+    if (selectedCount === 0) {
+        return 'none';
+    }
+    return 'partial';
+};

--- a/modules/lib/src/main/resources/i18n/dialogs.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs.properties
@@ -42,7 +42,6 @@ dialog.publish.publishing.error=Error occurred while publishing items
 dialog.publish.beingPublished=Publishing {0} item(s)...
 dialog.publish.success.single=Item "{0}" has been published.
 dialog.publish.success.multiple={0} items have been published.
-dialog.publish.dependants=Other items that will be published
 dialog.publish.itemRequired=This item is required for publishing
 dialog.duplicate.success.single=Item "{0}" has been duplicated.
 dialog.duplicate.success.multiple={0} items have been duplicated.

--- a/modules/lib/src/main/resources/i18n/dialogs_be.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_be.properties
@@ -120,7 +120,6 @@ dialog.projectAccess.confirm = Змена рэжыму доступу прывя
 dialog.publish = Майстар публікацыі
 dialog.publish.addSchedule = Дадаць расклад
 dialog.publish.changesReady = Змяненні гатовыя да публікацыі
-dialog.publish.dependants = Таксама будуць апублікаваныя
 dialog.publish.exclude.noPermissions = Выключыць элементы без правоў на публікацыю
 dialog.publish.excludeFromPublishing = Выключыць з публікацыі
 dialog.publish.excluded.hide = Схаваць выключаныя элементы

--- a/modules/lib/src/main/resources/i18n/dialogs_es.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_es.properties
@@ -120,7 +120,6 @@ dialog.projectAccess.confirm = Cambiar el modo de acceso modificará los permiso
 dialog.publish = Asistente de Publicación
 dialog.publish.addSchedule = Añadir programación
 dialog.publish.changesReady = Sus cambios están listos para publicación
-dialog.publish.dependants = Otros elementos que serán publicados
 dialog.publish.exclude.noPermissions = Excluir elementos con permisos faltantes
 dialog.publish.excludeFromPublishing = Excluir de la publicación
 dialog.publish.excluded.hide = Ocultar excluidos

--- a/modules/lib/src/main/resources/i18n/dialogs_fr.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_fr.properties
@@ -120,7 +120,6 @@ dialog.projectAccess.confirm = La modification du mode d'accès modifiera les pe
 dialog.publish = Assistant de publication
 dialog.publish.addSchedule = Ajouter un horaire
 dialog.publish.changesReady = Vos modifications sont prêtes à être publiées
-dialog.publish.dependants = Autres éléments qui seront publiés
 dialog.publish.exclude.noPermissions = Exclure les éléments avec des autorisations manquantes
 dialog.publish.excludeFromPublishing = Exclure de la publication
 dialog.publish.excluded.hide = Masquer les exclusions

--- a/modules/lib/src/main/resources/i18n/dialogs_it.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_it.properties
@@ -132,7 +132,6 @@ dialog.projectAccess.confirm = La modifica della modalità di accesso cambierà 
 dialog.publish = Pubblicazione guidata
 dialog.publish.addSchedule = Aggiungi pianificazione
 dialog.publish.changesReady = Le tue modifiche sono pronte per la pubblicazione
-dialog.publish.dependants = Altri elementi che verranno pubblicati
 dialog.publish.exclude.noPermissions = Escludi elementi con autorizzazioni mancanti
 dialog.publish.excludeFromPublishing = Escludi dalla pubblicazione
 dialog.publish.excluded.hide = Nascondi elementi esclusi

--- a/modules/lib/src/main/resources/i18n/dialogs_nl.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_nl.properties
@@ -120,7 +120,6 @@ dialog.projectAccess.confirm = Door de toegangsmodus te wijzigen, worden de mach
 dialog.publish = Publicatie Wizard
 dialog.publish.addSchedule = Schema toevoegen
 dialog.publish.changesReady = Jouw wijzigingen zijn klaar voor publicatie
-dialog.publish.dependants = Andere items die worden gepubliceerd
 dialog.publish.exclude.noPermissions = Items met ontbrekende machtigingen uitsluiten
 dialog.publish.excludeFromPublishing = Uitsluiten van publicatie
 dialog.publish.excluded.hide = Verberg uitgesloten

--- a/modules/lib/src/main/resources/i18n/dialogs_no.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_no.properties
@@ -221,7 +221,6 @@ dialog.publish = Publiseringsveiviser
 dialog.publish.addSchedule = Legg til tidsstyring
 dialog.publish.beingPublished = Publisere {0} element(er)...
 dialog.publish.changesReady = Dine endringer er klar for publisering
-dialog.publish.dependants = Andre elementer som vil bli publisert
 dialog.publish.exclude.noPermissions = Utelat elementer med manglende rettigheter
 dialog.publish.excludeFromPublishing = Fjern fra publisering
 dialog.publish.excluded.hide = Skjul utelatte elementer

--- a/modules/lib/src/main/resources/i18n/dialogs_pl.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_pl.properties
@@ -120,7 +120,6 @@ dialog.projectAccess.confirm = Zmiana trybu dostępu spowoduje zmianę uprawnie�
 dialog.publish = Przewodnik po publikowaniu
 dialog.publish.addSchedule = Dodaj harmonogram
 dialog.publish.changesReady = Twoje zmiany są gotowe do publikacji
-dialog.publish.dependants = Inne elementy, które zostaną opublikowane
 dialog.publish.exclude.noPermissions = Wyklucz elementy z brakującymi uprawnieniami
 dialog.publish.excludeFromPublishing = Wyklucz z publikacji
 dialog.publish.excluded.hide = Ukryj wykluczone

--- a/modules/lib/src/main/resources/i18n/dialogs_pt.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_pt.properties
@@ -124,7 +124,6 @@ dialog.projectAccess.confirm = A alteração no modo de acesso modificará as pe
 dialog.publish = Assistente de Publicação
 dialog.publish.addSchedule = Adicionar à agenda
 dialog.publish.changesReady = Suas mudanças estão prontas para serem publicadas
-dialog.publish.dependants = Outros itens que serão publicados
 dialog.publish.excludeFromPublishing = Remover da Publicação
 dialog.publish.excluded.hide = Ocultar excluído
 dialog.publish.excluded.show = Mostrar excluído

--- a/modules/lib/src/main/resources/i18n/dialogs_ru.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_ru.properties
@@ -221,7 +221,6 @@ dialog.publish = Мастер публикации
 dialog.publish.addSchedule = Добавить расписание
 dialog.publish.beingPublished = Идет публикация {0} элементов...
 dialog.publish.changesReady = Изменения готовы к публикации
-dialog.publish.dependants = Также будут опубликованы
 dialog.publish.exclude.noPermissions = Исключить элементы без прав на публикацию
 dialog.publish.excludeFromPublishing = Исключить из публикации
 dialog.publish.excluded.hide = Скрыть исключенные элементы

--- a/modules/lib/src/main/resources/i18n/dialogs_sv.properties
+++ b/modules/lib/src/main/resources/i18n/dialogs_sv.properties
@@ -124,7 +124,6 @@ dialog.projectAccess.confirm = Ändrar du tillgångsläge så kommer du att änd
 dialog.publish = Publiceringsvägvisaren
 dialog.publish.addSchedule = Lägg till publiceringsplan
 dialog.publish.changesReady = Dina ändringar är redo att publiceras
-dialog.publish.dependants = Andra element som blir publicerat
 dialog.publish.exclude.noPermissions = Uteslut objekt som inte har rättigheter
 dialog.publish.excludeFromPublishing = Exkludera från publicering
 dialog.publish.excluded.hide = Göm exkluderade objekt


### PR DESCRIPTION
Adds the tri-state "All (N)" batch-select checkbox to the dependencies list, shared across the Publish, Request Publish, Create Issue, and Issue Details dialogs.

- New `DependantsSelectAll` component and `dependantsSelection` util (`calcDependantsSelection`, `nextDependantExclusions`), with a read-model and toggle command per dialog store.
- Checkbox shows the total dependant count, reflects all/none/partial selection, and is checked and disabled when every dependant is mandatory.
- Renames the publish dependants header to "Dependencies" and removes the now-unused `dialog.publish.dependants` phrase from all locales.
- Spacing relies on 8px paddings instead of negative margins; the empty-list placeholder is padded to match.
- Unit tests for the selection util plus per-store wiring tests for all four dialogs.

Closes #10868

<sub>*Drafted with AI assistance*</sub>
