### PR TITLE
Attachment validator #10776

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/attachment-uploader/AttachmentUploaderInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/attachment-uploader/AttachmentUploaderInput.tsx
@@ -2,6 +2,7 @@ import {type ChangeEvent, type DragEvent as ReactDragEvent, type ReactElement, u
 import {type SelfManagedComponentProps} from '@enonic/lib-admin-ui/form2';
 import {type AttachmentUploaderConfig} from './AttachmentUploaderConfig';
 import {useAttachmentUploader} from './useAttachmentUploader';
+import {useAttachmentServerErrors} from './useAttachmentServerErrors';
 import {useI18n} from '../../../../hooks/useI18n';
 import {AttachmentUploaderButton} from './AttachmentUploaderButton';
 import {AttachmentUploaderList} from './AttachmentUploaderList';
@@ -22,6 +23,7 @@ export const AttachmentUploaderInput = ({
     const noAttachmentLabel = useI18n('field.content.noattachment');
     const uploadLabel = useI18n('action.upload');
     const attachmentNames: string[] = useMemo(() => values.filter((v) => v.isNotNull()).map((v) => v.getString()), [values]);
+    const serverErrors = useAttachmentServerErrors(attachmentNames);
     const [isDragging, setIsDragging] = useState(false);
     const {progress, canUpload, isUploading, isMultiple, contentId, handleFiles, handleRemove} = useAttachmentUploader({
         values,
@@ -97,6 +99,7 @@ export const AttachmentUploaderInput = ({
                     contentId={contentId}
                     onRemove={handleRemove}
                     disabled={!enabled}
+                    errors={serverErrors}
                 />
                 {attachmentNames.length === 0 && !isUploading && <p className="text-subtle text-center py-2">{noAttachmentLabel}</p>}
             </div>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/attachment-uploader/AttachmentUploaderList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/attachment-uploader/AttachmentUploaderList.tsx
@@ -1,5 +1,6 @@
 import {type ReactElement} from 'react';
 import {cn, GridList, IconButton, Link} from '@enonic/ui';
+import {FieldError} from '@enonic/lib-admin-ui/form2';
 import {X} from 'lucide-react';
 import {getCmsApiUrl} from '../../../../utils/url/cms';
 
@@ -8,24 +9,29 @@ export type AttachmentUploaderListProps = {
     contentId: string | undefined;
     onRemove: (index: number) => void;
     disabled: boolean;
+    errors?: ReadonlyMap<string, string>;
 };
 
-export const AttachmentUploaderList = ({contentId, names, onRemove, disabled}: AttachmentUploaderListProps): ReactElement => {
+export const AttachmentUploaderList = ({contentId, names, onRemove, disabled, errors}: AttachmentUploaderListProps): ReactElement => {
     if (names.length === 0) return null;
 
     return (
         <GridList disabled={disabled} className="rounded p-2 -m-2">
             {names.map((name, index) => {
                 const url = getCmsApiUrl(`media/${contentId}/${encodeURIComponent(name)}`);
+                const error = errors?.get(name);
 
                 return (
                     <GridList.Row key={name} id={index.toString()} className={cn('flex items-center justify-between gap-2 py-1')}>
                         <GridList.Cell>
-                            <GridList.Action>
-                                <Link className="flex items-center gap-2 truncate" href={url} target="_blank">
-                                    {name}
-                                </Link>
-                            </GridList.Action>
+                            <div className="flex flex-col gap-0.5 min-w-0">
+                                <GridList.Action>
+                                    <Link className="flex items-center gap-2 truncate" href={url} target="_blank">
+                                        {name}
+                                    </Link>
+                                </GridList.Action>
+                                {error && <FieldError message={error} className="text-sm" />}
+                            </div>
                         </GridList.Cell>
                         <GridList.Cell>
                             <GridList.Action>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/attachment-uploader/useAttachmentServerErrors.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/attachment-uploader/useAttachmentServerErrors.ts
@@ -1,0 +1,17 @@
+import {useMemo} from 'react';
+import {useStore} from '@nanostores/preact';
+import {$attachmentServerErrorEntries} from '../../../../store/wizardValidation.store';
+
+export function useAttachmentServerErrors(names: string[]): ReadonlyMap<string, string> {
+    const entries = useStore($attachmentServerErrorEntries);
+
+    return useMemo(() => {
+        const map = new Map<string, string>();
+        for (const entry of entries) {
+            if (names.includes(entry.attachment) && !map.has(entry.attachment)) {
+                map.set(entry.attachment, entry.message);
+            }
+        }
+        return map;
+    }, [entries, names]);
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/attachment-uploader/useAttachmentUploader.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/attachment-uploader/useAttachmentUploader.ts
@@ -10,6 +10,7 @@ import {
     type UploadAttachmentSuccess,
 } from '../../../../api/uploadAttachment';
 import {$uploads, addUpload, completeUpload, failUpload, updateUploadProgress} from '../../../../store/uploads.store';
+import {clearAttachmentServerError} from '../../../../store/wizardValidation.store';
 import {listenKeys} from 'nanostores';
 import {$contextContent} from '../../../../store/context/contextContent.store';
 import {$wizardDraftPage} from '../../../../store/wizardContent.store';
@@ -156,6 +157,7 @@ export const useAttachmentUploader = ({values, onAdd, onRemove, occurrences, inp
 
             if (inUse) {
                 onRemove(index);
+                clearAttachmentServerError(attachmentName);
                 fireContentRequiresSaveEvent(contentId);
                 return;
             }
@@ -165,6 +167,7 @@ export const useAttachmentUploader = ({values, onAdd, onRemove, occurrences, inp
             result.match(
                 () => {
                     onRemove(index);
+                    clearAttachmentServerError(attachmentName);
                     fireContentRequiresSaveEvent(contentId);
                 },
                 (error) => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.test.ts
@@ -18,9 +18,11 @@ import {
     setDraftDisplayName,
 } from './wizardContent.store';
 import {
+    $attachmentServerErrorEntries,
     $invalidTabs,
-    $serverErrorEntries,
+    $dataServerErrorEntries,
     $validationVisibility,
+    clearAttachmentServerError,
     clearServerErrorsAtPath,
     clearServerErrorsForField,
     escalateVisibility,
@@ -316,7 +318,7 @@ describe('wizardValidation.store', () => {
 
             setServerValidationErrors([serverError('long[1]', 'The value is not allowed')]);
 
-            expect($serverErrorEntries.get()).toEqual([{path: 'long[1]', message: 'The value is not allowed'}]);
+            expect($dataServerErrorEntries.get()).toEqual([{path: 'long[1]', message: 'The value is not allowed'}]);
         });
 
         it('should ignore system errors (built-in) and keep custom-app errors', () => {
@@ -334,7 +336,7 @@ describe('wizardValidation.store', () => {
 
             setServerValidationErrors([systemError, customError]);
 
-            expect($serverErrorEntries.get()).toEqual([{path: 'long', message: 'Custom app message'}]);
+            expect($dataServerErrorEntries.get()).toEqual([{path: 'long', message: 'Custom app message'}]);
         });
 
         it('should NOT clear server errors when the data version bumps (regression)', () => {
@@ -344,7 +346,7 @@ describe('wizardValidation.store', () => {
             // Simulate any field edit bumping the data version.
             $wizardDataVersion.set($wizardDataVersion.get() + 1);
 
-            expect($serverErrorEntries.get()).toEqual([{path: 'long[1]', message: 'bad'}]);
+            expect($dataServerErrorEntries.get()).toEqual([{path: 'long[1]', message: 'bad'}]);
         });
 
         it('clearServerErrorsAtPath should drop only the matching occurrence', () => {
@@ -353,7 +355,7 @@ describe('wizardValidation.store', () => {
 
             clearServerErrorsAtPath('mySet[1].title');
 
-            expect($serverErrorEntries.get()).toEqual([{path: 'mySet', message: 'a'}]);
+            expect($dataServerErrorEntries.get()).toEqual([{path: 'mySet', message: 'a'}]);
         });
 
         it('clearServerErrorsForField should drop every occurrence of the field only', () => {
@@ -366,7 +368,80 @@ describe('wizardValidation.store', () => {
 
             clearServerErrorsForField('mySet');
 
-            expect($serverErrorEntries.get()).toEqual([{path: 'other', message: 'c'}]);
+            expect($dataServerErrorEntries.get()).toEqual([{path: 'other', message: 'c'}]);
+        });
+    });
+
+    describe('attachment server validation errors', () => {
+        const attachmentError = (attachment: string, message: string, errorCode?: string) => {
+            const builder = ValidationError.create().setAttachment(attachment).setMessage(message);
+            if (errorCode) {
+                builder.setErrorCode(errorCode);
+            }
+            return builder.build();
+        };
+
+        it('should expose attachment server errors as attachment/message entries', () => {
+            setupWizard();
+
+            setServerValidationErrors([attachmentError('a.pdf', 'File too large')]);
+
+            expect($attachmentServerErrorEntries.get()).toEqual([{attachment: 'a.pdf', message: 'File too large'}]);
+        });
+
+        it('should mark the content tab invalid when an attachment error is present', () => {
+            setupWizard();
+            expect($invalidTabs.get().has('content')).toBe(false);
+
+            setServerValidationErrors([attachmentError('a.pdf', 'File too large')]);
+
+            expect($invalidTabs.get().has('content')).toBe(true);
+        });
+
+        it('should keep system attachment errors (no client-side equivalent in v6)', () => {
+            setupWizard();
+
+            setServerValidationErrors([attachmentError('a.pdf', 'System message', 'system:cms.attachmentInvalid')]);
+
+            expect($attachmentServerErrorEntries.get()).toEqual([{attachment: 'a.pdf', message: 'System message'}]);
+        });
+
+        it('should NOT clear attachment errors when the data version bumps (regression)', () => {
+            setupWizard();
+            setServerValidationErrors([attachmentError('a.pdf', 'bad')]);
+
+            $wizardDataVersion.set($wizardDataVersion.get() + 1);
+
+            expect($attachmentServerErrorEntries.get()).toEqual([{attachment: 'a.pdf', message: 'bad'}]);
+        });
+
+        it('clearAttachmentServerError should drop only the matching attachment', () => {
+            setupWizard();
+            setServerValidationErrors([attachmentError('a.pdf', 'a'), attachmentError('b.pdf', 'b')]);
+
+            clearAttachmentServerError('a.pdf');
+
+            expect($attachmentServerErrorEntries.get()).toEqual([{attachment: 'b.pdf', message: 'b'}]);
+        });
+
+        it('clearAttachmentServerError should re-validate the content tab once the last error is gone', () => {
+            setupWizard();
+            setServerValidationErrors([attachmentError('a.pdf', 'a')]);
+            expect($invalidTabs.get().has('content')).toBe(true);
+
+            clearAttachmentServerError('a.pdf');
+
+            expect($invalidTabs.get().has('content')).toBe(false);
+        });
+
+        it('resetValidation should clear attachment errors', () => {
+            setupWizard();
+            setServerValidationErrors([attachmentError('a.pdf', 'a')]);
+            expect($attachmentServerErrorEntries.get()).toHaveLength(1);
+
+            resetValidation();
+
+            expect($attachmentServerErrorEntries.get()).toEqual([]);
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.ts
@@ -1,4 +1,4 @@
-import {ComponentConfigValidationError, DataValidationError, MixinConfigValidationError, SiteConfigValidationError, type ValidationError} from '@enonic/lib-admin-ui/ValidationError';
+import {AttachmentValidationError, ComponentConfigValidationError, DataValidationError, MixinConfigValidationError, SiteConfigValidationError, type ValidationError} from '@enonic/lib-admin-ui/ValidationError';
 import {matchesFieldPath, matchesOccurrencePath, type RawValueMap, type ServerErrorEntry, type ValidationVisibility, validateForm} from '@enonic/lib-admin-ui/form2';
 import {atom, computed} from 'nanostores';
 import type {PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
@@ -33,14 +33,20 @@ export const $invalidTabs = atom<ReadonlySet<string>>(new Set());
 
 export const $invalidComponentPaths = atom<ReadonlySet<string>>(new Set());
 
-const $contentServerErrors = atom<DataValidationError[]>([]);
+const $dataServerErrors = atom<DataValidationError[]>([]);
 
-// Server content errors flattened for the form fields to display by data path.
-export const $serverErrorEntries = computed($contentServerErrors, (errors): ServerErrorEntry[] =>
+// Server data errors flattened for the form fields to display by data path.
+export const $dataServerErrorEntries = computed($dataServerErrors, (errors): ServerErrorEntry[] =>
     errors.map((e) => ({path: e.getPropertyPath(), message: e.getMessage()})),
 );
 
 const $componentConfigErrors = atom<ComponentConfigValidationError[]>([]);
+
+const $attachmentServerErrors = atom<AttachmentValidationError[]>([]);
+
+export const $attachmentServerErrorEntries = computed($attachmentServerErrors, (errors): {attachment: string; message: string}[] =>
+    errors.map((e) => ({attachment: e.getAttachment(), message: e.getMessage()})),
+);
 
 const contentRawValueMap: RawValueMap = new Map();
 
@@ -58,7 +64,7 @@ function runValidation(): void {
     const draftMixins = $wizardDraftMixins.get();
     const descriptors = $mixinsDescriptors.get();
     const enabledNames = $enabledMixinsNames.get();
-    const contentServerErrors = $contentServerErrors.get();
+    const dataServerErrors = $dataServerErrors.get();
 
     if (!contentType || !draftData) {
         setWizardFormValidation(true);
@@ -69,13 +75,14 @@ function runValidation(): void {
 
     const contentResult = validateForm(contentType.getForm(), draftData.getRoot(), {
         rawValues: contentRawValueMap,
-        serverErrors: contentServerErrors,
+        serverErrors: dataServerErrors,
     });
 
     const nextInvalidTabs = new Set<string>();
     const hasInvalidDisplayName = $wizardDraftDisplayName.get().trim().length === 0;
+    const hasAttachmentErrors = $attachmentServerErrors.get().length > 0;
 
-    if (!contentResult.isValid || hasInvalidDisplayName) {
+    if (!contentResult.isValid || hasInvalidDisplayName || hasAttachmentErrors) {
         nextInvalidTabs.add('content');
     }
 
@@ -113,7 +120,7 @@ function runValidation(): void {
 
     $invalidComponentPaths.set(allInvalidPaths);
     $invalidTabs.set(nextInvalidTabs);
-    setWizardFormValidation(contentResult.isValid && allMixinsValid && allInvalidPaths.size === 0);
+    setWizardFormValidation(contentResult.isValid && allMixinsValid && allInvalidPaths.size === 0 && !hasAttachmentErrors);
 
 }
 
@@ -318,12 +325,10 @@ function isSystemError(error: ValidationError): boolean {
 }
 
 export function setServerValidationErrors(errors: ValidationError[]): void {
-    // ! Only DataValidationError has a propertyPath that validateForm can match
-    // ! against content form fields. Base ValidationError and AttachmentValidationError
-    // ! return null from getPropertyPath(), which would crash matchServerErrors.
-    // ! System (built-in) errors are dropped — client-side validation covers them with
-    // ! clearer messages; keeping them would also make them sticky until the next save.
-    const contentErrors = errors.filter(
+    // ! Data errors route by propertyPath; attachment errors (null path) route by file
+    // ! name. Data system errors are dropped (client-side validation covers them better),
+    // ! but attachment ones are kept — v6 has no client-side check to re-surface them.
+    const dataErrors = errors.filter(
         (e): e is DataValidationError => e instanceof DataValidationError
             && !(e instanceof ComponentConfigValidationError)
             && !(e instanceof SiteConfigValidationError)
@@ -334,18 +339,24 @@ export function setServerValidationErrors(errors: ValidationError[]): void {
     const componentErrors = errors.filter(
         (e): e is ComponentConfigValidationError => e instanceof ComponentConfigValidationError,
     );
-    $contentServerErrors.set(contentErrors);
+
+    const attachmentErrors = errors.filter(
+        (e): e is AttachmentValidationError => e instanceof AttachmentValidationError,
+    );
+
+    $dataServerErrors.set(dataErrors);
     $componentConfigErrors.set(componentErrors);
+    $attachmentServerErrors.set(attachmentErrors);
     runValidation();
 }
 
 // Drop the server errors on an edited occurrence's data path (and its descendants).
 export function clearServerErrorsAtPath(occurrencePath: string): void {
-    const current = $contentServerErrors.get();
+    const current = $dataServerErrors.get();
     const next = current.filter((e) => !matchesOccurrencePath(e.getPropertyPath(), occurrencePath));
     if (next.length === current.length) return;
 
-    $contentServerErrors.set(next);
+    $dataServerErrors.set(next);
     runValidation();
 }
 
@@ -353,11 +364,20 @@ export function clearServerErrorsAtPath(occurrencePath: string): void {
 // occurrence changes (add/remove/move), where positional alignment is lost;
 // fresh errors arrive on the next save.
 export function clearServerErrorsForField(fieldPath: string): void {
-    const current = $contentServerErrors.get();
+    const current = $dataServerErrors.get();
     const next = current.filter((e) => !matchesFieldPath(e.getPropertyPath(), fieldPath));
     if (next.length === current.length) return;
 
-    $contentServerErrors.set(next);
+    $dataServerErrors.set(next);
+    runValidation();
+}
+
+export function clearAttachmentServerError(attachment: string): void {
+    const current = $attachmentServerErrors.get();
+    const next = current.filter((e) => e.getAttachment() !== attachment);
+    if (next.length === current.length) return;
+
+    $attachmentServerErrors.set(next);
     runValidation();
 }
 
@@ -394,8 +414,9 @@ export function resetValidation(): void {
     $validationVisibility.set('none');
     $invalidTabs.set(new Set());
     $invalidComponentPaths.set(new Set());
-    $contentServerErrors.set([]);
+    $dataServerErrors.set([]);
     $componentConfigErrors.set([]);
+    $attachmentServerErrors.set([]);
     contentRawValueMap.clear();
     mixinRawValueMaps.clear();
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/ContentForm.tsx
@@ -5,7 +5,7 @@ import {FormRenderer} from '../../../shared/form';
 import {useBreakpoints} from '../../../hooks/useBreakpoints';
 import {getAiFieldRegistry} from '../../../store/ai/ai.field-registry';
 import {$contentType, $wizardDraftData, $wizardReadOnly, notifyContentFormMounted} from '../../../store/wizardContent.store';
-import {$serverErrorEntries, $validationVisibility, clearServerErrorsAtPath, clearServerErrorsForField, getContentRawValueMap} from '../../../store/wizardValidation.store';
+import {$dataServerErrorEntries, $validationVisibility, clearServerErrorsAtPath, clearServerErrorsForField, getContentRawValueMap} from '../../../store/wizardValidation.store';
 import {DisplayNameInput} from './DisplayNameInput';
 import {ImageUploaderDescriptor} from '../../../shared/form/input-types/image-uploader';
 
@@ -15,7 +15,7 @@ export const ContentForm = (): ReactElement | null => {
     const contentType = useStore($contentType);
     const draftData = useStore($wizardDraftData);
     const visibility = useStore($validationVisibility);
-    const serverErrorEntries = useStore($serverErrorEntries);
+    const dataServerErrorEntries = useStore($dataServerErrorEntries);
     const readOnly = useStore($wizardReadOnly);
     const {lg} = useBreakpoints();
 
@@ -56,7 +56,7 @@ export const ContentForm = (): ReactElement | null => {
                 <RawValueProvider map={rawValueMap}>
                     <FieldRegistryProvider registry={fieldRegistry}>
                         <ServerErrorsProvider
-                            entries={serverErrorEntries}
+                            entries={dataServerErrorEntries}
                             clear={clearServerErrorsAtPath}
                             clearField={clearServerErrorsForField}
                         >


### PR DESCRIPTION
`AttachmentValidationError` carries only a file name (no property path), so it never fit the path-based form2 channel and was dropped. It now goes to a dedicated `$attachmentServerErrors` channel; each `AttachmentUploader` matches errors against the file names it shows and renders them inline via `FieldError`. While any attachment error is present the content tab is invalid and the wizard validity flag is cleared; the error clears on removal and a fresh set arrives on the next save. Also renamed the data-error channel (`$contentServerErrors` → `$dataServerErrors`) to disambiguate it from the attachment and component-config channels.

NB: this pull only fixes regression, we used to show this error on AttachmentUploader in legacy code. Further improvements, like showing the list of attachment errors in a separate area, to be discussed/done in a separate task.