### PR TITLE
Content Selector - Incorrect behaviour of allowContentType with type that does not match any content type  #9537

### DIFF
--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
@@ -18,6 +18,7 @@ import com.enonic.xp.site.Site;
 import com.google.common.base.Preconditions;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -69,26 +70,17 @@ public class ContentSelectorQueryJsonToContentQueryConverter
 
         if ( applicationKey != null )
         {
-            final ContentTypeNames filtered = this.filterContentTypeNames( applicationKey );
+            final ContentTypeNames matching = this.getMatchingContentTypeNames( applicationKey );
 
-            // A non-empty config that resolves to no existing type must still constrain the
-            // query (match nothing), not drop the constraint and return everything. Keep the
-            // configured names (qualified with the app key) so the query yields no matches.
-            return filtered.isEmpty() ? this.resolveConfiguredContentTypeNames( applicationKey ) : filtered;
+            return matching.isEmpty() ? nonMatchingContentTypeName( applicationKey ) : matching;
         }
 
         return contentTypeNames.stream().map( ContentTypeName::from ).collect( ContentTypeNames.collector() );
     }
 
-    private ContentTypeNames resolveConfiguredContentTypeNames( final ApplicationKey applicationKey )
+    private static ContentTypeNames nonMatchingContentTypeName( final ApplicationKey applicationKey )
     {
-        // Wildcards cannot denote a concrete content type, so they are dropped. 
-        // Bare names are qualified with the application key.
-        return this.contentQueryJson.getContentTypeNames()
-            .stream()
-            .filter( name -> !name.contains( "*" ) )
-            .map( name -> name.contains( ":" ) ? ContentTypeName.from( name ) : ContentTypeName.from( applicationKey, name ) )
-            .collect( ContentTypeNames.collector() );
+        return ContentTypeNames.from( ContentTypeName.from( applicationKey, "non-matching-" + UUID.randomUUID() ) );
     }
 
     private ApplicationKey getApplicationKey()
@@ -106,7 +98,7 @@ public class ContentSelectorQueryJsonToContentQueryConverter
         return null;
     }
 
-    private ContentTypeNames filterContentTypeNames( final ApplicationKey applicationKey )
+    private ContentTypeNames getMatchingContentTypeNames( final ApplicationKey applicationKey )
     {
         final ApplicationWildcardMatcher<ContentTypeName> wildcardMatcher =
             new ApplicationWildcardMatcher<>( applicationKey, ContentTypeName::toString );

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
@@ -69,10 +69,26 @@ public class ContentSelectorQueryJsonToContentQueryConverter
 
         if ( applicationKey != null )
         {
-            return this.filterContentTypeNames( applicationKey );
+            final ContentTypeNames filtered = this.filterContentTypeNames( applicationKey );
+
+            // A non-empty config that resolves to no existing type must still constrain the
+            // query (match nothing), not drop the constraint and return everything. Keep the
+            // configured names (qualified with the app key) so the query yields no matches.
+            return filtered.isEmpty() ? this.resolveConfiguredContentTypeNames( applicationKey ) : filtered;
         }
 
         return contentTypeNames.stream().map( ContentTypeName::from ).collect( ContentTypeNames.collector() );
+    }
+
+    private ContentTypeNames resolveConfiguredContentTypeNames( final ApplicationKey applicationKey )
+    {
+        // Wildcards cannot denote a concrete content type, so they are dropped. 
+        // Bare names are qualified with the application key.
+        return this.contentQueryJson.getContentTypeNames()
+            .stream()
+            .filter( name -> !name.contains( "*" ) )
+            .map( name -> name.contains( ":" ) ? ContentTypeName.from( name ) : ContentTypeName.from( applicationKey, name ) )
+            .collect( ContentTypeNames.collector() );
     }
 
     private ApplicationKey getApplicationKey()

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverterTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverterTest.java
@@ -32,6 +32,7 @@ import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.site.Site;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class ContentSelectorQueryJsonToContentQueryConverterTest
 {
@@ -256,6 +257,41 @@ public class ContentSelectorQueryJsonToContentQueryConverterTest
         assertEquals( "(_path LIKE '/content/path1*' AND (fulltext('displayName^5,_name^3,_alltext', 'check', 'AND') " +
                           "OR ngram('displayName^5,_name^3,_alltext', 'check', 'AND'))) ORDER BY _modifiedtime DESC",
                       contentQuery.getQueryExpr().toString() );
+    }
+
+    @Test
+    public void testAllowTypeThatMatchesNoContentType()
+    {
+        Mockito.when( contentTypeService.getAll() ).thenReturn( ContentTypes.from( createContentType( "myApplication:comment" ) ) );
+
+        final List<String> contentTypeNames = List.of( "myApplication:ghost" );
+
+        final List<String> allowPaths = List.of( "/path/to/parent" );
+
+        ContentSelectorQueryJson contentQueryJson = new ContentSelectorQueryJson( "", 0, 100, "summary", "content-id", "inputName",
+                                                                                  contentTypeNames, allowPaths, "myApplication" );
+
+        final ContentQuery contentQuery = getProcessor( contentQueryJson ).createQuery();
+
+        assertFalse( contentQuery.getContentTypes().isEmpty() );
+        assertFalse( contentQuery.getContentTypes().contains( ContentTypeName.from( "myApplication:comment" ) ) );
+    }
+
+    @Test
+    public void testAllowTypeWildcardThatMatchesNoContentType()
+    {
+        Mockito.when( contentTypeService.getAll() ).thenReturn( ContentTypes.from( createContentType( "otherApplication:article" ) ) );
+
+        final List<String> contentTypeNames = List.of( "myApplication:*" );
+
+        final List<String> allowPaths = List.of( "/path/to/parent" );
+
+        ContentSelectorQueryJson contentQueryJson = new ContentSelectorQueryJson( "", 0, 100, "summary", "content-id", "inputName",
+                                                                                  contentTypeNames, allowPaths, "myApplication" );
+
+        final ContentQuery contentQuery = getProcessor( contentQueryJson ).createQuery();
+
+        assertFalse( contentQuery.getContentTypes().isEmpty() );
     }
 
     private Content createContent( final String id, final String name, final ContentTypeName contentTypeName )


### PR DESCRIPTION
Filtering a non-empty config against existing types returned an empty ContentTypeNames, which the query treated as 'no constraint' and returned all content in the allowPath. Now falls back to the configured names (bare names qualified with the app key, wildcards dropped) so the query yields no matches and the dropdown shows 'No matching items'