### PR TITLE
HtmlArea dialogs in Site Configurator freezes browser window #10887

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-image/HtmlAreaImageDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-image/HtmlAreaImageDialog.tsx
@@ -1,5 +1,6 @@
 import {Button, Dialog} from '@enonic/ui';
-import {type ReactElement} from 'react';
+import {useEffect, type ReactElement} from 'react';
+import {registerHtmlAreaContextDialogOpen} from '../../../store/dialogs/htmlAreaModal.store';
 import {type CreateHtmlAreaContentDialogEvent} from '../../../../../app/inputtype/ui/text/CreateHtmlAreaContentDialogEvent';
 import {type CreateHtmlAreaDialogEvent, HtmlAreaDialogType} from '../../../../../app/inputtype/ui/text/CreateHtmlAreaDialogEvent';
 import type {DialogOverrides} from '../../form/input-types/html-area/setupEditor';
@@ -15,6 +16,11 @@ const DIALOG_NAME = 'HtmlAreaImageDialog';
 
 const HtmlAreaImageDialogInner = (): ReactElement => {
     const {state: {open}, isEditing, canSubmit, close, submit} = useHtmlAreaImageDialogContext();
+
+    useEffect(() => {
+        if (!open) return;
+        return registerHtmlAreaContextDialogOpen();
+    }, [open]);
 
     const title = useI18n('dialog.image.title');
     const insertLabel = useI18n('action.insert');

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-link/HtmlAreaLinkDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-link/HtmlAreaLinkDialog.tsx
@@ -1,5 +1,6 @@
 import {Button, Dialog, IdProvider} from '@enonic/ui';
-import {type ReactElement} from 'react';
+import {useEffect, type ReactElement} from 'react';
+import {registerHtmlAreaContextDialogOpen} from '../../../store/dialogs/htmlAreaModal.store';
 import {type CreateHtmlAreaContentDialogEvent} from '../../../../../app/inputtype/ui/text/CreateHtmlAreaContentDialogEvent';
 import {type CreateHtmlAreaDialogEvent, HtmlAreaDialogType} from '../../../../../app/inputtype/ui/text/CreateHtmlAreaDialogEvent';
 import type {DialogOverrides} from '../../form/input-types/html-area/setupEditor';
@@ -17,6 +18,11 @@ const INNER_NAME = `${DIALOG_NAME}Inner`;
 
 const HtmlAreaLinkDialogInner = (): ReactElement => {
     const {state: {open, isEditing}, canSubmit, close, submit} = useHtmlAreaLinkDialogContext();
+
+    useEffect(() => {
+        if (!open) return;
+        return registerHtmlAreaContextDialogOpen();
+    }, [open]);
 
     const title = useI18n('dialog.link.title');
     const insertLabel = useI18n('action.insert');

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-macro/HtmlAreaMacroDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-macro/HtmlAreaMacroDialog.tsx
@@ -1,5 +1,6 @@
 import {Button, Dialog} from '@enonic/ui';
-import {type ReactElement} from 'react';
+import {useEffect, type ReactElement} from 'react';
+import {registerHtmlAreaContextDialogOpen} from '../../../store/dialogs/htmlAreaModal.store';
 import {type CreateHtmlAreaDialogEvent, HtmlAreaDialogType} from '../../../../../app/inputtype/ui/text/CreateHtmlAreaDialogEvent';
 import {type CreateHtmlAreaMacroDialogEvent} from '../../../../../app/inputtype/ui/text/CreateHtmlAreaMacroDialogEvent';
 import type {MacroDialogParams} from '../../../../../app/inputtype/ui/text/HtmlEditorTypes';
@@ -16,6 +17,11 @@ const DIALOG_NAME = 'HtmlAreaMacroDialog';
 
 const HtmlAreaMacroDialogInner = (): ReactElement => {
     const {state: {open}, isEditing, canSubmit, close, submit} = useHtmlAreaMacroDialogContext();
+
+    useEffect(() => {
+        if (!open) return;
+        return registerHtmlAreaContextDialogOpen();
+    }, [open]);
 
     const title = useI18n('dialog.macro.title');
     const insertLabel = useI18n('action.insert');

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/site-configurator/SiteConfiguratorInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/site-configurator/SiteConfiguratorInput.tsx
@@ -11,7 +11,7 @@ import {type Form} from '@enonic/lib-admin-ui/form/Form';
 import type {SelfManagedComponentProps} from '@enonic/lib-admin-ui/form2';
 import {FieldError, getFirstError, validateForm} from '@enonic/lib-admin-ui/form2';
 import {type SortableGridListItemContext, SortableGridList} from '@enonic/lib-admin-ui/form2/components';
-import {Button, Dialog, IconButton} from '@enonic/ui';
+import {Button, cn, Dialog, IconButton} from '@enonic/ui';
 import {useStore} from '@nanostores/preact';
 import {Pencil, X} from 'lucide-react';
 import type {ReactElement} from 'react';
@@ -22,6 +22,7 @@ import {ProjectHelper} from '../../../../../../app/settings/data/project/Project
 import {useI18n} from '../../../../hooks/useI18n';
 import {$applications, loadApplications, reloadApplications} from '../../../../store/applications.store';
 import {$contextContent} from '../../../../store/context/contextContent.store';
+import {$isHtmlAreaModalDialogOpen, $isHtmlAreaOverlayOpen} from '../../../../store/dialogs/htmlAreaModal.store';
 import {requestMixinSeed} from '../../../../store/wizardContent.store';
 import {ConfirmationDialog} from '../../../dialogs/ConfirmationDialog';
 import {ApplicationIcon} from '../../../icons/ApplicationIcon';
@@ -202,6 +203,8 @@ export const SiteConfiguratorInput = (props: SelfManagedComponentProps<SiteConfi
 
     const handleDialogOpenChange = useCallback((open: boolean) => {
         if (open) return;
+
+        if ($isHtmlAreaOverlayOpen.get()) return;
 
         if (view === 'confirmation') {
             setView('main');
@@ -393,14 +396,22 @@ const SiteConfiguratorDialog = ({
         [editing?.appKey],
     );
 
+    const overlayOpen = useStore($isHtmlAreaOverlayOpen);
+    const modalDialogOpen = useStore($isHtmlAreaModalDialogOpen);
+
     if (!editing) return null;
 
     return (
         <Dialog.Root open onOpenChange={onOpenChange}>
             <Dialog.Portal>
-                <Dialog.Overlay />
+                {!modalDialogOpen && <Dialog.Overlay />}
                 {view === 'main' && form && (
-                    <Dialog.Content className="w-full h-full gap-6 sm:h-fit md:min-w-152 md:max-w-184 md:max-h-[85vh]">
+                    <Dialog.Content
+                        modal={!overlayOpen}
+                        className={cn(
+                            'w-full h-full gap-6 sm:h-fit md:min-w-152 md:max-w-184 md:max-h-[85vh]',
+                            modalDialogOpen && 'invisible',
+                        )}>
                         <Dialog.Header className="flex items-center gap-4">
                             <div className="flex items-center gap-3 flex-1 min-w-0">
                                 {application && (

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/htmlAreaModal.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/htmlAreaModal.store.ts
@@ -1,0 +1,44 @@
+import {atom, computed} from 'nanostores';
+import {$anchorDialog} from './anchorDialog.store';
+import {$bulletedListDialog} from './bulletedListDialog.store';
+import {$codeDialog} from './codeDialog.store';
+import {$fullscreenDialog} from './fullscreenDialog.store';
+import {$numberedListDialog} from './numberedListDialog.store';
+import {$searchPopup} from './searchPopup.store';
+import {$specialCharDialog} from './specialCharDialog.store';
+import {$tableDialog} from './tableDialog.store';
+import {$tableQuicktablePopup} from './tableQuicktablePopup.store';
+
+const $contextDialogOpenCount = atom(0);
+
+export function registerHtmlAreaContextDialogOpen(): () => void {
+    $contextDialogOpenCount.set($contextDialogOpenCount.get() + 1);
+    return () => $contextDialogOpenCount.set(Math.max(0, $contextDialogOpenCount.get() - 1));
+}
+
+export const $isHtmlAreaModalDialogOpen = computed(
+    [
+        $anchorDialog,
+        $bulletedListDialog,
+        $codeDialog,
+        $fullscreenDialog,
+        $numberedListDialog,
+        $specialCharDialog,
+        $tableDialog,
+        $contextDialogOpenCount,
+    ],
+    (anchor, bulleted, code, fullscreen, numbered, special, table, contextCount) =>
+        contextCount > 0 ||
+        anchor.open ||
+        bulleted.open ||
+        code.open ||
+        fullscreen.open ||
+        numbered.open ||
+        special.open ||
+        table.open,
+);
+
+export const $isHtmlAreaOverlayOpen = computed(
+    [$isHtmlAreaModalDialogOpen, $searchPopup, $tableQuicktablePopup],
+    (modalOpen, search, quicktable) => modalOpen || search.open || quicktable.open,
+);


### PR DESCRIPTION
Opening an HtmlArea dialog (Insert Link/Image/Macro/Anchor/Table/etc.) or a toolbar popover (find-and-replace, quick-table) from a CKEditor hosted inside the Site Configurator dialog froze the whole tab, and other tabs running the app froze too.

#### Cause

Observed trigger chain: those dialogs and popovers are portaled to `document.body`, i.e. outside the configurator's content. An outside click (e.g. clicking the first input of the Link dialog) or an Escape key reached the configurator's `@enonic/ui` Dialog and closed it. Closing unmounted the form, which destroyed the CKEditor instance mid-operation (pausing the debugger during the freeze landed in CKEditor's `instanceDestroyed`). Preventing that close removes the freeze. 
Have to state that it I am not 100% sure that this was exact reason - all the tabs froze, performance evaluation too. 

#### Fix

While any HtmlArea overlay opened from the form is up, the Site Configurator dialog no longer closes, so the editor is never torn down.

- Goes non-modal (`modal=false`) while an overlay is open: drops its focus trap and outside-close. This also fixes inputs in the inner dialog not receiving focus — previously the configurator's focus trap stole it, and an earlier `preventDefault` on `pointerdown` suppressed native focusing.
- Escape is handled by a guard in `handleDialogOpenChange` instead of `preventDefault`, so Escape still closes the inner dialog.
- For centered modal dialogs the configurator also hides itself (content `invisible`, no overlay) so two dialogs never stack visually. Toolbar-anchored popovers keep the configurator visible, since they are anchored to the toolbar inside it.

Detection uses two reactive nanostore signals in `htmlAreaModal.store.ts`:

- `$isHtmlAreaModalDialogOpen` — centered modal dialogs → hide the host.
- `$isHtmlAreaOverlayOpen` — modal dialogs + toolbar popovers → drop the trap and block close.

#### Not done, and why

Link/Image/Macro keep their open state in React context (not a nanostore like the other seven dialogs), so they report into a small counter instead. Migrating them to nanostores to match the others is a large rewrite of their context-bound state and is out of scope for a freeze fix. The configurator must stay mounted while the inner dialog is open, because the inner dialog is structurally rendered inside the form (`FormRenderer` → `HtmlAreaInput`), and v6 has no dialog manager or single-dialog enforcement to lean on.

#### Follow-up (separate task)

- Unify HtmlArea dialog open-state behind a single store (e.g. `$htmlAreaOverlay` holding the one currently-open dialog and whether it is modal), since only one HtmlArea dialog is ever open at a time; this replaces both the per-dialog store reads and the counter.
- Handle the remaining nested case where a Macro config form contains its own HtmlArea, in which the Macro dialog itself becomes the host.

<sub>*Drafted with AI assistance*</sub>
