### PR TITLE
Common validation error #10777

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -6,7 +6,7 @@ import {type ApplicationConfig} from '@enonic/lib-admin-ui/application/Applicati
 import {AuthHelper} from '@enonic/lib-admin-ui/auth/AuthHelper';
 import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
 import {CONFIG} from '@enonic/lib-admin-ui/util/Config';
-import {showFeedback} from '@enonic/lib-admin-ui/notify/MessageBus';
+import {showFeedback, showWarning} from '@enonic/lib-admin-ui/notify/MessageBus';
 import {NotifyManager} from '@enonic/lib-admin-ui/notify/NotifyManager';
 import {type ContentTypeName} from '@enonic/lib-admin-ui/schema/content/ContentTypeName';
 import {Action} from '@enonic/lib-admin-ui/ui/Action';
@@ -52,7 +52,7 @@ import {
     setPersistedContent as setWizardPersistedContent,
     setWizardReadOnly,
 } from '../../v6/features/store/wizardContent.store';
-import {escalateVisibility, initializeValidation, setServerValidationErrors} from '../../v6/features/store/wizardValidation.store';
+import {$generalServerErrorMessages, escalateVisibility, initializeValidation, setServerValidationErrors} from '../../v6/features/store/wizardValidation.store';
 import {calcSecondaryStatus, calcTreePublishStatus} from '../../v6/features/utils/cms/content/status';
 import {type PreviewToolbarElement} from '../../v6/features/views/browse/layout/preview/PreviewToolbar';
 import {ContentWizardTabsToolbarElement} from '../../v6/features/views/wizard/content-wizard-tabs/ContentWizardTabsToolbarElement';
@@ -676,6 +676,7 @@ export class ContentWizardPanel
             );
             initializeValidation(this.isNew());
             setServerValidationErrors(this.getPersistedItem().getValidationErrors());
+            this.notifyGeneralValidationErrors();
         } else if (this.contentType) {
             setWizardContentType(this.contentType);
         }
@@ -691,6 +692,10 @@ export class ContentWizardPanel
 
         const leftPanel: Panel = this.createSplitFormAndLivePanel(this.formPanel, this.livePanel);
         return this.createWizardAndDetailsSplitPanel(leftPanel);
+    }
+
+    private notifyGeneralValidationErrors(): void {
+        $generalServerErrorMessages.get().forEach((message: string) => showWarning(message));
     }
 
     private createSplitFormAndLivePanel(firstPanel: Panel, secondPanel: Panel): SplitPanel {
@@ -1438,6 +1443,7 @@ export class ContentWizardPanel
         // carries fresh validationErrors. getCurrentItem() is the in-memory draft
         // built from the form and has none, which would wipe the errors on save.
         setServerValidationErrors(persistedItem.getValidationErrors());
+        this.notifyGeneralValidationErrors();
 
         return Q.resolve(persistedItem);
     }

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
@@ -154,7 +154,7 @@ export const $hasPage = computed($wizardDraftPage, (page) => page != null);
 
 export const $contentTypeDisplayName = computed($contentType, (contentType) => contentType?.getTitle() ?? '');
 
-const $wizardDataChanged = computed([$wizardPersistedData, $wizardDraftData, $wizardDataVersion], (persistedData, draftData): boolean => {
+export const $wizardDataChanged = computed([$wizardPersistedData, $wizardDraftData, $wizardDataVersion], (persistedData, draftData): boolean => {
     return !dataTreesEqual(persistedData, draftData);
 });
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.test.ts
@@ -13,12 +13,15 @@ import type {ContentType} from '../../../app/inputtype/schema/ContentType';
 import {ValidationError} from '@enonic/lib-admin-ui/ValidationError';
 import {
     $wizardDataVersion,
+    $wizardDraftData,
+    $wizardPersistedData,
     initializeWizardContentState,
     resetWizardContent,
     setDraftDisplayName,
 } from './wizardContent.store';
 import {
     $attachmentServerErrorEntries,
+    $generalServerErrorMessages,
     $invalidTabs,
     $dataServerErrorEntries,
     $validationVisibility,
@@ -60,6 +63,7 @@ function createMockContentType(): ContentType {
         getDisplayName: () => 'Article',
         getTitle: () => 'Article',
         getForm: () => MOCK_FORM,
+        hasDisplayNameExpression: () => false,
     } as unknown as ContentType;
 }
 
@@ -442,6 +446,101 @@ describe('wizardValidation.store', () => {
             resetValidation();
 
             expect($attachmentServerErrorEntries.get()).toEqual([]);
+        });
+    });
+
+    describe('general server validation errors', () => {
+        const generalError = (message: string, errorCode?: string) => {
+            const builder = ValidationError.create().setMessage(message);
+            if (errorCode) {
+                builder.setErrorCode(errorCode);
+            }
+            return builder.build();
+        };
+
+        it('should expose custom app general errors as messages', () => {
+            setupWizard();
+
+            setServerValidationErrors([generalError('Content is not allowed here', 'com.acme.app:notAllowed')]);
+
+            expect($generalServerErrorMessages.get()).toEqual(['Content is not allowed here']);
+        });
+
+        it('should ignore system general errors (covered by client-side validation)', () => {
+            setupWizard();
+
+            setServerValidationErrors([
+                generalError('System message', 'system:cms.someGeneralError'),
+                generalError('Custom app message', 'com.acme.app:badContent'),
+            ]);
+
+            expect($generalServerErrorMessages.get()).toEqual(['Custom app message']);
+        });
+
+        it('should mark the content tab invalid when a general error is present', () => {
+            setupWizard();
+            expect($invalidTabs.get().has('content')).toBe(false);
+
+            setServerValidationErrors([generalError('bad')]);
+
+            expect($invalidTabs.get().has('content')).toBe(true);
+        });
+
+        it('should NOT clear general errors on a bare data version bump (no user edit)', () => {
+            setupWizard();
+            setServerValidationErrors([generalError('bad')]);
+
+            $wizardDataVersion.set($wizardDataVersion.get() + 1);
+
+            expect($generalServerErrorMessages.get()).toEqual(['bad']);
+        });
+
+        it('should drop general errors once the user edits the content data', () => {
+            setupWizard();
+            setServerValidationErrors([generalError('bad')]);
+            expect($invalidTabs.get().has('content')).toBe(true);
+
+            $wizardDraftData.get()?.addString('field', 'value');
+            $wizardDataVersion.set($wizardDataVersion.get() + 1);
+
+            expect($generalServerErrorMessages.get()).toEqual([]);
+            expect($invalidTabs.get().has('content')).toBe(false);
+        });
+
+        it('should keep a general error received on save while the form was dirty', () => {
+            setupWizard();
+
+            $wizardDraftData.get()?.addString('field', 'value');
+            $wizardDataVersion.set($wizardDataVersion.get() + 1);
+
+            setServerValidationErrors([generalError('bad')]);
+            expect($invalidTabs.get().has('content')).toBe(true);
+
+            $wizardPersistedData.set($wizardDraftData.get()?.copy() ?? null);
+
+            expect($generalServerErrorMessages.get()).toEqual(['bad']);
+            expect($invalidTabs.get().has('content')).toBe(true);
+        });
+
+        it('should drop general errors once a fresh validation carries none', () => {
+            setupWizard();
+            setServerValidationErrors([generalError('bad')]);
+            expect($invalidTabs.get().has('content')).toBe(true);
+
+            setServerValidationErrors([]);
+
+            expect($generalServerErrorMessages.get()).toEqual([]);
+            expect($invalidTabs.get().has('content')).toBe(false);
+        });
+
+        it('resetValidation should clear general errors', () => {
+            setupWizard();
+            setServerValidationErrors([generalError('bad')]);
+            expect($generalServerErrorMessages.get()).toHaveLength(1);
+
+            resetValidation();
+
+            expect($generalServerErrorMessages.get()).toEqual([]);
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardValidation.store.ts
@@ -10,6 +10,7 @@ import {
     $contentType,
     $enabledMixinsNames,
     $mixinsDescriptors,
+    $wizardDataChanged,
     $wizardDataVersion,
     $wizardDraftData,
     $wizardDraftDisplayName,
@@ -48,6 +49,12 @@ export const $attachmentServerErrorEntries = computed($attachmentServerErrors, (
     errors.map((e) => ({attachment: e.getAttachment(), message: e.getMessage()})),
 );
 
+const $generalServerErrors = atom<ValidationError[]>([]);
+
+export const $generalServerErrorMessages = computed($generalServerErrors, (errors): string[] =>
+    errors.map((e) => e.getMessage()),
+);
+
 const contentRawValueMap: RawValueMap = new Map();
 
 const mixinRawValueMaps = new Map<string, RawValueMap>();
@@ -81,8 +88,9 @@ function runValidation(): void {
     const nextInvalidTabs = new Set<string>();
     const hasInvalidDisplayName = $wizardDraftDisplayName.get().trim().length === 0;
     const hasAttachmentErrors = $attachmentServerErrors.get().length > 0;
+    const hasGeneralErrors = $generalServerErrors.get().length > 0;
 
-    if (!contentResult.isValid || hasInvalidDisplayName || hasAttachmentErrors) {
+    if (!contentResult.isValid || hasInvalidDisplayName || hasAttachmentErrors || hasGeneralErrors) {
         nextInvalidTabs.add('content');
     }
 
@@ -120,7 +128,9 @@ function runValidation(): void {
 
     $invalidComponentPaths.set(allInvalidPaths);
     $invalidTabs.set(nextInvalidTabs);
-    setWizardFormValidation(contentResult.isValid && allMixinsValid && allInvalidPaths.size === 0 && !hasAttachmentErrors);
+    setWizardFormValidation(
+        contentResult.isValid && allMixinsValid && allInvalidPaths.size === 0 && !hasAttachmentErrors && !hasGeneralErrors,
+    );
 
 }
 
@@ -226,6 +236,15 @@ function setupSubscriptions(): void {
     subscriptions.push(
         $wizardDataVersion.subscribe(() => {
             debouncedRunValidation();
+        }),
+    );
+
+    subscriptions.push(
+        $wizardDataChanged.subscribe((changed) => {
+            if (changed && $generalServerErrors.get().length > 0) {
+                $generalServerErrors.set([]);
+                runValidation();
+            }
         }),
     );
 
@@ -344,9 +363,14 @@ export function setServerValidationErrors(errors: ValidationError[]): void {
         (e): e is AttachmentValidationError => e instanceof AttachmentValidationError,
     );
 
+    const generalErrors = errors.filter(
+        (e) => !(e instanceof DataValidationError) && !(e instanceof AttachmentValidationError) && !isSystemError(e),
+    );
+
     $dataServerErrors.set(dataErrors);
     $componentConfigErrors.set(componentErrors);
     $attachmentServerErrors.set(attachmentErrors);
+    $generalServerErrors.set(generalErrors);
     runValidation();
 }
 
@@ -417,6 +441,7 @@ export function resetValidation(): void {
     $dataServerErrors.set([]);
     $componentConfigErrors.set([]);
     $attachmentServerErrors.set([]);
+    $generalServerErrors.set([]);
     contentRawValueMap.clear();
     mixinRawValueMaps.clear();
 }


### PR DESCRIPTION
Handle content-level "general" server validation errors that are not bound to any input. Previously these were dropped, so content the server marked invalid (e.g. via a custom app validator) showed a valid toolbar with no explanation.

General errors (base `ValidationError`, no property path or attachment) are now captured into the validation store and factored into the content tab and overall toolbar validity, so the wizard status reflects the content's server `valid` property on open. System errors (`system:` prefix) are excluded — client-side validation already covers them. Since these errors are field-less, their messages are shown as a notification on wizard open and after save, and they are cleared once the user edits the content data (re-validated on the next save).

Closes #10777

<sub>*Drafted with AI assistance*</sub>
