### PR TITLE
Publishing Wizard occasionally shows disabled "Publish now" with no status #10901

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.test.ts
@@ -35,6 +35,7 @@ import {
     togglePublishDialogShowExcluded,
 } from './publishDialog.store';
 import {
+    createDeferredPromise,
     createMockChangeItem,
     createMockContent,
     createResolveResult,
@@ -155,6 +156,41 @@ describe('publishDialog.store', () => {
         expect($publishCheckErrors.get().inProgress.count).toBe(0);
         expect($isPublishReady.get()).toBe(true);
         expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps publishable state consistent when an in-flight reload is superseded', async () => {
+        // Race: the open-time resolve is still in flight when an external update
+        // triggers a second resolve. The latest (update) resolve must win — the
+        // stale one's cleanup must not invalidate it, leaving 0 publishable items.
+        const itemId = new ContentId('item-1');
+        const original = createMockContent('item-1', {displayName: 'Original name'});
+        const updated = createMockContent('item-1', {displayName: 'Updated name'});
+
+        const openResolve = createDeferredPromise<ReturnType<typeof createResolveResult>>();
+        const updateResolve = createDeferredPromise<ReturnType<typeof createResolveResult>>();
+        mockResolvePublishDependencies
+            .mockReturnValueOnce(openResolve.promise)
+            .mockReturnValueOnce(updateResolve.promise);
+
+        // Reload A: opening starts the first resolve, left in flight.
+        openPublishDialog([original]);
+        await flushPromises();
+
+        // Reload B: an external update lands before A's resolve settles.
+        emitContentUpdated([updated]);
+        await vi.advanceTimersByTimeAsync(150);
+        await flushPromises();
+
+        expect(mockResolvePublishDependencies).toHaveBeenCalledTimes(2);
+
+        // Settle the stale reload first, then the fresh one.
+        openResolve.resolve(createResolveResult({publishable: [itemId]}));
+        await flushPromises(10);
+        updateResolve.resolve(createResolveResult({publishable: [itemId]}));
+        await flushPromises(10);
+
+        expect($totalPublishableItems.get()).toBe(1);
+        expect($isPublishReady.get()).toBe(true);
     });
 
     it('patches renamed tracked items without forcing a dependency reload', async () => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/dialogs/publishDialog.store.ts
@@ -755,8 +755,11 @@ async function reloadPublishDialogData(): Promise<void> {
         $publishDialog.setKey('failed', true);
         // TODO: Notify error
     } finally {
+        // ! Do not bump instanceId here: resolvePublishDependencies owns the guard
+        // token. Incrementing it after a stale reload bails would also invalidate a
+        // concurrently running reload, leaving both to skip their writes (0 publishable,
+        // no banner, disabled button).
         $publishChecks.setKey('loading', false);
-        instanceId += 1;
     }
 }
 


### PR DESCRIPTION
Fixes an intermittent state where the Publishing Wizard opens with "Publish now" disabled and no status banner, leaving no way to publish and no explanation.

Root cause: a content socket event landing while the open-time dependency resolve is in flight causes two `reloadPublishDialogData` calls to overlap. The `instanceId` guard is meant to let the latest reload win, but the reload's `finally` also incremented `instanceId`; when the stale reload bailed and bumped the counter it invalidated the concurrent fresh reload's guard token, so both returned early without writing. The stores were left out of sync (`$publishableContentIds` empty, `$publishChecks` idle), yielding `totalPublishableItems === 0` with no errors — so `SelectionStatusBar` renders nothing and `$isPublishReady` is `false`.

Changes:

- Removed the redundant `instanceId += 1` from `reloadPublishDialogData`'s `finally`; the guard token is now owned solely by `resolvePublishDependencies`, so a stale reload's cleanup can no longer cancel a concurrent fresh reload.
- Added a deterministic test that forces two overlapping reloads and pins the regression.

Closes #10901

<sub>*Drafted with AI assistance*</sub>
