### PR TITLE
Publishing Wizard reverts to "Mark as ready" right after marking content ready #10905

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/services/wizardContentSync.service.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/services/wizardContentSync.service.test.ts
@@ -98,6 +98,17 @@ describe('wizardContentSync.service', () => {
         expect(mocks.sendAndParse).not.toHaveBeenCalled();
     });
 
+    it('ignores a strictly-older echo so a late in-progress event cannot revert mark-as-ready', () => {
+        // Mark-as-ready saved READY at a newer modifiedTime.
+        setWizardContent(BASE_MODIFIED_MS + 1_000, WorkflowState.READY);
+
+        // A late echo from the earlier in-progress save arrives with an older modifiedTime.
+        emitContentUpdated([summary({modifiedMs: BASE_MODIFIED_MS, workflowState: WorkflowState.IN_PROGRESS})]);
+
+        expect(mocks.applyWorkflowFromServer).not.toHaveBeenCalled();
+        expect(mocks.sendAndParse).not.toHaveBeenCalled();
+    });
+
     it('ignores an echo event whose workflow matches the wizard state', () => {
         setWizardContent(BASE_MODIFIED_MS, WorkflowState.READY);
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/services/wizardContentSync.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/services/wizardContentSync.service.ts
@@ -80,6 +80,12 @@ function handleSummaryEvent(contents: readonly ContentSummary[] | undefined): vo
     const isEcho = summaryModifiedMs != null && lastKnownModifiedTimeMs != null && summaryModifiedMs <= lastKnownModifiedTimeMs;
 
     if (isEcho) {
+        // A strictly-older echo is stale — ignore it. Applying its outdated workflow
+        // would roll back a newer state, e.g. revert READY to IN_PROGRESS after
+        // mark-as-ready when the earlier in-progress save's event arrives late.
+        if (summaryModifiedMs < lastKnownModifiedTimeMs) {
+            return;
+        }
         const summaryWorkflowState = summary.getWorkflow()?.getState() ?? null;
         if (summaryWorkflowState !== $wizardPersistedWorkflowState.get()) {
             applyWorkflowFromServer(summaryWorkflowState);


### PR DESCRIPTION
Fixes an intermittent bug where the wizard's publish button reverts to "Mark as ready" shortly after the user marks content ready and the Publish dialog opens, staying wrong until a page reload even though the server holds the content as READY.

Root cause: in `wizardContentSync.service.ts` the echo branch applied the workflow state from any `contentUpdated` echo with `modifiedTime <= lastKnownModifiedTimeMs`, including strictly-older ones. A late event from the earlier in-progress save (older modifiedTime, IN_PROGRESS) was applied via `applyWorkflowFromServer`, reverting the freshly-saved READY state. The full-fetch path was already guarded against stale responses; the echo path was not.

Changes:

- Ignore a strictly-older echo; apply the echo workflow only when its `modifiedTime` equals `lastKnownModifiedTimeMs`.
- Added a test pinning the stale-older-echo case.

Closes #10905

<sub>*Drafted with AI assistance*</sub>
