### PR TITLE
Preview content missing, legacy publish control not removed #10909

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -180,13 +180,13 @@ export class ContentWizardPanel
 
     private persistedCompareStatus: CompareStatus;
 
-    private splitPanelThreshold: number = 960;
-
     private minimized: boolean = false;
 
     private minimizedFromFormOnly: boolean = false;
 
     private isTogglingMinimize: boolean = false;
+
+    private restoreSplitViewAfterMobile: boolean = false;
 
     private contentUpdateDisabled: boolean;
 
@@ -293,6 +293,7 @@ export class ContentWizardPanel
         this.minimized = !this.minimized;
         this.splitPanel.setSplitterIsHidden(this.minimized);
         this.formPanel.toggleClass('minimized');
+        this.splitPanel.toggleClass('form-minimized', this.minimized);
 
         new MinimizeWizardPanelEvent().fire();
 
@@ -303,6 +304,10 @@ export class ContentWizardPanel
 
             this.minimizedFromFormOnly = this.splitPanel.hasClass('toggle-form');
             if (this.minimizedFromFormOnly) {
+                if (this.inMobileViewMode) {
+                    this.restoreSplitViewAfterMobile = true;
+                }
+
                 this.splitPanel.removeClass('toggle-form').addClass('toggle-split');
                 this.splitPanel.showSecondPanel();
                 this.syncPreviewPanelVisibility();
@@ -605,7 +610,6 @@ export class ContentWizardPanel
                 .setContentCanBePublished(this.checkContentCanBePublished())
                 .setIsValid(this.isContentFormValid)
                 .refreshState();
-            this.appendChild(this.getContentWizardToolbarPublishControls().getMobilePublishControls());
 
             if (this.contentType?.hasDisplayNameExpression()) {
                 this.displayNameResolver.setExpression(this.contentType.getDisplayNameExpression());
@@ -696,12 +700,9 @@ export class ContentWizardPanel
     private createSplitFormAndLivePanel(firstPanel: Panel, secondPanel: Panel): SplitPanel {
         const builder: SplitPanelBuilder = new SplitPanelBuilder(firstPanel, secondPanel)
             .setFirstPanelMinSize(SplitPanelSize.PIXELS(280))
+            .setFirstPanelSize(SplitPanelSize.PERCENTS(38))
             .setSplitterThickness(1)
             .setAlignment(SplitPanelAlignment.VERTICAL);
-
-        if ($(window).width() > this.splitPanelThreshold) {
-            builder.setFirstPanelSize(SplitPanelSize.PERCENTS(38));
-        }
 
         this.splitPanel = builder.build();
 
@@ -742,20 +743,29 @@ export class ContentWizardPanel
         if (this.isVisible()) {
             this.updateStickyToolbar();
             if (item.isInRangeOrSmaller(ResponsiveRanges._720_960)) {
+                if (!this.inMobileViewMode) {
+                    this.restoreSplitViewAfterMobile = this.restoreSplitViewAfterMobile || this.isSplitView() || this.isLiveView();
+                }
+
                 this.inMobileViewMode = true;
-                if (this.isSplitView()) {
-                    if (this.isMinimized()) {
-                        this.toggleMinimize();
-                    }
+
+                if (this.isSplitView() && !this.isMinimized()) {
                     this.showForm();
                 }
             } else {
-                if (this.inMobileViewMode && this.isLiveView()) {
+                if (this.inMobileViewMode) {
                     this.inMobileViewMode = false;
-                    this.showLiveEdit();
-                }
 
-                this.inMobileViewMode = false;
+                    if (this.restoreSplitViewAfterMobile || this.isLiveView()) {
+                        if (this.isMinimized()) {
+                            this.minimizedFromFormOnly = false;
+                        }
+
+                        this.showLiveEdit();
+                    }
+
+                    this.restoreSplitViewAfterMobile = false;
+                }
             }
         }
     }
@@ -1357,6 +1367,14 @@ export class ContentWizardPanel
         if (ContentWizardPanel.debug) {
             console.debug('ContentWizardPanel.toggleLiveEdit at ' + new Date().toISOString());
         }
+
+        if (!ResponsiveRanges._960_1200.isFitOrBigger(this.getEl().getWidth())) {
+            this.inMobileViewMode = true;
+            this.restoreSplitViewAfterMobile = !!this.contentType;
+            this.showForm();
+            return Q.resolve();
+        }
+
         return Q.allSettled([this.shouldAndCanOpenEditorByDefault(), this.hasControllers()])
             .then(([canOpenEditor, hasControllers]) => {
                 if (canOpenEditor.value || hasControllers.value) {

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardToolbarPublishControls.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardToolbarPublishControls.ts
@@ -1,6 +1,5 @@
 import {DivEl} from '@enonic/lib-admin-ui/dom/DivEl';
 import {MenuButtonDropdownPos} from '@enonic/lib-admin-ui/ui/button/MenuButton';
-import {ActionButton} from '@enonic/lib-admin-ui/ui2/ActionButton';
 import {ContentWizardPublishMenuButton} from '../browse/ContentWizardPublishMenuButton';
 import {type ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
 import {IssueDialogsManager} from '../issue/IssueDialogsManager';
@@ -12,8 +11,6 @@ export class ContentWizardToolbarPublishControls
 
     private publishButton: ContentWizardPublishMenuButton;
 
-    private mobilePublishControls: DivEl;
-
     private actions: ContentWizardActions;
 
     constructor(actions: ContentWizardActions) {
@@ -22,8 +19,6 @@ export class ContentWizardToolbarPublishControls
         this.actions = actions;
 
         this.createPublishButton(actions);
-
-        this.initMobilePublishControls();
 
         this.initListeners();
 
@@ -68,46 +63,7 @@ export class ContentWizardToolbarPublishControls
         this.publishButton.addClass('content-wizard-toolbar-publish-button');
     }
 
-    protected initMobilePublishControls() {
-        this.mobilePublishControls = new DivEl('mobile-edit-publish-controls');
-        const publishButtonForMobile = this.createPublishButtonForMobile();
-        const markAsReadyButtonForMobile = this.createMarkAsReadyButtonForMobile();
-        this.mobilePublishControls.appendChildren(publishButtonForMobile, markAsReadyButtonForMobile);
-
-        this.handleMarkAsReadyStatus();
-    }
-
-    protected createPublishButtonForMobile(): ActionButton {
-        const publishButtonForMobile = new ActionButton({
-            action: this.actions.getPublishAction(),
-            className: 'mobile-edit-publish-button',
-        });
-
-        return publishButtonForMobile;
-    }
-
-    protected createMarkAsReadyButtonForMobile(): ActionButton {
-        const markAsReadyButtonForMobile = new ActionButton({
-            action: this.actions.getMarkAsReadyAction(),
-            className: 'mobile-edit-mark-as-ready-button',
-        });
-
-        return markAsReadyButtonForMobile;
-    }
-
     protected initListeners() {
-        const publishAction = this.actions.getPublishAction();
-        const markAsReadyAction = this.actions.getMarkAsReadyAction();
-
-        publishAction.onPropertyChanged(() => {
-            this.handleControlsChanged();
-        });
-
-        markAsReadyAction.onPropertyChanged(() => {
-            this.handleControlsChanged();
-            this.handleMarkAsReadyStatus();
-        });
-
         this.actions.onBeforeActionsStashed(() => {
             this.publishButton.setRefreshDisabled(true);
         });
@@ -117,28 +73,9 @@ export class ContentWizardToolbarPublishControls
         });
     }
 
-    private handleControlsChanged() {
-        const publishAction = this.actions.getPublishAction();
-        const markAsReadyAction = this.actions.getMarkAsReadyAction();
-
-        const controlsEnabled = publishAction.isEnabled() || markAsReadyAction.isEnabled();
-        this.mobilePublishControls.toggleClass('enabled', controlsEnabled);
-    }
-
-    private handleMarkAsReadyStatus() {
-        const markAsReadyAction = this.actions.getMarkAsReadyAction();
-
-        const markAsReadyEnabled = markAsReadyAction.isEnabled();
-        this.mobilePublishControls.toggleClass('mark-as-ready', markAsReadyEnabled);
-    }
-
     setContent(content: ContentSummaryAndCompareStatus): ContentWizardToolbarPublishControls {
         this.publishButton.setItem(content);
         return this;
-    }
-
-    getMobilePublishControls(): DivEl {
-        return this.mobilePublishControls;
     }
 
     getPublishButton(): ContentWizardPublishMenuButton {

--- a/modules/lib/src/main/resources/assets/styles/browse/content-publish-menu-button.less
+++ b/modules/lib/src/main/resources/assets/styles/browse/content-publish-menu-button.less
@@ -100,8 +100,4 @@
       display: none !important;
     }
   }
-
-  .mobile-edit-publish-controls {
-    display: none;
-  }
 }

--- a/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -292,12 +292,14 @@
       &._240-360,
       &._360-540,
       &._540-720 {
-        .form-panel {
-          width: 100% !important;
-        }
+        &:not(.form-minimized) {
+          .form-panel {
+            width: 100% !important;
+          }
 
-        & > .splitter, .live-form-panel {
-          display: none !important;
+          & > .splitter, .live-form-panel {
+            display: none !important;
+          }
         }
       }
     }
@@ -453,49 +455,6 @@
   &._240-360,
   &._360-540,
   &._540-720 {
-    .mobile-edit-publish-button {
-      .button(@form-button-font, @admin-green, @form-button-font, lighten(@admin-green, 30%));
-    }
-
-    .mobile-edit-mark-as-ready-button {
-      .button(@form-button-font, @admin-yellow, @form-button-font, lighten(@admin-yellow, 30%));
-    }
-
-    .mobile-edit-publish-button,
-    .mobile-edit-mark-as-ready-button {
-      display: flex !important;
-      position: fixed;
-      bottom: 0;
-      text-align: center;
-      height: 40px;
-      width: 100%;
-      opacity: 0.9;
-      z-index: @z-index-docked-panel;
-      justify-content: center;
-
-      span {
-        font-size: 16px;
-      }
-    }
-
-    .mobile-edit-publish-controls {
-      &:not(.enabled) {
-        display: none;
-      }
-
-      &.mark-as-ready {
-        .mobile-edit-publish-button {
-          display: none !important;
-        }
-      }
-
-      &:not(.mark-as-ready) {
-        .mobile-edit-mark-as-ready-button {
-          display: none !important;
-        }
-      }
-    }
-
     .toolbar-state-icon {
       &.ready,
       &.in-progress,
@@ -525,10 +484,6 @@
   &._1380-1620,
   &._1620-1920,
   &._1920-Infinity {
-    .mobile-edit-publish-controls {
-      display: none;
-    }
-
     .content-wizard-toolbar {
       .toolbar-publish-controls {
         .content-wizard-toolbar-publish-button {


### PR DESCRIPTION
Remove legacy publish controls, let preview be visible for mobile as well as fix display of splitview, splitview with form and splitview with form toggle to ensure a better ux for narrow and wide-screen users.