### PR TITLE
ContentSelector is slow in tree mode

### DIFF
--- a/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/rest/resource/content/ContentResource.java
+++ b/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/rest/resource/content/ContentResource.java
@@ -176,6 +176,7 @@ import com.enonic.xp.extractor.ExtractedData;
 import com.enonic.xp.i18n.LocaleService;
 import com.enonic.xp.index.ChildOrder;
 import com.enonic.xp.jaxrs.JaxRsComponent;
+import com.enonic.xp.node.NodeIndexPath;
 import com.enonic.xp.query.expr.CompareExpr;
 import com.enonic.xp.query.expr.FieldExpr;
 import com.enonic.xp.query.expr.FieldOrderExpr;
@@ -1365,26 +1366,7 @@ public final class ContentResource
     @Consumes(MediaType.APPLICATION_JSON)
     public ContentTreeSelectorListJson treeSelectorQuery( final ContentTreeSelectorQueryJson contentQueryJson )
     {
-        final Integer from = contentQueryJson.getFrom();
-        contentQueryJson.setFrom( 0 );
-
-        final Integer size = contentQueryJson.getSize();
-        contentQueryJson.setSize( -1 );
-
-        final ContentPaths targetContentPaths = findContentPathsBySelectorQuery( contentQueryJson );
-
         final ContentPath parentPath = contentQueryJson.getParentPath();
-        final int parentPathSize = parentPath != null ? parentPath.elementCount() : 0;
-
-        final Set<ContentPath> layerPaths = targetContentPaths.stream()
-            .filter( path -> parentPath == null || path.isChildOf( parentPath ) )
-            .map( path -> path.getAncestorPath( path.elementCount() - parentPathSize - 1 ) )
-            .collect( Collectors.toSet() );
-
-        if ( layerPaths.isEmpty() )
-        {
-            return ContentTreeSelectorListJson.empty();
-        }
 
         final ChildOrder layerOrder = parentPath == null
             ? ContentConstants.DEFAULT_CONTENT_REPO_ROOT_ORDER
@@ -1399,20 +1381,62 @@ public final class ContentResource
                                                                                                    .size( -1 )
                                                                                                    .build() );
 
-        final List<Content> layersContents = findLayerContentsResult.getContents()
-            .stream()
-            .filter( content -> layerPaths.contains( content.getPath() ) )
-            .collect( Collectors.toList() );
+        final List<Content> children = findLayerContentsResult.getContents().stream().collect( Collectors.toList() );
 
-        final List<ContentPath> relativeTargetContentPaths =
-            targetContentPaths.stream().map( ContentPath::asRelative ).collect( Collectors.toList() );
+        if ( children.isEmpty() )
+        {
+            return ContentTreeSelectorListJson.empty();
+        }
 
-        final List<ContentTreeSelectorJson> resultItems = layersContents.stream()
-            .map( content -> new ContentTreeSelectorJson( jsonObjectsFactory.createContentJson( content ),
-                                                          relativeTargetContentPaths.contains( content.getPath().asRelative() ),
-                                                          relativeTargetContentPaths.stream()
-                                                              .anyMatch( path -> path.isChildOf( content.getPath().asRelative() ) ) ) )
-            .collect( Collectors.toList() );
+        contentQueryJson.setFrom( 0 );
+        contentQueryJson.setSize( 0 );
+
+        // Number of contents in the expanded subtree that match the selector query.
+        final long selectorMatches = countContentsBySelectorQuery( contentQueryJson, parentPath );
+
+        if ( selectorMatches == 0 )
+        {
+            return ContentTreeSelectorListJson.empty();
+        }
+
+        final List<ContentTreeSelectorJson> resultItems;
+
+        if ( selectorMatches == countContentsUnderPath( parentPath ) )
+        {
+            // Every descendant in the subtree matches the selector (e.g. plain browsing with no search/type filter).
+            // In this case all children are selectable and a child is expandable exactly when it has children, so the
+            // expensive full path scan can be skipped entirely.
+            resultItems = children.stream()
+                .map( content -> new ContentTreeSelectorJson( jsonObjectsFactory.createContentJson( content ), true,
+                                                              content.hasChildren() ) )
+                .collect( Collectors.toList() );
+        }
+        else
+        {
+            // A real filter is applied, so the matches are a small subset of the subtree. Fetch the matching paths
+            // (scoped to this subtree) and derive selectable/expandable from them, as before.
+            contentQueryJson.setSize( -1 );
+
+            final ContentPaths targetContentPaths = findContentPathsBySelectorQuery( contentQueryJson, parentPath );
+
+            final int parentPathSize = parentPath != null ? parentPath.elementCount() : 0;
+
+            final Set<ContentPath> layerPaths = targetContentPaths.stream()
+                .filter( path -> parentPath == null || path.isChildOf( parentPath ) )
+                .map( path -> path.getAncestorPath( path.elementCount() - parentPathSize - 1 ) )
+                .collect( Collectors.toSet() );
+
+            final List<ContentPath> relativeTargetContentPaths =
+                targetContentPaths.stream().map( ContentPath::asRelative ).collect( Collectors.toList() );
+
+            resultItems = children.stream()
+                .filter( content -> layerPaths.contains( content.getPath() ) )
+                .map( content -> new ContentTreeSelectorJson( jsonObjectsFactory.createContentJson( content ),
+                                                              relativeTargetContentPaths.contains( content.getPath().asRelative() ),
+                                                              relativeTargetContentPaths.stream()
+                                                                  .anyMatch( path -> path.isChildOf( content.getPath().asRelative() ) ) ) )
+                .collect( Collectors.toList() );
+        }
 
         final ContentListMetaData metaData = ContentListMetaData.create()
             .hits( findLayerContentsResult.getHits() )
@@ -1424,16 +1448,28 @@ public final class ContentResource
 
     private FindContentIdsByQueryResult findContentsBySelectorQuery( final ContentSelectorQueryJson contentQueryJson )
     {
-        return contentService.find( makeConverterFromSelectorQuery( contentQueryJson ).createQuery() );
+        return contentService.find( makeConverterFromSelectorQuery( contentQueryJson, null ).createQuery() );
     }
 
-    private ContentPaths findContentPathsBySelectorQuery( final ContentSelectorQueryJson contentQueryJson )
+    private long countContentsBySelectorQuery( final ContentSelectorQueryJson contentQueryJson, final ContentPath parentScope )
     {
-        return contentService.findPaths( makeConverterFromSelectorQuery( contentQueryJson ).createQuery() ).getContentPaths();
+        return contentService.find( makeConverterFromSelectorQuery( contentQueryJson, parentScope ).createQuery() ).getTotalHits();
+    }
+
+    private long countContentsUnderPath( final ContentPath parentPath )
+    {
+        final String pathValue = "/" + ContentConstants.CONTENT_ROOT_NAME + ( parentPath != null ? parentPath.toString() : "" ) + "/**";
+        final QueryExpr queryExpr = QueryExpr.from( CompareExpr.like( FieldExpr.from( NodeIndexPath.PATH ), ValueExpr.string( pathValue ) ) );
+        return contentService.find( ContentQuery.create().queryExpr( queryExpr ).size( 0 ).build() ).getTotalHits();
+    }
+
+    private ContentPaths findContentPathsBySelectorQuery( final ContentSelectorQueryJson contentQueryJson, final ContentPath parentScope )
+    {
+        return contentService.findPaths( makeConverterFromSelectorQuery( contentQueryJson, parentScope ).createQuery() ).getContentPaths();
     }
 
     private ContentSelectorQueryJsonToContentQueryConverter makeConverterFromSelectorQuery(
-        final ContentSelectorQueryJson contentQueryJson )
+        final ContentSelectorQueryJson contentQueryJson, final ContentPath parentScope )
     {
         return ContentSelectorQueryJsonToContentQueryConverter.create()
             .contentQueryJson( contentQueryJson )
@@ -1441,6 +1477,7 @@ public final class ContentResource
             .contentTypeService( this.contentTypeService )
             .relationshipTypeService( this.relationshipTypeService )
             .contentTypeParseMode( this.contentTypeParseMode )
+            .parentScope( parentScope )
             .build();
     }
 

--- a/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
+++ b/modules/rest/src/main/java/com/enonic/xp/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
@@ -11,6 +11,7 @@ import com.enonic.xp.app.ApplicationWildcardMatcher;
 import com.enonic.xp.app.contentstudio.rest.resource.content.json.ContentSelectorQueryJson;
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentConstants;
+import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.content.ContentQuery;
 import com.enonic.xp.content.ContentService;
 import com.enonic.xp.node.NodeIndexPath;
@@ -46,6 +47,8 @@ public class ContentSelectorQueryJsonToContentQueryConverter
 
     private final ApplicationWildcardMatcher.Mode contentTypeParseMode;
 
+    private final ContentPath parentScope;
+
     private Site parentSite;
 
     private static final FieldExpr PATH_FIELD_EXPR = FieldExpr.from( NodeIndexPath.PATH );
@@ -58,6 +61,7 @@ public class ContentSelectorQueryJsonToContentQueryConverter
         this.content = contentQueryJson.getContentId() != null ? contentService.getById( contentQueryJson.getContentId() ) : null;
         this.contentTypeService = builder.contentTypeService;
         this.contentTypeParseMode = builder.contentTypeParseMode;
+        this.parentScope = builder.parentScope;
     }
 
     public ContentQuery createQuery()
@@ -65,10 +69,29 @@ public class ContentSelectorQueryJsonToContentQueryConverter
         final ContentQuery.Builder builder = ContentQuery.create()
             .from( this.contentQueryJson.getFrom() )
             .size( this.contentQueryJson.getSize() )
-            .queryExpr( this.createQueryExpr() )
+            .queryExpr( this.applyParentScope( this.createQueryExpr() ) )
             .addContentTypeNames( this.getContentTypeNamesFromJson() );
 
         return builder.build();
+    }
+
+    private QueryExpr applyParentScope( final QueryExpr queryExpr )
+    {
+        if ( parentScope == null )
+        {
+            return queryExpr;
+        }
+
+        // Restrict the query to the descendants of the expanded node so the index only returns the relevant
+        // subtree instead of every match in the whole repository. This is a non-scoring filter (unlike pathMatch),
+        // and the result is identical because only paths within this subtree are ever consumed by the caller.
+        final CompareExpr scopeExpr = CompareExpr.like( PATH_FIELD_EXPR, ValueExpr.string(
+            "/" + ContentConstants.CONTENT_ROOT_NAME + parentScope + "/**" ) );
+
+        final ConstraintExpr constraint = queryExpr.getConstraint();
+        final ConstraintExpr combined = constraint == null ? scopeExpr : LogicalExpr.and( constraint, scopeExpr );
+
+        return QueryExpr.from( combined, queryExpr.getOrderList() );
     }
 
     private ContentTypeNames getContentTypeNamesFromJson()
@@ -249,6 +272,8 @@ public class ContentSelectorQueryJsonToContentQueryConverter
 
         private ApplicationWildcardMatcher.Mode contentTypeParseMode;
 
+        private ContentPath parentScope;
+
         public Builder contentQueryJson( final ContentSelectorQueryJson contentQueryJson )
         {
             this.contentQueryJson = contentQueryJson;
@@ -276,6 +301,12 @@ public class ContentSelectorQueryJsonToContentQueryConverter
         public Builder contentTypeParseMode( final ApplicationWildcardMatcher.Mode contentTypeParseMode )
         {
             this.contentTypeParseMode = contentTypeParseMode;
+            return this;
+        }
+
+        public Builder parentScope( final ContentPath parentScope )
+        {
+            this.parentScope = parentScope;
             return this;
         }
 

--- a/modules/rest/src/test/java/com/enonic/xp/app/contentstudio/rest/resource/content/ContentResourceTest.java
+++ b/modules/rest/src/test/java/com/enonic/xp/app/contentstudio/rest/resource/content/ContentResourceTest.java
@@ -1443,8 +1443,30 @@ public class ContentResourceTest
     {
         ContentResource contentResource = getResourceInstance();
 
-        Mockito.when( this.contentService.findPaths( Mockito.isA( ContentQuery.class ) ) )
-            .thenReturn( FindContentPathsByQueryResult.create().build() );
+        Mockito.doReturn( FindContentByParentResult.create().contents( Contents.empty() ).build() )
+            .when( this.contentService )
+            .findByParent( Mockito.isA( FindContentByParentParams.class ) );
+
+        ContentTreeSelectorQueryJson json = initContentTreeSelectorQueryJson( null );
+        ContentTreeSelectorListJson result = contentResource.treeSelectorQuery( json );
+
+        assertEquals( ContentTreeSelectorListJson.empty(), result );
+    }
+
+    @Test
+    public void treeSelectorQuery_no_matches()
+    {
+        ContentResource contentResource = getResourceInstance();
+
+        Content content1 = createContent( "content-id1", "content-name1", "myapplication:content-type" );
+
+        Mockito.doReturn( FindContentByParentResult.create().totalHits( 1L ).contents( Contents.from( content1 ) ).build() )
+            .when( this.contentService )
+            .findByParent( Mockito.isA( FindContentByParentParams.class ) );
+
+        // The selector matches nothing in the subtree.
+        Mockito.when( this.contentService.find( Mockito.isA( ContentQuery.class ) ) )
+            .thenReturn( FindContentIdsByQueryResult.create().totalHits( 0L ).build() );
 
         ContentTreeSelectorQueryJson json = initContentTreeSelectorQueryJson( null );
         ContentTreeSelectorListJson result = contentResource.treeSelectorQuery( json );
@@ -1478,6 +1500,15 @@ public class ContentResourceTest
                              .totalHits( 1 )
                              .build() );
 
+        // For every expansion: selector matches (1) < total contents in subtree (2), so the path-scan branch is used.
+        Mockito.when( this.contentService.find( Mockito.isA( ContentQuery.class ) ) )
+            .thenReturn( FindContentIdsByQueryResult.create().totalHits( 1L ).build(),
+                         FindContentIdsByQueryResult.create().totalHits( 2L ).build(),
+                         FindContentIdsByQueryResult.create().totalHits( 1L ).build(),
+                         FindContentIdsByQueryResult.create().totalHits( 2L ).build(),
+                         FindContentIdsByQueryResult.create().totalHits( 1L ).build(),
+                         FindContentIdsByQueryResult.create().totalHits( 2L ).build() );
+
         Mockito.doReturn( FindContentByParentResult.create().totalHits( 1L ).contents( Contents.from( content1 ) ).build() )
             .when( this.contentService )
             .findByParent( Mockito.isA( FindContentByParentParams.class ) );
@@ -1501,6 +1532,34 @@ public class ContentResourceTest
         json = initContentTreeSelectorQueryJson( content2.getPath() );
         result = contentResource.treeSelectorQuery( json );
         assertEquals( result.getItems().get( 0 ).getContent().getId(), content3.getId().toString() );
+    }
+
+    @Test
+    public void treeSelectorQuery_all_match_skips_path_scan()
+    {
+        ContentResource contentResource = getResourceInstance();
+
+        Content content1 = createContent( "content-id1", "content-name1", "myapplication:content-type" );
+
+        Mockito.when( this.contentService.getByIds( new GetContentByIdsParams( ContentIds.from( content1.getId() ) ) ) )
+            .thenReturn( Contents.from( content1 ) );
+
+        Mockito.doReturn( FindContentByParentResult.create().totalHits( 1L ).contents( Contents.from( content1 ) ).build() )
+            .when( this.contentService )
+            .findByParent( Mockito.isA( FindContentByParentParams.class ) );
+
+        // Selector matches every content in the subtree (matches == total), so the path scan must be skipped.
+        Mockito.when( this.contentService.find( Mockito.isA( ContentQuery.class ) ) )
+            .thenReturn( FindContentIdsByQueryResult.create().totalHits( 5L ).build() );
+
+        ContentTreeSelectorQueryJson json = initContentTreeSelectorQueryJson( null );
+        ContentTreeSelectorListJson result = contentResource.treeSelectorQuery( json );
+
+        assertEquals( content1.getId().toString(), result.getItems().get( 0 ).getContent().getId() );
+        assertEquals( Boolean.TRUE, result.getItems().get( 0 ).getSelectable() );
+        assertEquals( Boolean.valueOf( content1.hasChildren() ), result.getItems().get( 0 ).getExpandable() );
+
+        Mockito.verify( this.contentService, Mockito.never() ).findPaths( Mockito.isA( ContentQuery.class ) );
     }
 
     @Test


### PR DESCRIPTION
(A) Subtree scoping — `ContentSelectorQueryJsonToContentQueryConverter` now accepts a parentScope and AND-s a real, non-scoring path filter (`_path LIKE  '/content<parentPath>/**'`) so the index only returns the expanded subtree. Provably identical results, since the caller only ever consumes paths within that subtree.

(B) Fast browse path — `treeSelectorQuery` now does `findByParent` first, then a cheap `size=0` count comparison. When every descendant in the subtree matches the selector (plain browsing, no search/type filter), `selectable=true` and `expandable=hasChildren` directly — the full path scan is skipped entirely. A real filter falls through to the scoped path-scan branch, where matches are naturally few.

  Verified live (same content, same query)
  | Expansion | Before | After |
  |---|---|---|
  | root (initial open) | 5571 ms | 72 ms |
  | `/nb` (32 children) | 5694 ms | 77 ms |
  | deep node | 5524 ms | 68 ms |
  | search "seminar" | ~5500 ms | ~1000 ms |