### PR TITLE
Context Panel: adjust panel size #10914

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/ResponsiveBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ResponsiveBrowsePanel.ts
@@ -12,6 +12,7 @@ import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
 import {SelectionMode} from '@enonic/lib-admin-ui/ui/selector/list/SelectableListBoxWrapper';
 import {NonMobileContextPanelToggleButton} from '../view/context/button/NonMobileContextPanelToggleButton';
 import {$isContextOpen, setContextOpen} from '../../v6/features/store/contextWidgets.store';
+import {LayoutTokens} from '../../v6/features/layout/layout.tokens';
 import {ContextPanelState} from '../view/context/ContextPanelState';
 
 export abstract class ResponsiveBrowsePanel extends BrowsePanel {
@@ -63,7 +64,7 @@ export abstract class ResponsiveBrowsePanel extends BrowsePanel {
         const rightPanel: DockedContextPanel = new DockedContextPanel(this.contextView);
 
         this.contextSplitPanel = ContextSplitPanel.create(leftPanel, rightPanel)
-            .setSecondPanelSize(SplitPanelSize.PERCENTS(25))
+            .setSecondPanelSize(SplitPanelSize.PERCENTS(LayoutTokens.contextPanel.dockedWidthPercent.browse))
             .setContextView(this.contextView)
             .setToggleButton(this.contextSplitPanelToggler)
             .build();

--- a/modules/lib/src/main/resources/assets/js/app/view/context/ContextSplitPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/ContextSplitPanel.ts
@@ -6,9 +6,9 @@ import {SplitPanelSize} from '@enonic/lib-admin-ui/ui/panel/SplitPanelSize';
 import {type ResponsiveItem} from '@enonic/lib-admin-ui/ui/responsive/ResponsiveItem';
 import {ResponsiveManager} from '@enonic/lib-admin-ui/ui/responsive/ResponsiveManager';
 import {type ResponsiveRange} from '@enonic/lib-admin-ui/ui/responsive/ResponsiveRange';
-import {ResponsiveRanges} from '@enonic/lib-admin-ui/ui/responsive/ResponsiveRanges';
 import {AppHelper} from '@enonic/lib-admin-ui/util/AppHelper';
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
+import {LayoutTokens} from '../../../v6/features/layout/layout.tokens';
 import {getContentAsCSCS} from '../../../v6/features/store/content.store';
 import {InspectEvent} from '../../event/InspectEvent';
 import {ContextPanelState} from './ContextPanelState';
@@ -23,7 +23,7 @@ export enum ContextPanelMode {
 export class ContextSplitPanel
     extends SplitPanel {
 
-    public static CONTEXT_MIN_WIDTH: number = 310;
+    public static CONTEXT_MIN_WIDTH: number = LayoutTokens.contextPanel.minWidth;
 
     private contextPanelMode: ContextPanelMode;
     private contextPanelState: ContextPanelState = ContextPanelState.COLLAPSED;
@@ -115,7 +115,7 @@ export class ContextSplitPanel
     }
 
     protected getLeftPanelResponsiveRangeToSwitchToFloatingMode(): ResponsiveRange {
-        return ResponsiveRanges._960_1200;
+        return LayoutTokens.contextPanel.floatingThreshold.browse;
     }
 
     private isContextPanelLessThanMin(): boolean {
@@ -158,7 +158,7 @@ export class ContextSplitPanel
     }
 
     getSplitterThickness(): number {
-        return 1;
+        return LayoutTokens.contextPanel.splitterThickness;
     }
 
     private resetToggleButtonActiveState(): void {
@@ -182,13 +182,14 @@ export class ContextSplitPanel
 
     private requiresCollapsedContextPanel(): boolean {
         const totalWidth: number = Body.get().getEl().getWidthWithBorder();
-        return ResponsiveRanges._1620_1920.isFitOrSmaller(totalWidth) || this.getExpectedContextPanelMode() === ContextPanelMode.FLOATING;
+        return LayoutTokens.contextPanel.initialCollapseThreshold.isFitOrSmaller(totalWidth)
+               || this.getExpectedContextPanelMode() === ContextPanelMode.FLOATING;
     }
 
     private subscribeContextPanelsOnEvents(): void {
         const responsiveHandler = (item: ResponsiveItem) => {
             this.debouncedResizeHandler();
-            this.toggleMobileMode(item.isInRangeOrSmaller(ResponsiveRanges._540_720));
+            this.toggleMobileMode(item.isInRangeOrSmaller(LayoutTokens.contextPanel.mobileThreshold));
         };
         ResponsiveManager.onAvailableSizeChanged(this.getParentElement(), responsiveHandler);
         this.onRemoved(() => {
@@ -321,7 +322,7 @@ export class ContextSplitPanelBuilder
 
         this.setAlignment(SplitPanelAlignment.VERTICAL);
         this.setSecondPanelMinSize(SplitPanelSize.PIXELS(ContextSplitPanel.CONTEXT_MIN_WIDTH));
-        this.setAnimationDelay(600);
+        this.setAnimationDelay(LayoutTokens.contextPanel.animationDelayMs);
         this.setSecondPanelShouldSlideRight(true);
     }
 

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardContextSplitPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardContextSplitPanel.ts
@@ -1,6 +1,6 @@
 import {type Panel} from '@enonic/lib-admin-ui/ui/panel/Panel';
 import {type ResponsiveRange} from '@enonic/lib-admin-ui/ui/responsive/ResponsiveRange';
-import {ResponsiveRanges} from '@enonic/lib-admin-ui/ui/responsive/ResponsiveRanges';
+import {LayoutTokens} from '../../v6/features/layout/layout.tokens';
 import {ContextSplitPanel, ContextSplitPanelBuilder} from '../view/context/ContextSplitPanel';
 import {type LiveFormPanel} from './page/LiveFormPanel';
 import {type DockedContextPanel} from '../view/context/DockedContextPanel';
@@ -23,14 +23,14 @@ export class ContentWizardContextSplitPanel
 
     protected getLeftPanelResponsiveRangeToSwitchToFloatingMode(): ResponsiveRange {
         if (!this.liveFormPanel || !this.isPageEditorShown()) {
-            return ResponsiveRanges._720_960;
+            return LayoutTokens.contextPanel.floatingThreshold.wizardNoEditor;
         }
 
         if (this.isWizardPanelMaximized()) {
-            return ResponsiveRanges._1200_1380;
+            return LayoutTokens.contextPanel.floatingThreshold.wizardMaximized;
         }
 
-        return ResponsiveRanges._540_720;
+        return LayoutTokens.contextPanel.floatingThreshold.wizardNormal;
     }
 
     private isPageEditorShown(): boolean {
@@ -43,7 +43,7 @@ export class ContentWizardContextSplitPanel
 
     getActiveWidthPxOfSecondPanel(): number {
         if (this.isPageEditorShown() && this.isWizardPanelMaximized() && this.isFloatingMode()) {
-            return this.getEl().getWidthWithBorder() / 100 * 24;
+            return this.getEl().getWidthWithBorder() / 100 * LayoutTokens.contextPanel.floatingWidthPercent.wizardWithEditor;
         }
 
         return super.getActiveWidthPxOfSecondPanel();

--- a/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/ContentWizardPanel.ts
@@ -26,6 +26,7 @@ import {type ValidityChangedEvent} from '@enonic/lib-admin-ui/ValidityChangedEve
 import Q from 'q';
 import {LiveEditModel} from '../../page-editor/LiveEditModel';
 import {compareContent} from '../../v6/features/api/compare';
+import {LayoutTokens} from '../../v6/features/layout/layout.tokens';
 import {cleanupWizardMixinsService, initWizardMixinsService} from '../../v6/features/services/wizardMixins.service';
 import {
     cleanupWizardContentSyncService,
@@ -474,7 +475,10 @@ export class ContentWizardPanel
         const contextToggleButton = new NonMobileContextPanelToggleButton();
 
         this.contextSplitPanel = ContentWizardContextSplitPanel.create(leftPanel, rightPanel)
-            .setSecondPanelSize(SplitPanelSize.PERCENTS(this.livePanel ? 16 : 38))
+            .setSecondPanelSize(SplitPanelSize.PERCENTS(
+                this.livePanel
+                ? LayoutTokens.contextPanel.dockedWidthPercent.wizardWithEditor
+                : LayoutTokens.contextPanel.dockedWidthPercent.wizardNoEditor))
             .setContextView(this.contextView)
             .setLiveFormPanel(this.getLivePanel())
             .setWizardFormPanel(this.formPanel)

--- a/modules/lib/src/main/resources/assets/js/v6/features/layout/layout.tokens.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/layout/layout.tokens.ts
@@ -1,0 +1,27 @@
+import {ResponsiveRanges} from '@enonic/lib-admin-ui/ui/responsive/ResponsiveRanges';
+
+export const LayoutTokens = {
+    contextPanel: {
+        minWidth: 360,
+        // ? Overrides SplitPanel's default thickness of 5; used only in float-size width math.
+        splitterThickness: 1,
+        animationDelayMs: 600,
+        dockedWidthPercent: {
+            browse: 25,
+            wizardWithEditor: 16,
+            wizardNoEditor: 38,
+        },
+        floatingWidthPercent: {
+            wizardWithEditor: 24,
+        },
+        // Left-panel responsive range at or below which the context panel switches to floating mode.
+        floatingThreshold: {
+            browse: ResponsiveRanges._960_1200,
+            wizardNoEditor: ResponsiveRanges._720_960,
+            wizardMaximized: ResponsiveRanges._1200_1380,
+            wizardNormal: ResponsiveRanges._540_720,
+        },
+        mobileThreshold: ResponsiveRanges._540_720,
+        initialCollapseThreshold: ResponsiveRanges._1620_1920,
+    },
+};

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/media/MediaSelectorItemView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/media/MediaSelectorItemView.tsx
@@ -68,7 +68,7 @@ export const MediaSelectorItemView = ({content, hideStatus = false}: MediaSelect
                 </Tooltip>
             </div>
 
-            {!hideStatus && <StatusBadge status={calcTreePublishStatus(content)} />}
+            {!hideStatus && <StatusBadge status={calcTreePublishStatus(content)} className="@max-[360px]:hidden" />}
         </div>
     );
 };

--- a/modules/lib/src/main/resources/assets/styles/view/context/context-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/view/context/context-panel.less
@@ -4,9 +4,9 @@
   position: absolute;
   float: right;
   z-index: 2;
-  width: 280px;
+  width: 360px;
   top: 0;
-  right: -280px;
+  right: -360px;
   background-color: @admin-white;
   transition: right 0.5s ease-in-out;
   max-height: 100%;


### PR DESCRIPTION
Increased the context panel minimum width from 310px to 360px (`ContextSplitPanel.CONTEXT_MIN_WIDTH` plus the matching `context-panel.less` width/offset).

Centralized all context panel sizing into a single `v6/features/layout/layout.tokens.ts` module (min width, splitter thickness, animation delay, docked/floating width percents, and the responsive thresholds for floating/mobile/initial-collapse). Refactored `ContextSplitPanel`, `ContentWizardContextSplitPanel`, `ContentWizardPanel`, and `ResponsiveBrowsePanel` to read from it instead of inline magic numbers. Behavior is unchanged; lib-admin-ui is only read, not modified.

Hid the selector item status badge on narrow widths: `MediaSelectorItemView` now renders `StatusBadge` with `@max-[360px]:hidden`, scoped to the `@container` declared on the `ListItem` in `SelectorSelectionItem`, so the status disappears when the item is under 360px wide (Tailwind container query, no `ResponsiveManager`).
