### PR TITLE
Image editor: line thickness doesn't scale #10928

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputImage/ImageUploaderInputCropSvg.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputImage/ImageUploaderInputCropSvg.tsx
@@ -1,7 +1,19 @@
 import {type ReactElement, useEffect, useRef, useState} from 'react';
 import {type TargetedMouseEvent, type TargetedTouchEvent} from 'preact';
 import {useImageUploaderContext} from '../ImageUploaderContext';
-import {applyMove, applyResize, getCropSvgCursor, getClientXYFromEvent, HANDLE_CURSOR, toLocalFromClient, CROP_STROKE_WIDTH} from '../lib/crop';
+import {
+    applyMove,
+    applyResize,
+    getCropSvgCursor,
+    getClientXYFromEvent,
+    HANDLE_CURSOR,
+    toLocalFromClient,
+    CROP_STROKE_WIDTH,
+    DASH_PX,
+    HANDLE_PX,
+    HANDLE_HIT_PX,
+    MIN_CROP_SIZE,
+} from '../lib/crop';
 import {type Crop, type DragState, type HandleId} from '../lib/types';
 
 export const ImageUploaderInputCropSvg = (): ReactElement => {
@@ -10,19 +22,32 @@ export const ImageUploaderInputCropSvg = (): ReactElement => {
     const [dragState, setDragState] = useState<DragState>(null);
     const [liveCrop, setLiveCrop] = useState<Crop | null>(null);
     const [isOverRect, setIsOverRect] = useState(false);
+    // Image-pixels per screen-pixel, used to size handle markers at a constant on-screen size.
+    const [scale, setScale] = useState(1);
 
-    const handleVisualSize = 4 * CROP_STROKE_WIDTH;
-    const handleHitSize = Math.max(handleVisualSize * 2, 20);
-    const minSize = Math.max(CROP_STROKE_WIDTH * 2, 4);
-    const dragThreshold = minSize;
+    const handleVisualSize = HANDLE_PX * scale;
+    const handleHitSize = HANDLE_HIT_PX * scale;
+    const dragThreshold = MIN_CROP_SIZE;
 
     // Only use liveCrop during an active drag; otherwise always derive from context crop.
     const displayRect: Crop =
-        dragState != null && liveCrop != null
-            ? liveCrop
-            : crop ?? {x1: 0, y1: 0, x2: dimensions.w, y2: dimensions.h};
+        dragState != null && liveCrop != null ? liveCrop : (crop ?? {x1: 0, y1: 0, x2: dimensions.w, y2: dimensions.h});
 
     const svgCursor = getCropSvgCursor(dragState, isOverRect);
+
+    // Tracks the rendered svg width so handle markers stay a constant size on screen.
+    useEffect(() => {
+        const svg = svgRef.current;
+        if (!svg) return;
+        const update = (): void => {
+            const w = svg.getBoundingClientRect().width;
+            if (w > 0) setScale(dimensions.w / w);
+        };
+        update();
+        const ro = new ResizeObserver(update);
+        ro.observe(svg);
+        return () => ro.disconnect();
+    }, [dimensions.w]);
 
     useEffect(() => {
         if (!dragState) return;
@@ -36,7 +61,7 @@ export const ImageUploaderInputCropSvg = (): ReactElement => {
             const p = toLocalFromClient(svg, clientX, clientY, dimensions);
             if (!p) return;
             if (dragState.type === 'resize') {
-                setLiveCrop(applyResize(dragState.handle, dragState.snapshot, p, minSize));
+                setLiveCrop(applyResize(dragState.handle, dragState.snapshot, p, MIN_CROP_SIZE));
             } else {
                 setLiveCrop(applyMove(dragState.snapshot, dragState.anchor, p, dimensions));
             }
@@ -51,7 +76,7 @@ export const ImageUploaderInputCropSvg = (): ReactElement => {
 
                 if (p) {
                     if (dragState.type === 'resize') {
-                        setCrop(applyResize(dragState.handle, dragState.snapshot, p, minSize));
+                        setCrop(applyResize(dragState.handle, dragState.snapshot, p, MIN_CROP_SIZE));
                     } else {
                         const dx = Math.abs(p.x - dragState.anchor.x);
                         const dy = Math.abs(p.y - dragState.anchor.y);
@@ -139,6 +164,27 @@ export const ImageUploaderInputCropSvg = (): ReactElement => {
             setLiveCrop(displayRect);
         };
 
+    // Two-tone marching-ants outline so it stays visible on any background.
+    const renderCropOutline = (r: Crop): ReactElement => {
+        const props = {
+            x: r.x1,
+            y: r.y1,
+            width: r.x2 - r.x1,
+            height: r.y2 - r.y1,
+            fill: 'none',
+            strokeWidth: CROP_STROKE_WIDTH,
+            strokeDasharray: DASH_PX,
+            vectorEffect: 'non-scaling-stroke',
+            style: {pointerEvents: 'none'},
+        };
+        return (
+            <>
+                <rect {...props} stroke="white" />
+                <rect {...props} stroke="red" strokeDashoffset={DASH_PX} />
+            </>
+        );
+    };
+
     const renderHandle = (handle: HandleId, cx: number, cy: number): ReactElement => (
         <g key={handle}>
             {/* Enlarged transparent hit area for easier tapping on mobile */}
@@ -157,9 +203,10 @@ export const ImageUploaderInputCropSvg = (): ReactElement => {
                 y={cy - handleVisualSize / 2}
                 width={handleVisualSize}
                 height={handleVisualSize}
-                fill="red"
-                stroke="white"
-                strokeWidth={Math.max(1, CROP_STROKE_WIDTH * 0.3)}
+                fill="white"
+                stroke="red"
+                strokeWidth={1}
+                vectorEffect="non-scaling-stroke"
                 style={{pointerEvents: 'none'}}
             />
         </g>
@@ -205,17 +252,7 @@ export const ImageUploaderInputCropSvg = (): ReactElement => {
                 fillOpacity={0.5}
                 style={{pointerEvents: 'none'}}
             />
-            <rect
-                x={displayRect.x1}
-                y={displayRect.y1}
-                width={displayRect.x2 - displayRect.x1}
-                height={displayRect.y2 - displayRect.y1}
-                fill="none"
-                stroke="red"
-                strokeWidth={CROP_STROKE_WIDTH}
-                strokeDasharray={CROP_STROKE_WIDTH * 2}
-                style={{pointerEvents: 'none'}}
-            />
+            {renderCropOutline(displayRect)}
             {renderHandles(displayRect)}
         </svg>
     );

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputImage/ImageUploaderInputFocusSvg.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/ImageUploaderInputImage/ImageUploaderInputFocusSvg.tsx
@@ -4,7 +4,7 @@ import {type TargetedMouseEvent, type TargetedTouchEvent} from 'preact';
 import {useImageUploaderContext} from '../ImageUploaderContext';
 import {getClientXYFromEvent} from '../lib/crop';
 import {type Point} from '../lib/types';
-import {FOCUS_STROKE_WIDTH} from '../lib/focus';
+import {FOCUS_STROKE_WIDTH, FOCUS_DASH_PX} from '../lib/focus';
 
 export const ImageUploaderInputFocusSvg = (): ReactElement => {
     const {dimensions, crop, base64Image, mode, focus, setFocus} = useImageUploaderContext();
@@ -97,6 +97,25 @@ export const ImageUploaderInputFocusSvg = (): ReactElement => {
         };
     }, [isDragging]); // eslint-disable-line react-hooks/exhaustive-deps
 
+    // Two-tone marching-ants ring so it stays visible on any background.
+    const renderFocusRing = (cx: number, cy: number, r: number): ReactElement => {
+        const props = {
+            cx,
+            cy,
+            r,
+            fill: 'none',
+            strokeWidth: FOCUS_STROKE_WIDTH,
+            strokeDasharray: FOCUS_DASH_PX,
+            vectorEffect: 'non-scaling-stroke',
+        };
+        return (
+            <>
+                <circle {...props} stroke="white" />
+                <circle {...props} stroke="red" strokeDashoffset={FOCUS_DASH_PX} />
+            </>
+        );
+    };
+
     return (
         <svg
             ref={svgRef}
@@ -117,29 +136,11 @@ export const ImageUploaderInputFocusSvg = (): ReactElement => {
                         <circle cx={displayFocus.x} cy={displayFocus.y} r={radius} fill="black" />
                     </mask>
                     <rect x={viewX} y={viewY} width={viewW} height={viewH} fill="black" fillOpacity={0.5} mask="url(#focus-mask)" />
-                    <circle
-                        cx={displayFocus.x}
-                        cy={displayFocus.y}
-                        r={radius}
-                        fill="none"
-                        stroke="red"
-                        strokeWidth={FOCUS_STROKE_WIDTH}
-                        strokeDasharray={FOCUS_STROKE_WIDTH * 2}
-                    />
+                    {renderFocusRing(displayFocus.x, displayFocus.y, radius)}
                 </>
             )}
 
-            {!isFocusing && focus && focus.x !== cropXCenter && focus.y !== cropYCenter && (
-                <circle
-                    cx={focus.x}
-                    cy={focus.y}
-                    r={radius}
-                    fill="none"
-                    stroke="red"
-                    strokeWidth={FOCUS_STROKE_WIDTH}
-                    strokeDasharray={FOCUS_STROKE_WIDTH * 2}
-                />
-            )}
+            {!isFocusing && focus && focus.x !== cropXCenter && focus.y !== cropYCenter && renderFocusRing(focus.x, focus.y, radius)}
         </svg>
     );
 };

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/lib/crop.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/lib/crop.ts
@@ -1,7 +1,14 @@
 import {applyTransform, FORWARD_MATRICES, INVERSE_MATRICES} from './matrices';
 import {type HandleId, type Crop, type DragState, type Dimensions, type Point} from './types';
 
+// Screen-pixel sizes, kept constant on screen via vector-effect: non-scaling-stroke.
 export const CROP_STROKE_WIDTH = 2;
+export const DASH_PX = 4;
+export const HANDLE_PX = 8;
+export const HANDLE_HIT_PX = 24;
+
+// Minimum crop size, in image pixels.
+export const MIN_CROP_SIZE = 4;
 
 // Cursor styles for the 8 handle positions on the crop rectangle.
 export const HANDLE_CURSOR: Record<HandleId, string> = {

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/lib/focus.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-uploader/lib/focus.ts
@@ -1,7 +1,9 @@
 import {applyTransform, FORWARD_MATRICES, INVERSE_MATRICES} from './matrices';
 import {type Dimensions, type Point} from './types';
 
+// Screen-pixel sizes, kept constant on screen via vector-effect: non-scaling-stroke.
 export const FOCUS_STROKE_WIDTH = 2;
+export const FOCUS_DASH_PX = 4;
 
 export function adjustFocusToBaseOrientation(point: Point, fromOrientation: number, dimensions: Dimensions): Point | null {
     if (!point) return null;


### PR DESCRIPTION
Turns out SVG has an attribute built exactly for this: vector-effect="non-scaling-stroke". Didn't know it existed. With it, the stroke keeps a constant on-screen thickness regardless of the image dimensions — no manual recalculation on our side.

Also, as described in the issue description, the image can happen to be the same color as our line (e.g. a red photo → red crop line vanishes). To cover that, the outline is now two interleaved dashed strokes — white and red alternating — so whatever the background, one of the two always contrasts.