### PR TITLE
"Reset" button is shown for a non-localised content in layer #10926

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/action/ContentWizardActions.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/action/ContentWizardActions.ts
@@ -442,8 +442,8 @@ export class ContentWizardActions extends WizardActions<Content> {
         const canBeMarkedAsReady: boolean = this.contentCanBeMarkedAsReady && this.userCanModify;
         const canBeRequestedPublish: boolean = this.canBeRequestedPublish();
         const isInheritedItem: boolean = this.wizardPanel.isContentExistsInParentProject() && this.content.hasOriginProject();
-        const canBeReset: boolean = isInheritedItem && !this.content.isFullyInherited();
         const canBeLocalized: boolean = isInheritedItem && this.content.isDataInherited();
+        const canBeReset: boolean = isInheritedItem && !this.content.isDataInherited();
 
         this.enableActions({
             PUBLISH: canBePublished,


### PR DESCRIPTION
- Fixed mutually exclusive visibility of the Reset and Localize wizard actions: now 'CONTENT' fields (data inheritance) decides do we see Localize or Reset button.