### PR TITLE
Save is enabled for a new content with a mixin #10940

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.test.ts
@@ -42,6 +42,7 @@ import {
     setContentFormExpanded,
     toggleContentFormExpanded,
     setPersistedContent,
+    setMixinsDescriptors,
     notifyContentFormMounted,
     notifyMixinMounted,
 } from './wizardContent.store';
@@ -85,6 +86,7 @@ function createContent({
     page = null,
     workflowState = WorkflowState.IN_PROGRESS,
     contentType = ContentTypeName.UNSTRUCTURED,
+    touched = false,
 }: {
     displayName?: string;
     data?: PropertyTree;
@@ -92,6 +94,7 @@ function createContent({
     page?: Page | null;
     workflowState?: WorkflowState;
     contentType?: ContentTypeName;
+    touched?: boolean;
 } = {}): Content {
     const workflow = Workflow.create().setState(workflowState).build();
     const builder = new ContentBuilder();
@@ -102,6 +105,9 @@ function createContent({
     builder.setPage(page);
     builder.setMixins(mixins);
     builder.setWorkflow(workflow);
+
+    builder.createdTime = new Date(1_000);
+    builder.modifiedTime = touched ? new Date(2_000) : new Date(1_000);
 
     return builder.build();
 }
@@ -586,7 +592,7 @@ describe('wizardContent.store', () => {
         expect($wizardHasChanges.get()).toBe(true);
     });
 
-    it('seeds defaults into the draft of an already-attached mandatory mixin and marks it dirty', () => {
+    it('seeds defaults into an already-attached mandatory mixin and baselines them on untouched content', () => {
         const descriptor = createMixinDescriptorWithForm('app:seo', false, checkboxForm('agree'));
         const presentEmptyMixin = new Mixin(new MixinName('app:seo'), new PropertyTree());
 
@@ -595,13 +601,31 @@ describe('wizardContent.store', () => {
         const draftMixin = $wizardDraftMixins.get().find((m) => m.getName().toString() === 'app:seo');
         expect(draftMixin?.getData().getRoot().getPropertyArray('agree')?.get(0)?.getValue().getBoolean()).toBe(true);
 
-        // Persisted baseline stays empty, so the content is dirty until saved.
+        const persistedMixin = $wizardPersistedMixins.get().find((m) => m.getName().toString() === 'app:seo');
+        expect(persistedMixin?.getData().getRoot().getPropertyArray('agree')?.get(0)?.getValue().getBoolean()).toBe(true);
+        expect($wizardSectionChanges.get().mixins).toBe(false);
+    });
+
+    it('seeds defaults into an already-attached mandatory mixin and marks touched content dirty', () => {
+        const descriptor = createMixinDescriptorWithForm('app:seo', false, checkboxForm('agree'));
+        const presentEmptyMixin = new Mixin(new MixinName('app:seo'), new PropertyTree());
+
+        initializeWizardContentState(
+            createContent({mixins: [presentEmptyMixin], touched: true}),
+            null,
+            [descriptor],
+            WorkflowState.IN_PROGRESS,
+        );
+
+        const draftMixin = $wizardDraftMixins.get().find((m) => m.getName().toString() === 'app:seo');
+        expect(draftMixin?.getData().getRoot().getPropertyArray('agree')?.get(0)?.getValue().getBoolean()).toBe(true);
+
         const persistedMixin = $wizardPersistedMixins.get().find((m) => m.getName().toString() === 'app:seo');
         expect(persistedMixin?.getData().getRoot().getPropertyArray('agree')).toBeUndefined();
         expect($wizardSectionChanges.get().mixins).toBe(true);
     });
 
-    it('seeds a mandatory mixin missing from the content into the draft only', () => {
+    it('seeds a mandatory mixin missing from untouched content into both draft and baseline', () => {
         const descriptor = createMixinDescriptorWithForm('app:seo', false, checkboxForm('agree'));
 
         initializeWizardContentState(createContent(), null, [descriptor], WorkflowState.IN_PROGRESS);
@@ -609,8 +633,8 @@ describe('wizardContent.store', () => {
         const draftMixin = $wizardDraftMixins.get().find((m) => m.getName().toString() === 'app:seo');
         expect(draftMixin?.getData().getRoot().getPropertyArray('agree')?.get(0)?.getValue().getBoolean()).toBe(true);
 
-        expect($wizardPersistedMixins.get().some((m) => m.getName().toString() === 'app:seo')).toBe(false);
-        expect($wizardSectionChanges.get().mixins).toBe(true);
+        expect($wizardPersistedMixins.get().some((m) => m.getName().toString() === 'app:seo')).toBe(true);
+        expect($wizardSectionChanges.get().mixins).toBe(false);
     });
 
     it('marks mixins as changed when mixin PropertyTree is mutated in-place', () => {
@@ -819,20 +843,20 @@ describe('wizardContent.store', () => {
             expect($wizardHasChanges.get()).toBe(true);
         });
 
-        it('should keep a seeded mandatory mixin missing from the content dirty after the tab mounts', async () => {
+        it('should treat a seeded mandatory mixin on untouched content as the clean baseline', async () => {
             const descriptor = createMixinDescriptorWithForm('app:seo', false, checkboxForm('agree'));
             initializeWizardContentState(createContent(), null, [descriptor], WorkflowState.IN_PROGRESS);
 
-            expect($wizardSectionChanges.get().mixins).toBe(true);
+            expect($wizardSectionChanges.get().mixins).toBe(false);
 
             notifyMixinMounted('app:seo');
             await vi.advanceTimersByTimeAsync(0);
 
-            expect($wizardSectionChanges.get().mixins).toBe(true);
-            expect($wizardHasChanges.get()).toBe(true);
+            expect($wizardSectionChanges.get().mixins).toBe(false);
+            expect($wizardHasChanges.get()).toBe(false);
         });
 
-        it('should keep a seeded already-attached mandatory mixin dirty after the tab mounts', async () => {
+        it('should treat a seeded already-attached mandatory mixin on untouched content as clean', async () => {
             const descriptor = createMixinDescriptorWithForm('app:seo', false, checkboxForm('agree'));
             const presentEmptyMixin = new Mixin(new MixinName('app:seo'), new PropertyTree());
             initializeWizardContentState(
@@ -841,6 +865,56 @@ describe('wizardContent.store', () => {
                 [descriptor],
                 WorkflowState.IN_PROGRESS,
             );
+
+            expect($wizardSectionChanges.get().mixins).toBe(false);
+
+            notifyMixinMounted('app:seo');
+            await vi.advanceTimersByTimeAsync(0);
+
+            expect($wizardSectionChanges.get().mixins).toBe(false);
+            expect($wizardHasChanges.get()).toBe(false);
+        });
+
+        it('should treat a late-seeded mixin on untouched content as clean', async () => {
+            const descriptor = createMixinDescriptorWithForm('app:seo', false, checkboxForm('agree'));
+            const presentEmptyMixin = new Mixin(new MixinName('app:seo'), new PropertyTree());
+
+            // The real wizard initialises with no descriptors (loaded asynchronously),
+            // so the rendered-snapshot baseline is armed while the empty mixin is clean.
+            initializeWizardContentState(
+                createContent({mixins: [presentEmptyMixin]}),
+                null,
+                [],
+                WorkflowState.IN_PROGRESS,
+            );
+
+            expect($wizardSectionChanges.get().mixins).toBe(false);
+
+            setMixinsDescriptors([descriptor]);
+
+            expect($wizardSectionChanges.get().mixins).toBe(false);
+
+            notifyMixinMounted('app:seo');
+            await vi.advanceTimersByTimeAsync(0);
+
+            expect($wizardSectionChanges.get().mixins).toBe(false);
+            expect($wizardHasChanges.get()).toBe(false);
+        });
+
+        it('should keep a late-seeded mixin dirty on already-saved (touched) content', async () => {
+            const descriptor = createMixinDescriptorWithForm('app:seo', false, checkboxForm('agree'));
+            const presentEmptyMixin = new Mixin(new MixinName('app:seo'), new PropertyTree());
+
+            initializeWizardContentState(
+                createContent({mixins: [presentEmptyMixin], touched: true}),
+                null,
+                [],
+                WorkflowState.IN_PROGRESS,
+            );
+
+            expect($wizardSectionChanges.get().mixins).toBe(false);
+
+            setMixinsDescriptors([descriptor]);
 
             expect($wizardSectionChanges.get().mixins).toBe(true);
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/wizardContent.store.ts
@@ -477,6 +477,13 @@ function mixinsEqual(a: Mixin[], b: Mixin[]): boolean {
     return true;
 }
 
+function isContentUntouched(content: Content): boolean {
+    const created = content.getCreatedTime()?.getTime();
+    const modified = content.getModifiedTime()?.getTime();
+
+    return created != null && modified != null && created === modified;
+}
+
 function buildPersistedSectionsSnapshot(content: Content): WizardPersistedSectionsSnapshot {
     return {
         displayName: content.getDisplayName() ?? '',
@@ -514,6 +521,8 @@ function applyPersistedSectionsSnapshot(snapshot: WizardPersistedSectionsSnapsho
 let contentDisarmTimer: ReturnType<typeof setTimeout> | null = null;
 const mixinDisarmTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+let isPersistedContentUntouched = false;
+
 function armRenderedSnapshot(content: Content): void {
     if (contentDisarmTimer != null) {
         clearTimeout(contentDisarmTimer);
@@ -545,6 +554,7 @@ export function setWizardFormValidation(isValid: boolean): void {
 }
 
 export function setPersistedContent(content: Content): void {
+    isPersistedContentUntouched = isContentUntouched(content);
     applyPersistedSectionsSnapshot(buildPersistedSectionsSnapshot(content));
     $wizardDataValidation.set({});
 
@@ -583,6 +593,7 @@ export type ApplyServerContentResult = {
 };
 
 export function applyServerSidePersistedContent(content: Content): ApplyServerContentResult {
+    isPersistedContentUntouched = isContentUntouched(content);
     const snapshot = buildPersistedSectionsSnapshot(content);
 
     applyDisplayNameFromServer(snapshot.displayName);
@@ -854,15 +865,18 @@ function seedMixinDefaults(): void {
     const draftByName = new Map(draft.map((m) => [m.getName().toString(), m]));
 
     const draftAdditions: Mixin[] = [];
+    const seededNames: string[] = [];
 
     for (const descriptor of descriptors) {
         const name = descriptor.getName();
 
-        // Draft only — the persisted baseline must keep reflecting the server,
-        // so seeded defaults stay dirty until actually saved.
+        // Seed into the draft only. On already-saved content the persisted
+        // baseline keeps reflecting the server, so seeded defaults stay dirty;
+        // untouched content rebaselines them below.
         const draftMixin = draftByName.get(name);
         if (draftMixin) {
             seedMixinTree(draftMixin, descriptor);
+            seededNames.push(name);
         } else if (!descriptor.isOptional()) {
             draftAdditions.push(new Mixin(new MixinName(name), createSeededMixinTree(descriptor)));
         }
@@ -870,6 +884,62 @@ function seedMixinDefaults(): void {
 
     if (draftAdditions.length > 0) {
         $wizardDraftMixins.set([...draft, ...draftAdditions]);
+    }
+
+    if (isPersistedContentUntouched) {
+        baselineMixinsFromDraft();
+        return;
+    }
+
+    disarmSeededMixinSnapshots(seededNames);
+}
+
+function baselineMixinsFromDraft(): void {
+    const draftMixins = $wizardDraftMixins.get();
+
+    $wizardPersistedMixins.set(cloneMixins(draftMixins));
+    bumpMixinsVersion();
+
+    const pending = new Set($mixinsPendingMount.get());
+    for (const mixin of draftMixins) {
+        pending.add(mixin.getName().toString());
+    }
+    $mixinsPendingMount.set(pending);
+}
+
+// Descriptors load asynchronously, so seeding often runs after the rendered
+// snapshot was armed against a still-empty mixin. A seeded default that makes
+// the draft diverge from the server is a genuine unsaved change; release it
+// from the pending-mount baseline so the tab mount does not swallow it.
+function disarmSeededMixinSnapshots(names: string[]): void {
+    const pending = $mixinsPendingMount.get();
+    const needing = $mixinsNeedingSnapshot.get();
+    let nextPending = pending;
+    let nextNeeding = needing;
+
+    for (const name of names) {
+        if (!isMixinDirtyByName(name)) {
+            continue;
+        }
+        if (nextPending.has(name)) {
+            if (nextPending === pending) {
+                nextPending = new Set(pending);
+            }
+            nextPending.delete(name);
+        }
+        if (nextNeeding.has(name)) {
+            if (nextNeeding === needing) {
+                nextNeeding = new Set(needing);
+            }
+            nextNeeding.delete(name);
+        }
+    }
+
+    if (nextPending !== pending) {
+        $mixinsPendingMount.set(nextPending);
+    }
+    if (nextNeeding !== needing) {
+        $mixinsNeedingSnapshot.set(nextNeeding);
     }
 }
 
@@ -1244,6 +1314,7 @@ export function resetWizardContent(): void {
     $wizardMixinsVersion.set(0);
     $mixinsPendingMount.set(new Set());
     $mixinsNeedingSnapshot.set(new Set());
+    isPersistedContentUntouched = false;
 
     $wizardPersistedPage.set(null);
     $wizardDraftPage.set(null);


### PR DESCRIPTION
Root cause: mixin descriptors load asynchronously, so `seedMixinDefaults` seeds default values into the draft mixins only after the persisted baseline has been captured. Seeding added the defaults to the draft only, so the draft diverged from the (empty) persisted baseline and the mixins section was always reported as changed. This came from #10782, which intentionally kept seeded defaults dirty so that already-saved content re-saves missing values — but the same path also made brand-new content dirty right on open.

Fix: distinguish untouched content (never saved after creation) from already-saved content using the persisted content's timestamps, `createdTime === modifiedTime`. This signal is read straight from the Content, so it survives a page reload — unlike `FormState.isNew()` / `displayAsNew`, which are dropped from the URL once the draft is persisted. For untouched content the seeded defaults are the initial baseline: persisted mixins are mirrored from the draft and re-armed for the mount snapshot, so the content is not marked dirty. For already-saved content the previous #10782 behaviour is preserved — seeded defaults the server never stored remain a visible unsaved change.

Defaults are still persisted on save in both cases, because the update routine always sends the full draft mixins regardless of the dirty flag.

Closes #10940

<sub>*Drafted with AI assistance*</sub>
