### PR TITLE
Don't preset focused input in context #10948

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.host.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.host.test.ts
@@ -2,11 +2,10 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 import type {AiPlugin, AiPluginContext, AiPluginInstance} from './ai-protocol';
 import {
     __resetAiHostForTest,
-    captureOperatorSeed,
     getAiHost,
     handleDataActivePath,
     mountReadyPlugins,
-    openOperatorWithSeed,
+    openPluginDialog,
 } from './ai.host';
 import {$aiPluginDialogOpen, $aiReady} from './ai.store';
 
@@ -110,57 +109,13 @@ describe('Content Operator context', () => {
         expect(operator.received).toEqual(['/title']);
     });
 
-    it('seeds the dialog with the field focused at capture time on open', () => {
+    it('does not preset context when the dialog opens after a field was focused while closed', () => {
         const operator = mountOperator();
+        $aiPluginDialogOpen.setKey('ai.contentOperator', false);
 
-        // Focus while closed: remembered, not sent.
         handleDataActivePath('.title');
-        expect(operator.received).toEqual([]);
-
-        captureOperatorSeed();
-        openOperatorWithSeed();
-
-        expect(operator.received).toEqual(['/title']);
-    });
-
-    it('does not seed when no field is focused at capture time', () => {
-        const operator = mountOperator();
-
-        // Focus then blur to a neutral element: live field cleared.
-        handleDataActivePath('.title');
-        handleDataActivePath(undefined);
-
-        captureOperatorSeed();
-        openOperatorWithSeed();
+        openPluginDialog('ai.contentOperator');
 
         expect(operator.received).toEqual([]);
-    });
-
-    it('seeds the most recently focused field, not a stale one', () => {
-        const operator = mountOperator();
-
-        handleDataActivePath('.title');
-        handleDataActivePath('.body');
-
-        captureOperatorSeed();
-        openOperatorWithSeed();
-
-        expect(operator.received).toEqual(['/body']);
-    });
-
-    it('clears the pending seed after opening, so a later open does not re-seed', () => {
-        const operator = mountOperator();
-
-        handleDataActivePath('.title');
-        captureOperatorSeed();
-        openOperatorWithSeed();
-        expect(operator.received).toEqual(['/title']);
-
-        // No new capture: blur the field, then open again.
-        handleDataActivePath(undefined);
-        captureOperatorSeed();
-        openOperatorWithSeed();
-
-        expect(operator.received).toEqual(['/title']);
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.host.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/ai/ai.host.ts
@@ -24,12 +24,6 @@ type Registration = {
 const registry = new Map<AiPluginId, Registration>();
 let isInitialized = false;
 
-// Live context path of the focused data field, or null when none is focused.
-let activeDataContext: string | null = null;
-
-// Captured at toggle pointer-down, before the click blurs the focused field.
-let pendingOperatorSeed: string | null = null;
-
 function isKnownId(id: string): id is AiPluginId {
     return (KNOWN_IDS as readonly string[]).includes(id);
 }
@@ -175,38 +169,21 @@ export function sendPluginContext(id: AiPluginId, context: string | null): void 
 //
 // * Content Operator context bridge
 //
-// Focused field is pushed as context only while the dialog is open; while
-// closed it is remembered as a seed for the next open.
+// The focused field becomes context only while the dialog is open — opening it
+// never presets a field.
 
-// Records the focused data field and, while the operator dialog is open, pushes
-// it as context. Blur (undefined) clears the live field but sends nothing — the
-// plugin keeps its last context until another field is focused.
+// Blur (undefined) sends nothing, so the plugin keeps its last context until
+// another field is focused.
 export function handleDataActivePath(activePath: string | undefined): void {
-    if (activePath == null) {
-        activeDataContext = null;
+    if (activePath == null || !$aiPluginDialogOpen.get()['ai.contentOperator']) {
         return;
     }
     // Drop the leading dot: ".itemSet[1].field" -> "itemSet[1].field".
     const field = activePath.startsWith('.') ? activePath.slice(1) : activePath;
     const context = field.length > 0 ? toPluginContextPath({kind: 'data', field}) : null;
-    activeDataContext = context;
-    if (context != null && $aiPluginDialogOpen.get()['ai.contentOperator']) {
+    if (context != null) {
         sendPluginContext('ai.contentOperator', context);
     }
-}
-
-// Snapshots the live focused field as the seed for the next operator open. Call
-// from the toolbar toggle's pointer-down, before the click blurs the field.
-export function captureOperatorSeed(): void {
-    pendingOperatorSeed = activeDataContext;
-}
-
-export function openOperatorWithSeed(): void {
-    openPluginDialog('ai.contentOperator');
-    if (pendingOperatorSeed != null) {
-        sendPluginContext('ai.contentOperator', pendingOperatorSeed);
-    }
-    pendingOperatorSeed = null;
 }
 
 //
@@ -265,13 +242,7 @@ export function initAiHost(): void {
         }
     });
 
-    $aiContent.subscribe(() => {
-        // New content remounts the form; drop remembered focus and seed so the
-        // next open starts clean.
-        activeDataContext = null;
-        pendingOperatorSeed = null;
-        fanOutContent();
-    });
+    $aiContent.subscribe(() => fanOutContent());
     $aiContentType.subscribe(() => fanOutSchema());
     $aiContentLanguage.subscribe(() => fanOutLanguage());
     $aiInstructions.subscribe(() => fanOutConfig());
@@ -287,6 +258,4 @@ export function __resetAiHostForTest(): void {
     $aiRegisteredPlugins.setKey('ai.contentOperator', false);
     $aiPluginDialogOpen.setKey('ai.translator', false);
     $aiPluginDialogOpen.setKey('ai.contentOperator', false);
-    activeDataContext = null;
-    pendingOperatorSeed = null;
 }

--- a/modules/lib/src/main/resources/assets/js/v6/features/store/ai/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/store/ai/index.ts
@@ -17,9 +17,7 @@ export {initAiHost} from './ai.host';
 
 // Write: AI plugin host commands
 export {
-    captureOperatorSeed,
     closePluginDialog,
-    openOperatorWithSeed,
     openPluginDialog,
     sendPluginContext,
 } from './ai.host';

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/browse/toolbar/ContentWizardToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/browse/toolbar/ContentWizardToolbar.tsx
@@ -10,7 +10,7 @@ import {LayerIndicator} from '../../../shared/icons/LayerIndicator';
 import {ProjectIcon} from '../../../shared/icons/ProjectIcon';
 import {StatusIcon} from '../../../shared/icons/StatusIcon';
 import {StatusBadge} from '../../../shared/status/StatusBadge';
-import {$aiPluginDialogOpen, $aiRegisteredPlugins, captureOperatorSeed, closePluginDialog, openOperatorWithSeed} from '../../../store/ai';
+import {$aiPluginDialogOpen, $aiRegisteredPlugins, closePluginDialog, openPluginDialog} from '../../../store/ai';
 import {setInspectSaveAction} from '../../../store/inspect-panel.store';
 import {$wizardToolbar} from '../../../store/wizardToolbar.store';
 import {formatContentFullPath} from '../../../utils/cms/content/paths';
@@ -151,14 +151,9 @@ export const ContentWizardToolbar = ({
     const [desktopPublishSplitRef, isDesktopPublishSplitVisible] = useElementVisibility<HTMLDivElement>();
     const [mobileActionsSplitRef, isMobileActionsSplitVisible] = useElementVisibility<HTMLDivElement>();
 
-    // Capture the focused field before this click blurs it; consumed on open.
-    const handleAiOperatorPointerDown = (): void => {
-        captureOperatorSeed();
-    };
-
     const handleAiOperatorToggle = (pressed: boolean): void => {
         if (pressed) {
-            openOperatorWithSeed();
+            openPluginDialog('ai.contentOperator');
         } else {
             closePluginDialog('ai.contentOperator');
         }
@@ -285,7 +280,6 @@ export const ContentWizardToolbar = ({
                                     startIcon={JukeIcon}
                                     startIconClassName="size-7"
                                     pressed={isOperatorDialogOpen}
-                                    onPointerDown={handleAiOperatorPointerDown}
                                     onPressedChange={handleAiOperatorToggle}
                                 />
                             </Toolbar.Item>

--- a/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/views/wizard/content-wizard-tabs/DisplayNameInput.tsx
@@ -13,6 +13,7 @@ import {
     type ReactElement,
 } from 'react';
 import {
+    $aiPluginDialogOpen,
     $aiTopicError,
     $aiTopicHighlight,
     $aiTopicProcessing,
@@ -33,6 +34,10 @@ import {$validationVisibility} from '../../../store/wizardValidation.store';
 const DISPLAY_NAME_INPUT_NAME = 'DisplayNameInput';
 
 function setAIContext(): void {
+    // Gate like data fields: send the topic only while the dialog is open.
+    if (!$aiPluginDialogOpen.get()['ai.contentOperator']) {
+        return;
+    }
     sendPluginContext('ai.contentOperator', AI_TOPIC_PATH);
 }
 


### PR DESCRIPTION
## Changes

- Removed the operator-seed mechanism so opening the Content Operator dialog no longer presets the focused field as context.
- Toolbar toggle now opens via `openPluginDialog`; dropped the pointer-down seed capture and the orphaned `activeDataContext`/`pendingOperatorSeed` host state.
- Gated `DisplayNameInput`'s topic context push on dialog-open state, matching the data-field behavior.
- Replaced the seed tests in `ai.host.test.ts` with a no-preset-on-open regression test.

Closes #10948

<sub>*Drafted with AI assistance*</sub>
