### PR TITLE
Context Panel's header is shifted a bit #10931

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/rename-content/RenameContentDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/rename-content/RenameContentDialog.tsx
@@ -96,7 +96,7 @@ export const RenameContentDialog = (): ReactElement => {
                     }}
                 >
                     <Dialog.DefaultHeader title={title} withClose>
-                        <Dialog.Description className='text-subtle'>
+                        <Dialog.Description className='overflow-hidden text-subtle text-ellipsis'>
                             {fullPath}
                         </Dialog.Description>
                     </Dialog.DefaultHeader>

--- a/modules/lib/src/main/resources/assets/styles/wizard/page/live-form-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/page/live-form-panel.less
@@ -1,5 +1,4 @@
 .live-form-panel {
-  margin-top: -1px;
 
   &:before {
     content: '';


### PR DESCRIPTION
Long content name overflows 'New name' input in Rename dialog #10950