### PR TITLE
Incorrect handling of a link to non-existing content in the Insert Link dialog #10939

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-link/HtmlAreaLinkDialogContext.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-link/HtmlAreaLinkDialogContext.tsx
@@ -1,4 +1,3 @@
-import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {StringHelper} from '@enonic/lib-admin-ui/util/StringHelper';
 import {isBlank} from '../../../utils/format/isBlank';
@@ -651,7 +650,7 @@ export function HtmlAreaLinkDialogProvider({children, openRef}: HtmlAreaLinkDial
                 });
             },
             (error) => {
-                DefaultErrorHandler.handle(error);
+                console.error(error);
             },
         );
     }, []);

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/selection/ContentNotAvailable.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/selection/ContentNotAvailable.tsx
@@ -1,0 +1,25 @@
+import {FileQuestionMarkIcon} from 'lucide-react';
+import {useI18n} from '../../../../hooks/useI18n';
+import {type ReactElement} from 'react';
+import {cn} from '@enonic/ui';
+
+export type ContentNotAvailableProps = {
+    contentId: string;
+    className?: string;
+};
+
+export const ContentNotAvailable = ({contentId, className}: ContentNotAvailableProps): ReactElement => {
+    const contentNotAvailableLabel = useI18n('text.content.not.found');
+
+    return (
+        <div className={cn('flex items-center gap-2.5 min-w-0', className)}>
+            <div className="shrink-0">
+                <FileQuestionMarkIcon size={24} absoluteStrokeWidth className="text-error" />
+            </div>
+            <div className="min-w-0 w-full">
+                <span className="font-semibold text-base block whitespace-nowrap overflow-hidden text-ellipsis">{contentId}</span>
+                <span className="text-sm text-error block whitespace-nowrap overflow-hidden text-ellipsis">{contentNotAvailableLabel}</span>
+            </div>
+        </div>
+    );
+};

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/selection/ContentSelection.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/selection/ContentSelection.tsx
@@ -1,6 +1,6 @@
 import {cn, GridList} from '@enonic/ui';
 import {useCallback, useEffect, useRef, useState, type ReactElement} from 'react';
-import type {ContentSummary} from '../../../../../../app/content/ContentSummary';
+import {ContentSummary, ContentSummaryBuilder} from '../../../../../../app/content/ContentSummary';
 import {fetchContentByIds} from '../../../../api/content-fetcher';
 import {useI18n} from '../../../../hooks/useI18n';
 import {ContentSelectionItem} from './ContentSelectionItem';
@@ -86,11 +86,9 @@ export const ContentSelection = ({
         fetchContentByIds([...selection])
             .then((items) => {
                 if (requestId !== requestIdRef.current) return;
-                // Preserve selection order
+                // Preserve selection order; use a pathless stub for ids not found (deleted/missing)
                 const itemMap = new Map(items.map(item => [item.getId(), item]));
-                const ordered = selection
-                    .map(id => itemMap.get(id))
-                    .filter((item): item is ContentSummary => item != null);
+                const ordered = selection.map(id => itemMap.get(id) ?? new ContentSummaryBuilder().setId(id).build());
                 setLoadedItems(ordered);
             })
             .finally(() => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/selection/ContentSelectionItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/selection/ContentSelectionItem.tsx
@@ -6,6 +6,7 @@ import {ContentButton} from '../../../content/ContentButton';
 import {StatusBadge} from '../../../status/StatusBadge';
 import {useI18n} from '../../../../hooks/useI18n';
 import {calcTreePublishStatus} from '../../../../utils/cms/content/status';
+import {ContentNotAvailable} from './ContentNotAvailable';
 
 //
 // * Types
@@ -37,14 +38,10 @@ const CONTENT_SELECTION_ITEM_NAME = 'ContentSelectionItem';
  * Left cell: clickable content label (opens content for editing).
  * Right cell: status badge and remove button.
  */
-export const ContentSelectionItem = ({
-    content,
-    onRemove,
-    disabled = false,
-    className,
-}: ContentSelectionItemProps): ReactElement => {
-    const id = content.getId();
+export const ContentSelectionItem = ({content, onRemove, disabled = false, className}: ContentSelectionItemProps): ReactElement => {
     const removeLabel = useI18n('action.remove');
+    const id = content.getId();
+    const isRemoved = !content.getPath();
 
     return (
         <GridList.Row
@@ -54,18 +51,22 @@ export const ContentSelectionItem = ({
             disabled={disabled}
             className={className ?? 'gap-3 px-1.5'}
         >
-            <GridList.Cell className='flex-1 min-w-0'>
-                <GridList.Action>
-                    <ContentButton content={content} disabled={disabled} labelVariant='detailed' />
-                </GridList.Action>
+            <GridList.Cell className="flex-1 min-w-0">
+                {isRemoved ? (
+                    <ContentNotAvailable contentId={id} />
+                ) : (
+                    <GridList.Action>
+                        <ContentButton content={content} disabled={disabled} labelVariant="detailed" />
+                    </GridList.Action>
+                )}
             </GridList.Cell>
-                <StatusBadge status={calcTreePublishStatus(content)} />
+            {!isRemoved && <StatusBadge status={calcTreePublishStatus(content)} />}
             <GridList.Cell>
                 <GridList.Action>
                     <IconButton
                         icon={X}
-                        size='sm'
-                        variant='text'
+                        size="sm"
+                        variant="text"
                         iconSize={18}
                         iconStrokeWidth={2}
                         onClick={(event) => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/selection/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/content/selection/index.ts
@@ -1,2 +1,3 @@
 export {ContentSelection, type ContentSelectionProps} from './ContentSelection';
 export {ContentSelectionItem, type ContentSelectionItemProps} from './ContentSelectionItem';
+export {ContentNotAvailable, type ContentNotAvailableProps} from './ContentNotAvailable';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/media/MediaSelectorItemView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/media/MediaSelectorItemView.tsx
@@ -1,12 +1,11 @@
 import {Tooltip} from '@enonic/ui';
-import {FileQuestionMarkIcon} from 'lucide-react';
 import {type ReactElement} from 'react';
 import type {ContentSummary} from '../../../../../app/content/ContentSummary';
-import {useI18n} from '../../../hooks/useI18n';
 import {calcContentState} from '../../../utils/cms/content/workflow';
 import {calcTreePublishStatus} from '../../../utils/cms/content/status';
 import {WorkflowContentIcon} from '../../icons/WorkflowContentIcon';
 import {StatusBadge} from '../../status/StatusBadge';
+import {ContentNotAvailable} from '../content/selection';
 
 export type MediaSelectorItemViewProps = {
     /** The content to display */
@@ -20,8 +19,6 @@ const MEDIA_SELECTOR_ITEM_VIEW = 'MediaSelectorItemView';
 // Gets an image content and render its image within a squared box, with its name and path to the side of the box.
 // The squared box adjusts its size to be 36% of the element's width. For that, add @container class to the element you want to use as reference for the box size.
 export const MediaSelectorItemView = ({content, hideStatus = false}: MediaSelectorItemViewProps): ReactElement => {
-    const contentNotAvailableLabel = useI18n('text.content.not.found');
-
     // Content without a path is considered removed (deleted or archived)
     const isRemoved = !content.getPath();
 
@@ -32,19 +29,7 @@ export const MediaSelectorItemView = ({content, hideStatus = false}: MediaSelect
     const status = statusHidden ? null : calcContentState(content);
 
     if (isRemoved) {
-        return (
-            <div data-component={MEDIA_SELECTOR_ITEM_VIEW} className="flex items-center gap-2.5 min-w-0">
-                <div className="shrink-0">
-                    <FileQuestionMarkIcon size={24} absoluteStrokeWidth className="text-error" />
-                </div>
-                <div className="min-w-0 w-full">
-                    <span className="font-semibold text-base block whitespace-nowrap overflow-hidden text-ellipsis">{contentId}</span>
-                    <span className="text-sm text-error block whitespace-nowrap overflow-hidden text-ellipsis">
-                        {contentNotAvailableLabel}
-                    </span>
-                </div>
-            </div>
-        );
+        return <ContentNotAvailable contentId={contentId}  />;
     }
 
     return (


### PR DESCRIPTION
Added ContentNotAvailable shared component with the removed-content view (icon + id + label). 
Reused it in MediaSelectorItemView and ContentSelectionItem instead of inline markup. 
ContentSelection now keeps a pathless ContentSummaryBuilder stub for unresolved ids instead of dropping them, so the selector renders a removable row. 
ContentSelectionItem shows ContentNotAvailable and hides the status badge for pathless (removed) items. HtmlAreaLinkDialogContext no longer surfaces an error toast when a linked content is missing; logs to console instead.