### PR TITLE
Fix incremental build to resolve correct lib-admin-ui types

### DIFF
--- a/modules/lib/pnpm-lock.yaml
+++ b/modules/lib/pnpm-lock.yaml
@@ -178,10 +178,10 @@ importers:
         specifier: ^1.2.0
         version: 1.2.4(@types/react@19.2.14)(react@19.2.7)
       dayjs:
-        specifier: ^1.11.20
+        specifier: ^1.11.21
         version: 1.11.21
       dompurify:
-        specifier: ~3.4.5
+        specifier: ~3.4.11
         version: 3.4.11
       fine-uploader:
         specifier: ^5.16.2
@@ -202,7 +202,7 @@ importers:
         specifier: ^1.6.5
         version: 1.6.5
       nanoid:
-        specifier: ~5.1.11
+        specifier: ~5.1.15
         version: 5.1.16
       nanostores:
         specifier: ~1.3.0
@@ -212,8 +212,8 @@ importers:
         version: 1.5.1
     devDependencies:
       '@biomejs/biome':
-        specifier: ~2.4.15
-        version: 2.4.16
+        specifier: ~2.5.0
+        version: 2.5.1
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -221,23 +221,23 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@enonic/ui':
-        specifier: ~1.0.0-beta.7
+        specifier: ^1.0.5
         version: 1.0.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.7))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(lucide-react@1.22.0(react@19.2.7))(preact@10.29.3)(react-dom@19.2.7(react@19.2.7))(react-virtuoso@4.18.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.59.0)
       '@storybook/addon-docs':
-        specifier: ~10.4.1
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
+        specifier: ~10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
       '@storybook/addon-themes':
-        specifier: ~10.4.1
+        specifier: ~10.4.6
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))
       '@storybook/preact-vite':
-        specifier: ~10.4.1
-        version: 10.4.6(esbuild@0.27.7)(preact@10.29.3)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
+        specifier: ~10.4.6
+        version: 10.4.6(esbuild@0.27.7)(preact@10.29.3)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
       '@tailwindcss/vite':
-        specifier: ~4.3.0
-        version: 4.3.2(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
+        specifier: ~4.3.1
+        version: 4.3.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
       '@types/jquery':
         specifier: ^3.5.33
         version: 3.5.34
@@ -248,8 +248,8 @@ importers:
         specifier: ^1.6.15
         version: 1.6.15
       '@types/node':
-        specifier: ~25.9.1
-        version: 25.9.4
+        specifier: ~26.0.0
+        version: 26.0.0
       '@types/q':
         specifier: ^1.5.8
         version: 1.5.8
@@ -263,7 +263,7 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       cssnano:
-        specifier: ^8.0.1
+        specifier: ^8.0.2
         version: 8.0.2(postcss@8.5.15)
       enonic-admin-artifacts:
         specifier: ^2.5.0
@@ -275,25 +275,25 @@ importers:
         specifier: ~2.7.0
         version: 2.7.0
       less:
-        specifier: ^4.6.4
+        specifier: ^4.6.6
         version: 4.6.7
       lucide-react:
-        specifier: ^1.16.0
+        specifier: ^1.21.0
         version: 1.22.0(react@19.2.7)
       postcss-normalize:
         specifier: ^13.0.1
         version: 13.0.1(browserslist@4.28.2)(postcss@8.5.15)
       postcss-sort-media-queries:
-        specifier: ^6.6.1
+        specifier: ^6.6.2
         version: 6.6.2(postcss@8.5.15)
       preact:
         specifier: ^10.29.2
         version: 10.29.3
       storybook:
-        specifier: ~10.4.1
+        specifier: ~10.4.6
         version: 10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7)
       tailwindcss:
-        specifier: ~4.3.0
+        specifier: ~4.3.1
         version: 4.3.2
       tw-animate-css:
         specifier: ~1.4.0
@@ -302,11 +302,11 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.14
-        version: 8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
       vitest:
-        specifier: ~4.1.7
-        version: 4.1.9(@types/node@25.9.4)(@vitest/ui@4.1.9)(happy-dom@20.8.9)(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
+        specifier: ~4.1.9
+        version: 4.1.9(@types/node@26.0.0)(@vitest/ui@4.1.9)(happy-dom@20.8.9)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
 
 packages:
 
@@ -325,59 +325,59 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.4.16':
-    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
+  '@biomejs/biome@2.5.1':
+    resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.16':
-    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
+  '@biomejs/cli-darwin-arm64@2.5.1':
+    resolution: {integrity: sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.16':
-    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
+  '@biomejs/cli-darwin-x64@2.5.1':
+    resolution: {integrity: sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.16':
-    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
+  '@biomejs/cli-linux-arm64-musl@2.5.1':
+    resolution: {integrity: sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.16':
-    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
+  '@biomejs/cli-linux-arm64@2.5.1':
+    resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.16':
-    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
+  '@biomejs/cli-linux-x64-musl@2.5.1':
+    resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.16':
-    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
+  '@biomejs/cli-linux-x64@2.5.1':
+    resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.16':
-    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
+  '@biomejs/cli-win32-arm64@2.5.1':
+    resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.16':
-    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
+  '@biomejs/cli-win32-x64@2.5.1':
+    resolution: {integrity: sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -2272,9 +2272,6 @@ packages:
 
   '@types/node-forge@1.3.14':
     resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
-
-  '@types/node@25.9.4':
-    resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
 
   '@types/node@26.0.0':
     resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
@@ -4993,9 +4990,6 @@ packages:
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -5294,39 +5288,39 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@biomejs/biome@2.4.16':
+  '@biomejs/biome@2.5.1':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.16
-      '@biomejs/cli-darwin-x64': 2.4.16
-      '@biomejs/cli-linux-arm64': 2.4.16
-      '@biomejs/cli-linux-arm64-musl': 2.4.16
-      '@biomejs/cli-linux-x64': 2.4.16
-      '@biomejs/cli-linux-x64-musl': 2.4.16
-      '@biomejs/cli-win32-arm64': 2.4.16
-      '@biomejs/cli-win32-x64': 2.4.16
+      '@biomejs/cli-darwin-arm64': 2.5.1
+      '@biomejs/cli-darwin-x64': 2.5.1
+      '@biomejs/cli-linux-arm64': 2.5.1
+      '@biomejs/cli-linux-arm64-musl': 2.5.1
+      '@biomejs/cli-linux-x64': 2.5.1
+      '@biomejs/cli-linux-x64-musl': 2.5.1
+      '@biomejs/cli-win32-arm64': 2.5.1
+      '@biomejs/cli-win32-x64': 2.5.1
 
-  '@biomejs/cli-darwin-arm64@2.4.16':
+  '@biomejs/cli-darwin-arm64@2.5.1':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.16':
+  '@biomejs/cli-darwin-x64@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.16':
+  '@biomejs/cli-linux-arm64-musl@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.16':
+  '@biomejs/cli-linux-arm64@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.16':
+  '@biomejs/cli-linux-x64-musl@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.16':
+  '@biomejs/cli-linux-x64@2.5.1':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.16':
+  '@biomejs/cli-win32-arm64@2.5.1':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.16':
+  '@biomejs/cli-win32-x64@2.5.1':
     optional: true
 
   '@borewit/text-codec@0.2.2': {}
@@ -6320,10 +6314,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.7)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
       '@storybook/icons': 2.1.0(react@19.2.7)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))
       react: 19.2.7
@@ -6344,25 +6338,25 @@ snapshots:
       storybook: 10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7)
       ts-dedent: 2.3.0
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
       storybook: 10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7)
       ts-dedent: 2.3.0
-      vite: 8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.59.0
-      vite: 8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
 
   '@storybook/global@5.0.0': {}
 
@@ -6370,13 +6364,13 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  '@storybook/preact-vite@10.4.6(esbuild@0.27.7)(preact@10.29.3)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
+  '@storybook/preact-vite@10.4.6(esbuild@0.27.7)(preact@10.29.3)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
     dependencies:
-      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(rollup@4.59.0)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
       '@storybook/preact': 10.4.6(preact@10.29.3)(storybook@10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7))
       preact: 10.29.3
       storybook: 10.4.6(@testing-library/dom@8.20.1)(@types/react@19.2.14)(react@19.2.7)
-      vite: 8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -6596,12 +6590,12 @@ snapshots:
       tailwindcss: 4.2.1
       vite: 7.3.2(@types/node@26.0.0)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.32.0)
 
-  '@tailwindcss/vite@4.3.2(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
+  '@tailwindcss/vite@4.3.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
     dependencies:
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.2
-      vite: 8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
 
   '@testing-library/dom@8.20.1':
     dependencies:
@@ -6666,11 +6660,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6682,11 +6676,11 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.8
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
 
   '@types/core-js@2.5.8': {}
 
@@ -6696,7 +6690,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -6718,7 +6712,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
 
   '@types/jquery@3.5.34':
     dependencies:
@@ -6738,16 +6732,11 @@ snapshots:
 
   '@types/node-forge@1.3.14':
     dependencies:
-      '@types/node': 25.9.4
-
-  '@types/node@25.9.4':
-    dependencies:
-      undici-types: 7.24.6
+      '@types/node': 26.0.0
 
   '@types/node@26.0.0':
     dependencies:
       undici-types: 8.3.0
-    optional: true
 
   '@types/q@1.5.8': {}
 
@@ -6768,11 +6757,11 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -6781,7 +6770,7 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
       '@types/send': 0.17.6
 
   '@types/signals@1.0.4': {}
@@ -6790,7 +6779,7 @@ snapshots:
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
 
   '@types/sortablejs@1.15.9': {}
 
@@ -6801,7 +6790,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
 
   '@typescript/typescript-aix-ppc64@7.0.1-rc':
     optional: true
@@ -6888,13 +6877,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@26.0.0)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.32.0)
 
-  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6931,7 +6920,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@25.9.4)(@vitest/ui@4.1.9)(happy-dom@20.8.9)(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
+      vitest: 4.1.9(@types/node@26.0.0)(@vitest/ui@4.1.9)(happy-dom@20.8.9)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -8079,7 +8068,7 @@ snapshots:
 
   happy-dom@20.8.9:
     dependencies:
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -9599,10 +9588,7 @@ snapshots:
       buffer: 5.7.1
       through: 2.3.8
 
-  undici-types@7.24.6: {}
-
-  undici-types@8.3.0:
-    optional: true
+  undici-types@8.3.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -9648,7 +9634,7 @@ snapshots:
       less: 4.6.7
       lightningcss: 1.32.0
 
-  vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7):
+  vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -9656,40 +9642,11 @@ snapshots:
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 25.9.4
+      '@types/node': 26.0.0
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0
       less: 4.6.7
-
-  vitest@4.1.9(@types/node@25.9.4)(@vitest/ui@4.1.9)(happy-dom@20.8.9)(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.4)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.9.4
-      '@vitest/ui': 4.1.9(vitest@4.1.9)
-      happy-dom: 20.8.9
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.9(@types/node@26.0.0)(@vitest/ui@4.1.9)(happy-dom@20.8.9)(vite@7.3.2(@types/node@26.0.0)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.32.0)):
     dependencies:
@@ -9712,6 +9669,35 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@26.0.0)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.0.0
+      '@vitest/ui': 4.1.9(vitest@4.1.9)
+      happy-dom: 20.8.9
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.9(@types/node@26.0.0)(@vitest/ui@4.1.9)(happy-dom@20.8.9)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(less@4.6.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.0.0

--- a/modules/lib/tsconfig.json
+++ b/modules/lib/tsconfig.json
@@ -22,7 +22,6 @@
         "noImplicitThis": true,
         "strictNullChecks": false,
         "skipLibCheck": true,
-        "incremental": true,
         "types": [
             "ckeditor",
             "hasher",


### PR DESCRIPTION
Fixes incremental build problems that prevented the build from resolving the correct lib-admin-ui types.

## Changes

- Removed `incremental: true` from `modules/lib/tsconfig.json` so `tsc` no longer reuses a stale `tsbuildinfo` cache that pinned outdated lib-admin-ui types.
- Regenerated `modules/lib/pnpm-lock.yaml` to refresh the `.xp/dev/lib-admin-ui` importer with current lib-admin-ui dependencies.

<sub>*Drafted with AI assistance*</sub>
