### PR TITLE
СontentSelector query results are not limited by the nearest site #10874

### DIFF
--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentRelativePathResolver.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentRelativePathResolver.java
@@ -17,7 +17,14 @@ public class ContentRelativePathResolver
 
     public static String resolveWithSite( final String pathExpression, final Site parentSite )
     {
-        return makeEndWithStar( makeStartWithSlash( resolveSitePath( pathExpression, parentSite ) ) );
+        final String resolved = makeStartWithSlash( resolveSitePath( pathExpression, parentSite ) );
+
+        if ( SITE_WILDCARD.equals( pathExpression ) )
+        {
+            return makeEndWithStar( makeEndWithSlash( resolved ) );
+        }
+
+        return makeEndWithStar( resolved );
     }
 
     public static boolean anyPathNeedsSiteResolving( final List<String> allowedPaths )
@@ -104,6 +111,18 @@ public class ContentRelativePathResolver
         else
         {
             return "/" + str;
+        }
+    }
+
+    private static String makeEndWithSlash( final String str )
+    {
+        if ( str.endsWith( "/" ) )
+        {
+            return str;
+        }
+        else
+        {
+            return str + "/";
         }
     }
 

--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
@@ -177,7 +177,20 @@ public class ContentSelectorQueryJsonToContentQueryConverter
 
     private ConstraintExpr addAllowPathToExpr( final String allowedPath, final ConstraintExpr expr )
     {
-        return createAndAppendExpr( doResolvePath( allowedPath ), expr );
+        final ConstraintExpr pathExpr = createPathExpr( allowedPath );
+        return expr == null ? pathExpr : LogicalExpr.or( expr, pathExpr );
+    }
+
+    private ConstraintExpr createPathExpr( final String allowedPath )
+    {
+        final ConstraintExpr subtreeExpr = createCompareExpr( doResolvePath( allowedPath ) );
+
+        if ( ContentRelativePathResolver.SITE_WILDCARD.equals( allowedPath ) && this.parentSite != null )
+        {
+            return LogicalExpr.or( createCompareExpr( this.parentSite.getPath().toString() ), subtreeExpr );
+        }
+
+        return subtreeExpr;
     }
 
     private String doResolvePath( final String allowedPath )
@@ -187,11 +200,6 @@ public class ContentSelectorQueryJsonToContentQueryConverter
             return ContentRelativePathResolver.resolveWithSite( allowedPath, this.parentSite );
         }
         return ContentRelativePathResolver.resolve( this.content, allowedPath );
-    }
-
-    private ConstraintExpr createAndAppendExpr( final String resolvedPath, final ConstraintExpr expr )
-    {
-        return expr == null ? createCompareExpr( resolvedPath ) : LogicalExpr.or( expr, createCompareExpr( resolvedPath ) );
     }
 
     private CompareExpr createCompareExpr( final String resolvedPath )

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentRelativePathResolverTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentRelativePathResolverTest.java
@@ -23,7 +23,7 @@ public class ContentRelativePathResolverTest
         final String resolvedWildcardOption2 =
             ContentRelativePathResolver.resolveWithSite( ContentRelativePathResolver.SITE_WILDCARD + "/somepath/", parentSite );
 
-        assertEquals( "/mySitePath/test*", resolvedWildcardOption1 );
+        assertEquals( "/mySitePath/test/*", resolvedWildcardOption1 );
         assertEquals( "/mySitePath/test/somepath/*", resolvedWildcardOption2 );
     }
 

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverterTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverterTest.java
@@ -117,6 +117,67 @@ public class ContentSelectorQueryJsonToContentQueryConverterTest
     }
 
     @Test
+    public void testBareSiteWildcardMatchesSiteAndSubtree()
+    {
+        final Content content = createContent( "content-id", "my-content", ContentTypeName.folder() );
+
+        final Site site = createSite( "site-id", "my-site" );
+
+        final List<String> allowPaths = List.of( "${site}" );
+
+        Mockito.when( contentService.getById( Mockito.isA( ContentId.class ) ) ).thenReturn( content );
+
+        Mockito.when( contentService.getNearestSite( Mockito.isA( ContentId.class ) ) ).thenReturn( site );
+
+        ContentSelectorQueryJson contentQueryJson =
+            new ContentSelectorQueryJson( "", 0, 100, "summary", "content-id", "inputName", Collections.emptyList(), allowPaths, null );
+
+        final ContentQuery contentQuery = getProcessor( contentQueryJson ).createQuery();
+
+        assertEquals( "(_path LIKE '/content/my-site' OR _path LIKE '/content/my-site/*')", contentQuery.getQueryExpr().toString() );
+    }
+
+    @Test
+    public void testBareSiteWildcardWithoutSiteMatchesWholeRepository()
+    {
+        final Content content = createContent( "content-id", "my-content", ContentTypeName.folder() );
+
+        final List<String> allowPaths = List.of( "${site}" );
+
+        Mockito.when( contentService.getById( Mockito.isA( ContentId.class ) ) ).thenReturn( content );
+
+        Mockito.when( contentService.getNearestSite( Mockito.isA( ContentId.class ) ) ).thenReturn( null );
+
+        ContentSelectorQueryJson contentQueryJson =
+            new ContentSelectorQueryJson( "", 0, 100, "summary", "content-id", "inputName", Collections.emptyList(), allowPaths, null );
+
+        final ContentQuery contentQuery = getProcessor( contentQueryJson ).createQuery();
+
+        assertEquals( "_path LIKE '/content/*'", contentQuery.getQueryExpr().toString() );
+    }
+
+    @Test
+    public void testSiteSubtreeWildcardMatchesDescendantsOnly()
+    {
+        final Content content = createContent( "content-id", "my-content", ContentTypeName.folder() );
+
+        final Site site = createSite( "site-id", "my-site" );
+
+        final List<String> allowPaths = List.of( "${site}/*" );
+
+        Mockito.when( contentService.getById( Mockito.isA( ContentId.class ) ) ).thenReturn( content );
+
+        Mockito.when( contentService.getNearestSite( Mockito.isA( ContentId.class ) ) ).thenReturn( site );
+
+        ContentSelectorQueryJson contentQueryJson =
+            new ContentSelectorQueryJson( "", 0, 100, "summary", "content-id", "inputName", Collections.emptyList(), allowPaths, null );
+
+        final ContentQuery contentQuery = getProcessor( contentQueryJson ).createQuery();
+
+        assertEquals( "_path LIKE '/content/my-site/*'", contentQuery.getQueryExpr().toString() );
+    }
+
+    @Test
     public void testPathWithAllowTypePassedFromJson()
     {
         Mockito.when( contentTypeService.getAll() )

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-link/ContentTabPanel.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-link/ContentTabPanel.tsx
@@ -10,6 +10,7 @@ import {$contextContent} from '../../../store/context/contextContent.store';
 import {useStore} from '@nanostores/preact';
 import {type MediaOption, useHtmlAreaLinkDialogContext} from './HtmlAreaLinkDialogContext';
 import {ContentSelector} from '../../selectors/content';
+import {resolveAllowedContentPaths} from './resolveAllowedContentPaths';
 
 const COMPONENT_NAME = 'ContentTabPanel';
 
@@ -47,21 +48,20 @@ export const ContentTabPanel = (): ReactElement => {
     const addLabel = useI18n('action.add');
     const uploadMediaLabel = useI18n('tooltip.button.uploadMedia');
 
-    // Load parent site path for scoping
-    const [parentSitePath, setParentSitePath] = useState<string | undefined>(undefined);
+    const [isInSite, setIsInSite] = useState(false);
 
     useEffect(() => {
         const contentId = contentSummary?.getContentId();
         if (!contentId) {
-            setParentSitePath(undefined);
+            setIsInSite(false);
             return;
         }
         fetchNearestSite(contentId).match(
             (site) => {
-                setParentSitePath(site ? site.getPath().toString() : undefined);
+                setIsInSite(!!site);
             },
             () => {
-                setParentSitePath(undefined);
+                setIsInSite(false);
             },
         );
     }, [contentSummary]);
@@ -80,12 +80,10 @@ export const ContentTabPanel = (): ReactElement => {
         }
     }, [deselectContent, selectContentById]);
 
-    const allowedContentPaths = useMemo(() => {
-        if (showAllContent || !parentSitePath) {
-            return undefined;
-        }
-        return [parentSitePath];
-    }, [showAllContent, parentSitePath]);
+    const allowedContentPaths = useMemo(
+        () => resolveAllowedContentPaths({isInSite, showAllContent}),
+        [isInSite, showAllContent],
+    );
 
     // Media upload
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -121,6 +119,7 @@ export const ContentTabPanel = (): ReactElement => {
                         onSelectionChange={handleSelectionChange}
                         selectionMode='single'
                         allowedContentPaths={allowedContentPaths}
+                        contextContent={contentSummary}
                         error={!!errors.content}
                         closeOnBlur
                         className='flex-1 focus-within:z-10'
@@ -149,7 +148,7 @@ export const ContentTabPanel = (): ReactElement => {
                 </div>
             </div>
 
-            {parentSitePath && !selectedContent && (
+            {isInSite && !selectedContent && (
                 <Checkbox
                     checked={showAllContent}
                     onCheckedChange={(checked) => setShowAllContent(checked === true)}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-link/resolveAllowedContentPaths.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-link/resolveAllowedContentPaths.test.ts
@@ -1,0 +1,17 @@
+import {describe, expect, it} from 'vitest';
+import {SITE_PATH} from '../../../utils/form/form';
+import {resolveAllowedContentPaths} from './resolveAllowedContentPaths';
+
+describe('resolveAllowedContentPaths', () => {
+    it('scopes to the site placeholder when inside a site and not showing all content', () => {
+        expect(resolveAllowedContentPaths({isInSite: true, showAllContent: false})).toEqual([SITE_PATH]);
+    });
+
+    it('returns undefined (whole repository) when showing all content', () => {
+        expect(resolveAllowedContentPaths({isInSite: true, showAllContent: true})).toBeUndefined();
+    });
+
+    it('returns undefined (whole repository) when not inside a site', () => {
+        expect(resolveAllowedContentPaths({isInSite: false, showAllContent: false})).toBeUndefined();
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-link/resolveAllowedContentPaths.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/dialogs/htmlarea-link/resolveAllowedContentPaths.ts
@@ -1,0 +1,14 @@
+import {SITE_PATH} from '../../../utils/form/form';
+
+type ScopeOptions = {
+    isInSite: boolean;
+    showAllContent: boolean;
+};
+
+export function resolveAllowedContentPaths({isInSite, showAllContent}: ScopeOptions): string[] | undefined {
+    if (showAllContent || !isInSite) {
+        return undefined;
+    }
+
+    return [SITE_PATH];
+}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/content-selector/ContentSelectorDescriptor.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/content-selector/ContentSelectorDescriptor.test.ts
@@ -1,0 +1,19 @@
+import {describe, expect, it} from 'vitest';
+import {ContentSelectorDescriptor} from './ContentSelectorDescriptor';
+import {SITE_PATH} from '../../../../utils/form/form';
+
+describe('ContentSelectorDescriptor', () => {
+    it('defaults allowPath to the site wildcard when allowPath is not configured', () => {
+        const config = ContentSelectorDescriptor.readConfig({});
+
+        expect(config.allowPath).toEqual([SITE_PATH]);
+    });
+
+    it('reads configured allowPath entries and ignores blank values', () => {
+        const config = ContentSelectorDescriptor.readConfig({
+            allowPath: [{value: '/site-a/*'}, {value: ''}, {value: '/site-b/*'}],
+        });
+
+        expect(config.allowPath).toEqual(['/site-a/*', '/site-b/*']);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/content-selector/ContentSelectorDescriptor.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/content-selector/ContentSelectorDescriptor.ts
@@ -4,7 +4,7 @@ import {type ValueType} from '@enonic/lib-admin-ui/data/ValueType';
 import {type Value} from '@enonic/lib-admin-ui/data/Value';
 import {ValueTypes} from '@enonic/lib-admin-ui/data/ValueTypes';
 import type {RawInputConfig} from '@enonic/lib-admin-ui/form/Input';
-import {SITE_PATH} from '../../../../utils/form/form';
+import {SITE_PATH, readAllowPath} from '../../../../utils/form/form';
 
 export const ContentSelectorDescriptor: InputTypeDescriptor<ContentSelectorConfig> = {
     name: 'ContentSelector' as const,
@@ -15,7 +15,7 @@ export const ContentSelectorDescriptor: InputTypeDescriptor<ContentSelectorConfi
 
     readConfig(raw: RawInputConfig): ContentSelectorConfig {
         const allowContentType = raw?.['allowContentType']?.map((cfg) => cfg['value'] as string).filter((val) => !!val);
-        const allowPath = raw?.['allowPath']?.map((cfg) => cfg['value'] as string).filter((val) => !!val) ?? [SITE_PATH];
+        const allowPath = readAllowPath(raw, [SITE_PATH]);
         const treeMode = raw?.['treeMode']?.[0]?.value === true;
         const hideToggleIcon = raw?.['hideToggleIcon']?.[0]?.value === true;
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/hooks/useSelectorInput.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/hooks/useSelectorInput.test.ts
@@ -1,0 +1,72 @@
+import {renderHook} from '@testing-library/preact';
+import {atom} from 'nanostores';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {SITE_PATH} from '../../../../utils/form/form';
+import {type ContentSummary} from '../../../../../../app/content/ContentSummary';
+
+vi.mock('../../../../store/context/contextContent.store', () => ({
+    $contextContent: atom<unknown>(null),
+}));
+
+vi.mock('../../../../hooks/useI18n', () => ({
+    useI18n: (key: string): string => key,
+}));
+
+vi.mock('./useSelectorInputHasError', () => ({
+    useSelectorInputHasError: () => false,
+}));
+
+import {useSelectorInput} from './useSelectorInput';
+import * as contextContentStore from '../../../../store/context/contextContent.store';
+
+const $contextContent = contextContentStore.$contextContent;
+
+const content = {getId: () => 'content-1'} as unknown as ContentSummary;
+
+function makeProps(allowPath: string[]): Parameters<typeof useSelectorInput>[0] {
+    const props = {
+        values: [],
+        onChange: vi.fn(),
+        onAdd: vi.fn(),
+        onRemove: vi.fn(),
+        onMove: vi.fn(),
+        occurrences: {getMaximum: () => 1},
+        config: {allowPath, treeMode: false, hideToggleIcon: false},
+        input: undefined,
+        enabled: true,
+        errors: [],
+    };
+
+    return props as unknown as Parameters<typeof useSelectorInput>[0];
+}
+
+describe('useSelectorInput', () => {
+    afterEach(() => {
+        $contextContent.set(null);
+        vi.restoreAllMocks();
+    });
+
+    it('always passes the context content, even when allowPath is only the site wildcard', () => {
+        $contextContent.set(content);
+
+        const {result} = renderHook(() => useSelectorInput(makeProps([SITE_PATH])));
+
+        expect(result.current.contextContent).toBe(content);
+    });
+
+    it('passes the context content for absolute allowPath as well', () => {
+        $contextContent.set(content);
+
+        const {result} = renderHook(() => useSelectorInput(makeProps(['/some/path'])));
+
+        expect(result.current.contextContent).toBe(content);
+    });
+
+    it('returns undefined context content when there is no content in scope', () => {
+        $contextContent.set(null);
+
+        const {result} = renderHook(() => useSelectorInput(makeProps([SITE_PATH])));
+
+        expect(result.current.contextContent).toBeUndefined();
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/hooks/useSelectorInput.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/hooks/useSelectorInput.ts
@@ -6,7 +6,6 @@ import {useCallback, useMemo} from 'react';
 import {useI18n} from '../../../../hooks/useI18n';
 import {useStore} from '@nanostores/preact';
 import {$contextContent} from '../../../../store/context/contextContent.store';
-import {SITE_PATH} from '../../../../utils/form/form';
 import {type ContentSummary} from '../../../../../../app/content/ContentSummary';
 import {useSelectorInputHasError} from './useSelectorInputHasError';
 
@@ -30,9 +29,7 @@ export const useSelectorInput = <T extends Omit<GeneralSelectorConfig, 'allowCon
     const contextContent = useStore($contextContent);
 
     // Constants
-    const resolvedContextContent: ContentSummary | undefined = config.allowPath.some((path) => path !== SITE_PATH)
-        ? contextContent
-        : undefined;
+    const resolvedContextContent: ContentSummary | undefined = contextContent ?? undefined;
     const resolvedSelectionMode: 'single' | 'multiple' = occurrences.getMaximum() === 1 ? 'single' : 'multiple';
     const resolvedListMode: 'tree' | 'flat' = config.treeMode ? 'tree' : 'flat';
     const resolvedHasErrors: boolean = useSelectorInputHasError(occurrences, errors);

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-selector/ImageSelectorDescriptor.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-selector/ImageSelectorDescriptor.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from 'vitest';
+import {ImageSelectorDescriptor} from './ImageSelectorDescriptor';
+
+describe('ImageSelectorDescriptor', () => {
+    it('defaults allowPath to no restriction (whole repository) when allowPath is not configured', () => {
+        const config = ImageSelectorDescriptor.readConfig({});
+
+        expect(config.allowPath).toEqual([]);
+    });
+
+    it('reads configured allowPath entries and ignores blank values', () => {
+        const config = ImageSelectorDescriptor.readConfig({
+            allowPath: [{value: '/site-a/*'}, {value: ''}, {value: '/site-b/*'}],
+        });
+
+        expect(config.allowPath).toEqual(['/site-a/*', '/site-b/*']);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-selector/ImageSelectorDescriptor.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/image-selector/ImageSelectorDescriptor.ts
@@ -4,7 +4,7 @@ import {type ValueType} from '@enonic/lib-admin-ui/data/ValueType';
 import {type Value} from '@enonic/lib-admin-ui/data/Value';
 import {ValueTypes} from '@enonic/lib-admin-ui/data/ValueTypes';
 import type {RawInputConfig} from '@enonic/lib-admin-ui/form/Input';
-import {SITE_PATH} from '../../../../utils/form/form';
+import {readAllowPath} from '../../../../utils/form/form';
 
 export const ImageSelectorDescriptor: InputTypeDescriptor<ImageSelectorConfig> = {
     name: 'ImageSelector' as const,
@@ -14,7 +14,7 @@ export const ImageSelectorDescriptor: InputTypeDescriptor<ImageSelectorConfig> =
     },
 
     readConfig(raw: RawInputConfig): ImageSelectorConfig {
-        const allowPath = raw?.['allowPath']?.map((cfg) => cfg['value'] as string).filter((val) => !!val) ?? [SITE_PATH];
+        const allowPath = readAllowPath(raw, []);
         const treeMode = raw?.['treeMode']?.[0]?.value === true;
         const hideToggleIcon = raw?.['hideToggleIcon']?.[0]?.value === true;
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/media-selector/MediaSelectorDescriptor.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/media-selector/MediaSelectorDescriptor.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from 'vitest';
+import {MediaSelectorDescriptor} from './MediaSelectorDescriptor';
+
+describe('MediaSelectorDescriptor', () => {
+    it('defaults allowPath to no restriction (whole repository) when allowPath is not configured', () => {
+        const config = MediaSelectorDescriptor.readConfig({});
+
+        expect(config.allowPath).toEqual([]);
+    });
+
+    it('reads configured allowPath entries and ignores blank values', () => {
+        const config = MediaSelectorDescriptor.readConfig({
+            allowPath: [{value: '/site-a/*'}, {value: ''}, {value: '/site-b/*'}],
+        });
+
+        expect(config.allowPath).toEqual(['/site-a/*', '/site-b/*']);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/media-selector/MediaSelectorDescriptor.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/media-selector/MediaSelectorDescriptor.ts
@@ -4,7 +4,7 @@ import {type ValueType} from '@enonic/lib-admin-ui/data/ValueType';
 import {type Value} from '@enonic/lib-admin-ui/data/Value';
 import {ValueTypes} from '@enonic/lib-admin-ui/data/ValueTypes';
 import type {RawInputConfig} from '@enonic/lib-admin-ui/form/Input';
-import {SITE_PATH} from '../../../../utils/form/form';
+import {readAllowPath} from '../../../../utils/form/form';
 
 export const MediaSelectorDescriptor: InputTypeDescriptor<MediaSelectorConfig> = {
     name: 'MediaSelector' as const,
@@ -17,7 +17,7 @@ export const MediaSelectorDescriptor: InputTypeDescriptor<MediaSelectorConfig> =
         const allowContentType = raw?.['allowContentType']
             ?.map((cfg) => cfg['value'] as string)
             .filter((val) => !!val && val.startsWith('media:'));
-        const allowPath = raw?.['allowPath']?.map((cfg) => cfg['value'] as string).filter((val) => !!val) ?? [SITE_PATH];
+        const allowPath = readAllowPath(raw, []);
         const treeMode = raw?.['treeMode']?.[0]?.value === true;
         const hideToggleIcon = raw?.['hideToggleIcon']?.[0]?.value === true;
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/form/form.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/form/form.test.ts
@@ -1,0 +1,16 @@
+import {describe, expect, it} from 'vitest';
+import {readAllowPath, SITE_PATH} from './form';
+
+describe('readAllowPath', () => {
+    it('returns the fallback when allowPath is not configured', () => {
+        expect(readAllowPath({}, [SITE_PATH])).toEqual([SITE_PATH]);
+    });
+
+    it('reads configured values and drops blanks', () => {
+        expect(readAllowPath({allowPath: [{value: '/a'}, {value: ''}, {value: '/b'}]}, [SITE_PATH])).toEqual(['/a', '/b']);
+    });
+
+    it('returns an empty configured list as-is, without applying the fallback', () => {
+        expect(readAllowPath({allowPath: []}, [SITE_PATH])).toEqual([]);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/utils/form/form.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/utils/form/form.ts
@@ -1,1 +1,7 @@
+import type {RawInputConfig} from '@enonic/lib-admin-ui/form/Input';
+
 export const SITE_PATH = '${site}';
+
+export function readAllowPath(raw: RawInputConfig, fallback: string[]): string[] {
+    return raw?.['allowPath']?.map((cfg) => cfg['value'] as string).filter((val) => !!val) ?? fallback;
+}


### PR DESCRIPTION
Fixes a cluster of regressions in the v6 content/media/image selectors where allowed-path scoping produced the wrong result set. The v6 rewrite diverged from the legacy inputs in several places; this restores correct scoping and removes an over-matching bug on the backend.

## What

Backend

- `ContentRelativePathResolver`: the bare `${site}` wildcard now resolves to the site subtree (`/<site>/*`) instead of a bare prefix (`/<site>*`), which previously also matched sibling sites sharing a name prefix (opening a selector in `site1` matched `site12`, `site123`).
- `ContentSelectorQueryJsonToContentQueryConverter`: for the bare `${site}` wildcard the query now also matches the site node itself, producing `(_path LIKE '/content/<site>' OR _path LIKE '/content/<site>/*')`; when the content is outside any site it degrades to the whole repository.

Frontend

- `useSelectorInput`: the context content is now always passed to the request. Previously it was dropped when `allowPath` was only `${site}`, so the backend could not resolve `${site}` and the selector silently listed the whole repository.
- Descriptor defaults: `ContentSelector` keeps the site-scoped default (`${site}`), while `MediaSelector` and `ImageSelector` default to no restriction (whole repository), matching the legacy behavior. All three previously defaulted to `${site}`, so media/image outside the current site was hidden.
- `htmlarea-link` content tab: the selector now sends the `${site}` placeholder plus the context content and lets the backend resolve it, instead of resolving the nearest site on the client and sending a concrete `/site` path (which reintroduced the sibling-prefix over-match). The nearest-site lookup is kept only as an "is inside a site" flag that drives the "show all content" checkbox.

Refactor

- Extracted `readAllowPath(raw, fallback)` so the three descriptors share one parser and differ only by an explicit fallback argument, removing the copy-paste that caused the default divergence.
- Extracted `resolveAllowedContentPaths` from the link dialog into a pure, testable function.

## Why

The v6 selectors are a rewrite of the legacy inputs, and several behaviors were carried over imperfectly: media/image inherited the content selector's site-scoped default, the context content was conditionally dropped, and `${site}` was resolved on the client into a prefix match that leaked into sibling sites. Together these made selectors show the wrong content — either the whole repository when they should be scoped to the site, or sibling sites when scoped. The fixes move all path resolution to the backend, where the logic already lives, and make each selector's default explicit instead of implicit.

## Tests

- Backend: added converter cases for `${site}` (site node plus subtree), `${site}` without a site (whole repository), and `${site}/*` (descendants only); updated the resolver test for the site subtree.
- Frontend: added descriptor default tests (content versus media/image), a `useSelectorInput` test pinning that context content is always sent, and unit tests for `readAllowPath` and `resolveAllowedContentPaths`.

Closes #10874

<sub>*Drafted with AI assistance*</sub>
