### PR TITLE
UI-tests to verify fixed bugs #11054

### DIFF
--- a/testing/libs/app_const.js
+++ b/testing/libs/app_const.js
@@ -502,7 +502,7 @@ module.exports = Object.freeze({
         MODIFIED: 'Modified',
         MOVED: 'Moved',
         MOVED_MODIFIED: 'Moved, Modified',
-        PUBLISHING_SCHEDULED: 'Scheduled',
+        SCHEDULED: 'Scheduled',
         SCHEDULED_MODIFIED: 'Scheduled, Modified',
     },
     PUBLISH_MENU: {

--- a/testing/page_objects/content.publish.dialog.js
+++ b/testing/page_objects/content.publish.dialog.js
@@ -268,6 +268,7 @@ class ContentPublishDialog extends Page {
     async waitForDialogClosed() {
         try {
             await this.waitForElementNotDisplayed(XPATH.container);
+            await this.pause(300);
         } catch (err) {
             await this.handleError(`Publish Dialog, wait for dialog to be closed `, 'err_close_publish_dialog', err);
         }

--- a/testing/specs/browse.panel.grid.context.menu.spec.js
+++ b/testing/specs/browse.panel.grid.context.menu.spec.js
@@ -92,7 +92,6 @@ describe('browse.panel.grid.context.menu.spec - Tests for grid context menu', fu
             await contentBrowsePanel.waitForContextMenuItemNotDisplayed(appConst.GRID_CONTEXT_MENU.PUBLISH);
         });
 
-    // TODO  new-ui bug
     it(`GIVEN one published and one new folders are selected WHEN do right click on the selected items THEN Publish and Unpublish menu items should be enabled`,
         async () => {
             let contentBrowsePanel = new ContentBrowsePanel();

--- a/testing/specs/browse.panel.selections.spec.js
+++ b/testing/specs/browse.panel.selections.spec.js
@@ -87,7 +87,8 @@ describe('browse.panel.selections.spec - tests for selection items in Browse Pan
         });
 
     // https://github.com/enonic/app-contentstudio/issues/9238
-    // TODO bug
+    // TODO bug 11053
+    // https://github.com/enonic/app-contentstudio/issues/11053
     it.skip("GIVEN one row is highlighted WHEN hold down 'Shift' key AND click on the 5th row in grid THEN 5 content items get checked",
         async () => {
             let contentBrowsePanel = new ContentBrowsePanel();
@@ -140,8 +141,7 @@ describe('browse.panel.selections.spec - tests for selection items in Browse Pan
             assert.equal(number2, 0, "expected - no selected rows in grid");
         });
 
-    // TODO bug
-    it.skip("GIVEN existing content is selected WHEN 'Refresh' button in the grid toolbar has been clicked THEN the row remains checked",
+    it("GIVEN existing content is selected WHEN 'Refresh' button in the grid toolbar has been clicked THEN the row remains checked",
         async () => {
             let contentBrowsePanel = new ContentBrowsePanel();
             await contentBrowsePanel.pause(2000);

--- a/testing/specs/browse.toolbar.shortcut.spec.js
+++ b/testing/specs/browse.toolbar.shortcut.spec.js
@@ -32,8 +32,7 @@ describe('Browse toolbar shortcut spec`', function () {
 
     // Enter key doesn't open content for Edit #8756
     // https://github.com/enonic/app-contentstudio/issues/8756
-    // TODO enonic ui bug
-    it.skip(`GIVEN 2 item are checked in the grid WHEN 'Enter' key has been pressed THEN both folders should be opened in new tabs`,
+    it(`GIVEN 2 item are checked in the grid WHEN 'Enter' key has been pressed THEN both folders should be opened in new tabs`,
         async () => {
             let contentBrowsePanel = new ContentBrowsePanel();
             let contentWizard = new ContentWizard();

--- a/testing/specs/content.toggle.icon.spec.js
+++ b/testing/specs/content.toggle.icon.spec.js
@@ -46,7 +46,7 @@ describe('content.toggle.icon.spec: tests for expand/collapse icon', function ()
             await contentBrowsePanel.waitForContentDisplayed(CHILD_FOLDER_1.displayName);
         });
 
-    // TODO bug Enonic ui
+    // Filtered Grid - Folder gets collapsed after adding new child content  #10924
     it(`GIVEN existing folder is selected and expanded WHEN one more child folder has been created THEN the parent folder remains expanded`,
         async () => {
             let contentBrowsePanel = new ContentBrowsePanel();
@@ -57,12 +57,11 @@ describe('content.toggle.icon.spec: tests for expand/collapse icon', function ()
             // 2. Add a child folder:
             await studioUtils.doAddFolder(CHILD_FOLDER_2);
             await studioUtils.saveScreenshot("parent_should_be_expanded");
-            // TODO bug Enonic ui
             // 3. Verify that the parent folder remains expanded:
-           // let isExpanded = await contentBrowsePanel.isContentExpanded(PARENT_FOLDER.displayName);
-            // assert.ok(isExpanded, "Parent folder should be expanded");
+            let isExpanded = await contentBrowsePanel.isContentExpanded(PARENT_FOLDER.displayName);
+            assert.ok(isExpanded, "Parent folder should be expanded");
             // 4. Verify that the child folder is visible
-           // await contentBrowsePanel.waitForContentDisplayed(CHILD_FOLDER_2.displayName);
+            await contentBrowsePanel.waitForContentDisplayed(CHILD_FOLDER_2.displayName);
         });
 
     it(`GIVEN existing parent folder with child content WHEN child content have been deleted THEN the parent content should be displayed without toggle icon`,

--- a/testing/specs/folder.wizard.toolbar.spec.js
+++ b/testing/specs/folder.wizard.toolbar.spec.js
@@ -36,45 +36,47 @@ describe('folder.wizard.toolbar.spec: tests for toolbar in folder wizard', funct
             assert.equal(actualMessage, NO_SELECTED_CONTROLLER_MSG, 'Expected no controller message should be displayed');
         });
 
-    it(`GIVEN folder-wizard is opened WHEN name input is empty THEN all buttons have expected state`, async () => {
-        let contentWizard = new ContentWizard();
-        // 1. Open new folder-wizard
-        await studioUtils.openContentWizard(appConst.contentTypes.FOLDER);
-        await contentWizard.waitForDeleteButtonEnabled();
-        // 2. 'Save' button should be disabled (name input is empty)
-        await contentWizard.waitForSaveButtonDisabled();
-        // 3 'Create Issue' is Default action
-        await contentWizard.waitForCreateIssueButtonDisplayed();
-        // 4. Only 'Create Issue' menu item should be enabled:
-        await contentWizard.waitForPublishMenuDropdownHandleDisabled();
-        await contentWizard.waitForCreateIssueButtonDisplayed();
-        // 5. Duplicate button should be enabled
-        await contentWizard.waitForDuplicateButtonEnabled();
-        // 6. Verify that the content is invalid:
-        let result = await contentWizard.isContentInvalid();
-        assert.ok(result, 'The folder should be invalid, because the name input is empty');
-    });
+    it(`GIVEN folder-wizard is opened WHEN name input is empty THEN all buttons have expected state`,
+        async () => {
+            let contentWizard = new ContentWizard();
+            // 1. Open new folder-wizard
+            await studioUtils.openContentWizard(appConst.contentTypes.FOLDER);
+            await contentWizard.waitForDeleteButtonEnabled();
+            // 2. 'Save' button should be disabled (name input is empty)
+            await contentWizard.waitForSaveButtonDisabled();
+            // 3 'Create Issue' is Default action
+            await contentWizard.waitForCreateIssueButtonDisplayed();
+            // 4. Only 'Create Issue' menu item should be enabled:
+            await contentWizard.waitForPublishMenuDropdownHandleDisabled();
+            await contentWizard.waitForCreateIssueButtonDisplayed();
+            // 5. Duplicate button should be enabled
+            await contentWizard.waitForDuplicateButtonEnabled();
+            // 6. Verify that the content is invalid:
+            let result = await contentWizard.isContentInvalid();
+            assert.ok(result, 'The folder should be invalid, because the name input is empty');
+        });
 
-    it(`GIVEN folder-wizard is opened WHEN name has been typed THEN 'Save' button gets enabled`, async () => {
-        let contentWizard = new ContentWizard();
-        // 1. Open new folder-wizard
-        await studioUtils.openContentWizard(appConst.contentTypes.FOLDER);
-        // 2. Type a name:
-        await contentWizard.typeDisplayName(FOLDER_1_NAME);
-        // 3. Save button gets enabled
-        await contentWizard.waitForSaveButtonEnabled();
-        await contentWizard.waitForMarkAsReadyButtonVisible();
-        // 4. Verify that the content gets valid
-        let result = await contentWizard.isContentInvalid();
-        assert.ok(result === false, 'The folder should be valid before the name saving');
-        // 5. Only Unpublish menu item should be disabled:
-        await contentWizard.openPublishMenu();
-        // TODO bug https://github.com/enonic/app-contentstudio/issues/10462
-        await contentWizard.waitForPublishMenuItemEnabled(appConst.PUBLISH_MENU.CREATE_ISSUE);
-        //await contentWizard.waitForPublishMenuItemDisabled(appConst.PUBLISH_MENU.REQUEST_PUBLISH);
-        await contentWizard.waitForPublishMenuItemDisabled(appConst.PUBLISH_MENU.UNPUBLISH);
-        //await contentWizard.waitForPublishMenuItemEnabled(appConst.PUBLISH_MENU.PUBLISH);
-    });
+    it(`GIVEN folder-wizard is opened WHEN name has been typed THEN 'Save' button gets enabled`,
+        async () => {
+            let contentWizard = new ContentWizard();
+            // 1. Open new folder-wizard
+            await studioUtils.openContentWizard(appConst.contentTypes.FOLDER);
+            // 2. Type a name:
+            await contentWizard.typeDisplayName(FOLDER_1_NAME);
+            // 3. Save button gets enabled
+            await contentWizard.waitForSaveButtonEnabled();
+            await contentWizard.waitForMarkAsReadyButtonVisible();
+            // 4. Verify that the content gets valid
+            let result = await contentWizard.isContentInvalid();
+            assert.ok(result === false, 'The folder should be valid before the name saving');
+            // 5. Only Unpublish menu item should be disabled:
+            await contentWizard.openPublishMenu();
+            //Verify the bug https://github.com/enonic/app-contentstudio/issues/10462
+            await contentWizard.waitForPublishMenuItemEnabled(appConst.PUBLISH_MENU.CREATE_ISSUE);
+            await contentWizard.waitForPublishMenuItemEnabled(appConst.PUBLISH_MENU.REQUEST_PUBLISH);
+            await contentWizard.waitForPublishMenuItemDisabled(appConst.PUBLISH_MENU.UNPUBLISH);
+            await contentWizard.waitForPublishMenuItemEnabled(appConst.PUBLISH_MENU.PUBLISH);
+        });
 
     it(`GIVEN folder-wizard is opened AND a name has been typed WHEN 'Save' button has been pressed THEN 'Saved' button gets disabled`,
         async () => {

--- a/testing/specs/publish/unpublish.dialog.dependent.item.scheduled.spec.js
+++ b/testing/specs/publish/unpublish.dialog.dependent.item.scheduled.spec.js
@@ -1,5 +1,5 @@
 /**
- * Created on 18.02.2022
+ * Created on 18.02.2022  updated on 14.07.2026
  */
 const assert = require('node:assert');
 const webDriverHelper = require('../../libs/WebDriverHelper');
@@ -22,14 +22,14 @@ describe('Tests for dependent items in Unpublish dialog (for scheduled content)'
     const DATE_TIME_IN_FUTURE = '2029-09-10 00:00';
     let SITE;
 
-    // TODO epic-enonic-ui new tests: verify scheduled status in versions widget
+    // Scheduled content incorrectly shows "Published" status in preview toolbar #11051
     it(`WHEN existing site(include child items) has been scheduled THEN PUBLISHING SCHEDULED status should be displayed in the grid`,
         async () => {
             let contentWizard = new ContentWizard();
             let contentPublishDialog = new ContentPublishDialog();
             let contentBrowsePanel = new ContentBrowsePanel();
             let displayName = contentBuilder.generateRandomName('site-test');
-            SITE = contentBuilder.buildSite(displayName, 'test for displaying of metadata', [appConst.APP_CONTENT_TYPES]);
+            SITE = contentBuilder.buildSite(displayName, null, [appConst.APP_CONTENT_TYPES]);
             await studioUtils.doAddReadySite(SITE);
             // 1. Select the site:
             await studioUtils.findAndSelectItem(SITE.displayName);
@@ -37,28 +37,27 @@ describe('Tests for dependent items in Unpublish dialog (for scheduled content)'
             await contentBrowsePanel.openPublishMenuSelectItem(appConst.PUBLISH_MENU.PUBLISH_TREE);
             await contentPublishDialog.waitForDialogOpened();
             // 3. Click on Add Schedule:
-            await contentPublishDialog.clickOnAddScheduleIcon();
+            await contentPublishDialog.clickOnAddScheduleButton();
             await contentPublishDialog.typeInOnlineFrom(DATE_TIME_IN_FUTURE);
             await studioUtils.saveScreenshot('scheduled_site_publish_dialog');
             // 4. Press the 'Schedule' button in the dialog:
-            await contentPublishDialog.clickOnScheduleButton();
+            await contentPublishDialog.clickOnConfirmScheduleButton();
             let actualMessage = await contentWizard.waitForNotificationMessage();
             assert.equal(actualMessage, appConst.NOTIFICATION_MESSAGES.TWO_ITEMS_PUBLISHED, '2 items have been published. -  notification message should appear');
             await contentPublishDialog.waitForDialogClosed();
-            // 5. Verify that status is 'Publishing Scheduled' in Grid:
+            // 5. Verify that status is 'Scheduled' in Browse Panel:
             let actualStatus = await contentBrowsePanel.getContentStatus(SITE.displayName);
-            assert.equal(actualStatus, appConst.CONTENT_STATUS.PUBLISHING_SCHEDULED, "Scheduled status should be displayed in the grid");
+            assert.equal(actualStatus, appConst.CONTENT_STATUS.SCHEDULED, "Scheduled status should be displayed in the grid");
             let contentItemPreviewPanel = new ContentItemPreviewPanel();
+            // TODO  #11051
             // 6. 'Scheduled' status should be displayed in the 'Preview Item toolbar':
-            //let status = await contentItemPreviewPanel.getContentStatus();
-            //assert.equal(status, appConst.CONTENT_STATUS.PUBLISHING_SCHEDULED,
-            //   "'Scheduled' status should be displayed in the Preview Item toolbar");
-            // 7. 'Show Changes' button should be displayed in the 'Preview Item' toolbar:
-            // await contentItemPreviewPanel.waitForShowChangesButtonNotDisplayed();
+            let status = await contentItemPreviewPanel.getLabelInOpenVersionsHistoryButton();
+            //assert.equal(status, appConst.CONTENT_STATUS.SCHEDULED,
         });
 
     // Verify issue: Unpublish Item dialog - dependent items are not displayed when content with children are scheduled #4185
     // https://github.com/enonic/app-contentstudio/issues/4185
+    // https://github.com/enonic/app-contentstudio/issues/11052
     it(`GIVEN existing scheduled site is selected WHEN Unpublish menu item has been clicked THEN 'Show dependent items' link should be displayed in the modal dialog`,
         async () => {
             let contentUnpublishDialog = new ContentUnpublishDialog();
@@ -75,13 +74,13 @@ describe('Tests for dependent items in Unpublish dialog (for scheduled content)'
             let dependantItems = await contentUnpublishDialog.getDependentItemsPath();
             assert.ok(dependantItems.length === 1, 'One dependent item should be displayed in the dialog');
             // 5. Verify that 'Publishing Scheduled' status is displayed in the modal dialog:
-            assert.equal(actualStatus, appConst.CONTENT_STATUS.PUBLISHING_SCHEDULED, 'Scheduled status should be displayed in the dialog');
+            assert.equal(actualStatus, appConst.CONTENT_STATUS.SCHEDULED, 'Scheduled status should be displayed in the dialog');
             let actualNumber = await contentUnpublishDialog.getNumberInUnpublishButton();
             assert.equal(actualNumber, '2', '2 items will be unpablished');
         });
 
-    // Test for Publish button caption #8939
-    it(`GIVEN existing scheduled site has been modified WHEN 'Publish' menu has been has been clicked THEN 'Update Scheduled' button should be displayed in the Publish Dialog`,
+    // TODO https://github.com/enonic/app-contentstudio/issues/11052
+    it.skip(`GIVEN existing scheduled site has been modified WHEN 'Publish' menu has been has been clicked THEN 'Update Scheduled' button should be displayed in the Publish Dialog`,
         async () => {
             let contentWizard = new ContentWizard();
             let contentPublishDialog = new ContentPublishDialog();
@@ -93,7 +92,8 @@ describe('Tests for dependent items in Unpublish dialog (for scheduled content)'
             await contextWindow.selectItemInWidgetSelector(appConst.WIDGET_SELECTOR_OPTIONS.PAGE);
             let pageInspectionPanel = new PageInspectionPanel();
             await pageInspectionPanel.selectPageTemplateOrController(appConst.CONTROLLER_NAME.MAIN_REGION);
-            // 3. Click on 'Publish...' menu item
+            // 3. Click on 'Publish' menu item
+            // TODO  https://github.com/enonic/app-contentstudio/issues/11052
             await contentWizard.openPublishMenuSelectItem(appConst.PUBLISH_MENU.PUBLISH);
             await contentPublishDialog.waitForDialogOpened();
             // 4. Verify that 'Update Scheduled' button is disabled in the modal dialog:

--- a/testing/specs/publish/unpublish.dialog.dependent.item.scheduled.spec.js
+++ b/testing/specs/publish/unpublish.dialog.dependent.item.scheduled.spec.js
@@ -45,6 +45,7 @@ describe('Tests for dependent items in Unpublish dialog (for scheduled content)'
             let actualMessage = await contentWizard.waitForNotificationMessage();
             assert.equal(actualMessage, appConst.NOTIFICATION_MESSAGES.TWO_ITEMS_PUBLISHED, '2 items have been published. -  notification message should appear');
             await contentPublishDialog.waitForDialogClosed();
+            await contentBrowsePanel.pause(1000);
             // 5. Verify that status is 'Scheduled' in Browse Panel:
             let actualStatus = await contentBrowsePanel.getContentStatus(SITE.displayName);
             assert.equal(actualStatus, appConst.CONTENT_STATUS.SCHEDULED, "Scheduled status should be displayed in the grid");

--- a/testing/specs/site.configurator.required.input.spec.js
+++ b/testing/specs/site.configurator.required.input.spec.js
@@ -32,7 +32,8 @@ describe('site.configurator.required.input.spec: verifies wizard validation when
             // 2. Click on Edit icon and open Site Configurator Dialog:
             await siteFormPanel.openSiteConfiguratorDialog(APP_WITH_REQ_TEXT_INPUT);
             let message = await siteConfiguratorDialog.getValidationMessage();
-            assert.equal(message, appConst.VALIDATION_MESSAGE.THIS_FIELD_IS_REQUIRED, "This field is required - Validation message should be displayed");
+            assert.equal(message, appConst.VALIDATION_MESSAGE.THIS_FIELD_IS_REQUIRED,
+                "This field is required - Validation message should be displayed");
             await studioUtils.saveScreenshot('site_configurator_1');
 
             // 3. Verify that this input is focused by default( issue#427)
@@ -52,8 +53,7 @@ describe('site.configurator.required.input.spec: verifies wizard validation when
 
     //https://github.com/enonic/app-contentstudio/issues/10892
     // Missing invalid icon when required Site Configurator fields are empty
-    //TODO
-    it.skip(`GIVEN existing site with the configurator WHEN required input in the config is empty THEN the selected application-configurator option-view should be red`,
+    it(`GIVEN existing site with the configurator WHEN required input in the config is empty THEN the selected application-configurator option-view should be red`,
         async () => {
             let siteFormPanel = new SiteFormPanel();
             let contentWizard = new ContentWizard();

--- a/testing/specs/site.duplicate.delete.spec.js
+++ b/testing/specs/site.duplicate.delete.spec.js
@@ -114,7 +114,7 @@ describe('site.duplicate.exclude.child.spec:  tests for Duplicate and Confirm Va
             await contentDuplicateDialog.clickOnDuplicateButton();
             await contentDuplicateDialog.waitForDialogClosed();
             // 3. Verify that site does not have expander icon:
-            // TODO  Verify the issue  https://github.com/enonic/app-contentstudio/issues/7071
+            // Verify the issue  https://github.com/enonic/app-contentstudio/issues/7071
             await studioUtils.findAndSelectItem(SITE.displayName + '-copy-2');
             await studioUtils.saveScreenshot('site_duplicated_no_child');
             // 4. Verify - 'Site should be displayed without expand-toggle, because the site has no child items'

--- a/testing/specs/wizard.save.button.spec.js
+++ b/testing/specs/wizard.save.button.spec.js
@@ -45,9 +45,8 @@ describe('wizard.save.button.spec:  Save and Saved buttons spec', function () {
             await contentWizard.waitForSavedButtonVisible();
         });
 
-    // TODO bug
     // https://github.com/enonic/app-contentstudio/issues/10469
-    it.skip("WHEN the name that is already in use has been inserted in name-input THEN 'Save' button should be disabled, 'Not available' message appears",
+    it("WHEN the name that is already in use has been inserted in name-input THEN 'Save' button should be disabled, 'Not available' message appears",
         async () => {
             let wizard = new ContentWizard();
             // 1. Open wizard for new folder:

--- a/testing/wdio/wdio.publish.chrome.conf.js
+++ b/testing/wdio/wdio.publish.chrome.conf.js
@@ -17,7 +17,6 @@ exports.config = {
         path.join(__dirname, '../specs/publish/request.publish.dialog.spec.js'),
         path.join(__dirname, '../specs/publish/request.publish.dialog.validation.spec.js'),
         path.join(__dirname, '../specs/publish/request.publishing.dialog.mark.as.ready.spec.js'),
-        path.join(__dirname, '../specs/publish/unpublish.dialog.dependent.item.scheduled.spec.js'),
         path.join(__dirname, '../specs/publish/version.items.after.publishing.spec.js'),
 
         path.join(__dirname, '../specs/issue/create.issue.dialog.spec.js'),


### PR DESCRIPTION
https://github.com/enonic/app-contentstudio/issues/10469
Non-unique path should immediately make the content invalid

Enter key doesn't open content for Edit 
 https://github.com/enonic/app-contentstudio/issues/8756

Folder gets collapsed after adding new child content   10924


https://github.com/enonic/app-contentstudio/issues/10462
Content wizard - Items in the Publish menu are displayed incorrectly

https://github.com/enonic/app-contentstudio/issues/10892
 Missing invalid icon when required Site Configurator fields are empty