### PR TITLE
Save button is enabled before any changes are made

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/util/ContentDiffHelper.test.ts
+++ b/modules/lib/src/main/resources/assets/js/app/util/ContentDiffHelper.test.ts
@@ -1,0 +1,114 @@
+import { PropertyTree } from '@enonic/lib-admin-ui/data/PropertyTree';
+import { ValueTypes } from '@enonic/lib-admin-ui/data/ValueTypes';
+import { describe, expect, it } from 'vitest';
+import { ContentDiffHelper } from './ContentDiffHelper';
+
+describe('ContentDiffHelper.dataEquivalent', () => {
+    it('treats a null property as equal to an absent property', () => {
+        const persisted = new PropertyTree();
+        persisted.addString('title', 'Original');
+
+        const rendered = persisted.copy();
+        rendered.getRoot().addProperty('details', ValueTypes.STRING.newNullValue());
+
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered)).toBe(true);
+        expect(ContentDiffHelper.dataEquivalent(rendered, persisted)).toBe(true);
+    });
+
+    it('treats null properties inside a nested set as equal to absent ones', () => {
+        const persisted = new PropertyTree();
+        persisted.addPropertySet('menu-item');
+
+        const rendered = persisted.copy();
+        const renderedSet = rendered.getRoot().getPropertySet('menu-item');
+        renderedSet.addProperty('menuItem', ValueTypes.BOOLEAN.newNullValue());
+        renderedSet.addProperty('menuName', ValueTypes.STRING.newNullValue());
+
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered)).toBe(true);
+    });
+
+    it('treats a null property as equal to an absent one when siblings in the same item-set differ in shape', () => {
+        const persisted = new PropertyTree();
+        const oldVersion = persisted.addPropertySet('version');
+        oldVersion.addString('versionNumber', '4.5.0');
+        const newVersion = persisted.addPropertySet('version');
+        newVersion.addString('versionNumber', '4.6.0');
+        newVersion.addString('sha512', 'abc');
+
+        const rendered = persisted.copy();
+        rendered.getRoot().getPropertySet('version', 0).addProperty('sha512', ValueTypes.STRING.newNullValue());
+
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered)).toBe(true);
+    });
+
+    it('detects a changed value', () => {
+        const persisted = new PropertyTree();
+        persisted.addString('title', 'Original');
+
+        const rendered = new PropertyTree();
+        rendered.addString('title', 'Changed');
+
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered)).toBe(false);
+    });
+
+    it('detects a null property replacing a real value', () => {
+        const persisted = new PropertyTree();
+        persisted.addString('details', 'Something');
+
+        const rendered = new PropertyTree();
+        rendered.getRoot().addProperty('details', ValueTypes.STRING.newNullValue());
+
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered)).toBe(false);
+    });
+
+    it('does not treat an empty string as absent', () => {
+        const persisted = new PropertyTree();
+
+        const rendered = new PropertyTree();
+        rendered.addString('details', '');
+
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered)).toBe(false);
+    });
+
+    it('does not treat a false boolean as absent', () => {
+        const persisted = new PropertyTree();
+
+        const rendered = new PropertyTree();
+        rendered.getRoot().addProperty('flag', ValueTypes.BOOLEAN.newValue('false'));
+
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered)).toBe(false);
+    });
+
+    it('keeps null properties on changed paths significant', () => {
+        const persisted = new PropertyTree();
+        persisted.addString('title', 'a');
+
+        const rendered = persisted.copy();
+        rendered.getRoot().addProperty('details', ValueTypes.STRING.newNullValue());
+
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered)).toBe(true);
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered, ['details'])).toBe(false);
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered, ['details[1]'])).toBe(false);
+    });
+
+    it('keeps a null occurrence alongside real values significant', () => {
+        const persisted = new PropertyTree();
+        persisted.addString('title', 'a');
+
+        const rendered = persisted.copy();
+        rendered.getRoot().addProperty('title', ValueTypes.STRING.newNullValue());
+
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered)).toBe(false);
+        expect(ContentDiffHelper.dataEquivalent(rendered, persisted)).toBe(false);
+    });
+
+    it('detects an added empty set occurrence', () => {
+        const persisted = new PropertyTree();
+        persisted.addString('title', 'Original');
+
+        const rendered = persisted.copy();
+        rendered.addPropertySet('version');
+
+        expect(ContentDiffHelper.dataEquivalent(persisted, rendered)).toBe(false);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/app/util/ContentDiffHelper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/util/ContentDiffHelper.ts
@@ -5,7 +5,10 @@ import {MixinByMixinNameComparator} from '../content/MixinByMixinNameComparator'
 import {ContentSummaryHelper} from '../content/ContentSummaryHelper';
 import {type Content} from '../content/Content';
 import {ObjectHelper} from '@enonic/lib-admin-ui/ObjectHelper';
+import {type Property} from '@enonic/lib-admin-ui/data/Property';
+import {type PropertySet} from '@enonic/lib-admin-ui/data/PropertySet';
 import {type PropertyTree} from '@enonic/lib-admin-ui/data/PropertyTree';
+import {ValueTypes} from '@enonic/lib-admin-ui/data/ValueTypes';
 
 export class ContentDiffHelper {
     public static diff(item: Content, other: Content, ignoreEmptyDataValues: boolean = false): ContentDiff {
@@ -36,6 +39,70 @@ export class ContentDiffHelper {
 
     public static dataEquals(data: PropertyTree, other: PropertyTree, ignoreEmptyValues: boolean = false): boolean {
         return PropertyTreeHelper.propertyTreesEqual(data, other, ignoreEmptyValues);
+    }
+
+    /**
+     * Compares two property trees for equivalence rather than strict equality.
+     *
+     * Unlike {@link dataEquals}, a property whose occurrences are all null is treated as
+     * equal to the property being absent: the form serializes every rendered empty input
+     * as an explicit null property, while content written through the API (or saved
+     * before its schema gained a field) simply omits it — the two carry the same
+     * information, and `dataEquals` would report them as different.
+     *
+     * The tolerance is per property array, and only for entirely-null arrays — the shape
+     * the form produces when seeding inputs that have no stored data. A null occurrence
+     * alongside real values (e.g. `['a', null]` vs `['a']`) is a deliberate occurrence
+     * change and stays significant, as do null properties on `changedPathKeys` (paths the
+     * user actually edited).
+     *
+     * Also unlike `dataEquals` with `ignoreEmptyValues=true` — which additionally ignores
+     * empty strings, `false` booleans and empty sets — only null-vs-absent differences are
+     * tolerated here; every actual value remains significant.
+     */
+    public static dataEquivalent(data: PropertyTree, other: PropertyTree, changedPathKeys: string[] = []): boolean {
+        if (!data || !other) {
+            return data === other;
+        }
+
+        const changedBaseKeys = new Set(changedPathKeys.map((key) => ContentDiffHelper.toBasePathKey(key)));
+        const prunedData = data.copy();
+        const prunedOther = other.copy();
+        ContentDiffHelper.removeNullProperties(prunedData.getRoot(), changedBaseKeys);
+        ContentDiffHelper.removeNullProperties(prunedOther.getRoot(), changedBaseKeys);
+
+        return ObjectHelper.equals(prunedData, prunedOther);
+    }
+
+    private static removeNullProperties(set: PropertySet, changedBaseKeys: Set<string>): void {
+        const toRemove: Property[] = [];
+
+        for (const propertyArray of set.getPropertyArrays()) {
+            const properties = propertyArray.getProperties();
+
+            for (const property of properties) {
+                if (!property.hasNullValue() && property.getType().equals(ValueTypes.DATA)) {
+                    ContentDiffHelper.removeNullProperties(property.getValue().getPropertySet(), changedBaseKeys);
+                }
+            }
+
+            const allNull = properties.length > 0 && properties.every((property) => property.hasNullValue());
+            if (allNull && !changedBaseKeys.has(ContentDiffHelper.toBasePathKey(ContentDiffHelper.toPathKey(properties[0])))) {
+                toRemove.push(...properties);
+            }
+        }
+
+        set.removeProperties(toRemove);
+        set.removeEmptyArrays(set);
+    }
+
+    private static toPathKey(property: Property): string {
+        const pathString = property.getPath().toString();
+        return pathString.startsWith('.') ? pathString.slice(1) : pathString;
+    }
+
+    private static toBasePathKey(pathKey: string): string {
+        return pathKey.replace(/\[\d+]$/, '');
     }
 
     public static extraDataEquals(extraData: Mixin[], other: Mixin[], ignoreEmptyValues: boolean = false): boolean {

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/model/wizardContent.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/model/wizardContent.store.test.ts
@@ -232,6 +232,24 @@ describe('wizardContent.store', () => {
         expect($wizardSectionChanges.get().data).toBe(false);
     });
 
+    it('does not mark data as changed when the draft has a null property absent from persisted data', () => {
+        const persistedData = new PropertyTree();
+        persistedData.addString('title', 'Original');
+        initializeWizardContentState(
+            createContent({ data: persistedData, touched: true }),
+            null,
+            [],
+            WorkflowState.IN_PROGRESS,
+        );
+
+        $wizardDraftData.get().getRoot().addProperty('details', ValueTypes.STRING.newNullValue());
+        setDraftStringByPath(PropertyPath.fromString('title'), 'Edited');
+        setDraftStringByPath(PropertyPath.fromString('title'), 'Original');
+
+        expect($wizardSectionChanges.get().data).toBe(false);
+        expect($wizardHasChanges.get()).toBe(false);
+    });
+
     it('clears data change after editing and clearing absent persisted field', () => {
         initializeWizardContentState(createContent({ data: new PropertyTree() }), null, [], WorkflowState.IN_PROGRESS);
         const path = PropertyPath.fromString('title');
@@ -334,6 +352,35 @@ describe('wizardContent.store', () => {
         formData.setDraftStringByPath(PropertyPath.fromString('keywords[2]'), 'c');
 
         expect($wizardSectionChanges.get().mixins).toBe(false);
+    });
+
+    it('does not mark mixins as changed when a seeded mixin absent from persisted content holds no values', () => {
+        const descriptor = createMixinDescriptor('app:menu-item', false);
+        initializeWizardContentState(
+            createContent({ mixins: [], touched: true }),
+            null,
+            [descriptor],
+            WorkflowState.IN_PROGRESS,
+        );
+
+        expect($wizardDraftMixins.get().some((m) => m.getName().toString() === 'app:menu-item')).toBe(true);
+        expect($wizardSectionChanges.get().mixins).toBe(false);
+        expect($wizardHasChanges.get()).toBe(false);
+    });
+
+    it('marks mixins as changed when the user enables an optional mixin without values', () => {
+        const descriptor = createMixinDescriptor('app:seo', true);
+        initializeWizardContentState(
+            createContent({ mixins: [], touched: true }),
+            null,
+            [descriptor],
+            WorkflowState.IN_PROGRESS,
+        );
+        expect($wizardSectionChanges.get().mixins).toBe(false);
+
+        setDraftMixinEnabled('app:seo', true);
+
+        expect($wizardSectionChanges.get().mixins).toBe(true);
     });
 
     it('should notify server-mixins-changed when the persisted mixin set changes', () => {

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/model/wizardContent.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/model/wizardContent.store.ts
@@ -413,7 +413,7 @@ function dataTreesEqual(a: PropertyTree | null, b: PropertyTree | null): boolean
         return a === b;
     }
 
-    return ContentDiffHelper.dataEquals(a, b, false);
+    return ContentDiffHelper.dataEquivalent(a, b, Object.keys($wizardDataChangedPaths.get()));
 }
 
 function getPortalSiteConfigBaseUrl(data: PropertyTree): string | null {
@@ -480,23 +480,29 @@ function contentNamesEqual(a: ContentName | null, b: ContentName | null): boolea
     return a.equals(b);
 }
 
-function mixinsEqual(a: Mixin[], b: Mixin[]): boolean {
-    if (a.length !== b.length) {
-        return false;
+type MixinChangedPathsProvider = (mixinName: string) => string[];
+
+let mixinChangedPathsProvider: MixinChangedPathsProvider = () => [];
+
+export function setMixinChangedPathsProvider(provider: MixinChangedPathsProvider): void {
+    mixinChangedPathsProvider = provider;
+}
+
+const userToggledMixins = new Set<string>();
+
+export function markMixinsAsUserChanged(names: string[]): void {
+    for (const name of names) {
+        userToggledMixins.add(name);
     }
+}
 
-    const sortedA = [...a].sort((left, right) => left.getName().toString().localeCompare(right.getName().toString()));
-    const sortedB = [...b].sort((left, right) => left.getName().toString().localeCompare(right.getName().toString()));
+function mixinsEqual(a: Mixin[], b: Mixin[]): boolean {
+    const aByName = new Map(a.map((m) => [m.getName().toString(), m]));
+    const bByName = new Map(b.map((m) => [m.getName().toString(), m]));
+    const names = new Set([...aByName.keys(), ...bByName.keys()]);
 
-    for (let i = 0; i < sortedA.length; i += 1) {
-        const leftMixin = sortedA[i];
-        const rightMixin = sortedB[i];
-
-        if (leftMixin.getName().toString() !== rightMixin.getName().toString()) {
-            return false;
-        }
-
-        if (!ContentDiffHelper.dataEquals(leftMixin.getData(), rightMixin.getData(), false)) {
+    for (const name of names) {
+        if (isMixinDataDirty(aByName.get(name), bByName.get(name))) {
             return false;
         }
     }
@@ -695,8 +701,23 @@ function applyDataFromServer(nextPersisted: PropertyTree | null): void {
 
 function isMixinDataDirty(draftMixin: Mixin | undefined, persistedMixin: Mixin | undefined): boolean {
     if (draftMixin == null && persistedMixin == null) return false;
-    if (draftMixin == null || persistedMixin == null) return true;
-    return !ContentDiffHelper.dataEquals(draftMixin.getData(), persistedMixin.getData(), false);
+
+    if (draftMixin == null || persistedMixin == null) {
+        const presentMixin = draftMixin ?? persistedMixin;
+        const name = presentMixin.getName().toString();
+        if (userToggledMixins.has(name)) {
+            return true;
+        }
+
+        const data = presentMixin.getData();
+        return data != null && !ContentDiffHelper.dataEquivalent(data, new PropertyTree(), mixinChangedPathsProvider(name));
+    }
+
+    return !ContentDiffHelper.dataEquivalent(
+        draftMixin.getData(),
+        persistedMixin.getData(),
+        mixinChangedPathsProvider(draftMixin.getName().toString()),
+    );
 }
 
 function isMixinDirtyByName(name: string): boolean {
@@ -745,12 +766,13 @@ function applyMixinsFromServer(nextPersisted: Mixin[]): Set<string> {
         }
     }
 
-    // Locally added/enabled mixins missing on server: keep only if dirty.
+    // Locally added/enabled mixins missing on server: keep seeded ones (never
+    // persisted), and previously-persisted ones only if dirty.
     for (const draftMixin of currentDraft) {
         const name = draftMixin.getName().toString();
         if (handledNames.has(name)) continue;
 
-        if (isMixinDataDirty(draftMixin, oldPersistedByName.get(name))) {
+        if (!oldPersistedByName.has(name) || isMixinDataDirty(draftMixin, oldPersistedByName.get(name))) {
             nextDraft.push(draftMixin.clone());
         }
     }
@@ -1110,6 +1132,8 @@ export function setDraftMixinEnabled(name: string, enabled: boolean): void {
         return;
     }
 
+    userToggledMixins.add(name);
+
     const nextMixins = enabled
         ? (() => {
               const persistedMixin = $wizardPersistedMixins.get().find((mixin) => mixin.getName().toString() === name);
@@ -1388,6 +1412,7 @@ export function resetWizardContent(): void {
     $wizardMixinsVersion.set(0);
     $mixinsPendingMount.set(new Set());
     $mixinsNeedingSnapshot.set(new Set());
+    userToggledMixins.clear();
     isPersistedContentUntouched = false;
 
     $wizardPersistedPage.set(null);

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/model/wizardMixinData.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/model/wizardMixinData.store.ts
@@ -2,7 +2,12 @@ import type { PropertyPath } from '@enonic/lib-admin-ui/data/PropertyPath';
 import type { PropertyTree } from '@enonic/lib-admin-ui/data/PropertyTree';
 import { type ReadableAtom, computed, map } from 'nanostores';
 import type { FormDataContextValue } from '../ui/content-wizard-tabs/FormDataContext';
-import { $wizardDraftMixins, $wizardPersistedMixins, onWizardContentReset } from './wizardContent.store';
+import {
+    $wizardDraftMixins,
+    $wizardPersistedMixins,
+    onWizardContentReset,
+    setMixinChangedPathsProvider,
+} from './wizardContent.store';
 import { addStringOccurrence, removeStringOccurrence, setStringValue } from './wizardPropertyTree.utils';
 
 type MixinDataStores = {
@@ -105,3 +110,5 @@ function resetMixinDataStores(): void {
 }
 
 onWizardContentReset(resetMixinDataStores);
+
+setMixinChangedPathsProvider((mixinName) => Object.keys(mixinDataStoresMap.get(mixinName)?.$changedPaths.get() ?? {}));

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/model/wizardMixins.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/model/wizardMixins.service.ts
@@ -14,6 +14,7 @@ import {
     onMixinSeedRequested,
     onWizardPersistedContentSet,
     onWizardServerMixinsChanged,
+    markMixinsAsUserChanged,
     setMixinsDescriptors,
 } from './wizardContent.store';
 
@@ -74,12 +75,15 @@ function seedMixinsForApplications(applicationKeys: string[]): ResultAsync<void,
     );
 
     return ResultAsync.combine(requests).map((results) => {
+        const previousNames = new Set($mixinsDescriptors.get().map((descriptor) => descriptor.getName()));
         const byName = new Map($mixinsDescriptors.get().map((descriptor) => [descriptor.getName(), descriptor]));
         for (const descriptors of results) {
             for (const descriptor of descriptors) {
                 byName.set(descriptor.getName(), descriptor);
             }
         }
+
+        markMixinsAsUserChanged([...byName.keys()].filter((name) => !previousNames.has(name)));
         setMixinsDescriptors([...byName.values()]);
     });
 }


### PR DESCRIPTION
## Suggested fix
  
Treat a null-valued property as equal to an absent one in the wizard's change detection, except on paths recorded in the wizard's changed-paths tracking, so deliberate user actions (adding/removing an empty occurrence) still register as changes. Empty strings, `false` booleans and empty sets stay significant, unlike the broad `ignoreEmptyValues` comparison mode.