### PR TITLE
Incorrect image fallback icon in dark mode #11063

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/new-content/ui/NewContentDialogContentTypesTab.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/new-content/ui/NewContentDialogContentTypesTab.tsx
@@ -53,6 +53,7 @@ export const NewContentDialogContentTypesTab = ({
                                                 url={iconUrl}
                                                 className="size-12"
                                                 imageSize={48}
+                                                typeIcon
                                             />
                                         }
                                         primary={displayName}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/content-type-filter/ContentTypeFilterItemView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/input-types/content-type-filter/ContentTypeFilterItemView.tsx
@@ -16,7 +16,7 @@ export const ContentTypeFilterItemView = ({ contentType }: ContentTypeFilterItem
 
     return (
         <ItemLabel
-            icon={<ContentIcon contentType={key} url={iconUrl} />}
+            icon={<ContentIcon contentType={key} url={iconUrl} typeIcon />}
             primary={displayName}
             secondary={key}
             className="w-full"

--- a/modules/lib/src/main/resources/assets/js/v6/shared/ui/icons/ContentIcon.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/ui/icons/ContentIcon.tsx
@@ -33,11 +33,22 @@ import { cn } from '@enonic/ui';
 
 type Props = {
     className?: string;
+    /** Content type name, e.g. `base:folder` or `com.myapp:person`. */
     contentType: string;
+    /** Server icon URL: a content's image/thumbnail or a content type's icon glyph. */
     url?: string | null;
+    /** Requested image size in px; fetched at 2x for sharpness. */
     imageSize?: number;
+    /** Crop the image to a square instead of fitting it. */
     crop?: boolean;
+    /** The content has an uploaded thumbnail, so `url` resolves to a photo. */
     hasThumbnail?: boolean;
+    /**
+     * Declares that `url` points to the content type's own icon (a monochrome glyph)
+     * rather than a content item's image or thumbnail. Known image types then render
+     * their built-in vector icon, which stays visible in dark mode.
+     */
+    typeIcon?: boolean;
 };
 
 type BuiltInIconProps = Pick<Props, 'contentType'> & React.ComponentProps<LucideIcon>;
@@ -85,7 +96,9 @@ export const ContentIcon = ({
     imageSize = 64,
     crop = false,
     hasThumbnail = false,
+    typeIcon = false,
 }: Props): React.ReactElement => {
+    // 2x size for better quality
     const src = url ? createImageUrl(url, { size: imageSize * 2, crop }) : undefined;
 
     const [isImageBroken, setImageBroken] = useState(false);
@@ -94,18 +107,18 @@ export const ContentIcon = ({
         setImageBroken(false);
     }, [src]);
 
-    const isImageType = IMAGE_CONTENT_TYPES.has(contentType);
-    const isUnknownType = !BUILT_IN_CONTENT_TYPE_ICON_MAP.has(contentType);
+    // A photo is a content's own image or uploaded thumbnail; rendered as-is, never inverted.
+    const isPhoto = !typeIcon && (IMAGE_CONTENT_TYPES.has(contentType) || hasThumbnail);
 
-    const canShowImage = (isImageType || isUnknownType || hasThumbnail) && !isImageBroken;
+    // Custom types have no built-in icon; their server glyph is monochrome, inverted in dark mode.
+    const isCustomTypeGlyph = !BUILT_IN_CONTENT_TYPE_ICON_MAP.has(contentType);
 
-    if (canShowImage && src) {
-        // 2x size for better quality
+    if (src && !isImageBroken && (isPhoto || isCustomTypeGlyph)) {
         return (
             <Image
                 className={cn(
                     'size-6 p-px object-contain',
-                    !isImageType && !hasThumbnail && 'dark:invert-100 dark:brightness-75 dark:contrast-125',
+                    !isPhoto && 'dark:invert-100 dark:brightness-75 dark:contrast-125',
                     className
                 )}
                 alt={contentType}

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/context-panel/widget/dependencies/DependenciesWidgetFlowSection.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/context-panel/widget/dependencies/DependenciesWidgetFlowSection.tsx
@@ -86,7 +86,11 @@ const DependenciesList = ({ type, dependencies, contentId }: DependenciesProps) 
                         onClick={() => onDependencyClick(dependency)}
                         label={createLabel(dependency.contentType, dependency.itemCount)}
                     >
-                        <ContentIcon contentType={dependency.contentType.toString()} url={dependency.iconUrl} />
+                        <ContentIcon
+                            contentType={dependency.contentType.toString()}
+                            url={dependency.iconUrl}
+                            typeIcon
+                        />
                     </Button>
                 </li>
             ))}


### PR DESCRIPTION
Added 'typeIcon' prop to 'ContentIcon' marking 'url' as a type glyph, not a photo.
Image types now render their built-in Lucide icon, visible in dark mode.
Passed it from dependencies widget, content type filter and new content dialog.
Simplified render logic into 'isPhoto' / 'isCustomTypeGlyph'.