### PR TITLE
Incorrect behaviour of the project toggler control #11071

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/entities/project/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/project/index.ts
@@ -9,6 +9,7 @@ export {
     onActiveProjectChanged,
 } from './activeProject.store';
 export {
+    $hasMultipleProjects,
     $projects,
     $noProjectMode,
     clearPendingDeletedProject,

--- a/modules/lib/src/main/resources/assets/js/v6/entities/project/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/project/projects.store.ts
@@ -53,6 +53,8 @@ export const $noProjectMode = computed($projects, (store) => {
     return !store.projects.some(isAvailableProject);
 });
 
+export const $hasMultipleProjects = computed($projects, ({projects}) => projects.length > 1);
+
 //
 // * Internal writer: applies an id to $projects map AND publishes the
 // * canonical Project instance to activeProject.store. The activeProject

--- a/modules/lib/src/main/resources/assets/js/v6/pages/browse/BrowseAppBar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/browse/BrowseAppBar.tsx
@@ -6,7 +6,7 @@ import { ArrowLeftRight, BellDotIcon, BellIcon } from 'lucide-react';
 import type { ReactElement } from 'react';
 import { ShowIssuesDialogEvent } from '../../../app/browse/ShowIssuesDialogEvent';
 import { useI18n } from '../../shared/lib/hooks/useI18n';
-import { $activeProjectName, $noProjectMode } from '../../entities/project';
+import {$activeProjectName, $hasMultipleProjects, $noProjectMode} from '../../entities/project';
 import { setProjectSelectionDialogOpen } from '../../shared/dialogs/dialogs.store';
 import { $issuesStats } from '../../entities/issue';
 import { $activeWidget, isMainWidget } from '../../widgets/context-panel/model/sidebarWidgets.store';
@@ -32,6 +32,7 @@ function createIssuesLabelKeys(stats: Readonly<IssueStatsJson> | undefined): [`f
 export const BrowseAppBar = (): ReactElement => {
     const activeProjectName = useStore($activeProjectName);
     const noProjectMode = useStore($noProjectMode);
+    const hasMultipleProjects = useStore($hasMultipleProjects);
     const isProjectSelectorVisible = useStore($isProjectSelectorVisible);
     const activeWidget = useStore($activeWidget);
     const isIssuesButtonVisible = isMainWidget(activeWidget);
@@ -46,12 +47,13 @@ export const BrowseAppBar = (): ReactElement => {
         <header className="bg-surface-neutral h-15 px-5 py-2 pr-24 flex items-center gap-2.5 border-b border-bdr-soft">
             {!noProjectMode && isProjectSelectorVisible ? (
                 <Button
-                    className="mr-auto"
+                    className="mr-auto disabled:opacity-100"
                     size="sm"
-                    endIcon={ArrowLeftRight}
+                    endIcon={hasMultipleProjects ? ArrowLeftRight : undefined}
                     onClick={() => setProjectSelectionDialogOpen(true)}
-                    aria-label={projectAriaLabel}
+                    aria-label={hasMultipleProjects ? projectAriaLabel : undefined}
                     label={activeProjectName}
+                    disabled={!hasMultipleProjects}
                 />
             ) : (
                 <h1 className="mr-auto text-2xl font-semibold">{appName || applicationName}</h1>

--- a/testing/libs/elements.js
+++ b/testing/libs/elements.js
@@ -98,7 +98,7 @@ const BUTTONS = {
     submitButtonByLabel: (label) => `//button[@type='submit' and contains(.,'${label}')]`,
     radioButtonByLabel: (label) => `//button[@role='radio' and contains(.,'${label}')]`,
     BUTTON_MENU_POPUP: "//button[@aria-haspopup='menu']",
-    buttonAriaLabel: (ariaLabel) => `//button[contains(@type,'button') and contains(@aria-label,'${ariaLabel}') and not(ancestor::*[@aria-hidden='true']) and not(ancestor::*[contains(@class,'sm:hidden')])]`,
+    buttonAriaLabel: (ariaLabel) => `//button[@type='button' and contains(@aria-label,'${ariaLabel}') and not(ancestor::*[@aria-hidden='true']) and not(ancestor::*[contains(@class,'sm:hidden')])]`,
     toolbarButtonAriaLabel: (ariaLabel) => `//button[@data-component='Toolbar.Item' and contains(@aria-label,'${ariaLabel}') and not(ancestor::*[@aria-hidden='true']) and not(ancestor::*[contains(@class,'sm:hidden')])]`,
     toolbarTooltipButtonAriaLabel: (ariaLabel) => `//button[@data-component='Tooltip' and contains(@aria-label,'${ariaLabel}') and not(ancestor::*[@aria-hidden='true']) and not(ancestor::*[contains(@class,'sm:hidden')])]`,
     buttonStatusBar: (label) => `//button[@data-component='StatusBarEntryButton' and contains(.,'${label}')]`,

--- a/testing/page_objects/browsepanel/content.browse.panel.js
+++ b/testing/page_objects/browsepanel/content.browse.panel.js
@@ -196,7 +196,7 @@ class ContentBrowsePanel extends BaseBrowsePanel {
     }
 
     get projectViewerButton() {
-        return COMMON.CONTENT_APP_BAR_DIV + BUTTONS.buttonAriaLabel('Switch project');
+        return COMMON.CONTENT_APP_BAR_DIV + "//button[@data-component='Button' and contains(@class,'mr-auto')]";
     }
 
     async clickOnProjectViewerButton() {
@@ -944,7 +944,7 @@ class ContentBrowsePanel extends BaseBrowsePanel {
 
     async getCurrentProjectDisplayName() {
         try {
-            await this.waitForElementDisplayed(this.projectViewerButton, appConst.shortTimeout);
+            await this.waitForElementDisplayed(this.projectViewerButton);
             return await this.getText(this.projectViewerButton);
         } catch (err) {
             await this.handleError('Tried to get current project display name', 'err_get_current_project_display_name', err);
@@ -952,7 +952,7 @@ class ContentBrowsePanel extends BaseBrowsePanel {
     }
 
     async getContextLanguage() {
-        await this.waitForElementDisplayed(this.projectViewerButton, appConst.mediumTimeout);
+        await this.waitForElementDisplayed(this.projectViewerButton);
         let result = await this.getText(this.projectViewerButton);
         let lang = result.split('(')[1].split(')')[0];
         return lang;

--- a/testing/specs/browse.panel.selections.spec.js
+++ b/testing/specs/browse.panel.selections.spec.js
@@ -47,8 +47,8 @@ describe('browse.panel.selections.spec - tests for selection items in Browse Pan
             let status = await contentBrowsePanel.getContentStatus(appConst.TEST_FOLDER_WITH_IMAGES_NAME);
             assert.equal(status, appConst.CONTENT_STATUS.OFFLINE);
             await contentBrowsePanel.waitForStatus(appConst.TEST_FOLDER_WITH_IMAGES_NAME, 'Offline');
-            let aa = await contentBrowsePanel.getCurrentProjectDisplayName();
-            let aaa = await contentBrowsePanel.getWorkflowStateByDisplayName(appConst.TEST_FOLDER_WITH_IMAGES);
+            let currentProject = await contentBrowsePanel.getCurrentProjectDisplayName();
+            //let aaa = await contentBrowsePanel.getWorkflowStateByDisplayName(appConst.TEST_FOLDER_WITH_IMAGES);
 
             // 1. Click on the checkbox:
             await contentBrowsePanel.clickOnCheckboxAndSelectRowByName(appConst.TEST_FOLDER_WITH_IMAGES_NAME);
@@ -67,6 +67,7 @@ describe('browse.panel.selections.spec - tests for selection items in Browse Pan
             // 5. Verify that the  folder gets collapsed:
             isExpanded = await contentBrowsePanel.isContentExpanded(appConst.TEST_FOLDER_WITH_IMAGES_NAME);
             assert.ok(isExpanded === false, 'The folder gets collapsed');
+            assert.equal(currentProject,'Default', "Default project should be displayed in Browse App Bar");
         });
 
     it("GIVEN one row is checked WHEN hold down 'Shift' key AND press Arrow down key 3 times THEN 3 content items get checked",


### PR DESCRIPTION
Add $hasMultipleProjects to project.store.ts
Disable switch project button along with icon and aria-label when projects < 2