### PR TITLE
Guillotine extension won't open on a clean instance #11072

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/entities/project/projects.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/project/projects.store.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { errAsync, okAsync } from 'neverthrow';
-import { AppError } from '../../shared/api/errors';
+import {AppError} from '../../shared/api';
 
 type MockProject = {
     getName(): string;
@@ -292,6 +292,15 @@ describe('projects.store init', () => {
         localStorage.clear();
     });
 
+    it('persists the active URL project on a clean load', async () => {
+        const current = createProject('current');
+        const other = createProject('other');
+
+        await loadStore([current, other], 'current');
+
+        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('current'));
+    });
+
     it('uses the URL project even when storage holds a different id', async () => {
         localStorage.setItem(LAST_SELECTED_STORAGE_KEY, JSON.stringify('saved'));
         const url = createProject('url-project');
@@ -299,6 +308,7 @@ describe('projects.store init', () => {
         const store = await loadStore([url, saved], 'url-project');
 
         expect(store.$projects.get().activeProjectId).toBe('url-project');
+        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('url-project'));
     });
 
     it('falls back to the storage value in browse mode when the URL has no project', async () => {
@@ -360,6 +370,7 @@ describe('projects.store init', () => {
 
         expect(store.$projects.get().activeProjectId).toBe('other-layer');
         expect(store.getActiveProject().getName()).toBe('other-layer');
+        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('other-layer'));
         expect(mockSetProjectSelectionDialogOpen).not.toHaveBeenCalledWith(true);
     });
 
@@ -373,6 +384,7 @@ describe('projects.store init', () => {
         });
 
         expect(store.$projects.get().activeProjectId).toBeUndefined();
+        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('ghost'));
         expect(mockSetProjectSelectionDialogOpen).toHaveBeenCalledWith(true);
     });
 });
@@ -402,7 +414,7 @@ describe('projects.store selectProject', () => {
         expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('b'));
     });
 
-    it('leaves active project and storage untouched when the project is not in the store', async () => {
+    it('leaves active project and its persisted id untouched when the project is not in the store', async () => {
         const a = createProject('a');
         const stranger = createProject('stranger');
         const store = await loadStore([a], 'a');
@@ -411,7 +423,7 @@ describe('projects.store selectProject', () => {
         store.selectProject(stranger);
 
         expect(store.$projects.get().activeProjectId).toBe('a');
-        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBeNull();
+        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('a'));
     });
 });
 
@@ -470,7 +482,7 @@ describe('projects.store storage cleanup on deletion', () => {
         expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('current'));
     });
 
-    it('clears the last selected id when removeProject (no navigate) removes the stored value', async () => {
+    it('keeps the active project id when removeProject (no navigate) removes an unrelated project', async () => {
         localStorage.setItem(LAST_SELECTED_STORAGE_KEY, JSON.stringify('alpha'));
         const alpha = createProject('alpha');
         const beta = createProject('beta');
@@ -478,8 +490,7 @@ describe('projects.store storage cleanup on deletion', () => {
 
         store.removeProject('alpha', false);
 
-        const stored = localStorage.getItem(LAST_SELECTED_STORAGE_KEY);
-        expect(stored === null || stored === 'null').toBe(true);
+        expect(localStorage.getItem(LAST_SELECTED_STORAGE_KEY)).toBe(JSON.stringify('beta'));
     });
 });
 

--- a/modules/lib/src/main/resources/assets/js/v6/entities/project/projects.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/project/projects.store.ts
@@ -38,8 +38,8 @@ export const $projects = map<ProjectsStore>({
 });
 
 //
-// * Last user-selected project, persisted across sessions.
-// * Written only on explicit UI selection or on deletion-driven fallback.
+// * Last active project, persisted across sessions.
+// * Written after project resolution, explicit UI selection, or deletion-driven fallback.
 // * Read in browse mode when the URL has no project; ignored on wizard URLs.
 //
 const $lastSelectedProjectId = atom<string | undefined>(undefined);
@@ -208,6 +208,7 @@ async function loadProjects(): Promise<void> {
             validateHostProjectId(projects);
             refreshActiveProjectInstance();
             updateActiveProject();
+            persistActiveProjectId();
             updateProjectsState({
                 loaded: true,
                 resolved: true,
@@ -268,6 +269,14 @@ function updateActiveProject(): void {
     clearActiveProject();
     setNoProjectMode();
     setProjectSelectionDialogOpen(true);
+}
+
+function persistActiveProjectId(): void {
+    const activeProjectId = getProjectId($activeProject.get());
+
+    if (activeProjectId) {
+        $lastSelectedProjectId.set(activeProjectId);
+    }
 }
 
 function updateActiveProjectAfterDeletion(deletedProject: Readonly<Project> | undefined): void {


### PR DESCRIPTION
Persisted the resolved active project during project loading. Added regression coverage for clean loads and updated storage expectations.