### PR TITLE
Scheduled content incorrectly shows "Published" status in preview too…

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/widgets/context-panel/widget/details/DetailsWidgetContentSection.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/context-panel/widget/details/DetailsWidgetContentSection.tsx
@@ -41,7 +41,10 @@ export const DetailsWidgetContentSection = (): ReactElement => {
     const publishStatus = calcTreePublishStatus(content);
     const secondaryStatus = calcSecondaryStatus(publishStatus, content);
     const showContentState =
-        contentState != null && !(publishStatus === PublishStatus.ONLINE && contentState === 'ready' && !secondaryStatus);
+        contentState != null &&
+        (![PublishStatus.ONLINE, PublishStatus.PENDING].includes(publishStatus) ||
+            contentState !== 'ready' ||
+            !!secondaryStatus);
 
     let secondaryOverride: string | undefined;
     if (secondaryStatus === 'modified') {

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/preview-panel/ui/PreviewToolbarVersionHistoryItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/preview-panel/ui/PreviewToolbarVersionHistoryItem.tsx
@@ -2,6 +2,7 @@ import { Button, Toolbar } from '@enonic/ui';
 import { History } from 'lucide-react';
 import type { ReactElement } from 'react';
 import type { ContentSummary } from '../../../../app/content/ContentSummary';
+import {PublishStatus} from '../../../../app/publish/PublishStatus';
 import { openContextWidget } from '../../context-panel/openContextWidget';
 import { useI18n } from '../../../shared/lib/hooks/useI18n';
 import {
@@ -19,11 +20,13 @@ export function PreviewToolbarVersionHistoryItem({
     contentSummary,
 }: PreviewToolbarVersionHistoryItemProps): ReactElement {
     const ariaLabel = useI18n('wcag.preview.toolbar.versionHistory.label');
-    const publishedLabel = useI18n('status.published');
 
-    const secondaryStatus = calcSecondaryStatus(calcTreePublishStatus(contentSummary), contentSummary);
+    const publishStatus = calcTreePublishStatus(contentSummary);
+    const primaryStatusKey = publishStatus === PublishStatus.PENDING ? 'status.scheduled' : 'status.published';
+    const primaryStatusLabel = useI18n(primaryStatusKey);
+    const secondaryStatus = calcSecondaryStatus(publishStatus, contentSummary);
     const secondaryStatusLabel = useI18n(secondaryStatus ? createSecondaryStatusKey(secondaryStatus) : '');
-    const buttonLabel = secondaryStatus ? secondaryStatusLabel : publishedLabel;
+    const buttonLabel = secondaryStatus ? secondaryStatusLabel : primaryStatusLabel;
 
     const handleShowVersionHistory = () => {
         openContextWidget(VERSIONS_WIDGET_NAME);

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/preview-panel/ui/PreviewToolbarVersionHistoryItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/preview-panel/ui/PreviewToolbarVersionHistoryItem.tsx
@@ -2,6 +2,7 @@ import { Button, Toolbar } from '@enonic/ui';
 import { History } from 'lucide-react';
 import type { ReactElement } from 'react';
 import type { ContentSummary } from '../../../../app/content/ContentSummary';
+import { PublishStatus } from '../../../../app/publish/PublishStatus';
 import { openContextWidget } from '../../context-panel/openContextWidget';
 import { useI18n } from '../../../shared/lib/hooks/useI18n';
 import {
@@ -19,11 +20,16 @@ export function PreviewToolbarVersionHistoryItem({
     contentSummary,
 }: PreviewToolbarVersionHistoryItemProps): ReactElement {
     const ariaLabel = useI18n('wcag.preview.toolbar.versionHistory.label');
-    const publishedLabel = useI18n('status.published');
 
-    const secondaryStatus = calcSecondaryStatus(calcTreePublishStatus(contentSummary), contentSummary);
-    const secondaryStatusLabel = useI18n(secondaryStatus ? createSecondaryStatusKey(secondaryStatus) : '');
-    const buttonLabel = secondaryStatus ? secondaryStatusLabel : publishedLabel;
+    const publishStatus = calcTreePublishStatus(contentSummary);
+    const primaryStatusKey = publishStatus === PublishStatus.PENDING ? 'status.scheduled' : 'status.published';
+    const primaryStatusLabel = useI18n(primaryStatusKey);
+
+    const secondaryStatus = calcSecondaryStatus(publishStatus, contentSummary);
+    const secondaryStatusKey = secondaryStatus ? createSecondaryStatusKey(secondaryStatus) : '';
+    const secondaryStatusLabel = useI18n(secondaryStatusKey);
+
+    const buttonLabel = secondaryStatus ? secondaryStatusLabel : primaryStatusLabel;
 
     const handleShowVersionHistory = () => {
         openContextWidget(VERSIONS_WIDGET_NAME);


### PR DESCRIPTION
…lbar #11051

Patched PreviewToolbarVersionHistoryItem.tsx to display scheduled instead of published when scheduled.