### PR TITLE
Navigation inside preview panel doesn't change selection in the grid #10241

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentBrowsePanel.ts
@@ -13,7 +13,7 @@ import { TreeListBoxExpandedHolder } from '@enonic/lib-admin-ui/ui/selector/list
 import { AppHelper } from '@enonic/lib-admin-ui/util/AppHelper';
 import type Q from 'q';
 import { $actionsNeedRefresh, clearActionsRefreshSignal } from '../../v6/app/actions.store';
-import { removeContent, setContent, hasCurrentItems, removeTreeNode } from '../../v6/entities/content';
+import { removeContent, setContent, hasCurrentItems, removeTreeNode, revealContentByPath } from '../../v6/entities/content';
 import { setContentFilterOpen } from '../../v6/features/search/model/contentFilter.store';
 import { onActiveProjectChanged } from '../../v6/entities/project/activeProject.store';
 import { onNoProjectsAvailable } from '../../v6/entities/project/projects.store';
@@ -31,7 +31,6 @@ import { EditContentEvent } from '../event/EditContentEvent';
 import { type ContentTreeSelectorItem } from '../item/ContentTreeSelectorItem';
 import { RenderingMode } from '../rendering/RenderingMode';
 import { UriHelper } from '../rendering/UriHelper';
-import { ContentExistsByPathRequest } from '../resource/ContentExistsByPathRequest';
 import { GetContentSummaryByIdRequest } from '../resource/GetContentSummaryByIdRequest';
 import { Router } from '../Router';
 import { UrlAction } from '../UrlAction';
@@ -405,66 +404,21 @@ export class ContentBrowsePanel extends ResponsiveBrowsePanel {
         });
     }
 
-    private selectInlinedContentInGrid(contentInlinePath: string) {
-        const path: string = this.getPathFromInlinePath(contentInlinePath);
+    private selectInlinedContentInGrid(contentInlinePath: string): void {
+        const path = this.getPathFromInlinePath(contentInlinePath);
+        if (!path) return;
 
-        if (path) {
-            new ContentExistsByPathRequest(path)
-                .sendAndParse()
-                .then((exists: boolean) => {
-                    const targetPath = ContentPath.create().fromString(path).build();
-                    this.expandToListElementByPath(this.treeListBox, targetPath.getPathAtLevel(1), targetPath);
-                })
-                .catch(DefaultErrorHandler.handle);
-        }
+        // Suppress the redundant preview reload the resulting selection change would
+        // trigger: the iframe already navigated to this content.
+        void revealContentByPath(path, {
+            onBeforeSelect: () => this.getPreviewPanel().setSkipNextSetItemCall(true),
+        });
     }
 
     private getPathFromInlinePath(contentPreviewPath: string): string {
         // if contentPreviewPath is a portal uri, get the content path from it,
         // otherwise assume it's a content path (i.e. came from 3rd party rendering engines)
         return UriHelper.getPathFromPortalInlineUri(contentPreviewPath, RenderingMode.INLINE) || contentPreviewPath;
-    }
-
-    private expandToListElementByPath(
-        list: ContentsTreeGridList,
-        itemPath: ContentPath,
-        targetPath: ContentPath,
-    ): void {
-        let loadCount = 0;
-
-        const itemFinder = () => {
-            const listElement = list.getListElementByPath(itemPath);
-
-            if (listElement) {
-                list.unItemsAdded(itemFinder);
-
-                listElement.whenRendered(() => {
-                    listElement.getHTMLElement().scrollIntoView();
-
-                    if (itemPath.equals(targetPath)) {
-                        this.selectionWrapper.deselectAll();
-                        this.selectionWrapper.select(listElement.getItem());
-                    } else {
-                        listElement.expand(); // if was loaded but the children list collapsed
-                        this.expandToListElementByPath(
-                            listElement.getList(),
-                            targetPath.getPathAtLevel(itemPath.getLevel() + 1),
-                            targetPath,
-                        );
-                    }
-                });
-            } else {
-                if (loadCount > 10) {
-                    return;
-                }
-
-                loadCount++;
-                list.load();
-            }
-        };
-
-        list.onItemsAdded(itemFinder);
-        itemFinder();
     }
 
     private subscribeOnContentEvents() {

--- a/modules/lib/src/main/resources/assets/js/app/browse/ContentsTreeGridList.ts
+++ b/modules/lib/src/main/resources/assets/js/app/browse/ContentsTreeGridList.ts
@@ -1,21 +1,19 @@
 import type Q from 'q';
-import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
+import { DefaultErrorHandler } from '@enonic/lib-admin-ui/DefaultErrorHandler';
 import {
     TreeListBox,
     type TreeListBoxParams,
     TreeListElement,
-    type TreeListElementParams
+    type TreeListElementParams,
 } from '@enonic/lib-admin-ui/ui/selector/list/TreeListBox';
-import {ContentSummaryAndCompareStatus} from '../content/ContentSummaryAndCompareStatus';
-import {ContentSummaryAndCompareStatusFetcher} from '../resource/ContentSummaryAndCompareStatusFetcher';
-import {type ContentResponse} from '../resource/ContentResponse';
-import {ContentPath} from '../content/ContentPath';
-import {ContentTreeGridListViewer} from './ContentTreeGridListViewer';
-import {type ChildOrder} from '../resource/order/ChildOrder';
+import { ContentSummaryAndCompareStatus } from '../content/ContentSummaryAndCompareStatus';
+import { ContentSummaryAndCompareStatusFetcher } from '../resource/ContentSummaryAndCompareStatusFetcher';
+import { type ContentResponse } from '../resource/ContentResponse';
+import { ContentPath } from '../content/ContentPath';
+import { ContentTreeGridListViewer } from './ContentTreeGridListViewer';
+import { type ChildOrder } from '../resource/order/ChildOrder';
 
-export class ContentsTreeGridList
-    extends TreeListBox<ContentSummaryAndCompareStatus> {
-
+export class ContentsTreeGridList extends TreeListBox<ContentSummaryAndCompareStatus> {
     public static FETCH_SIZE: number = 10;
 
     protected readonly fetcher: ContentSummaryAndCompareStatusFetcher;
@@ -33,8 +31,11 @@ export class ContentsTreeGridList
     }
 
     protected createItemView(item: ContentSummaryAndCompareStatus, readOnly: boolean): ContentsTreeGridListElement {
-        return new ContentsTreeGridListElement(item,
-            {scrollParent: this.scrollParent, parentList: this, expandedContext: this.options.expandedContext});
+        return new ContentsTreeGridListElement(item, {
+            scrollParent: this.scrollParent,
+            parentList: this,
+            expandedContext: this.options.expandedContext,
+        });
     }
 
     protected getItemId(item: ContentSummaryAndCompareStatus): string {
@@ -49,26 +50,28 @@ export class ContentsTreeGridList
         this.wasShownAndLoaded = true;
         this.loading = true;
 
-        this.fetch().then((items: ContentSummaryAndCompareStatus[]) => {
-            this.loading = false;
+        this.fetch()
+            .then((items: ContentSummaryAndCompareStatus[]) => {
+                this.loading = false;
 
-            if (items.length > 0) {
-                // first remove new items that are now to be added to avoid being shown twice
-                items.forEach((item: ContentSummaryAndCompareStatus) => {
-                   const itemId = this.getItemId(item);
+                if (items.length > 0) {
+                    // first remove new items that are now to be added to avoid being shown twice
+                    items.forEach((item: ContentSummaryAndCompareStatus) => {
+                        const itemId = this.getItemId(item);
 
-                    if (this.newItems.has(itemId)) {
-                        this.newItems.delete(itemId);
-                        this.removeItems([item], true);
-                    }
-                });
+                        if (this.newItems.has(itemId)) {
+                            this.newItems.delete(itemId);
+                            this.removeItems([item], true);
+                        }
+                    });
 
-                this.addItems(items);
-            }
-        }).catch((e) => {
-            DefaultErrorHandler.handle(e);
-            this.loading = false;
-        });
+                    this.addItems(items);
+                }
+            })
+            .catch((e) => {
+                DefaultErrorHandler.handle(e);
+                this.loading = false;
+            });
     }
 
     private fetch(): Q.Promise<ContentSummaryAndCompareStatus[]> {
@@ -88,9 +91,11 @@ export class ContentsTreeGridList
         const size: number = ContentsTreeGridList.FETCH_SIZE;
         const parent = this.getParentItem()?.getContentId();
 
-        return this.fetcher.fetchChildren(parent, from, size, order).then((data: ContentResponse<ContentSummaryAndCompareStatus>) => {
-            return data.getContents();
-        });
+        return this.fetcher
+            .fetchChildren(parent, from, size, order)
+            .then((data: ContentResponse<ContentSummaryAndCompareStatus>) => {
+                return data.getContents();
+            });
     }
 
     // new items to be shown on top of the list and must be taken into account when fetching new items, or removed on refresh
@@ -101,7 +106,8 @@ export class ContentsTreeGridList
             });
 
             this.addItems(items);
-        } else { // if parent didn't have children before then update it to show expand toggle
+        } else {
+            // if parent didn't have children before then update it to show expand toggle
             (this.options.parentListElement as ContentsTreeGridListElement)?.setContainsChildren(true);
         }
     }
@@ -116,8 +122,11 @@ export class ContentsTreeGridList
         }
     }
 
-    protected addItemView(item: ContentSummaryAndCompareStatus, readOnly?: boolean,
-                          index?: number): TreeListElement<ContentSummaryAndCompareStatus> {
+    protected addItemView(
+        item: ContentSummaryAndCompareStatus,
+        readOnly?: boolean,
+        index?: number,
+    ): TreeListElement<ContentSummaryAndCompareStatus> {
         (this.options.parentListElement as ContentsTreeGridListElement)?.setContainsChildren(true);
         return super.addItemView(item, readOnly, index);
     }
@@ -148,12 +157,12 @@ export class ContentsTreeGridList
 
     findParentLists(item: ContentSummaryAndCompareStatus | ContentPath): ContentsTreeGridList[] {
         const parents: ContentsTreeGridList[] = [];
-        const itemPath = item instanceof  ContentSummaryAndCompareStatus ? item.getPath() : item;
+        const itemPath = item instanceof ContentSummaryAndCompareStatus ? item.getPath() : item;
         const thisPath = this.getParentItem()?.getPath() || ContentPath.getRoot();
 
         if (itemPath.isDescendantOf(thisPath)) {
             // if the list is filtered then root may contain the item no matter what path is
-            if (itemPath.isChildOf(thisPath) || this.getItems().some(i => i.getPath().equals(itemPath))) {
+            if (itemPath.isChildOf(thisPath) || this.getItems().some((i) => i.getPath().equals(itemPath))) {
                 parents.push(this);
             }
 
@@ -169,11 +178,6 @@ export class ContentsTreeGridList
         return parents;
     }
 
-    getListElementByPath(path: ContentPath): ContentsTreeGridListElement | undefined {
-        return this.getItemViews().find(
-            (listElement: ContentsTreeGridListElement) => listElement.getItem().getPath().equals(path)) as ContentsTreeGridListElement;
-    }
-
     doRender(): Q.Promise<boolean> {
         return super.doRender().then((rendered: boolean) => {
             this.addClass('content-tree-grid-list');
@@ -181,16 +185,17 @@ export class ContentsTreeGridList
             return rendered;
         });
     }
-
 }
 
 export class ContentsTreeGridListElement extends TreeListElement<ContentSummaryAndCompareStatus> {
-
     declare protected childrenList: ContentsTreeGridList;
 
     private containsChildren: boolean;
 
-    constructor(content: ContentSummaryAndCompareStatus, params: TreeListElementParams<ContentSummaryAndCompareStatus>) {
+    constructor(
+        content: ContentSummaryAndCompareStatus,
+        params: TreeListElementParams<ContentSummaryAndCompareStatus>,
+    ) {
         super(content, params);
     }
 
@@ -241,17 +246,14 @@ export class ContentsTreeGridListElement extends TreeListElement<ContentSummaryA
             return rendered;
         });
     }
-
 }
 
 export class ContentsTreeGridListContext {
-
     private static instance: ContentsTreeGridListContext;
 
     private filtered: boolean = false;
 
-    private constructor() {
-    }
+    private constructor() {}
 
     static get(): ContentsTreeGridListContext {
         if (!ContentsTreeGridListContext.instance) {

--- a/modules/lib/src/main/resources/assets/js/app/view/ContentItemPreviewPanel.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/ContentItemPreviewPanel.ts
@@ -87,6 +87,7 @@ export class ContentItemPreviewPanel extends Panel implements ExtensionRenderer 
 
     public isPreviewUpdateNeeded(item: ContentSummaryAndCompareStatus, force?: boolean): Q.Promise<boolean> {
         if (this.skipNextSetItemCall) {
+            this.skipNextSetItemCall = false; // consume the one-shot suppression
             return Q(false);
         }
         if (this.isItemAllowsUpdate(item, force)) {
@@ -133,6 +134,10 @@ export class ContentItemPreviewPanel extends Panel implements ExtensionRenderer 
 
     public setItem(item: ViewItem) {
         this.debouncedSetItem(item);
+    }
+
+    public setSkipNextSetItemCall(skip: boolean): void {
+        this.skipNextSetItemCall = skip;
     }
 
     private setupListeners() {

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/index.ts
@@ -64,6 +64,9 @@ export {
     resetTree,
 } from './model/content-tree.store';
 export { clearProjectContentCache, removeContent, setContent, setContents } from './model/content.commands';
+export { revealContentByPath } from './model/content-reveal.service';
+export type { RevealContentByPathOptions } from './model/content-reveal.service';
+export { $revealScrollTarget, clearRevealScroll } from './model/content-reveal.store';
 export { $contentCache, getContent, getContentAsCSCS, getIdByPath, getMissingIds } from './model/content.store';
 export {
     start as startContentService,

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.service.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.service.test.ts
@@ -8,7 +8,14 @@ import { $activeProject } from '../../project/activeProject.store';
 import { setFilterActive } from './active-tree.store';
 import { clearRevealScroll, $revealScrollTarget } from './content-reveal.store';
 import { $activeId, $currentItem, $selection, clearSelection } from './content-selection.store';
-import { addTreeNode, hasTreeNode, isNodeExpanded, resetTree, setTreeChildren, setTreeRootIds } from './content-tree.store';
+import {
+    addTreeNode,
+    hasTreeNode,
+    isNodeExpanded,
+    resetTree,
+    setTreeChildren,
+    setTreeRootIds,
+} from './content-tree.store';
 import { clearAllContentCaches, setContents } from './content.commands';
 
 const mocks = vi.hoisted(() => ({
@@ -202,6 +209,30 @@ describe('content-reveal.service', () => {
 
         expect(onBeforeSelect).toHaveBeenCalledTimes(1);
         expect(activeIdAtCallback).toBeNull();
+        expect($activeId.get()).toBe('c');
+    });
+
+    it('skips select and callback when the target is already the sole current item', async () => {
+        seedLoadedTree();
+        $activeId.set('c');
+        const onBeforeSelect = vi.fn();
+
+        await revealContentByPath('/a/b/c', { onBeforeSelect });
+
+        // No $currentIds emission would follow, so the suppression must not be armed.
+        expect(onBeforeSelect).not.toHaveBeenCalled();
+        expect(mocks.fetchContentByIds).not.toHaveBeenCalled();
+        expect($activeId.get()).toBe('c');
+        expect($revealScrollTarget.get()).toBe('c'); // still scrolls the row into view
+    });
+
+    it('clears checkbox selection like a grid row click', async () => {
+        seedLoadedTree();
+        $selection.set(new Set(['a', 'b']));
+
+        await revealContentByPath('/a/b/c');
+
+        expect($selection.get().size).toBe(0);
         expect($activeId.get()).toBe('c');
     });
 

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.service.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.service.test.ts
@@ -1,0 +1,228 @@
+import { errAsync, okAsync } from 'neverthrow';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Content } from '../../../../app/content/Content';
+import type { ContentSummary } from '../../../../app/content/ContentSummary';
+import type { Project } from '../../../../app/settings/data/project/Project';
+import { AppError } from '../../../shared/api/errors';
+import { $activeProject } from '../../project/activeProject.store';
+import { setFilterActive } from './active-tree.store';
+import { clearRevealScroll, $revealScrollTarget } from './content-reveal.store';
+import { $activeId, $currentItem, $selection, clearSelection } from './content-selection.store';
+import { addTreeNode, hasTreeNode, isNodeExpanded, resetTree, setTreeChildren, setTreeRootIds } from './content-tree.store';
+import { clearAllContentCaches, setContents } from './content.commands';
+
+const mocks = vi.hoisted(() => ({
+    fetchContentByPath: vi.fn(),
+    fetchRootChildrenIdsOnly: vi.fn(),
+    fetchChildrenIdsOnly: vi.fn(),
+    fetchContentByIds: vi.fn(),
+}));
+
+vi.mock('../api/content.api', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../api/content.api')>()),
+    fetchContentByPath: mocks.fetchContentByPath,
+}));
+
+vi.mock('../api/content-fetcher', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../api/content-fetcher')>()),
+    fetchRootChildrenIdsOnly: mocks.fetchRootChildrenIdsOnly,
+    fetchChildrenIdsOnly: mocks.fetchChildrenIdsOnly,
+    fetchContentByIds: mocks.fetchContentByIds,
+}));
+
+import { revealContentByPath } from './content-reveal.service';
+
+// Minimal ContentSummary/Content stub: enough for setContents (getId/getPath),
+// getIdByPath (path index), fetchContentByPath results (getContentId), and
+// $currentItem resolution (cached object identity).
+function mk(id: string, path: string): ContentSummary {
+    return {
+        getId: () => id,
+        getContentId: () => ({ toString: () => id }),
+        getPath: () => ({ toString: () => path }),
+        getDisplayName: () => `Content ${id}`,
+    } as unknown as ContentSummary;
+}
+
+describe('content-reveal.service', () => {
+    beforeEach(() => {
+        $activeProject.set({ getName: () => 'default' } as unknown as Project);
+        resetTree();
+        clearAllContentCaches();
+        clearSelection();
+        $selection.set(new Set());
+        $activeId.set(null);
+        setFilterActive(false);
+        clearRevealScroll();
+
+        mocks.fetchContentByPath.mockReset().mockReturnValue(errAsync(new AppError('not found')));
+        mocks.fetchRootChildrenIdsOnly.mockReset().mockResolvedValue(undefined);
+        mocks.fetchChildrenIdsOnly.mockReset().mockResolvedValue(undefined);
+        mocks.fetchContentByIds.mockReset().mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+        $activeProject.set(undefined);
+        vi.restoreAllMocks();
+    });
+
+    // Seeds a fully-loaded /a/b/c tree with its cache populated.
+    function seedLoadedTree(): void {
+        setContents([mk('a', '/a'), mk('b', '/a/b'), mk('c', '/a/b/c')]);
+        addTreeNode({ id: 'a', parentId: null, hasChildren: true, childIds: ['b'] });
+        addTreeNode({ id: 'b', parentId: 'a', hasChildren: true, childIds: ['c'] });
+        addTreeNode({ id: 'c', parentId: 'b' });
+        setTreeRootIds(['a']);
+    }
+
+    it('selects, scrolls to, and expands ancestors of an already-loaded content', async () => {
+        seedLoadedTree();
+
+        await revealContentByPath('/a/b/c');
+
+        expect($activeId.get()).toBe('c');
+        expect($revealScrollTarget.get()).toBe('c');
+        expect(isNodeExpanded('a')).toBe(true);
+        expect(isNodeExpanded('b')).toBe(true);
+        expect(mocks.fetchContentByPath).not.toHaveBeenCalled();
+        expect(mocks.fetchRootChildrenIdsOnly).not.toHaveBeenCalled();
+        expect(mocks.fetchChildrenIdsOnly).not.toHaveBeenCalled();
+        expect(mocks.fetchContentByIds).toHaveBeenCalledWith(['c']);
+    });
+
+    it('progressively loads root + ancestors, then selects the leaf', async () => {
+        const byPath: Record<string, ContentSummary> = {
+            '/a': mk('a', '/a'),
+            '/a/b': mk('b', '/a/b'),
+            '/a/b/c': mk('c', '/a/b/c'),
+        };
+        mocks.fetchContentByPath.mockImplementation((p: string) =>
+            byPath[p] ? okAsync(byPath[p] as unknown as Content) : errAsync(new AppError('not found')),
+        );
+        mocks.fetchRootChildrenIdsOnly.mockImplementation(() => {
+            addTreeNode({ id: 'a', parentId: null, hasChildren: true });
+            setTreeRootIds(['a']);
+            return Promise.resolve();
+        });
+        mocks.fetchChildrenIdsOnly.mockImplementation((parentId: string) => {
+            if (parentId === 'a') {
+                addTreeNode({ id: 'b', parentId: 'a', hasChildren: true });
+                setTreeChildren('a', ['b']);
+            } else if (parentId === 'b') {
+                addTreeNode({ id: 'c', parentId: 'b' });
+                setTreeChildren('b', ['c']);
+            }
+            return Promise.resolve();
+        });
+
+        await revealContentByPath('/a/b/c');
+
+        expect(mocks.fetchRootChildrenIdsOnly).toHaveBeenCalledTimes(1);
+        expect(mocks.fetchChildrenIdsOnly).toHaveBeenCalledWith('a');
+        expect(mocks.fetchChildrenIdsOnly).toHaveBeenCalledWith('b');
+        expect(isNodeExpanded('a')).toBe(true);
+        expect(isNodeExpanded('b')).toBe(true);
+        expect(hasTreeNode('c')).toBe(true);
+        expect($activeId.get()).toBe('c');
+        expect($revealScrollTarget.get()).toBe('c');
+    });
+
+    it('aborts without selecting when the path cannot be resolved', async () => {
+        const onBeforeSelect = vi.fn();
+
+        await revealContentByPath('/missing', { onBeforeSelect });
+
+        expect($activeId.get()).toBeNull();
+        expect($revealScrollTarget.get()).toBeNull();
+        expect(onBeforeSelect).not.toHaveBeenCalled();
+        expect(mocks.fetchContentByIds).not.toHaveBeenCalled();
+    });
+
+    it('does not select when the leaf never lands in the tree', async () => {
+        setContents([mk('a', '/a'), mk('b', '/a/b'), mk('c', '/a/b/c')]);
+        addTreeNode({ id: 'a', parentId: null, hasChildren: true, childIds: ['b'] });
+        addTreeNode({ id: 'b', parentId: 'a', hasChildren: true }); // needs children, but mock won't add 'c'
+        setTreeRootIds(['a']);
+
+        await revealContentByPath('/a/b/c');
+
+        expect($activeId.get()).toBeNull();
+        expect($revealScrollTarget.get()).toBeNull();
+        expect(mocks.fetchContentByIds).not.toHaveBeenCalled();
+    });
+
+    it('prefetches the leaf into cache before selecting (preview bridge guard)', async () => {
+        // Progressive build with an empty cache; only the prefetch populates the leaf.
+        const byPath: Record<string, ContentSummary> = {
+            '/a': mk('a', '/a'),
+            '/a/b': mk('b', '/a/b'),
+            '/a/b/c': mk('c', '/a/b/c'),
+        };
+        mocks.fetchContentByPath.mockImplementation((p: string) =>
+            byPath[p] ? okAsync(byPath[p] as unknown as Content) : errAsync(new AppError('not found')),
+        );
+        mocks.fetchRootChildrenIdsOnly.mockImplementation(() => {
+            addTreeNode({ id: 'a', parentId: null, hasChildren: true });
+            setTreeRootIds(['a']);
+            return Promise.resolve();
+        });
+        mocks.fetchChildrenIdsOnly.mockImplementation((parentId: string) => {
+            if (parentId === 'a') {
+                addTreeNode({ id: 'b', parentId: 'a', hasChildren: true });
+                setTreeChildren('a', ['b']);
+            } else if (parentId === 'b') {
+                addTreeNode({ id: 'c', parentId: 'b' });
+                setTreeChildren('b', ['c']);
+            }
+            return Promise.resolve();
+        });
+
+        let activeIdWhenPrefetched: string | null = 'unset';
+        mocks.fetchContentByIds.mockImplementation((ids: string[]) => {
+            activeIdWhenPrefetched = $activeId.get(); // must run before setActive
+            setContents([mk('c', '/a/b/c')]);
+            return Promise.resolve([]);
+        });
+
+        await revealContentByPath('/a/b/c');
+
+        expect(mocks.fetchContentByIds).toHaveBeenCalledWith(['c']);
+        expect(activeIdWhenPrefetched).toBeNull(); // prefetch precedes selection
+        expect($currentItem.get()?.getId()).toBe('c'); // bridge would resolve the item
+    });
+
+    it('invokes onBeforeSelect exactly once, immediately before selecting', async () => {
+        seedLoadedTree();
+        let activeIdAtCallback: string | null = 'unset';
+        const onBeforeSelect = vi.fn(() => {
+            activeIdAtCallback = $activeId.get();
+        });
+
+        await revealContentByPath('/a/b/c', { onBeforeSelect });
+
+        expect(onBeforeSelect).toHaveBeenCalledTimes(1);
+        expect(activeIdAtCallback).toBeNull();
+        expect($activeId.get()).toBe('c');
+    });
+
+    it('in filter mode selects only, skipping expand and scroll', async () => {
+        setFilterActive(true);
+        setContents([mk('c', '/a/b/c')]);
+
+        await revealContentByPath('/a/b/c');
+
+        expect($activeId.get()).toBe('c');
+        expect(mocks.fetchContentByIds).toHaveBeenCalledWith(['c']);
+        expect(mocks.fetchRootChildrenIdsOnly).not.toHaveBeenCalled();
+        expect(mocks.fetchChildrenIdsOnly).not.toHaveBeenCalled();
+        expect($revealScrollTarget.get()).toBeNull();
+    });
+
+    it('does nothing for a degenerate path', async () => {
+        await revealContentByPath('');
+
+        expect($activeId.get()).toBeNull();
+        expect(mocks.fetchContentByPath).not.toHaveBeenCalled();
+        expect(mocks.fetchContentByIds).not.toHaveBeenCalled();
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.service.ts
@@ -3,7 +3,7 @@ import { fetchContentByPath } from '../api/content.api';
 import { fetchChildrenIdsOnly, fetchContentByIds, fetchRootChildrenIdsOnly } from '../api/content-fetcher';
 import { $isFilterActive } from './active-tree.store';
 import { requestRevealScroll } from './content-reveal.store';
-import { setActive } from './content-selection.store';
+import { $activeId, $selection, clearSelection, setActive } from './content-selection.store';
 import { expandNode, hasTreeNode, nodeNeedsChildrenLoad, $treeState } from './content-tree.store';
 import { getIdByPath } from './content.store';
 
@@ -27,8 +27,17 @@ export type RevealContentByPathOptions = {
 // bridge (which builds its item from $contentCache) resolves the item. No-op when
 // the content is already cached.
 async function selectContent(id: string, onBeforeSelect?: (id: string) => void): Promise<void> {
+    // $currentIds won't emit when the id is already the sole current item,
+    // so a one-shot suppression armed via onBeforeSelect would never be consumed.
+    if ($selection.get().size === 0 && $activeId.get() === id) return;
+
     await fetchContentByIds([id]).catch(() => undefined);
     onBeforeSelect?.(id);
+
+    // Mirror a grid row click: checkbox selection gives way to the new active row.
+    if ($selection.get().size > 0) {
+        clearSelection();
+    }
     setActive(id);
 }
 

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.service.ts
@@ -1,0 +1,88 @@
+import { ContentPath } from '../../../../app/content/ContentPath';
+import { fetchContentByPath } from '../api/content.api';
+import { fetchChildrenIdsOnly, fetchContentByIds, fetchRootChildrenIdsOnly } from '../api/content-fetcher';
+import { $isFilterActive } from './active-tree.store';
+import { requestRevealScroll } from './content-reveal.store';
+import { setActive } from './content-selection.store';
+import { expandNode, hasTreeNode, nodeNeedsChildrenLoad, $treeState } from './content-tree.store';
+import { getIdByPath } from './content.store';
+
+//
+// * Reveal service
+//
+// Reveals and selects a content in the main tree given its path (e.g. from
+// in-preview link navigation). The tree is built top-down, so a deeply nested,
+// never-loaded node's ancestors must be progressively loaded before it exists;
+// `expandNode`/`setActive` only affect nodes already present in the tree.
+//
+
+export type RevealContentByPathOptions = {
+    projectName?: string;
+    // Invoked immediately before setActive fires, so the caller can suppress the
+    // redundant preview reload triggered by the resulting selection change.
+    onBeforeSelect?: (id: string) => void;
+};
+
+// Ensures the content data is cached before selecting, so the selection→preview
+// bridge (which builds its item from $contentCache) resolves the item. No-op when
+// the content is already cached.
+async function selectContent(id: string, onBeforeSelect?: (id: string) => void): Promise<void> {
+    await fetchContentByIds([id]).catch(() => undefined);
+    onBeforeSelect?.(id);
+    setActive(id);
+}
+
+async function resolveId(pathStr: string, projectName?: string): Promise<string | undefined> {
+    const cached = getIdByPath(pathStr, projectName);
+    if (cached) return cached;
+
+    const result = await fetchContentByPath(pathStr, projectName);
+    if (result.isErr()) return undefined;
+    return result.value.getContentId().toString();
+}
+
+export async function revealContentByPath(pathStr: string, options: RevealContentByPathOptions = {}): Promise<void> {
+    const { projectName, onBeforeSelect } = options;
+
+    let targetPath: ContentPath;
+    try {
+        targetPath = ContentPath.create().fromString(pathStr).build();
+    } catch {
+        return;
+    }
+
+    const levels = targetPath.getLevel();
+    if (levels < 1) return;
+
+    // Filter mode hides the main tree; just track selection, skip expand/scroll.
+    if ($isFilterActive.get()) {
+        const id = await resolveId(pathStr, projectName);
+        if (!id) return;
+        await selectContent(id, onBeforeSelect);
+        return;
+    }
+
+    // Ensure level-1 nodes exist before descending.
+    if ($treeState.get().rootIds.length === 0) {
+        await fetchRootChildrenIdsOnly().catch(() => undefined);
+    }
+
+    for (let level = 1; level <= levels; level++) {
+        const segPath = targetPath.getPathAtLevel(level)?.toString();
+        if (!segPath) return;
+
+        const id = await resolveId(segPath, projectName);
+        if (!id) return; // not found / not in this project → abort silently
+
+        if (level < levels) {
+            if (nodeNeedsChildrenLoad(id)) {
+                await fetchChildrenIdsOnly(id).catch(() => undefined);
+            }
+            expandNode(id);
+        } else {
+            if (!hasTreeNode(id)) return; // ancestor chain broke; nothing to reveal
+            await selectContent(id, onBeforeSelect);
+            requestRevealScroll(id);
+        }
+    }
+}

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.store.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { $revealScrollTarget, clearRevealScroll, requestRevealScroll } from './content-reveal.store';
+
+describe('content-reveal.store', () => {
+    beforeEach(() => {
+        clearRevealScroll();
+    });
+
+    it('defaults to null', () => {
+        expect($revealScrollTarget.get()).toBeNull();
+    });
+
+    it('requestRevealScroll sets the target id', () => {
+        requestRevealScroll('abc');
+        expect($revealScrollTarget.get()).toBe('abc');
+    });
+
+    it('clearRevealScroll resets to null', () => {
+        requestRevealScroll('abc');
+        clearRevealScroll();
+        expect($revealScrollTarget.get()).toBeNull();
+    });
+
+    it('clearRevealScroll is a no-op when already null', () => {
+        clearRevealScroll();
+        expect($revealScrollTarget.get()).toBeNull();
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-reveal.store.ts
@@ -1,0 +1,22 @@
+import { atom, computed } from 'nanostores';
+
+//
+// * Reveal-scroll signal
+//
+// Holds the id of a tree row the grid should scroll into view.
+// Set by the reveal service, consumed and cleared by ContentTreeList.
+//
+
+const $revealScrollTargetAtom = atom<string | null>(null);
+
+export const $revealScrollTarget = computed($revealScrollTargetAtom, (value) => value);
+
+export function requestRevealScroll(id: string): void {
+    $revealScrollTargetAtom.set(id);
+}
+
+export function clearRevealScroll(): void {
+    if ($revealScrollTargetAtom.get() !== null) {
+        $revealScrollTargetAtom.set(null);
+    }
+}

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-tree.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-tree.store.ts
@@ -31,6 +31,7 @@ import {
     type CreateNodeOptions,
 } from '../../../shared/lib/tree-store';
 import { $uploads, type UploadItem } from './uploads.store';
+import { clearRevealScroll } from './content-reveal.store';
 import { $contentCache } from './content.store';
 import type { ContentData } from './ContentData';
 import type { ContentUploadData } from './ContentUploadData';
@@ -206,6 +207,8 @@ export function setNodesLoadingData(ids: string[], loading: boolean): void {
 export function resetTree(): void {
     $treeState.set(createEmptyState<ContentTreeNodeData>());
     $rootTotalChildren.set(undefined);
+    // A pending reveal-scroll target points into the discarded tree.
+    clearRevealScroll();
 }
 
 export function setRootTotalChildren(total: number): void {

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/browse-grid/ContentTreeList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/browse-grid/ContentTreeList.tsx
@@ -36,6 +36,8 @@ import {
     collapseNode,
     expandNode,
     nodeNeedsChildrenLoad,
+    $revealScrollTarget,
+    clearRevealScroll,
 } from '../../entities/content';
 import { useI18n } from '../../shared/lib/hooks/useI18n';
 import type { FlatNode } from '../../shared/lib/tree-store';
@@ -175,6 +177,7 @@ export const ContentTreeList = ({ contextMenuActions = {} }: ContentTreeListProp
     const activeId = useStore($activeId);
     const isFilterActive = useStore($isFilterActive);
     const activeProject = useStore($activeProject);
+    const revealScrollTarget = useStore($revealScrollTarget);
     const loadFailedLabel = useI18n('field.tree.loadFailed');
     const retryLabel = useI18n('action.retry');
 
@@ -345,6 +348,17 @@ export const ContentTreeList = ({ contextMenuActions = {} }: ContentTreeListProp
     useEffect(() => {
         loadVisibleContentData();
     }, [flatNodes, loadVisibleContentData]);
+
+    // Scroll a revealed row (e.g. from in-preview navigation) into view.
+    // Re-runs on visibleItems so a row still being materialized after the signal
+    // arrives is scrolled to once it appears; then the signal is cleared.
+    useEffect(() => {
+        if (!revealScrollTarget) return;
+        const index = visibleItems.findIndex((n) => n.id === revealScrollTarget);
+        if (index < 0) return;
+        virtuosoRef.current?.scrollToIndex({ index, align: 'center' });
+        clearRevealScroll();
+    }, [revealScrollTarget, visibleItems]);
 
     // Handle expand - load child IDs first, data will load via viewport
     // Works in both main and filter mode, using respective tree stores


### PR DESCRIPTION
- Re-targeted preview to content tree sync from the removed legacy tree to the v6 stores.
- Added revealContentByPath service: progressively loads and expands ancestors, prefetches the leaf into cache, selects it, and requests scroll-into-view.
- Added a reveal-scroll signal store: ContentTreeList scrolls the revealed row via virtuosoRef. Suppressed the redundant preview.
- Removed legacy expandToListElementByPath.
- Added content-reveal.service/store tests.