### PR TITLE
New Content dialog: show loading spinner while content types load #11136

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/new-content/model/newContentDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/new-content/model/newContentDialog.store.ts
@@ -34,8 +34,7 @@ type UploadOptions = {
 type NewContentDialogStore = {
     // Dialog state
     open: boolean;
-    //loading: boolean;
-    //failed: boolean;
+    loading: boolean;
     inputValue: string;
     selectedTab: string;
     isDragging: boolean;
@@ -48,8 +47,7 @@ type NewContentDialogStore = {
 
 const initialState: NewContentDialogStore = {
     open: false,
-    //loading: false,
-    //failed: false,
+    loading: false,
     inputValue: '',
     selectedTab: 'all',
     isDragging: false,
@@ -80,6 +78,7 @@ listenKeys($newContentDialog, ['open', 'parentContent'], ({ open, parentContent 
     if (!open || !activeProject) return;
 
     const loadId = ++loadCounter;
+    $newContentDialog.setKey('loading', true);
 
     task(async () => {
         const allContentTypes = await ContentTypesHelper.getAvailableContentTypes({
@@ -102,8 +101,14 @@ listenKeys($newContentDialog, ['open', 'parentContent'], ({ open, parentContent 
         $newContentDialog.setKey('isMediaAllowed', isMediaAllowed);
         $newContentDialog.setKey('baseContentTypes', baseContentTypes);
         $newContentDialog.setKey('suggestedContentTypes', suggestedContentTypes);
+        $newContentDialog.setKey('loading', false);
     }).catch((error) => {
         console.error(error);
+
+        // Stop the spinner only if this load is still the current one
+        if (loadId === loadCounter) {
+            $newContentDialog.setKey('loading', false);
+        }
     });
 });
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/new-content/ui/NewContentDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/new-content/ui/NewContentDialog.tsx
@@ -24,7 +24,7 @@ export const NewContentDialog = (): ReactElement => {
     const inputRef = useRef<HTMLInputElement>(null);
     const dialogContentRef = useRef<HTMLDivElement>(null);
     const shouldFocusInput = useRef(false);
-    const { open, selectedTab, inputValue, parentContent, isMediaAllowed } = useStore($newContentDialog);
+    const { open, selectedTab, inputValue, parentContent, isMediaAllowed, loading } = useStore($newContentDialog);
     const filteredBaseContentTypes = useStore($filteredBaseContentTypes);
     const filteredSuggestedContentTypes = useStore($filteredSuggestedContentTypes);
     const isTemplateFolder = parentContent?.getType().isTemplateFolder() ?? false;
@@ -202,12 +202,14 @@ export const NewContentDialog = (): ReactElement => {
                                     tabName="all"
                                     contentTypes={filteredBaseContentTypes}
                                     parentContent={parentContent}
+                                    loading={loading}
                                 />
 
                                 <NewContentDialogContentTypesTab
                                     tabName="suggested"
                                     contentTypes={filteredSuggestedContentTypes}
                                     parentContent={parentContent}
+                                    loading={loading}
                                 />
 
                                 <NewContentDialogMediaTab tabName="media" />

--- a/modules/lib/src/main/resources/assets/js/v6/features/new-content/ui/NewContentDialogContentTypesTab.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/new-content/ui/NewContentDialogContentTypesTab.tsx
@@ -1,5 +1,6 @@
 import { ContentTypeSummary } from '@enonic/lib-admin-ui/schema/content/ContentTypeSummary';
 import { Button, Tab } from '@enonic/ui';
+import { Loader2 } from 'lucide-react';
 import { ReactElement } from 'react';
 import type { ContentSummary } from '../../../../app/content/ContentSummary';
 import { NewContentEvent } from '../../../../app/create/NewContentEvent';
@@ -9,17 +10,20 @@ import { ItemLabel } from '../../../shared/ui/ItemLabel';
 import { ContentIcon } from '../../../shared/ui/icons/ContentIcon';
 
 const NEW_CONTENT_DIALOG_CONTENT_TYPES_TAB_NAME = 'NewContentDialogContentTypesTab';
+const NEW_CONTENT_DIALOG_CONTENT_TYPES_LOADER_NAME = 'NewContentDialogContentTypesLoader';
 
 type NewContentDialogContentTypesTabProps = {
     tabName: string;
     contentTypes: ContentTypeSummary[];
     parentContent: ContentSummary;
+    loading: boolean;
 };
 
 export const NewContentDialogContentTypesTab = ({
     tabName,
     contentTypes,
     parentContent,
+    loading,
 }: NewContentDialogContentTypesTabProps): ReactElement => {
     const notFoundLabel = useI18n('dialog.new.notFound');
 
@@ -29,8 +33,17 @@ export const NewContentDialogContentTypesTab = ({
     };
 
     return (
-        <Tab.Content value={tabName}>
-            {contentTypes.length > 0 && (
+        <Tab.Content value={tabName} className="mt-0 pt-2 h-full">
+            {loading && (
+                <div
+                    data-component={NEW_CONTENT_DIALOG_CONTENT_TYPES_LOADER_NAME}
+                    className="flex items-center justify-center h-full"
+                >
+                    <Loader2 className="size-12 animate-spin text-subtle" />
+                </div>
+            )}
+
+            {!loading && contentTypes.length > 0 && (
                 <ul className="grid grid-cols-2 gap-y-1.5 gap-x-7.5">
                     {contentTypes.map((contentType) => {
                         const key = contentType.getName();
@@ -67,7 +80,7 @@ export const NewContentDialogContentTypesTab = ({
                 </ul>
             )}
 
-            {contentTypes.length === 0 && <p className="text-sm text-subtle">{notFoundLabel}</p>}
+            {!loading && contentTypes.length === 0 && <p className="text-sm text-subtle">{notFoundLabel}</p>}
         </Tab.Content>
     );
 };

--- a/testing/page_objects/browsepanel/new.content.dialog.js
+++ b/testing/page_objects/browsepanel/new.content.dialog.js
@@ -2,7 +2,8 @@
  * Created on 1.12.2017. update on 29.04.2026
  */
 const Page = require('../page');
-const {BUTTONS} = require('../../libs/elements');
+const { BUTTONS } = require('../../libs/elements');
+const appConst = require('../../libs/app_const');
 const XPATH = {
     container: `//div[@role='dialog' and @data-state='open' and descendant::h3[contains(.,'Create content')]]`,
     dialogTitle: `//h3[contains(.,'Create content')]`,
@@ -13,6 +14,7 @@ const XPATH = {
     searchInput: `//input[@aria-label='Search']`,
     header: `//div[contains(@id,'NewContentDialogHeader')]`,
     typesList: `//ul//div[@data-component='ItemLabel']//span`,
+    typesLoader: "//div[@data-component='NewContentDialogContentTypesLoader']",
     mostPopularBlock: "//div[contains(@id,'MostPopularItemsBlock')]",
     emptyViewP: "//p[contains(.,'No content types found')]",
     contentTypeContainsName(name) {
@@ -24,7 +26,6 @@ const XPATH = {
 };
 
 class NewContentDialog extends Page {
-
     get title() {
         return XPATH.container + XPATH.dialogTitle;
     }
@@ -56,7 +57,11 @@ class NewContentDialog extends Page {
         try {
             return await this.waitForElementDisabled(this.mediaButton);
         } catch (err) {
-            await this.handleError(`New Content dialog, Media tab button should be disabled:`, 'err_media_tab_disabled', err);
+            await this.handleError(
+                `New Content dialog, Media tab button should be disabled:`,
+                'err_media_tab_disabled',
+                err,
+            );
         }
     }
 
@@ -64,7 +69,11 @@ class NewContentDialog extends Page {
         try {
             return await this.waitForElementDisabled(this.suggestedButton);
         } catch (err) {
-            await this.handleError(`New Content dialog, Suggested tab button should be disabled:`, 'err_suggested_tab_disabled', err);
+            await this.handleError(
+                `New Content dialog, Suggested tab button should be disabled:`,
+                'err_suggested_tab_disabled',
+                err,
+            );
         }
     }
 
@@ -89,19 +98,16 @@ class NewContentDialog extends Page {
         return await this.waitForElementNotDisplayed(XPATH.container + XPATH.allTabDiv);
     }
 
-
     //No content types found
     async waitForNoTypesFoundMessage(tabName) {
         const tabConfig = {
-            'All': XPATH.allTabDiv,
-            'Suggested': XPATH.suggestedTabDiv,
-            'Media': XPATH.mediaTabDiv,
+            All: XPATH.allTabDiv,
+            Suggested: XPATH.suggestedTabDiv,
+            Media: XPATH.mediaTabDiv,
         };
 
         if (!tabConfig[tabName]) {
-            throw new Error(
-                `Invalid tab name '${tabName}'. Expected: ${Object.keys(tabConfig).join(', ')}`
-            );
+            throw new Error(`Invalid tab name '${tabName}'. Expected: ${Object.keys(tabConfig).join(', ')}`);
         }
 
         try {
@@ -112,7 +118,8 @@ class NewContentDialog extends Page {
         } catch (err) {
             await this.handleError(
                 `New Content dialog, '${tabName}' tab - 'No content types found' message:`,
-                'err_no_content_types_new_content_dlg', err
+                'err_no_content_types_new_content_dlg',
+                err,
             );
         }
     }
@@ -188,7 +195,22 @@ class NewContentDialog extends Page {
         }
     }
 
+    // Wait until the content types have finished loading (spinner is gone).
+    // Guards against interacting with the list before the REST load resolves.
+    async waitForContentTypesLoaded() {
+        try {
+            return await this.waitForElementNotDisplayed(XPATH.container + XPATH.typesLoader, appConst.longTimeout);
+        } catch (err) {
+            await this.handleError(
+                `New Content dialog, content types loading spinner:`,
+                'err_new_content_types_loading',
+                err,
+            );
+        }
+    }
+
     async clickOnContentType(contentTypeName) {
+        await this.waitForContentTypesLoaded();
         let typeSelector = XPATH.contentTypeByName(contentTypeName);
         await this.waitForElementDisplayed(typeSelector);
         let elems = await this.getDisplayedElements(typeSelector);
@@ -197,7 +219,7 @@ class NewContentDialog extends Page {
     }
 
     async getItemsInAllTab() {
-        let locator = XPATH.allTabDiv+ XPATH.typesList;
+        let locator = XPATH.allTabDiv + XPATH.typesList;
         await this.waitForElementDisplayed(locator);
         return await this.getTextInElements(locator);
     }


### PR DESCRIPTION
Adds a real loading state to the New Content dialog so it no longer flashes "No content types found" while content types are still being fetched from the server.

- Store: a `loading` flag set on open and cleared on resolve/error, guarded against stale loads.
- UI: `NewContentDialogContentTypesTab` shows a centered spinner while loading; the list and the empty ("No content types found") state render only after loading finishes.
- Tests: the page object waits for the spinner to clear (`waitForContentTypesLoaded`) before selecting a content type, removing the 4s race that intermittently failed the `datetime.config` spec in `testInputTypes_2`.

Closes #11136

<sub>*Drafted with AI assistance*</sub>
