### PR TITLE
Expand/Reselect tree nodes after reload #10944

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/api/content-fetcher.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/api/content-fetcher.test.ts
@@ -10,12 +10,14 @@ import { $activeProject } from '../../project/activeProject.store';
 import type { Project } from '../../../../app/settings/data/project/Project';
 import {
     addTreeNodes,
+    expandNode,
     hasTreeNode,
     resetTree,
     setTreeChildren,
     setTreeRootIds,
     $treeState,
 } from '../model/content-tree.store';
+import { $activeId, $selection, clearSelection, setActive, setSelection } from '../model/content-selection.store';
 import { emitContentSorted } from '../../../shared/socket/socket.store';
 import { start as startContentService } from '../model/content.service';
 import { addFilterNodes, resetFilterTree, setFilterRootIds, $filterTreeState } from '../model/filter-tree.store';
@@ -35,6 +37,8 @@ import {
     isFilterChildrenIdsLoadFailed,
     isVisibleContentDataLoadFailed,
     isVisibleFilterContentDataLoadFailed,
+    reloadContentTree,
+    reloadMainTreePreservingExpansion,
     resetChildrenIdsRetryState,
     resetFilterChildrenIdsRetryState,
     resetVisibleContentDataRetryState,
@@ -654,6 +658,209 @@ describe('content-fetcher store integration', () => {
                 ]);
             });
             expect(mockListContentIdsByParent).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('reloadMainTreePreservingExpansion', () => {
+        beforeEach(() => {
+            // Ensure main mode: filter state can leak from earlier tests.
+            deactivateFilter();
+            // Selection/active are not reset by the outer beforeEach and leak.
+            clearSelection();
+            setActive(null);
+        });
+
+        function mockChildrenByParent(childrenByParent: Record<string, string[]>): void {
+            mockListContentIdsByParent.mockImplementation((params: { parentId?: { toString: () => string } }) => {
+                const key = params.parentId?.toString() ?? '__root__';
+                const ids = childrenByParent[key] ?? [];
+                return okAsync(ids.map((id) => ({ toString: () => id })));
+            });
+        }
+
+        it('re-expands previously expanded nodes and reloads their children', async () => {
+            mockChildrenByParent({
+                __root__: ['root-1'],
+                'root-1': ['child-1'],
+                'child-1': ['grandchild-1'],
+            });
+
+            addTreeNodes([
+                { id: 'root-1', data: null, parentId: null, hasChildren: true },
+                { id: 'child-1', data: null, parentId: 'root-1', hasChildren: true },
+            ]);
+            setTreeRootIds(['root-1']);
+            setTreeChildren('root-1', ['child-1']);
+            expandNode('root-1');
+            expandNode('child-1');
+
+            await reloadMainTreePreservingExpansion();
+
+            const state = $treeState.get();
+            expect(state.rootIds).toEqual(['root-1']);
+            expect(state.expandedIds.has('root-1')).toBe(true);
+            expect(state.expandedIds.has('child-1')).toBe(true);
+            expect(state.nodes.get('root-1')?.childIds).toEqual(['child-1']);
+            expect(state.nodes.get('child-1')?.childIds).toEqual(['grandchild-1']);
+        });
+
+        it('drops expansion for nodes that no longer exist after reload', async () => {
+            mockChildrenByParent({
+                __root__: ['root-1'],
+                'root-1': [],
+            });
+
+            addTreeNodes([
+                { id: 'root-1', data: null, parentId: null, hasChildren: true },
+                { id: 'gone', data: null, parentId: 'root-1', hasChildren: true },
+            ]);
+            setTreeRootIds(['root-1']);
+            setTreeChildren('root-1', ['gone']);
+            expandNode('root-1');
+            expandNode('gone');
+
+            await reloadMainTreePreservingExpansion();
+
+            const state = $treeState.get();
+            expect(state.expandedIds.has('root-1')).toBe(true);
+            expect(state.expandedIds.has('gone')).toBe(false);
+            expect(state.nodes.has('gone')).toBe(false);
+        });
+
+        it('ignores a second reload while one is already in progress', async () => {
+            mockChildrenByParent({
+                __root__: ['root-1'],
+                'root-1': ['child-1'],
+                'child-1': ['grandchild-1'],
+            });
+
+            addTreeNodes([
+                { id: 'root-1', data: null, parentId: null, hasChildren: true },
+                { id: 'child-1', data: null, parentId: 'root-1', hasChildren: true },
+            ]);
+            setTreeRootIds(['root-1']);
+            setTreeChildren('root-1', ['child-1']);
+            expandNode('root-1');
+            expandNode('child-1');
+
+            // Second call is a no-op: the guard drops it so it cannot reset mid-restore.
+            const first = reloadContentTree();
+            const second = reloadContentTree();
+            await Promise.all([first, second]);
+
+            const state = $treeState.get();
+            expect(state.expandedIds.has('root-1')).toBe(true);
+            expect(state.expandedIds.has('child-1')).toBe(true);
+            expect(state.nodes.get('child-1')?.childIds).toEqual(['grandchild-1']);
+        });
+
+        it('clears the active item when it no longer resolves on the server', async () => {
+            mockChildrenByParent({ __root__: ['root-1'] });
+            // The active item is not returned by the server anymore.
+            mockResolveContentSummaries.mockReturnValue(okAsync([]));
+
+            addTreeNodes([{ id: 'stale-active', data: null, parentId: null, hasChildren: false }]);
+            setTreeRootIds(['stale-active']);
+            setActive('stale-active');
+
+            await reloadMainTreePreservingExpansion();
+
+            expect($activeId.get()).toBeNull();
+        });
+
+        it('keeps the active item when it still resolves on the server', async () => {
+            mockChildrenByParent({ __root__: ['root-1'] });
+            mockResolveContentSummaries.mockReturnValue(okAsync([createMockContent('root-1')]));
+
+            addTreeNodes([{ id: 'root-1', data: null, parentId: null, hasChildren: false }]);
+            setTreeRootIds(['root-1']);
+            setActive('root-1');
+
+            await reloadMainTreePreservingExpansion();
+
+            expect($activeId.get()).toBe('root-1');
+        });
+
+        it('drops selected items that no longer resolve on the server', async () => {
+            mockChildrenByParent({ __root__: ['keep', 'gone'] });
+            // Only 'keep' is still returned; 'gone' was deleted.
+            mockResolveContentSummaries.mockReturnValue(okAsync([createMockContent('keep')]));
+
+            setTreeRootIds(['keep', 'gone']);
+            setSelection(['keep', 'gone']);
+
+            await reloadMainTreePreservingExpansion();
+
+            expect([...$selection.get()]).toEqual(['keep']);
+        });
+
+        it('keeps selected items that still resolve after reload', async () => {
+            mockChildrenByParent({ __root__: ['a', 'b'] });
+            mockResolveContentSummaries.mockReturnValue(
+                okAsync([createMockContent('a'), createMockContent('b')]),
+            );
+
+            setTreeRootIds(['a', 'b']);
+            setSelection(['a', 'b']);
+
+            await reloadMainTreePreservingExpansion();
+
+            expect([...$selection.get()].sort()).toEqual(['a', 'b']);
+        });
+
+        it('refetches off-screen selected items whose data is not cached', async () => {
+            mockChildrenByParent({ __root__: ['deep'] });
+            mockResolveContentSummaries.mockReturnValue(okAsync([createMockContent('deep')]));
+
+            setTreeRootIds(['deep']);
+            setSelection(['deep']);
+
+            await reloadMainTreePreservingExpansion();
+
+            // Selected ids are fetched up front, not awaited from the viewport.
+            expect(mockResolveContentSummaries).toHaveBeenCalled();
+            expect([...$selection.get()]).toEqual(['deep']);
+        });
+    });
+
+    describe('reloadContentTree in filter mode', () => {
+        beforeEach(() => {
+            clearSelection();
+            setActive(null);
+        });
+
+        it('preserves the active and selected items across a filter reload', async () => {
+            mockOtherQueryApi.mockReturnValue(
+                okAsync({ contents: [createMockContent('f-1'), createMockContent('f-2')], totalHits: 2 }),
+            );
+
+            await activateFilter(createMockQuery());
+            setActive('f-1');
+            setSelection(['f-1', 'f-2']);
+
+            mockResolveContentSummaries.mockReturnValue(
+                okAsync([createMockContent('f-1'), createMockContent('f-2')]),
+            );
+
+            await reloadContentTree();
+
+            expect($activeId.get()).toBe('f-1');
+            expect([...$selection.get()].sort()).toEqual(['f-1', 'f-2']);
+        });
+
+        it('clears the active item when it no longer resolves after a filter reload', async () => {
+            mockOtherQueryApi.mockReturnValue(
+                okAsync({ contents: [createMockContent('f-1')], totalHits: 1 }),
+            );
+
+            await activateFilter(createMockQuery());
+            setActive('f-gone');
+
+            mockResolveContentSummaries.mockReturnValue(okAsync([]));
+
+            await reloadContentTree();
+
+            expect($activeId.get()).toBeNull();
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/api/content-fetcher.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/api/content-fetcher.ts
@@ -16,12 +16,18 @@ import {
 import { createRootChildOrder } from '../lib/childOrder';
 import { $activeProject } from '../../project';
 import { getMissingIds, getContents, getIdByPath } from '../model/content.store';
-import { setContents } from '../model/content.commands';
+import { clearProjectContentCache, setContents } from '../model/content.commands';
+import { $activeId, $selection, setActive, setSelection } from '../model/content-selection.store';
 import { $contentDuplicated, $contentMoved, $contentSorted } from '../../../shared/socket/socket.store';
 import {
+    $isReloading,
     $treeState,
     addTreeNode,
     addTreeNodes,
+    expandNode,
+    nodeNeedsChildrenLoad,
+    resetTree,
+    setReloading,
     setTreeChildren,
     setTreeRootIds,
     appendTreeChildren,
@@ -476,6 +482,116 @@ export async function fetchRootChildrenIdsOnly(): Promise<string[]> {
     return fetchChildrenIdsOnly(null, createRootChildOrder());
 }
 
+/**
+ * Re-expands nodes that were expanded before a reload. A placeholder only
+ * reappears once its parent's children load, so the set is rescanned until no
+ * node can be processed; vanished nodes are skipped, a project switch aborts.
+ */
+async function restoreExpandedNodes(
+    expandedIds: ReadonlySet<string>,
+    projectName: string | undefined,
+): Promise<void> {
+    if (expandedIds.size === 0) return;
+
+    const processed = new Set<string>();
+    let madeProgress = true;
+
+    while (madeProgress) {
+        madeProgress = false;
+
+        for (const id of expandedIds) {
+            if (processed.has(id) || !$treeState.get().nodes.has(id)) continue;
+
+            processed.add(id);
+            madeProgress = true;
+            expandNode(id);
+
+            if (nodeNeedsChildrenLoad(id)) {
+                await fetchChildrenIdsOnly(id).catch(() => undefined);
+
+                if (isProjectStale(projectName)) return;
+            }
+        }
+    }
+}
+
+/**
+ * Refetches the selected/active items after a reload cleared the cache, then
+ * reconciles: drops from the selection any id the server no longer returns and
+ * keeps the active id only if it still resolves. The caller captures the values
+ * before reset, since the tree list clobbers active/selection mid-reload.
+ */
+async function reconcileSelectionAfterReload(
+    selectedIds: ReadonlySet<string>,
+    activeId: string | null,
+    projectName: string | undefined,
+): Promise<void> {
+    const ids = new Set(selectedIds);
+    if (activeId != null) ids.add(activeId);
+    if (ids.size === 0) return;
+
+    const resolved = await fetchContentByIds([...ids]).catch((): ContentSummary[] => []);
+    if (isProjectStale(projectName)) return;
+
+    const availableIds = new Set(resolved.map((content) => content.getId()));
+
+    setSelection(new Set([...selectedIds].filter((id) => availableIds.has(id))));
+    setActive(activeId != null && availableIds.has(activeId) ? activeId : null);
+}
+
+/**
+ * Reloads the main tree from the server while keeping previously expanded
+ * nodes open. The tree is rebuilt from IDs and content data reloads lazily via
+ * the viewport, so this refreshes data without discarding navigation context.
+ */
+export async function reloadMainTreePreservingExpansion(): Promise<void> {
+    const projectName = captureActiveProjectName();
+    const expandedIds = new Set($treeState.get().expandedIds);
+    // Captured before reset — the list clobbers active/selection mid-reload.
+    const selectedIds = $selection.get();
+    const activeId = $activeId.get();
+
+    resetTree();
+    clearProjectContentCache();
+
+    await fetchRootChildrenIdsOnly();
+    if (isProjectStale(projectName)) return;
+
+    await restoreExpandedNodes(expandedIds, projectName);
+    if (isProjectStale(projectName)) return;
+
+    await reconcileSelectionAfterReload(selectedIds, activeId, projectName);
+}
+
+/**
+ * Single entry point for the reload action: refreshes data while preserving
+ * navigation context, dispatching to the filter or main tree by active mode.
+ * `$isReloading` guards re-entry and keeps the toolbar button disabled for the
+ * whole operation, so overlapping reloads cannot start.
+ */
+export async function reloadContentTree(): Promise<void> {
+    if ($isReloading.get()) return;
+    setReloading(true);
+
+    try {
+        if ($isFilterActive.get()) {
+            const projectName = captureActiveProjectName();
+            const selectedIds = $selection.get();
+            const activeId = $activeId.get();
+
+            const query = getFilterQuery();
+            if (query) await activateFilter(query);
+            if (isProjectStale(projectName)) return;
+
+            await reconcileSelectionAfterReload(selectedIds, activeId, projectName);
+        } else {
+            await reloadMainTreePreservingExpansion();
+        }
+    } finally {
+        setReloading(false);
+    }
+}
+
 // Batch size for loading content data of visible nodes
 const DATA_BATCH_SIZE = 20;
 const VISIBLE_DATA_RETRY_DELAY_MS = 1_000;
@@ -750,6 +866,7 @@ function updateTreeNodesWithData(contents: ContentSummary[]): void {
 //
 
 import {
+    $isFilterActive,
     setFilterActive as setFilterActiveState,
     deactivateFilter as deactivateFilterState,
 } from '../model/active-tree.store';

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/index.ts
@@ -3,7 +3,7 @@ import { $activeId as $_activeIdAtom } from './model/content-selection.store';
 import { $filterRefreshNeeded as $_filterRefreshNeededAtom } from './model/filter-tree.store';
 import { $isFilterActive as $_isFilterActiveAtom } from './model/active-tree.store';
 import { $selection as $_selectionAtom } from './model/content-selection.store';
-import { $treeState as $_treeStateAtom } from './model/content-tree.store';
+import { $isReloading as $_isReloadingAtom, $treeState as $_treeStateAtom } from './model/content-tree.store';
 
 export { compareContent } from './api/compare.api';
 export type { CompareResult } from './api/compare.api';
@@ -26,6 +26,7 @@ export {
     isFilterChildrenIdsLoadFailed,
     isVisibleContentDataLoadFailed,
     isVisibleFilterContentDataLoadFailed,
+    reloadContentTree,
     reloadParentChildren,
 } from './api/content-fetcher';
 export { fetchContentById, fetchContentByPath, fetchNearestSite } from './api/content.api';
@@ -91,5 +92,6 @@ export {
 export const $activeId = computed($_activeIdAtom, (value) => value);
 export const $filterRefreshNeeded = computed($_filterRefreshNeededAtom, (value) => value);
 export const $isFilterActive = computed($_isFilterActiveAtom, (value) => value);
+export const $isReloading = computed($_isReloadingAtom, (value) => value);
 export const $selection = computed($_selectionAtom, (value) => value);
 export const $treeState = computed($_treeStateAtom, (value) => value);

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-selection.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-selection.store.test.ts
@@ -819,7 +819,10 @@ describe('contentTreeSelection.store', () => {
         });
     });
 
-    describe('active highlight on filter transitions', () => {
+    describe('active item across filter transitions', () => {
+        // The active id is the context/preview target and stays set across view
+        // switches (matching legacy). Whether the grid highlights it is decided in
+        // ContentTreeList by node presence, not by clearing $activeId here.
         beforeEach(() => {
             addTreeNodes([
                 { id: '1', data: createMockNodeData('1') },
@@ -828,15 +831,15 @@ describe('contentTreeSelection.store', () => {
             setTreeRootIds(['1', '2']);
         });
 
-        it('clears active highlight when entering filter mode', () => {
+        it('keeps the active item when entering filter mode', () => {
             setActive('1');
 
             setFilterActive(true);
 
-            expect($activeId.get()).toBeNull();
+            expect($activeId.get()).toBe('1');
         });
 
-        it('clears active highlight when leaving filter mode', () => {
+        it('keeps the active item when leaving filter mode', () => {
             setFilterActive(true);
             addFilterNodes([{ id: 'f1', data: createMockNodeData('f1') }]);
             setFilterRootIds(['f1']);
@@ -844,10 +847,10 @@ describe('contentTreeSelection.store', () => {
 
             setFilterActive(false);
 
-            expect($activeId.get()).toBeNull();
+            expect($activeId.get()).toBe('f1');
         });
 
-        it('clears active highlight when filter results change', () => {
+        it('keeps the active item when filter results change', () => {
             setFilterActive(true);
             addFilterNodes([{ id: 'f1', data: createMockNodeData('f1') }]);
             setFilterRootIds(['f1']);
@@ -857,10 +860,10 @@ describe('contentTreeSelection.store', () => {
             addFilterNodes([{ id: 'f2', data: createMockNodeData('f2') }]);
             setFilterRootIds(['f2']);
 
-            expect($activeId.get()).toBeNull();
+            expect($activeId.get()).toBe('f1');
         });
 
-        it('keeps active highlight when filter tree expands (roots unchanged)', () => {
+        it('keeps the active item when filter tree expands (roots unchanged)', () => {
             setFilterActive(true);
             addFilterNodes([{ id: 'f1', data: createMockNodeData('f1'), childIds: ['f1-1'] }]);
             setFilterRootIds(['f1']);

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-selection.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-selection.store.ts
@@ -246,16 +246,12 @@ $activeRawFlatNodes.subscribe((flatNodes) => {
 // * Filter Mode Transitions
 //
 
-// When switching between views (either direction), disable select-all mode
-// Select-all is view-specific - enabling it in one view should not affect the other
-// Selection IDs are preserved, but auto-selection behavior is disabled
+// Select-all is view-specific, so disable it on any view switch. Selection and
+// active are kept: active stays the context/preview target across views, and the
+// grid highlights it only when present in the current view (see ContentTreeList).
 $isFilterActive.subscribe(() => {
     if ($selectAllMode.get()) {
         $selectAllMode.set(false);
-    }
-
-    if ($activeId.get() !== null) {
-        $activeId.set(null);
     }
 });
 
@@ -280,10 +276,6 @@ $filterTreeState.subscribe((state) => {
     if (rootsChanged && $isFilterActive.get()) {
         if ($selectAllMode.get()) {
             $selectAllMode.set(false);
-        }
-
-        if ($activeId.get() !== null) {
-            $activeId.set(null);
         }
     }
 });

--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-tree.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content-tree.store.ts
@@ -57,6 +57,9 @@ export const $treeState = atom<ContentTreeState>(createEmptyState<ContentTreeNod
 /** Root-level total children count for pagination */
 const $rootTotalChildren = atom<number | undefined>(undefined);
 
+/** Whether a full tree reload (root fetch + expansion restore) is in progress. */
+export const $isReloading = atom<boolean>(false);
+
 //
 // * Computed Stores
 //
@@ -209,6 +212,10 @@ export function resetTree(): void {
     $rootTotalChildren.set(undefined);
     // A pending reveal-scroll target points into the discarded tree.
     clearRevealScroll();
+}
+
+export function setReloading(reloading: boolean): void {
+    $isReloading.set(reloading);
 }
 
 export function setRootTotalChildren(total: number): void {

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/browse-grid/ContentTreeList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/browse-grid/ContentTreeList.tsx
@@ -194,6 +194,13 @@ export const ContentTreeList = ({ contextMenuActions = {} }: ContentTreeListProp
         [flatNodes, isFilterActive],
     );
 
+    // Active persists across views for preview/details but may be absent here;
+    // feed it to the list only when present, else the list resets it to items[0].
+    const activePresent = useMemo(
+        () => activeId != null && flatNodes.some((node) => node.id === activeId),
+        [flatNodes, activeId],
+    );
+
     const failedNodeIdSet = useMemo(() => new Set(failedNodeIds), [failedNodeIds]);
     const hasPendingPlaceholders = useMemo(
         () => flatNodes.some((node) => node.nodeType === 'node' && node.data === null && !failedNodeIdSet.has(node.id)),
@@ -501,7 +508,7 @@ export const ContentTreeList = ({ contextMenuActions = {} }: ContentTreeListProp
             selection={selection}
             onSelectionChange={handleSelectionChange}
             selectionMode="multiple"
-            active={activeId}
+            active={activePresent ? activeId : null}
             onActiveChange={setActive}
             preserveFilteredSelection={isFilterActive}
             onExpand={handleExpand}

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/browse-tree/TreeListToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/browse-tree/TreeListToolbar.tsx
@@ -4,21 +4,14 @@ import { useStore } from '@nanostores/preact';
 import { RefreshCcw } from 'lucide-react';
 import { type ReactElement, useMemo } from 'react';
 import {
-    activateFilter,
-    fetchRootChildrenIdsOnly,
-    getFilterQuery,
-    $activeRawFlatNodes,
-    $isFilterActive,
-    clearProjectContentCache,
-    $activeId,
     $isAllLoadedSelected,
     $isNoneSelected,
+    $isReloading,
     $selectionCount,
     clearSelection,
+    reloadContentTree,
     selectAll,
-    setActive,
     $rootLoadingState,
-    resetTree,
 } from '../../entities/content';
 import { useI18n } from '../../shared/lib/hooks/useI18n';
 
@@ -26,36 +19,10 @@ type TreeListToolbarProps = {
     enabled?: boolean;
 };
 
-const restoreActiveAfterReload = (activeId: string | null): void => {
-    if (!activeId) {
-        setActive(null);
-        return;
-    }
-
-    const activeExists = $activeRawFlatNodes.get().some((node) => node.nodeType === 'node' && node.id === activeId);
-    setActive(activeExists ? activeId : null);
-};
-
-const handleReload = async (): Promise<void> => {
-    const activeId = $activeId.get();
-
-    try {
-        if ($isFilterActive.get()) {
-            const query = getFilterQuery();
-            if (query) await activateFilter(query);
-        } else {
-            resetTree();
-            clearProjectContentCache();
-            await fetchRootChildrenIdsOnly();
-        }
-    } finally {
-        restoreActiveAfterReload(activeId);
-    }
-};
-
 const TreeListToolbar = ({ enabled = true }: TreeListToolbarProps): ReactElement => {
     const loadingState = useStore($rootLoadingState);
-    const isLoading = loadingState === 'loading';
+    const isReloading = useStore($isReloading);
+    const isLoading = loadingState === 'loading' || isReloading;
     const isAllSelected = useStore($isAllLoadedSelected);
     const totalSelected = useStore($selectionCount);
     const isNoneSelected = useStore($isNoneSelected);
@@ -95,7 +62,7 @@ const TreeListToolbar = ({ enabled = true }: TreeListToolbarProps): ReactElement
                 aria-label={reloadLabel}
                 icon={RefreshCcw}
                 disabled={isLoading || !enabled}
-                onClick={handleReload}
+                onClick={() => void reloadContentTree()}
             />
         </div>
     );


### PR DESCRIPTION
- Also fixed a regression: keeping active/selected items when the filter is used or reset