### PR TITLE
Wait for input to be clickable before setValue in typeTextInInput

### DIFF
--- a/testing/page_objects/page.js
+++ b/testing/page_objects/page.js
@@ -121,6 +121,9 @@ class Page {
     async typeTextInInput(selector, text) {
         try {
             let inputElement = await this.findElement(selector);
+            // setValue clears the input first; wait until it is interactable so a not-yet-expanded
+            // panel (or in-flight animation) does not throw "element not interactable".
+            await inputElement.waitForClickable({timeout: appConst.mediumTimeout});
             await inputElement.setValue(text);
             return await this.pause(200);
         } catch (err) {


### PR DESCRIPTION
Guarded the shared `typeTextInInput` page-object helper with `waitForClickable` before `setValue`. Since `setValue` clears the input first, a not-yet-expanded panel or in-flight animation could throw `element not interactable` — this surfaced as an intermittent failure in the `testInputTypes_2` Selenium suite (`datetime.config.spec`) when filtering in the Browse Filter Panel. The guard waits up to `mediumTimeout` for the input to become interactable, fixing this class of flaky failures across every text input in the suite.

<sub>*Drafted with AI assistance*</sub>