### PR TITLE
Delete confirmation: toolbar and Details panel appear above the shader #11128

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/item-set/ItemSetOccurrenceView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/item-set/ItemSetOccurrenceView.tsx
@@ -108,6 +108,7 @@ export const ItemSetOccurrenceView = forwardRef<HTMLDivElement, ItemSetOccurrenc
                 ref={ref}
                 className={cn('w-full', isNew && 'animate-in fade-in duration-500')}
                 data-component={ITEM_SET_OCCURRENCE_VIEW_NAME}
+                data-confirming={confirmingDelete}
             >
                 {confirmingDelete && <SetConfirmOverlay />}
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/option-set/OptionSetOccurrenceView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/option-set/OptionSetOccurrenceView.tsx
@@ -144,6 +144,7 @@ export const OptionSetOccurrenceView = forwardRef<HTMLDivElement, OptionSetOccur
                 ref={ref}
                 className={cn('w-full', isNew && 'animate-in fade-in duration-500')}
                 data-component={OPTION_SET_OCCURRENCE_VIEW_NAME}
+                data-confirming={isConfirming}
             >
                 {isConfirming && <SetConfirmOverlay />}
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/option-set/OptionSetView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/option-set/OptionSetView.tsx
@@ -197,7 +197,7 @@ export const OptionSetView = ({ optionSet, propertySet }: OptionSetViewProps): R
     );
 
     return (
-        <div className="flex flex-col gap-3" data-component={OPTION_SET_VIEW_NAME}>
+        <div className="flex flex-col gap-3" data-component={OPTION_SET_VIEW_NAME} data-confirming={confirmingAdd}>
             {confirmingAdd && <SetConfirmOverlay />}
 
             {confirmingAdd && (

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/set-confirmation/SetConfirmOverlay.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/set-confirmation/SetConfirmOverlay.tsx
@@ -1,13 +1,7 @@
 import {type ReactElement} from 'react';
 
 export const SetConfirmOverlay = (): ReactElement => {
-    return (
-        <div
-            data-component="SetConfirmOverlay"
-            className="fixed inset-0 z-30 bg-overlay backdrop-blur-xs"
-            aria-hidden="true"
-        />
-    );
+    return <div className="fixed inset-0 z-30 bg-overlay backdrop-blur-xs" aria-hidden="true" />;
 };
 
 SetConfirmOverlay.displayName = 'SetConfirmOverlay';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/set-confirmation/SetConfirmOverlay.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/form/sets/set-confirmation/SetConfirmOverlay.tsx
@@ -1,7 +1,13 @@
 import {type ReactElement} from 'react';
 
 export const SetConfirmOverlay = (): ReactElement => {
-    return <div className="fixed inset-0 z-30 bg-overlay backdrop-blur-xs" aria-hidden="true" />;
+    return (
+        <div
+            data-component="SetConfirmOverlay"
+            className="fixed inset-0 z-30 bg-overlay backdrop-blur-xs"
+            aria-hidden="true"
+        />
+    );
 };
 
 SetConfirmOverlay.displayName = 'SetConfirmOverlay';

--- a/modules/lib/src/main/resources/assets/styles/variables.less
+++ b/modules/lib/src/main/resources/assets/styles/variables.less
@@ -2,6 +2,8 @@
 
 @toolbar-with-border-height: @toolbar-height + 1;
 
+@z-index-set-confirm-form: 3;
+
 @color-bg-state-errors: #ffebe9;
 
 @color-bg-state-ready: #e9ffeb;

--- a/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -1,5 +1,9 @@
 .content-wizard-panel {
 
+  .content-wizard-form-panel:has([data-component='SetConfirmOverlay']) {
+    z-index: 3;
+  }
+
   .form-panel .help-text-toggler {
     display: none;
   }

--- a/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-panel.less
+++ b/modules/lib/src/main/resources/assets/styles/wizard/content-wizard-panel.less
@@ -1,7 +1,7 @@
 .content-wizard-panel {
 
-  .content-wizard-form-panel:has([data-component='SetConfirmOverlay']) {
-    z-index: 3;
+  .content-wizard-form-panel:has([data-confirming='true']) {
+    z-index: @z-index-set-confirm-form;
   }
 
   .form-panel .help-text-toggler {


### PR DESCRIPTION
Fix set confirmation overlay stacking.
Cover wizard controls while keeping the selected set visible.