### PR TITLE
Keyboard navigation not working in the Page Components View #10831

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -6,10 +6,21 @@ import {
     type SortableDropHint,
     SortableList,
     type SortableListItemContext,
+    type SortableListItemProps,
 } from '@enonic/lib-admin-ui/form2/components';
 import { cn } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
-import { type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    type FocusEvent as ReactFocusEvent,
+    type KeyboardEvent as ReactKeyboardEvent,
+    type ReactElement,
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { ComponentPath } from '../../../../../../app/page/region/ComponentPath';
 import { PageNavigationEvent } from '../../../../../../app/wizard/PageNavigationEvent';
 import { PageNavigationEventData } from '../../../../../../app/wizard/PageNavigationEventData';
@@ -35,6 +46,14 @@ import { $invalidComponentPaths, $validationVisibility } from '../../../model/wi
 import { EditLockOverlay } from '../../../../../shared/ui/EditLockOverlay';
 import { PageComponentsContextMenu } from './PageComponentsContextMenu';
 import { calcSpacerWidth, PageComponentsItem, type PageComponentPageMetadata } from './PageComponentsItem';
+import {
+    focusPageComponentsRow,
+    getPageComponentsRow,
+    getPageComponentsRowNodeId,
+    PAGE_COMPONENTS_ROW_CLASS,
+    type PageComponentsNavigationKey,
+    resolvePageComponentsNavigation,
+} from './pageComponentsKeyboardNavigation';
 import {
     $componentsFlatNodes,
     $componentsTreeState,
@@ -62,6 +81,8 @@ export type PageComponentsViewProps = {
 
 export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProps = {}): ReactElement => {
     const containerRef = useRef<HTMLDivElement>(null);
+    const pendingFocusNodeIdRef = useRef<string | null>(null);
+    const [tabStopNodeId, setTabStopNodeId] = useState<string | null>(null);
     const componentsLabel = useI18n('field.components');
     const pageVersion = useStore($pageVersion);
     const page = useStore($page);
@@ -81,6 +102,15 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
     );
     const referenceLoading = isFragmentLoading || isComponentLoading;
     const [flatNodes, setFlatNodes] = useState(() => [...$componentsFlatNodes.get()]);
+    const visibleTabStopNodeId = useMemo(() => {
+        if (flatNodes.some((node) => node.id === tabStopNodeId)) {
+            return tabStopNodeId;
+        }
+        if (flatNodes.some((node) => node.id === inspectedPath)) {
+            return inspectedPath;
+        }
+        return flatNodes[0]?.id ?? null;
+    }, [flatNodes, inspectedPath, tabStopNodeId]);
     const selectedPageOption = useSelectedPageOption();
     const pageMetadata = useMemo<PageComponentPageMetadata | undefined>(() => {
         if (selectedPageOption == null) {
@@ -113,6 +143,97 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
         });
         return () => cancelAnimationFrame(handle);
     }, [inspectedPath]);
+
+    useEffect(() => {
+        const container = containerRef.current;
+        if (container?.contains(document.activeElement)) {
+            return;
+        }
+
+        setTabStopNodeId((currentNodeId) => {
+            if (flatNodes.some((node) => node.id === inspectedPath)) {
+                return inspectedPath;
+            }
+            if (flatNodes.some((node) => node.id === currentNodeId)) {
+                return currentNodeId;
+            }
+            return flatNodes[0]?.id ?? null;
+        });
+    }, [flatNodes, inspectedPath]);
+
+    useLayoutEffect(() => {
+        const container = containerRef.current;
+        const pendingFocusNodeId = pendingFocusNodeIdRef.current;
+        if (
+            container == null ||
+            pendingFocusNodeId == null ||
+            !flatNodes.some((node) => node.id === pendingFocusNodeId)
+        ) {
+            return;
+        }
+
+        if (focusPageComponentsRow(container, pendingFocusNodeId)) {
+            setTabStopNodeId(pendingFocusNodeId);
+            pendingFocusNodeIdRef.current = null;
+        }
+    }, [flatNodes]);
+
+    const focusNode = useCallback((nodeId: string): void => {
+        const container = containerRef.current;
+        if (container == null) {
+            return;
+        }
+
+        setTabStopNodeId(nodeId);
+        focusPageComponentsRow(container, nodeId);
+    }, []);
+
+    const handleFocusCapture = useCallback((event: ReactFocusEvent<HTMLDivElement>): void => {
+        const nodeId = getPageComponentsRowNodeId(getPageComponentsRow(event.target));
+        if (nodeId == null) {
+            return;
+        }
+
+        setTabStopNodeId(nodeId);
+    }, []);
+
+    const handleKeyDownCapture = useCallback(
+        (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+            if (
+                event.defaultPrevented ||
+                event.altKey ||
+                event.ctrlKey ||
+                event.metaKey ||
+                !isPageComponentsNavigationKey(event.key) ||
+                isEditableTarget(event.target)
+            ) {
+                return;
+            }
+
+            const row = getPageComponentsRow(event.target);
+            const nodeId = getPageComponentsRowNodeId(row);
+            if (row == null || nodeId == null) {
+                return;
+            }
+
+            // Once Space starts a keyboard drag, dnd-kit owns the arrow keys until
+            // Space drops the item again.
+            if (row.dataset.dragging === 'true') {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+
+            const action = resolvePageComponentsNavigation(flatNodes, nodeId, event.key);
+            if (action?.type === 'toggle') {
+                toggleComponentExpand(action.nodeId);
+            } else if (action?.type === 'focus') {
+                focusNode(action.nodeId);
+            }
+        },
+        [flatNodes, focusNode],
+    );
 
     const resolveProjection = useCallback(
         (info: SortableDragInfo): DropProjection | null => {
@@ -173,11 +294,14 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
                 return;
             }
 
+            const movedNodeId = computeMovedItemPath(sourceNode.id, targetComponentPath);
+            const movedPath = ComponentPath.fromString(movedNodeId);
+            pendingFocusNodeIdRef.current = movedNodeId;
+
             requestComponentMove(fromPath, toPath);
             remapExpandedIdsAfterMove(sourceNode.id, targetComponentPath);
             rebuildComponentsTree();
 
-            const movedPath = ComponentPath.fromString(computeMovedItemPath(sourceNode.id, targetComponentPath));
             inspectItem(movedPath);
             PageNavigationMediator.get().notify(
                 new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(movedPath)),
@@ -212,11 +336,23 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
         (context: SortableListItemContext<FlatNode<PageComponentNodeData>>): string => {
             const isSelected = context.item.id === inspectedPath;
             return cn(
+                PAGE_COMPONENTS_ROW_CLASS,
                 'w-full px-2.5 select-none cursor-pointer',
                 isSelected ? 'bg-surface-selected text-alt [&>button]:text-alt' : 'hover:bg-surface-neutral-hover',
             );
         },
         [inspectedPath],
+    );
+
+    const getItemProps = useCallback(
+        (context: SortableListItemContext<FlatNode<PageComponentNodeData>>): SortableListItemProps => ({
+            role: 'treeitem',
+            tabIndex: context.item.id === visibleTabStopNodeId ? 0 : -1,
+            'aria-expanded': context.item.hasChildren ? context.item.isExpanded : undefined,
+            'aria-level': context.item.level,
+            'aria-selected': context.item.id === inspectedPath,
+        }),
+        [inspectedPath, visibleTabStopNodeId],
     );
 
     const renderItem = useCallback(
@@ -259,7 +395,13 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
 
     return (
         <EditLockOverlay locked={readOnly}>
-            <div ref={containerRef} data-component={PAGE_COMPONENTS_VIEW_NAME} className="flex flex-col gap-1 py-2">
+            <div
+                ref={containerRef}
+                data-component={PAGE_COMPONENTS_VIEW_NAME}
+                className="flex flex-col gap-1 py-2"
+                onFocusCapture={handleFocusCapture}
+                onKeyDownCapture={handleKeyDownCapture}
+            >
                 {showTitle && <h3 className="text-base font-semibold">{componentsLabel}</h3>}
                 <SortableList
                     items={flatNodes}
@@ -272,6 +414,9 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
                     resolveDrop={resolveDrop}
                     animateLayoutChanges={animateLayoutChanges}
                     itemClassName={itemClassName}
+                    containerProps={{role: 'tree', 'aria-label': componentsLabel}}
+                    getItemProps={getItemProps}
+                    restoreFocus={false}
                     renderItem={renderItem}
                     className="flex flex-col gap-1.5"
                 />
@@ -300,4 +445,21 @@ function toDropNodes(flatNodes: FlatNode<PageComponentNodeData>[]): DropNode[] {
         });
     }
     return dropNodes;
+}
+
+function isPageComponentsNavigationKey(key: string): key is PageComponentsNavigationKey {
+    return key === 'ArrowDown' || key === 'ArrowLeft' || key === 'ArrowRight' || key === 'ArrowUp';
+}
+
+function isEditableTarget(target: EventTarget): boolean {
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+
+    return (
+        target.isContentEditable ||
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLSelectElement ||
+        target instanceof HTMLTextAreaElement
+    );
 }

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -414,7 +414,7 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
                     resolveDrop={resolveDrop}
                     animateLayoutChanges={animateLayoutChanges}
                     itemClassName={itemClassName}
-                    containerProps={{role: 'tree', 'aria-label': componentsLabel}}
+                    containerProps={{ role: 'tree', 'aria-label': componentsLabel }}
                     getItemProps={getItemProps}
                     restoreFocus={false}
                     renderItem={renderItem}

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -47,11 +47,11 @@ import { EditLockOverlay } from '../../../../../shared/ui/EditLockOverlay';
 import { PageComponentsContextMenu } from './PageComponentsContextMenu';
 import { calcSpacerWidth, PageComponentsItem, type PageComponentPageMetadata } from './PageComponentsItem';
 import {
-    focusPageComponentsRow,
+    computeTreeItemPositions,
+    focusPageComponentsRowAt,
     getPageComponentsRow,
-    getPageComponentsRowNodeId,
-    PAGE_COMPONENTS_ROW_CLASS,
-    type PageComponentsNavigationKey,
+    getPageComponentsRowIndex,
+    isPageComponentsNavigationKey,
     resolvePageComponentsNavigation,
 } from './pageComponentsKeyboardNavigation';
 import {
@@ -82,7 +82,7 @@ export type PageComponentsViewProps = {
 export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProps = {}): ReactElement => {
     const containerRef = useRef<HTMLDivElement>(null);
     const pendingFocusNodeIdRef = useRef<string | null>(null);
-    const [tabStopNodeId, setTabStopNodeId] = useState<string | null>(null);
+    const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
     const componentsLabel = useI18n('field.components');
     const pageVersion = useStore($pageVersion);
     const page = useStore($page);
@@ -102,15 +102,18 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
     );
     const referenceLoading = isFragmentLoading || isComponentLoading;
     const [flatNodes, setFlatNodes] = useState(() => [...$componentsFlatNodes.get()]);
-    const visibleTabStopNodeId = useMemo(() => {
-        if (flatNodes.some((node) => node.id === tabStopNodeId)) {
-            return tabStopNodeId;
+    // The roving tab stop follows real focus while the list has it, and falls back to the
+    // inspected row once focus leaves, so tabbing back in lands on the selected component.
+    const tabStopNodeId = useMemo(() => {
+        if (flatNodes.some((node) => node.id === focusedNodeId)) {
+            return focusedNodeId;
         }
         if (flatNodes.some((node) => node.id === inspectedPath)) {
             return inspectedPath;
         }
         return flatNodes[0]?.id ?? null;
-    }, [flatNodes, inspectedPath, tabStopNodeId]);
+    }, [flatNodes, focusedNodeId, inspectedPath]);
+    const treeItemPositions = useMemo(() => computeTreeItemPositions(flatNodes), [flatNodes]);
     const selectedPageOption = useSelectedPageOption();
     const pageMetadata = useMemo<PageComponentPageMetadata | undefined>(() => {
         if (selectedPageOption == null) {
@@ -144,62 +147,66 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
         return () => cancelAnimationFrame(handle);
     }, [inspectedPath]);
 
-    useEffect(() => {
-        const container = containerRef.current;
-        if (container?.contains(document.activeElement)) {
-            return;
-        }
-
-        setTabStopNodeId((currentNodeId) => {
-            if (flatNodes.some((node) => node.id === inspectedPath)) {
-                return inspectedPath;
-            }
-            if (flatNodes.some((node) => node.id === currentNodeId)) {
-                return currentNodeId;
-            }
-            return flatNodes[0]?.id ?? null;
-        });
-    }, [flatNodes, inspectedPath]);
-
+    // A keyboard drop unmounts the activator row, so focus is re-applied once the moved
+    // row is rendered. A single attempt keeps a missed restore from firing much later.
     useLayoutEffect(() => {
-        const container = containerRef.current;
         const pendingFocusNodeId = pendingFocusNodeIdRef.current;
-        if (
-            container == null ||
-            pendingFocusNodeId == null ||
-            !flatNodes.some((node) => node.id === pendingFocusNodeId)
-        ) {
+        if (pendingFocusNodeId == null) {
             return;
         }
+        pendingFocusNodeIdRef.current = null;
 
-        if (focusPageComponentsRow(container, pendingFocusNodeId)) {
-            setTabStopNodeId(pendingFocusNodeId);
-            pendingFocusNodeIdRef.current = null;
-        }
-    }, [flatNodes]);
-
-    const focusNode = useCallback((nodeId: string): void => {
         const container = containerRef.current;
         if (container == null) {
             return;
         }
 
-        setTabStopNodeId(nodeId);
-        focusPageComponentsRow(container, nodeId);
-    }, []);
-
-    const handleFocusCapture = useCallback((event: ReactFocusEvent<HTMLDivElement>): void => {
-        const nodeId = getPageComponentsRowNodeId(getPageComponentsRow(event.target));
-        if (nodeId == null) {
+        const index = flatNodes.findIndex((node) => node.id === pendingFocusNodeId);
+        if (index === -1) {
             return;
         }
 
-        setTabStopNodeId(nodeId);
+        focusPageComponentsRowAt(container, index);
+    }, [flatNodes]);
+
+    const handleFocusCapture = useCallback(
+        (event: ReactFocusEvent<HTMLDivElement>): void => {
+            const container = containerRef.current;
+            if (container == null) {
+                return;
+            }
+
+            const row = getPageComponentsRow(container, event.target);
+            if (row == null) {
+                return;
+            }
+
+            setFocusedNodeId(flatNodes[getPageComponentsRowIndex(container, row)]?.id ?? null);
+        },
+        [flatNodes],
+    );
+
+    const handleBlurCapture = useCallback((event: ReactFocusEvent<HTMLDivElement>): void => {
+        if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) {
+            return;
+        }
+
+        setFocusedNodeId(null);
+    }, []);
+
+    const handleSelect = useCallback((nodeId: string): void => {
+        const path = ComponentPath.fromString(nodeId);
+        inspectItem(path);
+        PageNavigationMediator.get().notify(
+            new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)),
+        );
     }, []);
 
     const handleKeyDownCapture = useCallback(
         (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+            const container = containerRef.current;
             if (
+                container == null ||
                 event.defaultPrevented ||
                 event.altKey ||
                 event.ctrlKey ||
@@ -210,29 +217,48 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
                 return;
             }
 
-            const row = getPageComponentsRow(event.target);
-            const nodeId = getPageComponentsRowNodeId(row);
-            if (row == null || nodeId == null) {
+            const row = getPageComponentsRow(container, event.target);
+            if (row == null) {
                 return;
             }
 
-            // Once Space starts a keyboard drag, dnd-kit owns the arrow keys until
+            // Once Space starts a keyboard drag, dnd-kit owns the keyboard until
             // Space drops the item again.
             if (row.dataset.dragging === 'true') {
                 return;
             }
 
+            // Swallowed even when nothing is resolved, so the panel never scrolls
+            // behind an arrow press and Enter never reaches dnd-kit's drag sensor.
             event.preventDefault();
             event.stopPropagation();
 
-            const action = resolvePageComponentsNavigation(flatNodes, nodeId, event.key);
-            if (action?.type === 'toggle') {
-                toggleComponentExpand(action.nodeId);
-            } else if (action?.type === 'focus') {
-                focusNode(action.nodeId);
+            const action = resolvePageComponentsNavigation(
+                flatNodes,
+                getPageComponentsRowIndex(container, row),
+                event.key,
+            );
+            if (action == null) {
+                return;
+            }
+
+            if (action.type === 'focus') {
+                focusPageComponentsRowAt(container, action.index);
+                return;
+            }
+
+            const targetNodeId = flatNodes[action.index]?.id;
+            if (targetNodeId == null) {
+                return;
+            }
+
+            if (action.type === 'toggle') {
+                toggleComponentExpand(targetNodeId);
+            } else {
+                handleSelect(targetNodeId);
             }
         },
-        [flatNodes, focusNode],
+        [flatNodes, handleSelect],
     );
 
     const resolveProjection = useCallback(
@@ -320,14 +346,6 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
         [flatNodes],
     );
 
-    const handleSelect = useCallback((nodeId: string): void => {
-        const path = ComponentPath.fromString(nodeId);
-        inspectItem(path);
-        PageNavigationMediator.get().notify(
-            new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)),
-        );
-    }, []);
-
     const isItemMovable = useCallback((node: FlatNode<PageComponentNodeData>): boolean => {
         return node.data?.draggable ?? false;
     }, []);
@@ -336,7 +354,6 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
         (context: SortableListItemContext<FlatNode<PageComponentNodeData>>): string => {
             const isSelected = context.item.id === inspectedPath;
             return cn(
-                PAGE_COMPONENTS_ROW_CLASS,
                 'w-full px-2.5 select-none cursor-pointer',
                 isSelected ? 'bg-surface-selected text-alt [&>button]:text-alt' : 'hover:bg-surface-neutral-hover',
             );
@@ -346,16 +363,21 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
 
     const getItemProps = useCallback(
         // ? The custom role drops dnd-kit's drag ARIA, so the drag state is restated here.
-        (context: SortableListItemContext<FlatNode<PageComponentNodeData>>): SortableListItemProps => ({
-            role: 'treeitem',
-            tabIndex: context.item.id === visibleTabStopNodeId ? 0 : -1,
-            'aria-disabled': !context.isMovable,
-            'aria-expanded': context.item.hasChildren ? context.item.isExpanded : undefined,
-            'aria-level': context.item.level,
-            'aria-roledescription': context.isMovable ? 'sortable' : undefined,
-            'aria-selected': context.item.id === inspectedPath,
-        }),
-        [inspectedPath, visibleTabStopNodeId],
+        (context: SortableListItemContext<FlatNode<PageComponentNodeData>>): SortableListItemProps => {
+            const position = treeItemPositions.get(context.item.id);
+
+            return {
+                role: 'treeitem',
+                tabIndex: context.item.id === tabStopNodeId ? 0 : -1,
+                'aria-expanded': context.item.hasChildren ? context.item.isExpanded : undefined,
+                'aria-level': context.item.level,
+                'aria-posinset': position?.posInSet,
+                'aria-setsize': position?.setSize,
+                'aria-roledescription': context.isMovable ? 'sortable tree item' : undefined,
+                'aria-selected': context.item.id === inspectedPath,
+            };
+        },
+        [inspectedPath, tabStopNodeId, treeItemPositions],
     );
 
     const renderItem = useCallback(
@@ -403,6 +425,7 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
                 data-component={PAGE_COMPONENTS_VIEW_NAME}
                 className="flex flex-col gap-1 py-2"
                 onFocusCapture={handleFocusCapture}
+                onBlurCapture={handleBlurCapture}
                 onKeyDownCapture={handleKeyDownCapture}
             >
                 {showTitle && <h3 className="text-base font-semibold">{componentsLabel}</h3>}
@@ -448,10 +471,6 @@ function toDropNodes(flatNodes: FlatNode<PageComponentNodeData>[]): DropNode[] {
         });
     }
     return dropNodes;
-}
-
-function isPageComponentsNavigationKey(key: string): key is PageComponentsNavigationKey {
-    return key === 'ArrowDown' || key === 'ArrowLeft' || key === 'ArrowRight' || key === 'ArrowUp';
 }
 
 function isEditableTarget(target: EventTarget): boolean {

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -345,11 +345,14 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
     );
 
     const getItemProps = useCallback(
+        // ? The custom role drops dnd-kit's drag ARIA, so the drag state is restated here.
         (context: SortableListItemContext<FlatNode<PageComponentNodeData>>): SortableListItemProps => ({
             role: 'treeitem',
             tabIndex: context.item.id === visibleTabStopNodeId ? 0 : -1,
+            'aria-disabled': !context.isMovable,
             'aria-expanded': context.item.hasChildren ? context.item.isExpanded : undefined,
             'aria-level': context.item.level,
+            'aria-roledescription': context.isMovable ? 'sortable' : undefined,
             'aria-selected': context.item.id === inspectedPath,
         }),
         [inspectedPath, visibleTabStopNodeId],

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponents.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponents.store.ts
@@ -8,7 +8,6 @@ import type { Region } from '../../../../../../app/page/region/Region';
 import { TextComponent } from '../../../../../../app/page/region/TextComponent';
 import {
     type CreateNodeOptions,
-    type TreeNode,
     type TreeState,
     collapse,
     createEmptyState,
@@ -175,7 +174,6 @@ function buildTreeFromPage(
         }
     } else {
         for (const [id, node] of state.nodes) {
-            if (isNestedLayout(node)) continue;
             if (node.hasChildren || node.childIds.length > 0) {
                 expandedIds.add(id);
             }
@@ -189,10 +187,6 @@ function buildTreeFromPage(
     }
 
     return { ...state, expandedIds };
-}
-
-function isNestedLayout(node: TreeNode<PageComponentNodeData>): boolean {
-    return node.data?.nodeType === 'layout' && node.parentId !== null;
 }
 
 function collectLayouts(page: Page | null): Map<string, LayoutComponent> {

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponents.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponents.store.ts
@@ -8,6 +8,7 @@ import type { Region } from '../../../../../../app/page/region/Region';
 import { TextComponent } from '../../../../../../app/page/region/TextComponent';
 import {
     type CreateNodeOptions,
+    type TreeNode,
     type TreeState,
     collapse,
     createEmptyState,
@@ -174,6 +175,7 @@ function buildTreeFromPage(
         }
     } else {
         for (const [id, node] of state.nodes) {
+            if (isNestedLayout(node)) continue;
             if (node.hasChildren || node.childIds.length > 0) {
                 expandedIds.add(id);
             }
@@ -187,6 +189,10 @@ function buildTreeFromPage(
     }
 
     return { ...state, expandedIds };
+}
+
+function isNestedLayout(node: TreeNode<PageComponentNodeData>): boolean {
+    return node.data?.nodeType === 'layout' && node.parentId !== null;
 }
 
 function collectLayouts(page: Page | null): Map<string, LayoutComponent> {

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponentsKeyboardNavigation.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponentsKeyboardNavigation.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { FlatNode } from '../../../../../shared/lib/tree-store';
+import {
+    computeTreeItemPositions,
+    focusPageComponentsRowAt,
+    getPageComponentsRow,
+    getPageComponentsRowIndex,
+    getPageComponentsRows,
+    isPageComponentsNavigationKey,
+    resolvePageComponentsNavigation,
+} from './pageComponentsKeyboardNavigation';
+import type { PageComponentNodeData } from './types';
+
+type NodeOptions = {
+    hasChildren?: boolean;
+    isExpanded?: boolean;
+};
+
+function createNode(
+    id: string,
+    parentId: string | null,
+    level: number,
+    options: NodeOptions = {},
+): FlatNode<PageComponentNodeData> {
+    return {
+        id,
+        parentId,
+        level,
+        data: {
+            displayName: id,
+            nodeType: 'part',
+            draggable: true,
+            layoutFragment: false,
+            hasDescriptor: true,
+        },
+        isExpanded: options.isExpanded ?? false,
+        isLoading: false,
+        isLoadingData: false,
+        hasChildren: options.hasChildren ?? false,
+        nodeType: 'node',
+    };
+}
+
+// 0 '/'          expanded
+// 1   '/main'    expanded
+// 2     '/main/0'
+// 3     '/main/1'  collapsed, has children
+// 4     '/main/2'
+// 5   '/footer'
+function createTree(): FlatNode<PageComponentNodeData>[] {
+    return [
+        createNode('/', null, 1, { hasChildren: true, isExpanded: true }),
+        createNode('/main', '/', 2, { hasChildren: true, isExpanded: true }),
+        createNode('/main/0', '/main', 3),
+        createNode('/main/1', '/main', 3, { hasChildren: true }),
+        createNode('/main/2', '/main', 3),
+        createNode('/footer', '/', 2),
+    ];
+}
+
+describe('isPageComponentsNavigationKey', () => {
+    it('should accept the navigation keys', () => {
+        for (const key of ['ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'End', 'Enter', 'Home']) {
+            expect(isPageComponentsNavigationKey(key)).toBe(true);
+        }
+    });
+
+    it('should reject keys owned by the drag sensor and other keys', () => {
+        for (const key of [' ', 'Space', 'Escape', 'Tab', 'a']) {
+            expect(isPageComponentsNavigationKey(key)).toBe(false);
+        }
+    });
+});
+
+describe('resolvePageComponentsNavigation', () => {
+    it('should return null for an index outside the list', () => {
+        const nodes = createTree();
+
+        expect(resolvePageComponentsNavigation(nodes, -1, 'ArrowDown')).toBeNull();
+        expect(resolvePageComponentsNavigation(nodes, nodes.length, 'ArrowDown')).toBeNull();
+        expect(resolvePageComponentsNavigation([], 0, 'Home')).toBeNull();
+    });
+
+    it('should move to the next and previous visible row', () => {
+        const nodes = createTree();
+
+        expect(resolvePageComponentsNavigation(nodes, 2, 'ArrowDown')).toEqual({ type: 'focus', index: 3 });
+        expect(resolvePageComponentsNavigation(nodes, 2, 'ArrowUp')).toEqual({ type: 'focus', index: 1 });
+    });
+
+    it('should not wrap around at the list edges', () => {
+        const nodes = createTree();
+
+        expect(resolvePageComponentsNavigation(nodes, 0, 'ArrowUp')).toBeNull();
+        expect(resolvePageComponentsNavigation(nodes, nodes.length - 1, 'ArrowDown')).toBeNull();
+    });
+
+    it('should jump to the first and last row', () => {
+        const nodes = createTree();
+
+        expect(resolvePageComponentsNavigation(nodes, 3, 'Home')).toEqual({ type: 'focus', index: 0 });
+        expect(resolvePageComponentsNavigation(nodes, 3, 'End')).toEqual({ type: 'focus', index: 5 });
+    });
+
+    it('should select the current row on Enter', () => {
+        const nodes = createTree();
+
+        expect(resolvePageComponentsNavigation(nodes, 4, 'Enter')).toEqual({ type: 'select', index: 4 });
+        expect(resolvePageComponentsNavigation(nodes, 0, 'Enter')).toEqual({ type: 'select', index: 0 });
+    });
+
+    describe('ArrowRight', () => {
+        it('should do nothing on a leaf', () => {
+            expect(resolvePageComponentsNavigation(createTree(), 2, 'ArrowRight')).toBeNull();
+        });
+
+        it('should expand a collapsed row', () => {
+            expect(resolvePageComponentsNavigation(createTree(), 3, 'ArrowRight')).toEqual({
+                type: 'toggle',
+                index: 3,
+            });
+        });
+
+        it('should move to the first child of an expanded row', () => {
+            expect(resolvePageComponentsNavigation(createTree(), 1, 'ArrowRight')).toEqual({
+                type: 'focus',
+                index: 2,
+            });
+        });
+
+        it('should do nothing when an expanded row renders no children', () => {
+            const nodes = [
+                createNode('/', null, 1, { hasChildren: true, isExpanded: true }),
+                createNode('/footer', null, 1),
+            ];
+
+            expect(resolvePageComponentsNavigation(nodes, 0, 'ArrowRight')).toBeNull();
+        });
+    });
+
+    describe('ArrowLeft', () => {
+        it('should collapse an expanded row', () => {
+            expect(resolvePageComponentsNavigation(createTree(), 1, 'ArrowLeft')).toEqual({
+                type: 'toggle',
+                index: 1,
+            });
+        });
+
+        it('should move to the parent of a leaf', () => {
+            expect(resolvePageComponentsNavigation(createTree(), 2, 'ArrowLeft')).toEqual({
+                type: 'focus',
+                index: 1,
+            });
+        });
+
+        it('should move to the parent of a collapsed row instead of collapsing again', () => {
+            expect(resolvePageComponentsNavigation(createTree(), 3, 'ArrowLeft')).toEqual({
+                type: 'focus',
+                index: 1,
+            });
+        });
+
+        it('should do nothing on a root row', () => {
+            const nodes = [createNode('/', null, 1)];
+
+            expect(resolvePageComponentsNavigation(nodes, 0, 'ArrowLeft')).toBeNull();
+        });
+
+        it('should do nothing when the parent is not visible', () => {
+            const nodes = [createNode('/main/0', '/main', 3)];
+
+            expect(resolvePageComponentsNavigation(nodes, 0, 'ArrowLeft')).toBeNull();
+        });
+    });
+});
+
+describe('computeTreeItemPositions', () => {
+    it('should number each row within its own sibling set', () => {
+        const positions = computeTreeItemPositions(createTree());
+
+        expect(positions.get('/')).toEqual({ posInSet: 1, setSize: 1 });
+        expect(positions.get('/main')).toEqual({ posInSet: 1, setSize: 2 });
+        expect(positions.get('/footer')).toEqual({ posInSet: 2, setSize: 2 });
+        expect(positions.get('/main/0')).toEqual({ posInSet: 1, setSize: 3 });
+        expect(positions.get('/main/1')).toEqual({ posInSet: 2, setSize: 3 });
+        expect(positions.get('/main/2')).toEqual({ posInSet: 3, setSize: 3 });
+    });
+
+    it('should return an empty map for an empty tree', () => {
+        expect(computeTreeItemPositions([]).size).toBe(0);
+    });
+});
+
+describe('DOM helpers', () => {
+    afterEach(() => {
+        document.body.replaceChildren();
+    });
+
+    function createContainer(): HTMLElement {
+        const container = document.createElement('div');
+        container.innerHTML = `
+            <div role="tree">
+                <div role="treeitem" tabindex="-1"><span class="label">first</span></div>
+                <div role="treeitem" tabindex="-1"><span class="label">second</span></div>
+                <div role="treeitem" tabindex="0"><span class="label">third</span></div>
+            </div>
+        `;
+        document.body.replaceChildren(container);
+        return container;
+    }
+
+    it('should collect the rows in document order', () => {
+        const container = createContainer();
+
+        expect(getPageComponentsRows(container).map((row) => row.textContent?.trim())).toEqual([
+            'first',
+            'second',
+            'third',
+        ]);
+    });
+
+    it('should resolve the row from a descendant of the row', () => {
+        const container = createContainer();
+        const label = container.querySelectorAll('.label')[1];
+
+        const row = getPageComponentsRow(container, label);
+
+        expect(row).not.toBeNull();
+        expect(getPageComponentsRowIndex(container, row)).toBe(1);
+    });
+
+    it('should ignore rows rendered outside the container', () => {
+        const container = createContainer();
+        const portalled = document.createElement('div');
+        portalled.setAttribute('role', 'treeitem');
+        document.body.append(portalled);
+
+        expect(getPageComponentsRow(container, portalled)).toBeNull();
+    });
+
+    it('should ignore targets that are not elements', () => {
+        const container = createContainer();
+
+        expect(getPageComponentsRow(container, null)).toBeNull();
+        expect(getPageComponentsRow(container, new EventTarget())).toBeNull();
+    });
+
+    it('should focus the row at the given index', () => {
+        const container = createContainer();
+
+        expect(focusPageComponentsRowAt(container, 1)).toBe(true);
+        expect(document.activeElement).toBe(getPageComponentsRows(container)[1]);
+    });
+
+    it('should report failure for an index without a row', () => {
+        const container = createContainer();
+
+        expect(focusPageComponentsRowAt(container, -1)).toBe(false);
+        expect(focusPageComponentsRowAt(container, 3)).toBe(false);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponentsKeyboardNavigation.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponentsKeyboardNavigation.ts
@@ -1,0 +1,74 @@
+import type {FlatNode} from '../../../../../shared/lib/tree-store';
+import type {PageComponentNodeData} from './types';
+
+export const PAGE_COMPONENTS_ROW_CLASS = 'page-components-list-item';
+
+export type PageComponentsNavigationKey = 'ArrowDown' | 'ArrowLeft' | 'ArrowRight' | 'ArrowUp';
+
+export type PageComponentsNavigationAction =
+    | { type: 'focus'; nodeId: string }
+    | { type: 'toggle'; nodeId: string };
+
+export function resolvePageComponentsNavigation(
+    nodes: FlatNode<PageComponentNodeData>[],
+    currentNodeId: string,
+    key: PageComponentsNavigationKey,
+): PageComponentsNavigationAction | null {
+    const currentIndex = nodes.findIndex((node) => node.id === currentNodeId);
+    if (currentIndex === -1) {
+        return null;
+    }
+
+    const currentNode = nodes[currentIndex];
+
+    if (key === 'ArrowUp') {
+        const previousNode = nodes[currentIndex - 1];
+        return previousNode == null ? null : {type: 'focus', nodeId: previousNode.id};
+    }
+
+    if (key === 'ArrowDown') {
+        const nextNode = nodes[currentIndex + 1];
+        return nextNode == null ? null : {type: 'focus', nodeId: nextNode.id};
+    }
+
+    if (key === 'ArrowRight') {
+        if (!currentNode.hasChildren) {
+            return null;
+        }
+
+        if (!currentNode.isExpanded) {
+            return {type: 'toggle', nodeId: currentNode.id};
+        }
+
+        const firstChild = nodes[currentIndex + 1];
+        return firstChild?.parentId === currentNode.id ? {type: 'focus', nodeId: firstChild.id} : null;
+    }
+
+    if (currentNode.hasChildren && currentNode.isExpanded) {
+        return {type: 'toggle', nodeId: currentNode.id};
+    }
+
+    return currentNode.parentId == null ? null : {type: 'focus', nodeId: currentNode.parentId};
+}
+
+export function getPageComponentsRow(target: EventTarget | null): HTMLElement | null {
+    return target instanceof Element ? target.closest<HTMLElement>(`.${PAGE_COMPONENTS_ROW_CLASS}`) : null;
+}
+
+export function getPageComponentsRowNodeId(row: HTMLElement | null): string | null {
+    return row?.querySelector<HTMLElement>('[data-node-id]')?.dataset.nodeId ?? null;
+}
+
+export function focusPageComponentsRow(container: HTMLElement, nodeId: string): boolean {
+    const row = getPageComponentsRows(container).find((candidate) => getPageComponentsRowNodeId(candidate) === nodeId);
+    if (row == null) {
+        return false;
+    }
+
+    row.focus();
+    return true;
+}
+
+function getPageComponentsRows(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.querySelectorAll<HTMLElement>(`.${PAGE_COMPONENTS_ROW_CLASS}`));
+}

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponentsKeyboardNavigation.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponentsKeyboardNavigation.ts
@@ -1,13 +1,11 @@
-import type {FlatNode} from '../../../../../shared/lib/tree-store';
-import type {PageComponentNodeData} from './types';
+import type { FlatNode } from '../../../../../shared/lib/tree-store';
+import type { PageComponentNodeData } from './types';
 
 export const PAGE_COMPONENTS_ROW_CLASS = 'page-components-list-item';
 
 export type PageComponentsNavigationKey = 'ArrowDown' | 'ArrowLeft' | 'ArrowRight' | 'ArrowUp';
 
-export type PageComponentsNavigationAction =
-    | { type: 'focus'; nodeId: string }
-    | { type: 'toggle'; nodeId: string };
+export type PageComponentsNavigationAction = { type: 'focus'; nodeId: string } | { type: 'toggle'; nodeId: string };
 
 export function resolvePageComponentsNavigation(
     nodes: FlatNode<PageComponentNodeData>[],
@@ -23,12 +21,12 @@ export function resolvePageComponentsNavigation(
 
     if (key === 'ArrowUp') {
         const previousNode = nodes[currentIndex - 1];
-        return previousNode == null ? null : {type: 'focus', nodeId: previousNode.id};
+        return previousNode == null ? null : { type: 'focus', nodeId: previousNode.id };
     }
 
     if (key === 'ArrowDown') {
         const nextNode = nodes[currentIndex + 1];
-        return nextNode == null ? null : {type: 'focus', nodeId: nextNode.id};
+        return nextNode == null ? null : { type: 'focus', nodeId: nextNode.id };
     }
 
     if (key === 'ArrowRight') {
@@ -37,18 +35,18 @@ export function resolvePageComponentsNavigation(
         }
 
         if (!currentNode.isExpanded) {
-            return {type: 'toggle', nodeId: currentNode.id};
+            return { type: 'toggle', nodeId: currentNode.id };
         }
 
         const firstChild = nodes[currentIndex + 1];
-        return firstChild?.parentId === currentNode.id ? {type: 'focus', nodeId: firstChild.id} : null;
+        return firstChild?.parentId === currentNode.id ? { type: 'focus', nodeId: firstChild.id } : null;
     }
 
     if (currentNode.hasChildren && currentNode.isExpanded) {
-        return {type: 'toggle', nodeId: currentNode.id};
+        return { type: 'toggle', nodeId: currentNode.id };
     }
 
-    return currentNode.parentId == null ? null : {type: 'focus', nodeId: currentNode.parentId};
+    return currentNode.parentId == null ? null : { type: 'focus', nodeId: currentNode.parentId };
 }
 
 export function getPageComponentsRow(target: EventTarget | null): HTMLElement | null {

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponentsKeyboardNavigation.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponentsKeyboardNavigation.ts
@@ -1,32 +1,68 @@
 import type { FlatNode } from '../../../../../shared/lib/tree-store';
 import type { PageComponentNodeData } from './types';
 
-export const PAGE_COMPONENTS_ROW_CLASS = 'page-components-list-item';
+const ROW_SELECTOR = '[role="treeitem"]';
 
-export type PageComponentsNavigationKey = 'ArrowDown' | 'ArrowLeft' | 'ArrowRight' | 'ArrowUp';
+export type PageComponentsNavigationKey =
+    | 'ArrowDown'
+    | 'ArrowLeft'
+    | 'ArrowRight'
+    | 'ArrowUp'
+    | 'End'
+    | 'Enter'
+    | 'Home';
 
-export type PageComponentsNavigationAction = { type: 'focus'; nodeId: string } | { type: 'toggle'; nodeId: string };
+export type PageComponentsNavigationAction =
+    | { type: 'focus'; index: number }
+    | { type: 'select'; index: number }
+    | { type: 'toggle'; index: number };
+
+/** Position of a row among its siblings, for `aria-posinset` / `aria-setsize`. */
+export type TreeItemPosition = {
+    posInSet: number;
+    setSize: number;
+};
+
+export function isPageComponentsNavigationKey(key: string): key is PageComponentsNavigationKey {
+    return (
+        key === 'ArrowDown' ||
+        key === 'ArrowLeft' ||
+        key === 'ArrowRight' ||
+        key === 'ArrowUp' ||
+        key === 'End' ||
+        key === 'Enter' ||
+        key === 'Home'
+    );
+}
 
 export function resolvePageComponentsNavigation(
     nodes: FlatNode<PageComponentNodeData>[],
-    currentNodeId: string,
+    currentIndex: number,
     key: PageComponentsNavigationKey,
 ): PageComponentsNavigationAction | null {
-    const currentIndex = nodes.findIndex((node) => node.id === currentNodeId);
-    if (currentIndex === -1) {
+    const currentNode = nodes[currentIndex];
+    if (currentNode == null) {
         return null;
     }
 
-    const currentNode = nodes[currentIndex];
+    if (key === 'Enter') {
+        return { type: 'select', index: currentIndex };
+    }
+
+    if (key === 'Home') {
+        return { type: 'focus', index: 0 };
+    }
+
+    if (key === 'End') {
+        return { type: 'focus', index: nodes.length - 1 };
+    }
 
     if (key === 'ArrowUp') {
-        const previousNode = nodes[currentIndex - 1];
-        return previousNode == null ? null : { type: 'focus', nodeId: previousNode.id };
+        return currentIndex === 0 ? null : { type: 'focus', index: currentIndex - 1 };
     }
 
     if (key === 'ArrowDown') {
-        const nextNode = nodes[currentIndex + 1];
-        return nextNode == null ? null : { type: 'focus', nodeId: nextNode.id };
+        return currentIndex === nodes.length - 1 ? null : { type: 'focus', index: currentIndex + 1 };
     }
 
     if (key === 'ArrowRight') {
@@ -35,30 +71,69 @@ export function resolvePageComponentsNavigation(
         }
 
         if (!currentNode.isExpanded) {
-            return { type: 'toggle', nodeId: currentNode.id };
+            return { type: 'toggle', index: currentIndex };
         }
 
-        const firstChild = nodes[currentIndex + 1];
-        return firstChild?.parentId === currentNode.id ? { type: 'focus', nodeId: firstChild.id } : null;
+        const firstChildIndex = currentIndex + 1;
+        return nodes[firstChildIndex]?.parentId === currentNode.id ? { type: 'focus', index: firstChildIndex } : null;
     }
 
     if (currentNode.hasChildren && currentNode.isExpanded) {
-        return { type: 'toggle', nodeId: currentNode.id };
+        return { type: 'toggle', index: currentIndex };
     }
 
-    return currentNode.parentId == null ? null : { type: 'focus', nodeId: currentNode.parentId };
+    if (currentNode.parentId == null) {
+        return null;
+    }
+
+    const parentIndex = nodes.findIndex((node) => node.id === currentNode.parentId);
+    return parentIndex === -1 ? null : { type: 'focus', index: parentIndex };
 }
 
-export function getPageComponentsRow(target: EventTarget | null): HTMLElement | null {
-    return target instanceof Element ? target.closest<HTMLElement>(`.${PAGE_COMPONENTS_ROW_CLASS}`) : null;
+/**
+ * ARIA requires `aria-posinset` and `aria-setsize` on tree items that are not
+ * wrapped in a `role="group"` — the rows here are rendered as one flat list.
+ */
+export function computeTreeItemPositions(nodes: FlatNode<PageComponentNodeData>[]): Map<string, TreeItemPosition> {
+    const setSizes = new Map<string, number>();
+    for (const node of nodes) {
+        const parentKey = toParentKey(node.parentId);
+        setSizes.set(parentKey, (setSizes.get(parentKey) ?? 0) + 1);
+    }
+
+    const positions = new Map<string, TreeItemPosition>();
+    const counters = new Map<string, number>();
+    for (const node of nodes) {
+        const parentKey = toParentKey(node.parentId);
+        const posInSet = (counters.get(parentKey) ?? 0) + 1;
+        counters.set(parentKey, posInSet);
+        positions.set(node.id, { posInSet, setSize: setSizes.get(parentKey) ?? 1 });
+    }
+
+    return positions;
 }
 
-export function getPageComponentsRowNodeId(row: HTMLElement | null): string | null {
-    return row?.querySelector<HTMLElement>('[data-node-id]')?.dataset.nodeId ?? null;
+export function getPageComponentsRows(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.querySelectorAll<HTMLElement>(ROW_SELECTOR));
 }
 
-export function focusPageComponentsRow(container: HTMLElement, nodeId: string): boolean {
-    const row = getPageComponentsRows(container).find((candidate) => getPageComponentsRowNodeId(candidate) === nodeId);
+export function getPageComponentsRow(container: HTMLElement, target: EventTarget | null): HTMLElement | null {
+    if (!(target instanceof Element)) {
+        return null;
+    }
+
+    // Portalled content (the context menu) reaches the container's React handlers
+    // without being a DOM descendant, so the row has to be verified against the container.
+    const row = target.closest<HTMLElement>(ROW_SELECTOR);
+    return row != null && container.contains(row) ? row : null;
+}
+
+export function getPageComponentsRowIndex(container: HTMLElement, row: HTMLElement): number {
+    return getPageComponentsRows(container).indexOf(row);
+}
+
+export function focusPageComponentsRowAt(container: HTMLElement, index: number): boolean {
+    const row = index < 0 ? undefined : getPageComponentsRows(container)[index];
     if (row == null) {
         return false;
     }
@@ -67,6 +142,10 @@ export function focusPageComponentsRow(container: HTMLElement, nodeId: string): 
     return true;
 }
 
-function getPageComponentsRows(container: HTMLElement): HTMLElement[] {
-    return Array.from(container.querySelectorAll<HTMLElement>(`.${PAGE_COMPONENTS_ROW_CLASS}`));
+//
+// * Internal
+//
+
+function toParentKey(parentId: string | null): string {
+    return parentId ?? '';
 }

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/ui/page-editor/PageEditorExtension.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/ui/page-editor/PageEditorExtension.tsx
@@ -1,6 +1,6 @@
 import { Tab } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
-import { type ReactElement } from 'react';
+import {type ReactElement, useRef} from 'react';
 import { useI18n } from '../../../../shared/lib/hooks/useI18n';
 import { $activeWidgetId, $isContextOpen } from '../../../context-panel/model/contextWidgets.store';
 import {
@@ -19,6 +19,7 @@ import { InspectPanel } from './inspect';
 const PAGE_EDITOR_EXTENSION_NAME = 'PageEditorExtension';
 
 export const PageEditorExtension = (): ReactElement | null => {
+    const tabRootRef = useRef<HTMLDivElement>(null);
     const isContextOpen = useStore($isContextOpen);
     const activeWidgetId = useStore($activeWidgetId);
     const isInsertTabAvailable = useStore($isInsertTabAvailable);
@@ -36,6 +37,7 @@ export const PageEditorExtension = (): ReactElement | null => {
 
     const insertLabel = useI18n('action.insert');
     const inspectLabel = useI18n('action.inspect');
+    const autoFocusTrigger = tabRootRef.current?.contains(document.activeElement) ?? false;
 
     if (!isContextOpen || activeWidgetId !== getPageEditorWidgetKey()) {
         return dragState ? <DragPreview /> : null;
@@ -44,9 +46,11 @@ export const PageEditorExtension = (): ReactElement | null => {
     return (
         <>
             <Tab.Root
+                ref={tabRootRef}
                 data-component={PAGE_EDITOR_EXTENSION_NAME}
                 value={activeTab}
                 onValueChange={setActiveTab}
+                autoFocusTrigger={autoFocusTrigger}
                 className="flex flex-col -mt-4"
             >
                 <Tab.List>

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/ui/page-editor/PageEditorExtension.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/ui/page-editor/PageEditorExtension.tsx
@@ -1,6 +1,6 @@
 import { Tab } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
-import {type ReactElement, useRef} from 'react';
+import { type ReactElement, useRef } from 'react';
 import { useI18n } from '../../../../shared/lib/hooks/useI18n';
 import { $activeWidgetId, $isContextOpen } from '../../../context-panel/model/contextWidgets.store';
 import {

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/ui/page-editor/PageEditorExtension.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/ui/page-editor/PageEditorExtension.tsx
@@ -1,6 +1,6 @@
 import { Tab } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
-import { type ReactElement, useRef } from 'react';
+import { type ReactElement } from 'react';
 import { useI18n } from '../../../../shared/lib/hooks/useI18n';
 import { $activeWidgetId, $isContextOpen } from '../../../context-panel/model/contextWidgets.store';
 import {
@@ -19,7 +19,6 @@ import { InspectPanel } from './inspect';
 const PAGE_EDITOR_EXTENSION_NAME = 'PageEditorExtension';
 
 export const PageEditorExtension = (): ReactElement | null => {
-    const tabRootRef = useRef<HTMLDivElement>(null);
     const isContextOpen = useStore($isContextOpen);
     const activeWidgetId = useStore($activeWidgetId);
     const isInsertTabAvailable = useStore($isInsertTabAvailable);
@@ -37,7 +36,6 @@ export const PageEditorExtension = (): ReactElement | null => {
 
     const insertLabel = useI18n('action.insert');
     const inspectLabel = useI18n('action.inspect');
-    const autoFocusTrigger = tabRootRef.current?.contains(document.activeElement) ?? false;
 
     if (!isContextOpen || activeWidgetId !== getPageEditorWidgetKey()) {
         return dragState ? <DragPreview /> : null;
@@ -46,11 +44,12 @@ export const PageEditorExtension = (): ReactElement | null => {
     return (
         <>
             <Tab.Root
-                ref={tabRootRef}
                 data-component={PAGE_EDITOR_EXTENSION_NAME}
                 value={activeTab}
                 onValueChange={setActiveTab}
-                autoFocusTrigger={autoFocusTrigger}
+                // ? The tab value is driven by external selection, which must not pull focus
+                //   out of the components list. Arrow navigation inside the list is unaffected.
+                autoFocusTrigger={false}
                 className="flex flex-col -mt-4"
             >
                 <Tab.List>

--- a/testing/page_objects/wizardpanel/base.page.components.view.js
+++ b/testing/page_objects/wizardpanel/base.page.components.view.js
@@ -263,12 +263,12 @@ class BasePageComponentView extends Page {
     }
 
     // Swaps two components in PCV using the keyboard-based dnd: Space picks the item up, arrow keys move it, Space drops it.
-    // Only draggable rows are collected (regions and the root have aria-disabled='true'):
+    // Only draggable rows are collected (regions and the root carry no aria-roledescription):
     async swapComponents(sourceName, destinationName) {
         try {
             const allItemsLocator =
                 this.container +
-                "//div[@data-component='SortableList']/div[@role='treeitem' and @aria-roledescription='sortable' and @aria-disabled='false']";
+                "//div[@data-component='SortableList']/div[@role='treeitem' and @aria-roledescription='sortable tree item']";
             const allItems = await this.findElements(allItemsLocator);
             let sourceIndex = -1;
             let destIndex = -1;

--- a/testing/page_objects/wizardpanel/base.page.components.view.js
+++ b/testing/page_objects/wizardpanel/base.page.components.view.js
@@ -289,11 +289,10 @@ class BasePageComponentView extends Page {
             await this.getBrowser().execute((el) => el.focus(), sourceElem);
             await this.pause(200);
             await this.keys('Space');
-            // dnd-kit sets aria-pressed='true' on the row when the item is picked up:
             await this.getBrowser().waitUntil(
                 async () => {
-                    let ariaPressed = await sourceElem.getAttribute('aria-pressed');
-                    return ariaPressed === 'true';
+                    let dragging = await sourceElem.getAttribute('data-dragging');
+                    return dragging === 'true';
                 },
                 { timeout: appConst.shortTimeout, timeoutMsg: `DnD - the component '${sourceName}' was not picked up` },
             );

--- a/testing/page_objects/wizardpanel/base.page.components.view.js
+++ b/testing/page_objects/wizardpanel/base.page.components.view.js
@@ -3,40 +3,40 @@
  */
 const Page = require('../page');
 const appConst = require('../../libs/app_const');
-const {COMMON} = require('../../libs/elements');
+const { COMMON } = require('../../libs/elements');
 
 const xpath = {
     parentListElement: "//ancestor::div[contains(@class,'item-view-wrapper')]",
     pageComponentsItemName: "//div[@data-component='ContextMenu.Trigger']//span[text()]",
-    fragmentsName: "//div[@data-component='ContextMenu.Trigger'][.//*[contains(@class,'lucide-puzzle')]]//span[contains(@class,'truncate')]",
+    fragmentsName:
+        "//div[@data-component='ContextMenu.Trigger'][.//*[contains(@class,'lucide-puzzle')]]//span[contains(@class,'truncate')]",
     pageComponentsItemViewer: "//div[contains(@id,'PageComponentsItemViewer')]",
-    contextMenuItems:"//div[@data-component='ContextMenu.Content']//div[@data-component='ContextMenu.Item']",
+    contextMenuItems: "//div[@data-component='ContextMenu.Content']//div[@data-component='ContextMenu.Item']",
     pageComponentsItemViewerByType(componentType) {
-        return `//div[contains(@id,'PageComponentsItemViewer') and contains(@class,'${componentType}')]`
+        return `//div[contains(@id,'PageComponentsItemViewer') and contains(@class,'${componentType}')]`;
     },
     pageComponentsTreeGrid: `//div[contains(@id,'PageComponentsTreeGrid')]`,
     contextMenuTrigger(name) {
-        return `//div[@data-component='ContextMenu.Trigger']//span[@class and contains(@class, 'truncate') and text()='${name}']`
+        return `//div[@data-component='ContextMenu.Trigger']//span[@class and contains(@class, 'truncate') and text()='${name}']`;
     },
     contextMenuItemByName(name) {
-        return `//div[@data-component='ContextMenu.Content']//div[@data-component='ContextMenu.Item' and text()='${name}']`
+        return `//div[@data-component='ContextMenu.Content']//div[@data-component='ContextMenu.Item' and text()='${name}']`;
     },
     // Matches Item or SubTrigger in the top-level menu (text only, no SVG children at this level)
     contextMenuTopLevelItemByName(name) {
-        return `//div[@data-component='ContextMenu.Content']//*[(@data-component='ContextMenu.Item' or @data-component='ContextMenu.SubTrigger') and normalize-space(text())='${name}']`
+        return `//div[@data-component='ContextMenu.Content']//*[(@data-component='ContextMenu.Item' or @data-component='ContextMenu.SubTrigger') and normalize-space(text())='${name}']`;
     },
     // Matches Item inside a SubContent panel (icon + text node)
     contextSubMenuItemByName(name) {
-        return `//div[@data-component='ContextMenu.SubContent']//div[@data-component='ContextMenu.Item' and normalize-space(.)='${name}']`
+        return `//div[@data-component='ContextMenu.SubContent']//div[@data-component='ContextMenu.Item' and normalize-space(.)='${name}']`;
     },
     // Expand/collapse button inside the ContextMenu.Trigger row for the given component name
     rowExpanderButton(name) {
-        return `//div[@data-component='ContextMenu.Trigger' and .//span[contains(@class,'truncate') and text()='${name}']]//button`
+        return `//div[@data-component='ContextMenu.Trigger' and .//span[contains(@class,'truncate') and text()='${name}']]//button`;
     },
 };
 
 class BasePageComponentView extends Page {
-
     async rightClickAndOpenContextMenu(name) {
         try {
             let contextMenuTrigger = this.container + xpath.contextMenuTrigger(name);
@@ -44,13 +44,17 @@ class BasePageComponentView extends Page {
             await this.pause(300);
             // Perform right click
             let element = await this.findElement(contextMenuTrigger);
-            await element.click({button: 2});
+            await element.click({ button: 2 });
             // Wait for context menu to appear
             let locator = COMMON.PCV.contextMenuDiv;
             await this.waitForElementDisplayed(locator);
             return await this.pause(500);
         } catch (err) {
-            await this.handleError(`Error when right-clicking on context menu trigger: ${name} in PCV`, 'err_right_click_menu', err);
+            await this.handleError(
+                `Error when right-clicking on context menu trigger: ${name} in PCV`,
+                'err_right_click_menu',
+                err,
+            );
         }
     }
 
@@ -61,15 +65,20 @@ class BasePageComponentView extends Page {
             await this.clickOnElement(selector);
             return await this.pause(700);
         } catch (err) {
-            await this.handleError(`Error when clicking on the menu item: ${menuItem} in PCV`, 'err_click_menu_item', err);
+            await this.handleError(
+                `Error when clicking on the menu item: ${menuItem} in PCV`,
+                'err_click_menu_item',
+                err,
+            );
         }
     }
 
     async isComponentSelected(displayName) {
         try {
-            let locator = this.container +
-                          `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${displayName}']` +
-                          `/ancestor::div[@role='button']`;
+            let locator =
+                this.container +
+                `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${displayName}']` +
+                `/ancestor::div[@role='treeitem']`;
             await this.waitForElementDisplayed(locator, appConst.shortTimeout);
             let attr = await this.getAttribute(locator, 'class');
             return attr.includes('bg-surface-selected');
@@ -80,41 +89,53 @@ class BasePageComponentView extends Page {
     }
 
     async waitForItemSelected(displayName) {
-        let locator = this.container +
-                      `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${displayName}']` +
-                      `/ancestor::div[@role='button']`;
-        await this.getBrowser().waitUntil(async () => {
-            let result = await this.getAttribute(locator, 'class');
-            return result.includes('bg-surface-selected');
-        }, {timeout: appConst.mediumTimeout, timeoutMsg: `PCV item '${displayName}' should be selected`});
+        let locator =
+            this.container +
+            `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${displayName}']` +
+            `/ancestor::div[@role='treeitem']`;
+        await this.getBrowser().waitUntil(
+            async () => {
+                let result = await this.getAttribute(locator, 'class');
+                return result.includes('bg-surface-selected');
+            },
+            { timeout: appConst.mediumTimeout, timeoutMsg: `PCV item '${displayName}' should be selected` },
+        );
     }
 
     async waitForItemNotSelected(displayName) {
-        let locator = this.container +
-                      `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${displayName}']` +
-                      `/ancestor::div[@role='button']`;
-        await this.getBrowser().waitUntil(async () => {
-            let result = await this.getAttribute(locator, 'class');
-            return !result.includes('bg-surface-selected');
-        }, {timeout: appConst.mediumTimeout, timeoutMsg: `PCV item '${displayName}' should not be selected`});
+        let locator =
+            this.container +
+            `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${displayName}']` +
+            `/ancestor::div[@role='treeitem']`;
+        await this.getBrowser().waitUntil(
+            async () => {
+                let result = await this.getAttribute(locator, 'class');
+                return !result.includes('bg-surface-selected');
+            },
+            { timeout: appConst.mediumTimeout, timeoutMsg: `PCV item '${displayName}' should not be selected` },
+        );
     }
 
     async waitForComponentItemDisplayed(displayName) {
-        let selector = this.container +
-                       `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${displayName}']`;
+        let selector =
+            this.container +
+            `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${displayName}']`;
         return await this.waitForElementDisplayed(selector);
     }
 
     async clickOnComponentByDisplayName(displayName) {
         try {
-            let selector = this.container +
-                           `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${displayName}']`;
+            let selector =
+                this.container +
+                `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${displayName}']`;
             await this.waitForElementDisplayed(selector);
             await this.clickOnElement(selector);
             return await this.pause(400);
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_component_click');
-            throw new Error(`Page Component View - Error occurred after clicking on the component, screenshot${screenshot}: ` + err);
+            throw new Error(
+                `Page Component View - Error occurred after clicking on the component, screenshot${screenshot}: ` + err,
+            );
         }
     }
 
@@ -143,7 +164,6 @@ class BasePageComponentView extends Page {
             throw new Error(`PCV, Error clicking row expander for '${componentName}', screenshot:${screenshot} ` + err);
         }
     }
-
 
     async getContextMenuItems() {
         let locator = xpath.contextMenuItems;
@@ -186,7 +206,9 @@ class BasePageComponentView extends Page {
             return await this.pause(300);
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_select_context_menu');
-            throw new Error(`Error selecting context menu items: ${items.join(' → ')}, screenshot:${screenshot} ` + err);
+            throw new Error(
+                `Error selecting context menu items: ${items.join(' → ')}, screenshot:${screenshot} ` + err,
+            );
         }
     }
 
@@ -197,7 +219,9 @@ class BasePageComponentView extends Page {
             return this.waitForElementDisplayed(selector, appConst.mediumTimeout);
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_pcv_item');
-            throw new Error(`Page Component View - the context menu item is not displayed, screenshot: ${screenshot}  ` + err);
+            throw new Error(
+                `Page Component View - the context menu item is not displayed, screenshot: ${screenshot}  ` + err,
+            );
         }
     }
 
@@ -205,26 +229,36 @@ class BasePageComponentView extends Page {
     async waitForContextMenuItemDisabled(menuItem) {
         try {
             let locator = xpath.contextMenuItemByName(menuItem);
-            await this.getBrowser().waitUntil(async () => {
-                let atr = await this.getAttribute(locator, 'class');
-                return atr.includes('disabled');
-            }, {timeout: appConst.mediumTimeout, timeoutMsg: 'The context menu item is not disabled!'});
+            await this.getBrowser().waitUntil(
+                async () => {
+                    let atr = await this.getAttribute(locator, 'class');
+                    return atr.includes('disabled');
+                },
+                { timeout: appConst.mediumTimeout, timeoutMsg: 'The context menu item is not disabled!' },
+            );
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_pcv_context_menu');
-            throw new Error(`Page Component View - the context menu item is not disabled, screenshot: ${screenshot}  ` + err);
+            throw new Error(
+                `Page Component View - the context menu item is not disabled, screenshot: ${screenshot}  ` + err,
+            );
         }
     }
 
     async waitForContextMenuItemEnabled(menuItem) {
         try {
             let locator = xpath.contextMenuItemByName(menuItem);
-            await this.getBrowser().waitUntil(async () => {
-                let atr = await this.getAttribute(locator, 'class');
-                return !atr.includes('disabled');
-            }, {timeout: appConst.mediumTimeout, timeoutMsg: 'The context menu item is not enabled'});
+            await this.getBrowser().waitUntil(
+                async () => {
+                    let atr = await this.getAttribute(locator, 'class');
+                    return !atr.includes('disabled');
+                },
+                { timeout: appConst.mediumTimeout, timeoutMsg: 'The context menu item is not enabled' },
+            );
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_pcv_context_menu');
-            throw new Error(`Page Component View - the context menu item is not enabled, screenshot: ${screenshot}  ` + err);
+            throw new Error(
+                `Page Component View - the context menu item is not enabled, screenshot: ${screenshot}  ` + err,
+            );
         }
     }
 
@@ -232,8 +266,9 @@ class BasePageComponentView extends Page {
     // Only draggable rows are collected (regions and the root have aria-disabled='true'):
     async swapComponents(sourceName, destinationName) {
         try {
-            const allItemsLocator = this.container +
-                "//div[@data-component='SortableList']/div[@role='button' and @aria-roledescription='sortable' and @aria-disabled='false']";
+            const allItemsLocator =
+                this.container +
+                "//div[@data-component='SortableList']/div[@role='treeitem' and @aria-roledescription='sortable' and @aria-disabled='false']";
             const allItems = await this.findElements(allItemsLocator);
             let sourceIndex = -1;
             let destIndex = -1;
@@ -251,14 +286,17 @@ class BasePageComponentView extends Page {
             }
             const sourceElem = allItems[sourceIndex];
             // focus the row without clicking - a click selects the component and the focus gets lost after re-rendering:
-            await this.getBrowser().execute(el => el.focus(), sourceElem);
+            await this.getBrowser().execute((el) => el.focus(), sourceElem);
             await this.pause(200);
             await this.keys('Space');
             // dnd-kit sets aria-pressed='true' on the row when the item is picked up:
-            await this.getBrowser().waitUntil(async () => {
-                let ariaPressed = await sourceElem.getAttribute('aria-pressed');
-                return ariaPressed === 'true';
-            }, {timeout: appConst.shortTimeout, timeoutMsg: `DnD - the component '${sourceName}' was not picked up`});
+            await this.getBrowser().waitUntil(
+                async () => {
+                    let ariaPressed = await sourceElem.getAttribute('aria-pressed');
+                    return ariaPressed === 'true';
+                },
+                { timeout: appConst.shortTimeout, timeoutMsg: `DnD - the component '${sourceName}' was not picked up` },
+            );
             const steps = destIndex - sourceIndex;
             const arrowKey = steps > 0 ? 'ArrowDown' : 'ArrowUp';
             for (let i = 0; i < Math.abs(steps); i++) {
@@ -268,17 +306,23 @@ class BasePageComponentView extends Page {
             await this.keys('Space');
             return await this.pause(500);
         } catch (err) {
-            await this.handleError(`Error during components swap: '${sourceName}' and '${destinationName}' in PCV`, 'err_swap_components', err);
+            await this.handleError(
+                `Error during components swap: '${sourceName}' and '${destinationName}' in PCV`,
+                'err_swap_components',
+                err,
+            );
         }
     }
 
     async isItemWithDefaultIcon(partDisplayName, index) {
-        let selector = this.container + xpath.componentByName(partDisplayName) +
-                       "//div[contains(@id,'NamesAndIconView')]//div[contains(@class,'xp-admin-common-wrapper')]" +
-                       "//div[contains(@class,'font-icon-default')]";
+        let selector =
+            this.container +
+            xpath.componentByName(partDisplayName) +
+            "//div[contains(@id,'NamesAndIconView')]//div[contains(@class,'xp-admin-common-wrapper')]" +
+            "//div[contains(@class,'font-icon-default')]";
         let items = await this.findElements(selector);
         if (!items.length) {
-            throw new Error("Component-item with an icon was not found! " + partDisplayName);
+            throw new Error('Component-item with an icon was not found! ' + partDisplayName);
         }
         if (typeof index === 'undefined' || index === null) {
             return await items[0].isDisplayed();
@@ -297,37 +341,49 @@ class BasePageComponentView extends Page {
     }
 
     async getTextComponentsDisplayName() {
-        let locator = this.container +
-                      `//div[@data-component='ContextMenu.Trigger'][.//*[contains(@class,'lucide-pen-line')]]` +
-                      `//span[contains(@class,'truncate')]`;
+        let locator =
+            this.container +
+            `//div[@data-component='ContextMenu.Trigger'][.//*[contains(@class,'lucide-pen-line')]]` +
+            `//span[contains(@class,'truncate')]`;
         return await this.getTextInDisplayedElements(locator);
     }
 
     async waitForItemDisplayed(itemDisplayName) {
         try {
-            let locator = this.container +
-                          `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${itemDisplayName}']`;
+            let locator =
+                this.container +
+                `//div[@data-component='ContextMenu.Trigger']//span[contains(@class,'truncate') and text()='${itemDisplayName}']`;
             return await this.waitForElementDisplayed(locator);
         } catch (err) {
-            await this.handleError(`Page Component View - item '${itemDisplayName}' should be displayed`, 'err_pcv_item_displayed', err);
+            await this.handleError(
+                `Page Component View - item '${itemDisplayName}' should be displayed`,
+                'err_pcv_item_displayed',
+                err,
+            );
         }
     }
 
     async isComponentInvalid(name) {
         try {
-            let locator = this.container +
-                          `//div[@data-component='ContextMenu.Trigger' and descendant::span[contains(@class,'truncate') and text()='${name}']]` +
-                          `//*[contains(@class,'lucide-octagon-alert')]`;
+            let locator =
+                this.container +
+                `//div[@data-component='ContextMenu.Trigger' and descendant::span[contains(@class,'truncate') and text()='${name}']]` +
+                `//*[contains(@class,'lucide-octagon-alert')]`;
             return await this.isElementDisplayed(locator);
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_pcv_component_invalid');
-            throw new Error(`Error checking invalid state for component '${name}' in PCV, screenshot:${screenshot} ` + err);
+            throw new Error(
+                `Error checking invalid state for component '${name}' in PCV, screenshot:${screenshot} ` + err,
+            );
         }
     }
 
     async isComponentItemInvalid(itemDisplayName) {
         try {
-            let locator = this.container + xpath.componentByName(itemDisplayName) + "//div[contains(@class,'xp-admin-common-wrapper')]";  //div[contains(@class,'xp-admin-common-wrapper')]
+            let locator =
+                this.container +
+                xpath.componentByName(itemDisplayName) +
+                "//div[contains(@class,'xp-admin-common-wrapper')]"; //div[contains(@class,'xp-admin-common-wrapper')]
             await this.waitForElementDisplayed(locator, appConst.mediumTimeout);
             let attr = await this.getAttribute(locator, 'class');
             return attr.includes('icon-state-invalid');


### PR DESCRIPTION
Added tree navigation and accessibility semantics. Kept focus on moved components after keyboard drag-and-drop. Expanded layouts by default.
Prevented inspector tab changes from stealing list focus.


#####NOTE#####
This pull request is dependant on these:
https://github.com/enonic/npm-enonic-ui/pull/505
https://github.com/enonic/lib-admin-ui/pull/4603

PR is set to draft but is ready after PR above are merged.