### PR TITLE
GraalJS Compatibility #11174

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,8 @@
 junit = "6.1.2"
 mockito = "5.23.0"
 assertj = "3.27.7"
-graalvm = "25.0.3"
 enonicDefaults = "2.1.7"
-xpApp = "4.1.0"
+xpApp = "4.2.0"
 
 nodeGradle = "7.1.0"
 
@@ -31,8 +30,6 @@ mockito-core = { module = "org.mockito:mockito-core" }
 mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
 
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
-
-graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 
 # App
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commonsText" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 junit = "6.1.2"
 mockito = "5.23.0"
 assertj = "3.27.7"
+graalvm = "25.0.3"
 enonicDefaults = "2.1.7"
 xpApp = "4.1.0"
 
@@ -30,6 +31,8 @@ mockito-core = { module = "org.mockito:mockito-core" }
 mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
 
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+
+graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 
 # App
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commonsText" }

--- a/modules/app/build.gradle
+++ b/modules/app/build.gradle
@@ -65,8 +65,10 @@ dependencies {
     testImplementation( testFixtures( "com.enonic.xp:core-schema:${xpVersion}" ) )
     testImplementation( testFixtures( "com.enonic.xp:web-api:${xpVersion}" ) )
     testImplementation( testFixtures( "com.enonic.xp:core-content:${xpVersion}" ) )
+}
 
-    testRuntimeOnly libs.graalvm.js
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
 
 // Use task configuration avoidance
@@ -101,18 +103,6 @@ tasks.register( 'pnpmCheck', PnpmTask ) {
 tasks.named( 'check' ).configure {
     dependsOn tasks.named( 'pnpmCheck' )
 }
-
-def testGraalJs = tasks.register( 'testGraalJs', Test ) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
-}
-
-check.dependsOn testGraalJs
 
 tasks.register( 'pnpmBuild', PnpmTask ) {
     dependsOn tasks.named('pnpmInstall')
@@ -180,6 +170,6 @@ tasks.register( 'yolo' ) {
     checkLint.enabled = false
     check.enabled = false
     test.enabled = false
-    testGraalJs.enabled = false
+    tasks.named( 'testGraalJS' ).configure { enabled = false }
     compileTestJava.enabled = false
 }

--- a/modules/app/build.gradle
+++ b/modules/app/build.gradle
@@ -65,6 +65,8 @@ dependencies {
     testImplementation( testFixtures( "com.enonic.xp:core-schema:${xpVersion}" ) )
     testImplementation( testFixtures( "com.enonic.xp:web-api:${xpVersion}" ) )
     testImplementation( testFixtures( "com.enonic.xp:core-content:${xpVersion}" ) )
+
+    testRuntimeOnly libs.graalvm.js
 }
 
 // Use task configuration avoidance
@@ -99,6 +101,18 @@ tasks.register( 'pnpmCheck', PnpmTask ) {
 tasks.named( 'check' ).configure {
     dependsOn tasks.named( 'pnpmCheck' )
 }
+
+def testGraalJs = tasks.register( 'testGraalJs', Test ) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs
 
 tasks.register( 'pnpmBuild', PnpmTask ) {
     dependsOn tasks.named('pnpmInstall')
@@ -166,5 +180,6 @@ tasks.register( 'yolo' ) {
     checkLint.enabled = false
     check.enabled = false
     test.enabled = false
+    testGraalJs.enabled = false
     compileTestJava.enabled = false
 }

--- a/modules/app/src/main/resources/apis/styles/styles.js
+++ b/modules/app/src/main/resources/apis/styles/styles.js
@@ -40,8 +40,8 @@ exports.GET = function (req) {
 
 var getStyles = function (contentId, project, locales) {
     var bean = __.newBean('com.enonic.app.contentstudio.style.StyleHandler');
-    bean.contentId = __.nullOrValue(contentId);
-    bean.project = __.nullOrValue(project);
-    bean.locales = __.nullOrValue(locales);
+    bean.setContentId(__.nullOrValue(contentId));
+    bean.setProject(__.nullOrValue(project));
+    bean.setLocales(__.nullOrValue(locales));
     return __.toNativeObject(bean.getStyles());
 };

--- a/modules/app/src/test/java/com/enonic/app/contentstudio/style/StyleScriptTest.java
+++ b/modules/app/src/test/java/com/enonic/app/contentstudio/style/StyleScriptTest.java
@@ -1,0 +1,38 @@
+package com.enonic.app.contentstudio.style;
+
+import org.mockito.Mockito;
+
+import com.enonic.xp.i18n.LocaleService;
+import com.enonic.xp.project.Project;
+import com.enonic.xp.project.ProjectName;
+import com.enonic.xp.style.StyleDescriptorService;
+import com.enonic.xp.style.StyleDescriptors;
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+import static org.mockito.ArgumentMatchers.any;
+
+public class StyleScriptTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    protected void initialize()
+        throws Exception
+    {
+        super.initialize();
+
+        final StyleDescriptorService styleDescriptorService = Mockito.mock( StyleDescriptorService.class );
+        Mockito.when( styleDescriptorService.getByApplications( any() ) ).thenReturn( StyleDescriptors.empty() );
+        addService( StyleDescriptorService.class, styleDescriptorService );
+
+        addService( LocaleService.class, Mockito.mock( LocaleService.class ) );
+
+        final Project project = Project.create().name( ProjectName.from( "default" ) ).build();
+        Mockito.when( this.projectService.get( any() ) ).thenReturn( project );
+    }
+
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/apis/styles/styles-test.js";
+    }
+}

--- a/modules/app/src/test/resources/apis/styles/styles-test.js
+++ b/modules/app/src/test/resources/apis/styles/styles-test.js
@@ -1,0 +1,16 @@
+var assert = require('/lib/xp/testing');
+var styleApi = require('/apis/styles/styles');
+
+exports.testGetReturnsStyles = function () {
+    var result = styleApi.GET({
+        params: {
+            contentId: 'content-id',
+            project: 'default'
+        },
+        locales: ['en']
+    });
+
+    assert.assertEquals(200, result.status);
+    assert.assertEquals('application/json', result.contentType);
+    assert.assertJsonEquals({styles: [], css: []}, result.body);
+};

--- a/modules/app/src/test/resources/lib/xp/admin.js
+++ b/modules/app/src/test/resources/lib/xp/admin.js
@@ -1,0 +1,3 @@
+exports.extensionUrl = function (params) {
+    return '/admin/extension';
+};


### PR DESCRIPTION
Fixes #11174

## What

`apis/styles/styles.js` set its `StyleHandler` properties Nashorn-style. GraalJS does not map `bean.contentId = x` to `setContentId(x)`, and there is no field-write fallback — `StyleHandler` exposes only setters, so the member does not exist:

```
TypeError: writeMember (contentId) on com.enonic.app.contentstudio.style.StyleHandler
failed due to: Unknown identifier: contentId
```

All three writes now call the setters (`setContentId`/`setProject`/`setLocales`, verified against the Java class). The existing `__.nullOrValue(...)` wrapping is kept, so a `String` setter still receives `null` rather than `undefined` for an absent parameter.

## Tested on both engines

The repository had no JS-executing tests, so nothing reached this handler on either engine. `StyleScriptTest` now drives `GET` through the real `StyleHandler` bean once per script engine — Nashorn via `test` (the platform default) and GraalJS via the new `testGraalJs` task, both wired into `check`, mirroring `gradle/js-tests.gradle` in the platform.

Locally, against a build of the platform branch below:

```
test         1 test, 0 failed
testGraalJs  1 test, 0 failed
```

Before the fix, `testGraalJs` failed with the `TypeError` above while `test` stayed green — exactly the divergence the second engine exists to catch.

## Note on the version bump

`testGraalJs` needs the `ScriptRunnerSupport` fix from enonic/xp#12198, whose old `findTestNames()` closed the script executor before the dynamic tests ran (on GraalJS every test then failed with `The Context is already closed`, regardless of this app's code). That fix requires `xpVersion=8.1.0-SNAPSHOT` from `xp.enonicRepo('dev')`, both already present in this repository.

- Verified green above against a local build of that branch (`publishToMavenLocal`).
- **CI `testGraalJs` will stay red until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published** — the snapshot currently on `repo.enonic.com/dev` still carries the old `ScriptRunnerSupport`.

Holding this as a draft until then.

<sub>*Drafted with AI assistance*</sub>