### PR TITLE
Minor mobile enhancements #11187

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/view/context/PageEditorContextController.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/PageEditorContextController.ts
@@ -1,16 +1,15 @@
-import {type ContentSummaryAndCompareStatus} from '../../content/ContentSummaryAndCompareStatus';
-import {getIsMobile} from '@enonic/ui';
-import {InspectEvent} from '../../event/InspectEvent';
-import {PageEventsManager} from '../../wizard/PageEventsManager';
-import {type PageNavigationEvent} from '../../wizard/PageNavigationEvent';
-import {PageNavigationEventType} from '../../wizard/PageNavigationEventType';
-import {type PageNavigationHandler} from '../../wizard/PageNavigationHandler';
-import {PageNavigationMediator} from '../../wizard/PageNavigationMediator';
-import {type ContextView} from './ContextView';
-import {type ExtensionView} from './ExtensionView';
+import { type ContentSummaryAndCompareStatus } from '../../content/ContentSummaryAndCompareStatus';
+import { getIsMobile } from '@enonic/ui';
+import { InspectEvent } from '../../event/InspectEvent';
+import { PageEventsManager } from '../../wizard/PageEventsManager';
+import { type PageNavigationEvent } from '../../wizard/PageNavigationEvent';
+import { PageNavigationEventType } from '../../wizard/PageNavigationEventType';
+import { type PageNavigationHandler } from '../../wizard/PageNavigationHandler';
+import { PageNavigationMediator } from '../../wizard/PageNavigationMediator';
+import { type ContextView } from './ContextView';
+import { type ExtensionView } from './ExtensionView';
 
 export class PageEditorContextController implements PageNavigationHandler {
-
     private readonly contextView: ContextView;
     private readonly pageEditorWidget: ExtensionView;
     private readonly fallbackWidget: ExtensionView;
@@ -40,16 +39,15 @@ export class PageEditorContextController implements PageNavigationHandler {
 
     handle(event: PageNavigationEvent): void {
         const type = event.getType();
-        if (type === PageNavigationEventType.INSPECT ||
-            (type === PageNavigationEventType.SELECT && !getIsMobile())) {
+        if (type === PageNavigationEventType.INSPECT || (type === PageNavigationEventType.SELECT && !getIsMobile())) {
             this.activatePageEditor();
         }
     }
 
     private refresh(): void {
         const item = this.getItem();
-        const shouldActivate = (this.isPageRenderable && !item?.getType()?.isShortcut())
-            || item?.getContentSummary()?.isPage();
+        const shouldActivate =
+            (this.isPageRenderable && !item?.getType()?.isShortcut()) || item?.getContentSummary()?.isPage();
 
         if (shouldActivate) {
             this.activatePageEditor();

--- a/modules/lib/src/main/resources/assets/js/app/view/context/PageEditorContextController.ts
+++ b/modules/lib/src/main/resources/assets/js/app/view/context/PageEditorContextController.ts
@@ -1,4 +1,5 @@
 import {type ContentSummaryAndCompareStatus} from '../../content/ContentSummaryAndCompareStatus';
+import {getIsMobile} from '@enonic/ui';
 import {InspectEvent} from '../../event/InspectEvent';
 import {PageEventsManager} from '../../wizard/PageEventsManager';
 import {type PageNavigationEvent} from '../../wizard/PageNavigationEvent';
@@ -39,7 +40,8 @@ export class PageEditorContextController implements PageNavigationHandler {
 
     handle(event: PageNavigationEvent): void {
         const type = event.getType();
-        if (type === PageNavigationEventType.SELECT || type === PageNavigationEventType.INSPECT) {
+        if (type === PageNavigationEventType.INSPECT ||
+            (type === PageNavigationEventType.SELECT && !getIsMobile())) {
             this.activatePageEditor();
         }
     }

--- a/modules/lib/src/main/resources/assets/js/v6/features/delete/ui/DeleteDialogMainContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/delete/ui/DeleteDialogMainContent.tsx
@@ -70,7 +70,7 @@ export const DeleteDialogMainContent = ({
 
     return (
         <Dialog.Content
-            className="w-full h-full gap-10 sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
+            className="w-full gap-5 md:gap-10 p-5 md:p-10 sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
             onOpenAutoFocus={handleOpenAutoFocus}
             data-component={componentName}
         >

--- a/modules/lib/src/main/resources/assets/js/v6/features/duplicate/ui/DuplicateDialogMainContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/duplicate/ui/DuplicateDialogMainContent.tsx
@@ -60,7 +60,7 @@ export const DuplicateDialogMainContent = ({
 
     return (
         <Dialog.Content
-            className="w-full h-full gap-10 sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
+            className="w-full gap-5 md:gap-10 p-5 md:p-10 sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
             onOpenAutoFocus={handleOpenAutoFocus}
             data-component={componentName}
         >

--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/ui/new-issue/NewIssueDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/ui/new-issue/NewIssueDialogContent.tsx
@@ -153,7 +153,7 @@ export const NewIssueDialogContent = (): ReactElement => {
     return (
         <Dialog.Content
             data-component={NEW_ISSUE_DIALOG_CONTENT_NAME}
-            className="sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-236 gap-7.5 px-5"
+            className="h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-236 gap-5 md:gap-7.5 p-5 md:p-10 px-0 md:px-5"
         >
             <Dialog.Header className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 px-5">
                 <div className="flex min-w-0 items-center gap-2.5">

--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/ui/new-issue/NewIssueDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/ui/new-issue/NewIssueDialogContent.tsx
@@ -139,7 +139,7 @@ export const NewIssueDialogContent = (): ReactElement => {
     return (
         <Dialog.Content
             data-component={NEW_ISSUE_DIALOG_CONTENT_NAME}
-            className="sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-236 gap-7.5 px-5"
+            className="h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-236 gap-5 md:gap-7.5 p-5 md:p-10 px-0 md:px-5"
         >
             <Dialog.Header className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 px-5">
                 <div className="flex min-w-0 items-center gap-2.5">

--- a/modules/lib/src/main/resources/assets/js/v6/features/manage-project/ui/ProjectDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/manage-project/ui/ProjectDialog.tsx
@@ -128,7 +128,7 @@ export const ProjectDialog = (): ReactElement => {
                 <Dialog.Overlay />
                 {view === 'main' && (
                     <Dialog.Content
-                        className="w-full h-full gap-10 sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
+                        className="w-full h-full sm:h-fit gap-10 p-5 md:p-10  md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
                         data-component={PROJECT_DIALOG_NAME}
                     >
                         <ProjectDialogSteps.ParentStep.Header />

--- a/modules/lib/src/main/resources/assets/js/v6/features/manage-project/ui/ProjectSelectionDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/manage-project/ui/ProjectSelectionDialog.tsx
@@ -50,7 +50,7 @@ export const ProjectSelectionDialog = (): ReactElement => {
                 <ConfirmationDialog.Overlay />
                 <ConfirmationDialog.Content
                     className={cn(
-                        'w-full h-full max-w-full max-h-full sm:w-auto sm:h-fit gap-7.5',
+                        'w-full h-fit max-w-full max-h-full sm:w-auto gap-5 md:gap-7.5',
                         hasAvailableProjects ? 'md:max-w-180 md:max-h-[85vh] lg:max-w-220' : 'max-w-160',
                     )}
                     data-component={PROJECT_SELECTION_DIALOG_NAME}

--- a/modules/lib/src/main/resources/assets/js/v6/features/manage-project/ui/steps/ProjectDialogAccessStep.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/manage-project/ui/steps/ProjectDialogAccessStep.tsx
@@ -145,17 +145,17 @@ export const ProjectDialogAccessStepContent = ({
             >
                 <RadioGroup.Item value="public">
                     <RadioGroup.Indicator />
-                    <span className="ml-2">{publicLabel}</span>
+                    <span className="ml-2 text-start">{publicLabel}</span>
                 </RadioGroup.Item>
 
                 <RadioGroup.Item value="private">
                     <RadioGroup.Indicator />
-                    <span className="ml-2">{privateLabel}</span>
+                    <span className="ml-2 text-start">{privateLabel}</span>
                 </RadioGroup.Item>
 
                 <RadioGroup.Item value="custom">
                     <RadioGroup.Indicator />
-                    <span className="ml-2">{customLabel}</span>
+                    <span className="ml-2 text-start">{customLabel}</span>
                 </RadioGroup.Item>
             </RadioGroup.Root>
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/manage-project/ui/steps/ProjectDialogSummaryStep.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/manage-project/ui/steps/ProjectDialogSummaryStep.tsx
@@ -1,14 +1,61 @@
 import type { Principal } from '@enonic/lib-admin-ui/security/Principal';
-import { Avatar, Dialog, Tooltip } from '@enonic/ui';
+import { Avatar, cn, Dialog, Tooltip } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
-import type { ReactElement } from 'react';
+import { type ReactElement, useRef } from 'react';
 import { ProjectAccess } from '../../../../../app/settings/access/ProjectAccess';
 import { useI18n } from '../../../../shared/lib/hooks/useI18n';
 import { $projectDialog } from '../../model/projectDialog.store';
 import { $languages } from '../../../../entities/language';
 import { getInitials } from '../../../../shared/lib/format/initials';
+import { useVisibleAvatars } from '../../../../shared/lib/hooks/useVisibleAvatars';
 import { ApplicationIcon } from '../../../../shared/ui/icons/ApplicationIcon';
 import { FlagIcon } from '../../../../shared/ui/icons/FlagIcon';
+
+const PermissionAvatars = ({ principals }: { principals: Principal[] }): ReactElement => {
+    const listRef = useRef<HTMLDivElement>(null);
+    const { visibleCount } = useVisibleAvatars(listRef, principals.length, 0);
+    const maxVisiblePermissionAvatars =
+        principals.length > visibleCount ? Math.max(visibleCount - 1, 0) : principals.length;
+    const hiddenPrincipals = principals.slice(maxVisiblePermissionAvatars);
+
+    return (
+        <div ref={listRef} className="flex min-w-0 gap-2.5">
+            {principals.map((principal, index) => {
+                const principalDisplayName = principal.getDisplayName();
+                const principalKey = principal.getKey().toString();
+
+                return (
+                    <Tooltip delay={150} key={principalKey} value={principalDisplayName}>
+                        <Avatar
+                            size="sm"
+                            className={cn(
+                                'size-6 -my-0.5',
+                                index >= maxVisiblePermissionAvatars && 'invisible order-last',
+                            )}
+                        >
+                            <Avatar.Fallback className="text-alt font-semibold">
+                                {getInitials(principalDisplayName)}
+                            </Avatar.Fallback>
+                        </Avatar>
+                    </Tooltip>
+                );
+            })}
+            {hiddenPrincipals.length > 0 && (
+                <Tooltip
+                    delay={150}
+                    className="whitespace-pre-line"
+                    value={hiddenPrincipals.map((principal) => principal.getDisplayName()).join('\n')}
+                >
+                    <Avatar size="sm" className="size-6 -my-0.5 text-alt font-semibold">
+                        <Avatar.Fallback>+{hiddenPrincipals.length}</Avatar.Fallback>
+                    </Avatar>
+                </Tooltip>
+            )}
+        </div>
+    );
+};
+
+PermissionAvatars.displayName = 'PermissionAvatars';
 
 export const ProjectDialogSummaryStepHeader = (): ReactElement => {
     const { mode, title } = useStore($projectDialog, { keys: ['mode', 'title'] });
@@ -116,7 +163,7 @@ export const ProjectDialogSummaryStepContent = ({
 
     return (
         <Dialog.StepContent step="step-summary" locked={locked}>
-            <dl className="grid grid-cols-[auto_1fr] gap-x-7.5 gap-y-5 bg-surface-primary p-5 rounded-md text-sm">
+            <dl className="grid grid-cols-[auto_1fr] gap-x-3.5 md:gap-x-7.5 gap-y-2.5 md:gap-y-5 bg-surface-primary p-2.5 md:p-5 rounded-md overflow-hidden text-sm">
                 {parentProjects.length > 0 && (
                     <div className="contents">
                         <dt className="font-semibold">
@@ -162,21 +209,7 @@ export const ProjectDialogSummaryStepContent = ({
                         <dt className="font-semibold">{accessModeLabel}</dt>
                         <dd className="flex gap-2.5">
                             <span>{selectedAccessModeLabel}</span>
-                            {accessMode === 'custom' &&
-                                permissions.map((p) => {
-                                    const principalDisplayName = p.getDisplayName();
-                                    const principalKey = p.getKey().toString();
-
-                                    return (
-                                        <Tooltip delay={150} key={principalKey} value={principalDisplayName}>
-                                            <Avatar size="sm" className="size-6 -my-0.5">
-                                                <Avatar.Fallback className="text-alt font-semibold">
-                                                    {getInitials(principalDisplayName)}
-                                                </Avatar.Fallback>
-                                            </Avatar>
-                                        </Tooltip>
-                                    );
-                                })}
+                            {accessMode === 'custom' && <PermissionAvatars principals={permissions} />}
                         </dd>
                     </div>
                 )}
@@ -188,22 +221,7 @@ export const ProjectDialogSummaryStepContent = ({
                             {Array.from(principalsByRole.entries()).map(([label, principals]) => (
                                 <div className="contents" key={label}>
                                     <span>{label}</span>
-                                    <div className="flex gap-2.5">
-                                        {principals.map((p) => {
-                                            const principalDisplayName = p.getDisplayName();
-                                            const principalKey = p.getKey().toString();
-
-                                            return (
-                                                <Tooltip delay={150} key={principalKey} value={principalDisplayName}>
-                                                    <Avatar size="sm" className="size-6 -my-0.5">
-                                                        <Avatar.Fallback className="text-alt font-semibold">
-                                                            {getInitials(principalDisplayName)}
-                                                        </Avatar.Fallback>
-                                                    </Avatar>
-                                                </Tooltip>
-                                            );
-                                        })}
-                                    </div>
+                                    <PermissionAvatars principals={principals} />
                                 </div>
                             ))}
                         </dd>

--- a/modules/lib/src/main/resources/assets/js/v6/features/new-content/ui/NewContentDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/new-content/ui/NewContentDialog.tsx
@@ -1,4 +1,4 @@
-import { cn, Dialog, Tab } from '@enonic/ui';
+import { cn, Dialog, getIsMobile, Tab } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
 import { type KeyboardEvent, type ReactElement, useEffect, useRef } from 'react';
 import { useI18n } from '../../../shared/lib/hooks/useI18n';
@@ -31,8 +31,10 @@ export const NewContentDialog = (): ReactElement => {
     const isTemplateContent = parentContent?.getType().isPageTemplate() ?? false;
     const isMediaTabDisabled = isTemplateFolder || isTemplateContent || !isMediaAllowed;
     const isMediaTab = selectedTab === 'media';
+    const isMobile = getIsMobile();
     const isInputEmpty = inputValue.length === 0;
-    const isInputHidden = isInputEmpty || isMediaTab;
+    const isInputHidden = isMediaTab || (isInputEmpty && !isMobile);
+    const isFooterHidden = !isInputEmpty || isMediaTab || isMobile;
 
     const titleLabel = useI18n('dialog.new.title');
     const allTabLabel = useI18n('dialog.new.tab.all');
@@ -145,7 +147,7 @@ export const NewContentDialog = (): ReactElement => {
                 <Dialog.Overlay />
                 <Dialog.Content
                     ref={dialogContentRef}
-                    className="h-178 w-200 max-w-auto"
+                    className="p-5 md:p-10 gap-5 md:gap-10 h-178 w-200 max-w-auto"
                     onKeyDown={handleKeyDown}
                     onDragEnter={handleDragEnter}
                     onDragLeave={handleDragLeave}
@@ -216,7 +218,7 @@ export const NewContentDialog = (): ReactElement => {
                             </div>
                         </Dialog.Body>
 
-                        {isInputEmpty && !isMediaTab && (
+                        {!isFooterHidden && (
                             <Dialog.Footer className="flex justify-center mt-5">
                                 <p className="text-sm text-subtle">{hintLabel}</p>
                             </Dialog.Footer>

--- a/modules/lib/src/main/resources/assets/js/v6/features/new-content/ui/NewContentDialogContentTypesTab.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/new-content/ui/NewContentDialogContentTypesTab.tsx
@@ -44,7 +44,7 @@ export const NewContentDialogContentTypesTab = ({
             )}
 
             {!loading && contentTypes.length > 0 && (
-                <ul className="grid grid-cols-2 gap-y-1.5 gap-x-7.5">
+                <ul className="grid grid-cols-1 md:grid-cols-2 gap-y-1.5 gap-x-7.5">
                     {contentTypes.map((contentType) => {
                         const key = contentType.getName();
                         const displayName = contentType.getTitle();
@@ -56,7 +56,7 @@ export const NewContentDialogContentTypesTab = ({
                             <li key={key}>
                                 <Button
                                     variant="text"
-                                    className="w-full h-auto py-1.5 px-2 flex justify-start font-normal"
+                                    className="w-full h-auto py-1.5 px-0 md:px-2 flex justify-start font-normal"
                                     onClick={() => handleContentTypeSelected(contentType)}
                                 >
                                     <ItemLabel
@@ -71,7 +71,7 @@ export const NewContentDialogContentTypesTab = ({
                                         }
                                         primary={displayName}
                                         secondary={description}
-                                        className="[&>*:first-child]:size-12 ml-1.5 gap-4"
+                                        className="[&>*:first-child]:size-12 md:ml-1.5 gap-4"
                                     />
                                 </Button>
                             </li>

--- a/modules/lib/src/main/resources/assets/js/v6/features/publish/ui/PublishDialogMainContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/publish/ui/PublishDialogMainContent.tsx
@@ -140,7 +140,7 @@ export const PublishDialogMainContent = ({
 
     return (
         <Dialog.Content
-            className="w-full h-full sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
+            className="w-full h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
             data-component={componentName}
         >
             <Dialog.DefaultHeader titleId={titleId} title={title} withClose />

--- a/modules/lib/src/main/resources/assets/js/v6/features/rename/ui/RenameContentDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/rename/ui/RenameContentDialog.tsx
@@ -71,7 +71,7 @@ export const RenameContentDialog = (): ReactElement => {
             <Dialog.Portal>
                 <Dialog.Overlay />
                 <Dialog.Content
-                    className="w-full h-full gap-7.5 sm:h-fit md:min-w-180 md:max-w-184"
+                    className="w-full h-fit gap-7.5 sm:h-fit md:min-w-180 md:max-w-184"
                     data-component={RENAME_CONTENT_DIALOG_NAME}
                     onOpenAutoFocus={(event) => {
                         event.preventDefault();

--- a/modules/lib/src/main/resources/assets/js/v6/features/request-publish/ui/RequestPublishDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/request-publish/ui/RequestPublishDialogContent.tsx
@@ -4,7 +4,7 @@ import { CornerDownRight } from 'lucide-react';
 import { useMemo, type ReactElement } from 'react';
 import { IssueType } from '../../../../app/issue/IssueType';
 import { useI18n } from '../../../shared/lib/hooks/useI18n';
-import { $config } from '../../../shared/config/config.store';
+import { $config } from '../../../shared/config';
 import {
     $isRequestPublishReady,
     $isRequestPublishSelectionSynced,
@@ -126,7 +126,7 @@ export const RequestPublishDialogContent = (): ReactElement => {
     return (
         <Dialog.Content
             data-component={REQUEST_PUBLISH_DIALOG_CONTENT_NAME}
-            className="sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-236 gap-7.5 px-5"
+            className="h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-236 gap-5 md:gap-7.5 p-5 md:p-10 px-0 md:px-5"
         >
             <Dialog.Header className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 px-5">
                 <div className="flex min-w-0 items-center gap-2.5">

--- a/modules/lib/src/main/resources/assets/js/v6/features/request-publish/ui/RequestPublishDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/request-publish/ui/RequestPublishDialogContent.tsx
@@ -4,7 +4,7 @@ import { CornerDownRight } from 'lucide-react';
 import { useMemo, type ReactElement } from 'react';
 import { IssueType } from '../../../../app/issue/IssueType';
 import { useI18n } from '../../../shared/lib/hooks/useI18n';
-import { $config } from '../../../shared/config/config.store';
+import { $config } from '../../../shared/config';
 import {
     $isRequestPublishReady,
     $isRequestPublishSelectionSynced,
@@ -140,7 +140,7 @@ export const RequestPublishDialogContent = (): ReactElement => {
     return (
         <Dialog.Content
             data-component={REQUEST_PUBLISH_DIALOG_CONTENT_NAME}
-            className="sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-236 gap-7.5 px-5"
+            className="h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-236 gap-5 md:gap-7.5 p-5 md:p-10 px-0 md:px-5"
         >
             <Dialog.Header className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-4 px-5">
                 <div className="flex min-w-0 items-center gap-2.5">

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/ContentReferencesLink.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/ContentReferencesLink.tsx
@@ -1,6 +1,6 @@
 import { cn, Link, type LinkProps } from '@enonic/ui';
 import { forwardRef, useMemo } from 'react';
-
+import { Link as LinkIcon } from 'lucide-react';
 import type { ContentTypeName } from '@enonic/lib-admin-ui/schema/content/ContentTypeName';
 import { useStore } from '@nanostores/preact';
 import { type Branch } from '../../../app/versioning/Branch';
@@ -32,7 +32,6 @@ export const ContentReferencesLink = forwardRef<HTMLAnchorElement, ContentRefere
         const label = useI18n('action.showReferences');
         const projectName = useStore($activeProject)?.getName();
         const contentType = contentTypeName?.toString();
-
         const href = useMemo(
             () => getInboundReferencesUrl({ contentId, branch, project: projectName, contentType }),
             [projectName, branch, contentType, contentId],
@@ -46,11 +45,13 @@ export const ContentReferencesLink = forwardRef<HTMLAnchorElement, ContentRefere
                     'self-stretch px-2 visited:text-main active:bg-transparent data-[active=true]:bg-transparent',
                 )}
                 href={href}
+                aria-label={label}
                 newTab
                 data-component={componentName}
                 {...props}
             >
-                {label}
+                <span className="hidden md:inline">{label}</span>
+                <LinkIcon className="size-3.5 md:hidden" aria-hidden />
             </Link>
         );
     },

--- a/modules/lib/src/main/resources/assets/js/v6/features/unpublish/ui/UnpublishDialogMainContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/unpublish/ui/UnpublishDialogMainContent.tsx
@@ -67,7 +67,7 @@ export const UnpublishDialogMainContent = ({
 
     return (
         <Dialog.Content
-            className="w-full h-full gap-10 sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220"
+            className="w-full gap-2.5 md:gap-10 p-5 md:p-10 sm:h-fit md:min-w-180 md:max-w-184 h-fit md:max-h-[85vh] lg:max-w-220"
             onOpenAutoFocus={handleOpenAutoFocus}
             data-component={componentName}
         >

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsContextMenu.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsContextMenu.tsx
@@ -1,7 +1,14 @@
-import { ContextMenu } from '@enonic/ui';
+import { ContextMenu, getIsMobile } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
 import { Box, Columns2, PenLine, Puzzle } from 'lucide-react';
-import { type ReactElement, type ReactNode, useCallback, useMemo } from 'react';
+import {
+    type MouseEvent as ReactMouseEvent,
+    type ReactElement,
+    type ReactNode,
+    useCallback,
+    useMemo,
+    useState,
+} from 'react';
 import { SaveAsTemplateAction } from '../../../../../../app/wizard/action/SaveAsTemplateAction';
 import { FragmentComponent } from '../../../../../../app/page/region/FragmentComponent';
 import { ComponentPath } from '../../../../../../app/page/region/ComponentPath';
@@ -15,7 +22,6 @@ import { getNode } from '../../../../../shared/lib/tree-store';
 import { useI18n } from '../../../../../shared/lib/hooks/useI18n';
 import { openEditContentTab } from '../../../../../shared/lib/url/navigation';
 import {
-    inspectItem,
     requestComponentAdd,
     requestComponentCreateFragment,
     requestComponentDetachFragment,
@@ -62,6 +68,7 @@ const ROOT_NODE_ID = '/';
 
 export const PageComponentsContextMenu = ({ node, children }: PageComponentsContextMenuProps): ReactElement => {
     const data = node.data;
+    const [open, setOpen] = useState(false);
 
     const contentContext = useStore($contentContext);
     const page = useStore($page);
@@ -79,6 +86,36 @@ export const PageComponentsContextMenu = ({ node, children }: PageComponentsCont
     const editFragmentLabel = useI18n('action.editFragment');
     const saveAsTemplateLabel = useI18n('action.saveAsTemplate');
 
+    const handleClickCapture = useCallback((event: ReactMouseEvent<HTMLDivElement>): void => {
+        if (!getIsMobile() || event.button !== 0 || (event.target as Element).closest('button')) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+        event.currentTarget.dispatchEvent(
+            new MouseEvent('contextmenu', {
+                bubbles: true,
+                cancelable: true,
+                clientX: event.clientX,
+                clientY: event.clientY,
+                button: 2,
+                view: window,
+            }),
+        );
+    }, []);
+
+    const handlePointerDownOutside = useCallback((event: PointerEvent): void => {
+        if (getIsMobile()) event.preventDefault();
+    }, []);
+
+    const mobileDismissLayer = getIsMobile() ? (
+        <div
+            aria-hidden
+            className="fixed inset-0 z-40"
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={() => setOpen(false)}
+        />
+    ) : null;
+
     const fragmentRemoved = useMemo(
         () => isComponentReferenceMissing(node.id, page, fragmentOptions, [], isFragmentLoading),
         [node.id, page, fragmentOptions, isFragmentLoading],
@@ -92,10 +129,13 @@ export const PageComponentsContextMenu = ({ node, children }: PageComponentsCont
 
     if (isPageRoot) {
         return (
-            <ContextMenu data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
-                <ContextMenu.Trigger className="flex-1 min-w-0">{children}</ContextMenu.Trigger>
+            <ContextMenu open={open} onOpenChange={setOpen} data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
+                <ContextMenu.Trigger className="flex-1 min-w-0" onClickCapture={handleClickCapture}>
+                    {children}
+                </ContextMenu.Trigger>
                 <ContextMenu.Portal>
-                    <ContextMenu.Content className="min-w-48">
+                    {mobileDismissLayer}
+                    <ContextMenu.Content className="min-w-48" onPointerDownOutside={handlePointerDownOutside}>
                         <InspectItem nodeId={ROOT_NODE_ID} label={inspectLabel} />
                         <PageResetItem label={resetLabel} onSelect={requestPageReset} />
                         <SaveAsTemplateItem label={saveAsTemplateLabel} />
@@ -111,10 +151,13 @@ export const PageComponentsContextMenu = ({ node, children }: PageComponentsCont
     const isEmpty = isComponentEmpty(node.id);
 
     return (
-        <ContextMenu data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
-            <ContextMenu.Trigger className="flex-1 min-w-0">{children}</ContextMenu.Trigger>
+        <ContextMenu open={open} onOpenChange={setOpen} data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
+            <ContextMenu.Trigger className="flex-1 min-w-0" onClickCapture={handleClickCapture}>
+                {children}
+            </ContextMenu.Trigger>
             <ContextMenu.Portal>
-                <ContextMenu.Content className="min-w-48">
+                {mobileDismissLayer}
+                <ContextMenu.Content className="min-w-48" onPointerDownOutside={handlePointerDownOutside}>
                     <SelectParentItem nodeId={node.id} label={selectParentLabel} />
                     <InsertSubMenu nodeId={node.id} label={insertLabel} />
                     {isComponent && (
@@ -206,7 +249,6 @@ const SelectParentItem = ({ nodeId, label }: MenuItemProps): ReactElement | null
     const handleSelect = useCallback(() => {
         if (treeNode?.parentId != null) {
             const path = ComponentPath.fromString(treeNode.parentId);
-            inspectItem(path);
             PageNavigationMediator.get().notify(
                 new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)),
             );
@@ -225,9 +267,8 @@ SelectParentItem.displayName = 'SelectParentItem';
 const InspectItem = ({ nodeId, label }: MenuItemProps): ReactElement => {
     const handleSelect = useCallback(() => {
         const path = ComponentPath.fromString(nodeId);
-        inspectItem(path);
         PageNavigationMediator.get().notify(
-            new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)),
+            new PageNavigationEvent(PageNavigationEventType.INSPECT, new PageNavigationEventData(path)),
         );
     }, [nodeId]);
 
@@ -344,7 +385,6 @@ const InsertSubMenu = ({ nodeId, label }: MenuItemProps): ReactElement => {
             requestComponentAdd(insertPath, componentType);
             rebuildComponentsTree();
 
-            inspectItem(insertPath);
             PageNavigationMediator.get().notify(
                 new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(insertPath)),
             );

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsContextMenu.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsContextMenu.tsx
@@ -1,7 +1,14 @@
-import { ContextMenu } from '@enonic/ui';
+import { ContextMenu, getIsMobile } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
 import { Box, Columns2, PenLine, Puzzle } from 'lucide-react';
-import { type ReactElement, type ReactNode, useCallback, useMemo } from 'react';
+import {
+    type MouseEvent as ReactMouseEvent,
+    type ReactElement,
+    type ReactNode,
+    useCallback,
+    useMemo,
+    useState,
+} from 'react';
 import { SaveAsTemplateAction } from '../../../../../../app/wizard/action/SaveAsTemplateAction';
 import { FragmentComponent } from '../../../../../../app/page/region/FragmentComponent';
 import { ComponentPath } from '../../../../../../app/page/region/ComponentPath';
@@ -15,7 +22,6 @@ import { getNode } from '../../../../../shared/lib/tree-store';
 import { useI18n } from '../../../../../shared/lib/hooks/useI18n';
 import { openEditContentTab } from '../../../../../shared/lib/url/navigation';
 import {
-    inspectItem,
     requestComponentAdd,
     requestComponentCreateFragment,
     requestComponentDetachFragment,
@@ -62,6 +68,7 @@ const ROOT_NODE_ID = '/';
 
 export const PageComponentsContextMenu = ({ node, children }: PageComponentsContextMenuProps): ReactElement => {
     const data = node.data;
+    const [open, setOpen] = useState(false);
 
     const contentContext = useStore($contentContext);
     const page = useStore($page);
@@ -79,6 +86,43 @@ export const PageComponentsContextMenu = ({ node, children }: PageComponentsCont
     const editFragmentLabel = useI18n('action.editFragment');
     const saveAsTemplateLabel = useI18n('action.saveAsTemplate');
 
+    const handleClickCapture = useCallback((event: ReactMouseEvent<HTMLDivElement>): void => {
+        if (!getIsMobile() || event.button !== 0 || (event.target as Element).closest('button')) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+        event.currentTarget.dispatchEvent(
+            new MouseEvent('contextmenu', {
+                bubbles: true,
+                cancelable: true,
+                clientX: event.clientX,
+                clientY: event.clientY,
+                button: 2,
+                view: window,
+            }),
+        );
+    }, []);
+
+    const handleContextMenuCapture = useCallback((event: ReactMouseEvent<HTMLDivElement>): void => {
+        if (!getIsMobile() || !event.isTrusted) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+    }, []);
+
+    const handlePointerDownOutside = useCallback((event: PointerEvent): void => {
+        if (getIsMobile()) event.preventDefault();
+    }, []);
+
+    const mobileDismissLayer = getIsMobile() ? (
+        <div
+            aria-hidden
+            className="fixed inset-0 z-40"
+            onPointerDown={(event) => event.stopPropagation()}
+            onClick={() => setOpen(false)}
+        />
+    ) : null;
+
     const fragmentRemoved = useMemo(
         () => isComponentReferenceMissing(node.id, page, fragmentOptions, [], isFragmentLoading),
         [node.id, page, fragmentOptions, isFragmentLoading],
@@ -92,10 +136,17 @@ export const PageComponentsContextMenu = ({ node, children }: PageComponentsCont
 
     if (isPageRoot) {
         return (
-            <ContextMenu data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
-                <ContextMenu.Trigger className="flex-1 min-w-0">{children}</ContextMenu.Trigger>
+            <ContextMenu open={open} onOpenChange={setOpen} data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
+                <ContextMenu.Trigger
+                    className="flex-1 min-w-0"
+                    onClickCapture={handleClickCapture}
+                    onContextMenuCapture={handleContextMenuCapture}
+                >
+                    {children}
+                </ContextMenu.Trigger>
                 <ContextMenu.Portal>
-                    <ContextMenu.Content className="min-w-48">
+                    {mobileDismissLayer}
+                    <ContextMenu.Content className="min-w-48" onPointerDownOutside={handlePointerDownOutside}>
                         <InspectItem nodeId={ROOT_NODE_ID} label={inspectLabel} />
                         <PageResetItem label={resetLabel} onSelect={requestPageReset} />
                         <SaveAsTemplateItem label={saveAsTemplateLabel} />
@@ -111,10 +162,17 @@ export const PageComponentsContextMenu = ({ node, children }: PageComponentsCont
     const isEmpty = isComponentEmpty(node.id);
 
     return (
-        <ContextMenu data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
-            <ContextMenu.Trigger className="flex-1 min-w-0">{children}</ContextMenu.Trigger>
+        <ContextMenu open={open} onOpenChange={setOpen} data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
+            <ContextMenu.Trigger
+                className="flex-1 min-w-0"
+                onClickCapture={handleClickCapture}
+                onContextMenuCapture={handleContextMenuCapture}
+            >
+                {children}
+            </ContextMenu.Trigger>
             <ContextMenu.Portal>
-                <ContextMenu.Content className="min-w-48">
+                {mobileDismissLayer}
+                <ContextMenu.Content className="min-w-48" onPointerDownOutside={handlePointerDownOutside}>
                     <SelectParentItem nodeId={node.id} label={selectParentLabel} />
                     <InsertSubMenu nodeId={node.id} label={insertLabel} />
                     {isComponent && (
@@ -206,7 +264,6 @@ const SelectParentItem = ({ nodeId, label }: MenuItemProps): ReactElement | null
     const handleSelect = useCallback(() => {
         if (treeNode?.parentId != null) {
             const path = ComponentPath.fromString(treeNode.parentId);
-            inspectItem(path);
             PageNavigationMediator.get().notify(
                 new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)),
             );
@@ -225,9 +282,8 @@ SelectParentItem.displayName = 'SelectParentItem';
 const InspectItem = ({ nodeId, label }: MenuItemProps): ReactElement => {
     const handleSelect = useCallback(() => {
         const path = ComponentPath.fromString(nodeId);
-        inspectItem(path);
         PageNavigationMediator.get().notify(
-            new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)),
+            new PageNavigationEvent(PageNavigationEventType.INSPECT, new PageNavigationEventData(path)),
         );
     }, [nodeId]);
 
@@ -344,10 +400,14 @@ const InsertSubMenu = ({ nodeId, label }: MenuItemProps): ReactElement => {
             requestComponentAdd(insertPath, componentType);
             rebuildComponentsTree();
 
-            inspectItem(insertPath);
             PageNavigationMediator.get().notify(
                 new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(insertPath)),
             );
+            if (getIsMobile()) {
+                PageNavigationMediator.get().notify(
+                    new PageNavigationEvent(PageNavigationEventType.INSPECT, new PageNavigationEventData(insertPath)),
+                );
+            }
 
             const regionId = isRegion ? nodeId : path.getParentPath()?.toString();
             if (regionId != null) {

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -8,7 +8,7 @@ import {
     type SortableListItemContext,
     type SortableListItemProps,
 } from '@enonic/lib-admin-ui/form2/components';
-import { cn } from '@enonic/ui';
+import { cn, getIsMobile } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
 import {
     type FocusEvent as ReactFocusEvent,
@@ -29,7 +29,7 @@ import { PageNavigationMediator } from '../../../../../../app/wizard/PageNavigat
 import { useI18n } from '../../../../../shared/lib/hooks/useI18n';
 import { useSelectedPageOption } from '../../../../../widgets/inspectors/lib/usePageOptions';
 import type { FlatNode } from '../../../../../shared/lib/tree-store';
-import { inspectItem, requestComponentMove } from '../../../../../widgets/inspectors/model/page-editor';
+import { requestComponentMove } from '../../../../../widgets/inspectors/model/page-editor';
 import {
     $fragmentOptions,
     $isFragmentInspectionLoading,
@@ -84,6 +84,7 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
     const pendingFocusNodeIdRef = useRef<string | null>(null);
     const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
     const componentsLabel = useI18n('field.components');
+    const moveLabel = useI18n('action.move');
     const pageVersion = useStore($pageVersion);
     const page = useStore($page);
     const fragmentOptions = useStore($fragmentOptions);
@@ -196,7 +197,6 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
 
     const handleSelect = useCallback((nodeId: string): void => {
         const path = ComponentPath.fromString(nodeId);
-        inspectItem(path);
         PageNavigationMediator.get().notify(
             new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)),
         );
@@ -328,7 +328,6 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
             remapExpandedIdsAfterMove(sourceNode.id, targetComponentPath);
             rebuildComponentsTree();
 
-            inspectItem(movedPath);
             PageNavigationMediator.get().notify(
                 new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(movedPath)),
             );
@@ -435,7 +434,8 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
                     onDragStart={handleDragStart}
                     onMove={handleMove}
                     enabled={flatNodes.length > 1}
-                    fullRowDraggable
+                    fullRowDraggable={!getIsMobile()}
+                    dragLabel={moveLabel}
                     isItemMovable={isItemMovable}
                     resolveDrop={resolveDrop}
                     animateLayoutChanges={animateLayoutChanges}

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -7,7 +7,7 @@ import {
     SortableList,
     type SortableListItemContext,
 } from '@enonic/lib-admin-ui/form2/components';
-import { cn } from '@enonic/ui';
+import { cn, getIsMobile } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
 import { type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ComponentPath } from '../../../../../../app/page/region/ComponentPath';
@@ -18,7 +18,7 @@ import { PageNavigationMediator } from '../../../../../../app/wizard/PageNavigat
 import { useI18n } from '../../../../../shared/lib/hooks/useI18n';
 import { useSelectedPageOption } from '../../../../../widgets/inspectors/lib/usePageOptions';
 import type { FlatNode } from '../../../../../shared/lib/tree-store';
-import { inspectItem, requestComponentMove } from '../../../../../widgets/inspectors/model/page-editor';
+import { requestComponentMove } from '../../../../../widgets/inspectors/model/page-editor';
 import {
     $fragmentOptions,
     $isFragmentInspectionLoading,
@@ -63,6 +63,7 @@ export type PageComponentsViewProps = {
 export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProps = {}): ReactElement => {
     const containerRef = useRef<HTMLDivElement>(null);
     const componentsLabel = useI18n('field.components');
+    const moveLabel = useI18n('action.move');
     const pageVersion = useStore($pageVersion);
     const page = useStore($page);
     const fragmentOptions = useStore($fragmentOptions);
@@ -178,7 +179,6 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
             rebuildComponentsTree();
 
             const movedPath = ComponentPath.fromString(computeMovedItemPath(sourceNode.id, targetComponentPath));
-            inspectItem(movedPath);
             PageNavigationMediator.get().notify(
                 new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(movedPath)),
             );
@@ -198,7 +198,6 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
 
     const handleSelect = useCallback((nodeId: string): void => {
         const path = ComponentPath.fromString(nodeId);
-        inspectItem(path);
         PageNavigationMediator.get().notify(
             new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)),
         );
@@ -267,7 +266,8 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
                     onDragStart={handleDragStart}
                     onMove={handleMove}
                     enabled={flatNodes.length > 1}
-                    fullRowDraggable
+                    fullRowDraggable={!getIsMobile()}
+                    dragLabel={moveLabel}
                     isItemMovable={isItemMovable}
                     resolveDrop={resolveDrop}
                     animateLayoutChanges={animateLayoutChanges}

--- a/modules/lib/src/main/resources/assets/js/v6/shared/lib/hooks/useVisibleAvatars.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/lib/hooks/useVisibleAvatars.ts
@@ -12,7 +12,9 @@ export function useVisibleAvatars(containerRef: RefObject<HTMLElement>, totalCou
         const calculateVisible = () => {
             if (!containerRef.current) return;
             const containerRight = containerRef.current.getBoundingClientRect().right;
-            const children = Array.from(containerRef.current.children);
+            const children = Array.from(containerRef.current.children).filter(
+                (child) => !child.classList.contains('sr-only'),
+            );
             const visible = children.filter(
                 (child) => child.getBoundingClientRect().right <= containerRight - offset,
             ).length;
@@ -30,7 +32,7 @@ export function useVisibleAvatars(containerRef: RefObject<HTMLElement>, totalCou
             observer.disconnect();
             throttledCalc.cancel();
         };
-    }, [containerRef, offset]);
+    }, [containerRef, offset, totalCount]);
 
     return { visibleCount, extraCount: totalCount - visibleCount };
 }

--- a/modules/lib/src/main/resources/assets/js/v6/shared/ui/dialogs/ProgressDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/ui/dialogs/ProgressDialogContent.tsx
@@ -23,7 +23,7 @@ export const ProgressDialogContent = ({
     return (
         <Dialog.Content
             className={cn(
-                'w-full h-full gap-7.5 sm:h-fit md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220',
+                'w-full h-fit gap-7.5 md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220',
                 className,
             )}
             onEscapeKeyDown={(e) => e.preventDefault()}

--- a/modules/lib/src/main/resources/assets/js/v6/shared/ui/dialogs/ProgressDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/ui/dialogs/ProgressDialogContent.tsx
@@ -22,10 +22,7 @@ export const ProgressDialogContent = ({
 }: ProgressDialogProps): ReactElement => {
     return (
         <Dialog.Content
-            className={cn(
-                'w-full h-fit gap-7.5 md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220',
-                className,
-            )}
+            className={cn('w-full h-fit gap-7.5 md:min-w-180 md:max-w-184 md:max-h-[85vh] lg:max-w-220', className)}
             onEscapeKeyDown={(e) => e.preventDefault()}
             onPointerDownOutside={(e) => e.preventDefault()}
             {...props}

--- a/modules/lib/src/main/resources/assets/js/v6/shared/ui/dialogs/status-bar/StatusBarEntry.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/ui/dialogs/status-bar/StatusBarEntry.tsx
@@ -17,7 +17,7 @@ export const StatusBarEntry = ({
         <div
             data-component={dataComponent}
             className={cn(
-                'grid grid-flow-col auto-cols-max grid-cols-[max-content_1fr] items-center gap-2 md:min-h-19 p-2.5 sm:p-5 rounded-lg',
+                'grid grid-cols-[max-content_1fr] md:grid-flow-col md:auto-cols-max items-center gap-2 md:min-h-19 p-5 rounded-lg',
                 className,
             )}
         >

--- a/modules/lib/src/main/resources/assets/js/v6/shared/ui/dialogs/status-bar/StatusBarEntryButton.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/ui/dialogs/status-bar/StatusBarEntryButton.tsx
@@ -12,11 +12,7 @@ export const StatusBarEntryButton = ({
     return (
         <Button
             data-component={STATUS_BAR_ENTRY_BUTTON_NAME}
-            className={cn(
-                'col-span-full md:col-auto',
-                'bg-transparent hover:bg-btn-primary-hover/50',
-                className,
-            )}
+            className={cn('col-span-full md:col-auto', 'bg-transparent hover:bg-btn-primary-hover/50', className)}
             variant="outline"
             size="sm"
             {...props}

--- a/modules/lib/src/main/resources/assets/js/v6/shared/ui/dialogs/status-bar/StatusBarEntryButton.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/ui/dialogs/status-bar/StatusBarEntryButton.tsx
@@ -12,7 +12,11 @@ export const StatusBarEntryButton = ({
     return (
         <Button
             data-component={STATUS_BAR_ENTRY_BUTTON_NAME}
-            className={cn('bg-transparent hover:bg-btn-primary-hover/50', className)}
+            className={cn(
+                'col-span-full md:col-auto',
+                'bg-transparent hover:bg-btn-primary-hover/50',
+                className,
+            )}
             variant="outline"
             size="sm"
             {...props}

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/context-panel/widget/details/PermissionsList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/context-panel/widget/details/PermissionsList.tsx
@@ -29,9 +29,10 @@ const PermissionItem = ({ permission }: { permission: EffectivePermission }): Re
     const status = accessLabelMap.get(permission.getAccess());
     const principals = sortPrincipals(permission.getMembers().map((epm) => epm.toPrincipal()));
     const currentUser = AuthContext.get().getUser();
-    const { visibleCount, extraCount } = useVisibleAvatars(listRef, principals.length, AVATAR_OVERFLOW_OFFSET);
+    const { visibleCount } = useVisibleAvatars(listRef, principals.length, AVATAR_OVERFLOW_OFFSET);
     // +N avatar takes space of a regular avatar, render regular instead
     const maxVisibleCount = visibleCount + 1;
+    const hiddenCount = Math.max(principals.length - maxVisibleCount, 0);
 
     if (!status) return null;
 
@@ -59,10 +60,9 @@ const PermissionItem = ({ permission }: { permission: EffectivePermission }): Re
                         </Tooltip>
                     );
                 })}
-                {/* Render +N only when there are more than 2 extra avatars to hide */}
-                {extraCount >= 2 && (
+                {hiddenCount > 0 && (
                     <Avatar className="border-2 border-surface-neutral text-alt font-semibold">
-                        <Avatar.Fallback>+{extraCount}</Avatar.Fallback>
+                        <Avatar.Fallback>+{hiddenCount}</Avatar.Fallback>
                     </Avatar>
                 )}
             </div>

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/model/page-editor/bridge.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/model/page-editor/bridge.ts
@@ -1,3 +1,4 @@
+import { getIsMobile } from '@enonic/ui';
 import { PageEventsManager } from '../../../../../app/wizard/PageEventsManager';
 import type { PageNavigationEvent } from '../../../../../app/wizard/PageNavigationEvent';
 import { PageNavigationEventType } from '../../../../../app/wizard/PageNavigationEventType';
@@ -94,14 +95,16 @@ export function initPageEditorBridge(options?: InitPageEditorBridgeOptions): voi
     const navigationHandler: PageNavigationHandler = {
         handle(event: PageNavigationEvent): void {
             const type = event.getType();
-            if (type === PageNavigationEventType.SELECT || type === PageNavigationEventType.INSPECT) {
+            const isMobile = getIsMobile();
+
+            if (type === PageNavigationEventType.INSPECT || (type === PageNavigationEventType.SELECT && !isMobile)) {
                 const path = event.getData().getPath();
                 $inspectedPath.set(path?.toString() ?? null);
                 bumpSelectionEventNonce();
                 setContextOpen(true);
                 return;
             }
-            if (type === PageNavigationEventType.DESELECT) {
+            if (type === PageNavigationEventType.DESELECT && !isMobile) {
                 $inspectedPath.set(null);
                 bumpSelectionEventNonce();
             }

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/model/page-editor/store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/model/page-editor/store.ts
@@ -29,7 +29,7 @@ export const $contentContext = atom<PageEditorContentContext | null>(null);
 
 export const $inspectedPath = atom<string | null>(null);
 
-// ? Bumps on every explicit selection event (SELECT/INSPECT/inspectItem),
+// ? Bumps on every event accepted for inspection (SELECT/INSPECT/inspectItem),
 // ? even when $inspectedPath value is unchanged. Lets consumers react to
 // ? "user reselected the same path" (e.g. tab switch) which an atom set
 // ? with an identical value would otherwise swallow.


### PR DESCRIPTION
### Mobile dialogs

* Improved height, padding, and gaps across Delete, Duplicate, New Issue, Project Selection, Project, Rename, Request Publish, Unpublish, and Progress dialogs.
* Changed several mobile dialogs from full-height to content-height.

### New Content dialog
* Shows the search input by default on mobile while preserving type-to-search behavior on desktop.
* Hides the keyboard filtering hint on mobile.
* Uses a single-column content-type list on mobile and restores two columns from md.
* Adjusted mobile padding and alignment for content-type items.

### Content references
* Shows link icon below md.
* Shows text label from md.
* Preserved accessible label.

### Status bars
* First two elements occupy mobile row one.
* Status-bar buttons span full mobile rows.
* Desktop restores single-row column flow.

### Project and permission summaries
* Left-aligned project access option labels.
* Added responsive permission-avatar overflow.
* Hidden principals represented by accurate +N avatar.
* Tooltip lists hidden principal names.
* Reduced mobile summary spacing and padding.
* Avatar measurement ignores tooltip sr-only elements and recalculates when count changes.

### Mobile Page Components
* Single tap opens context menu.
* First outside tap closes menu without opening another.
* Toggle and drag buttons remain independently clickable.
* Dedicated mobile drag handle added.
* Desktop right-click and full-row dragging preserved.
* Newly inserted components automatically open in the inspector on mobile.

### Selection and inspection
* Mobile drag/focus continues selecting components without opening inspector.
* Only explicit Inspect action opens Page Editor on mobile.
* Desktop SELECT, INSPECT, and DESELECT behavior preserved.
* Legacy and modern Page Editor handlers use same mobile rule.