### PR TITLE
Allow icons for dialog navigation #11190

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/manage-project/ui/ProjectDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/manage-project/ui/ProjectDialog.tsx
@@ -1,5 +1,6 @@
 import { cn, Dialog, Tooltip } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
+import {ChevronLeft, ChevronRight, Plus, Save} from 'lucide-react';
 import { ReactElement, useCallback, useMemo, useRef } from 'react';
 import { useI18n } from '../../../shared/lib/hooks/useI18n';
 import {
@@ -149,9 +150,13 @@ export const ProjectDialog = (): ReactElement => {
 
                         <Dialog.Footer className="flex flex-col">
                             <Dialog.StepIndicator
+                                buttonDisplay="responsive"
                                 previousLabel={previousLabel}
+                                previousIcon={ChevronLeft}
                                 nextLabel={nextLabel}
+                                nextIcon={ChevronRight}
                                 lastStepLabel={submitLabel}
+                                lastStepIcon={mode === 'edit' ? Save : Plus}
                                 onLastStep={handleSubmit}
                                 pending={submitting}
                                 dots

--- a/modules/lib/src/main/resources/assets/js/v6/features/permissions/ui/PermissionsDialog.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/permissions/ui/PermissionsDialog.tsx
@@ -1,5 +1,6 @@
 import { showError, showSuccess, showWarning } from '@enonic/lib-admin-ui/notify/MessageBus';
 import { Dialog, Skeleton, Tooltip } from '@enonic/ui';
+import {Check, ChevronLeft, ChevronRight} from 'lucide-react';
 import { ReactElement, useCallback, useMemo } from 'react';
 import {
     $isPermissionsDialogDirty,
@@ -215,15 +216,19 @@ export const PermissionsDialog = (): ReactElement => {
 
                                 <Dialog.Footer className="flex flex-col">
                                     <Dialog.StepIndicator
-                                        dots
+                                        buttonDisplay="responsive"
                                         previousLabel={previousLabel}
+                                        previousIcon={ChevronLeft}
                                         nextLabel={nextLabel}
+                                        nextIcon={ChevronRight}
                                         lastStepLabel={
                                             replaceAllChildPermissions
                                                 ? replaceAllPermissionsLabel
                                                 : applyPermissionsLabel
                                         }
+                                        lastStepIcon={Check}
                                         onLastStep={handleSubmit}
+                                        dots
                                         renderDot={(dot, step) => (
                                             <Tooltip delay={150} side="top" value={stepsMap.get(step) ?? ''}>
                                                 {dot}


### PR DESCRIPTION
Adjustments of margins, paddings, gaps and icon replacements for cumbersome texts.

#####NOTE#####
This is depending on next release of npm-enonic-ui which needs to contain the following change:
https://github.com/enonic/npm-enonic-ui/pull/512