### PR TITLE
Show / Hide excluded is missing #11212

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/model/issueDialogDetails.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/model/issueDialogDetails.store.test.ts
@@ -20,7 +20,9 @@ import {
     $isIssueDialogDetailsSelectionSynced,
     $issueDialogDetails,
     $issueDialogDetailsDependantsSelection,
+    $issueDialogDetailsHasExcludedDependants,
     $issueDialogDetailsHasMoreDependants,
+    $showIssueDialogDetailsExcludedDependants,
     applyDraftIssueDialogDetailsSelection,
     cancelDraftIssueDialogDetailsSelection,
     loadIssueDialogItems,
@@ -29,6 +31,7 @@ import {
     setIssueDialogDetailsDependantIncluded,
     setIssueDialogDetailsItemIncludeChildren,
     toggleIssueDialogDetailsDependantsSelection,
+    toggleIssueDialogDetailsShowExcludedDependants,
     updateIssueDialogExcludedDependants,
     updateIssueDialogItems,
 } from './issueDialogDetails.store';
@@ -584,6 +587,94 @@ describe('issueDialogDetails.store', () => {
 
             expect($issueDialogDetails.get().appliedExcludeChildrenIds).toHaveLength(0);
             expect($issueDialogDetails.get().appliedExcludedDependantIds).toHaveLength(0);
+        });
+    });
+
+    describe('excluded dependants visibility', () => {
+        const item1 = new ContentId('item-1');
+        const dep1 = new ContentId('dep-1');
+        const dep2 = new ContentId('dep-2');
+
+        async function excludeDep1AndApply(): Promise<void> {
+            mockResolvePublishDependencies.mockResolvedValue(createResolveResult({ dependants: [dep1, dep2] }));
+            mockFetchContentSummaries.mockImplementation((contentIds: ContentId[]) =>
+                contentIds.map((id) => createMockContent(id.toString())),
+            );
+
+            await openListBackedIssueDetails(createMockIssue('issue-1', [item1]));
+            await flushPromises();
+
+            setIssueDialogDetailsDependantIncluded(dep1, false);
+            await applyDraftIssueDialogDetailsSelection();
+            await flushPromises();
+        }
+
+        it('should offer nothing to hide until an exclusion is applied', async () => {
+            mockResolvePublishDependencies.mockResolvedValue(createResolveResult({ dependants: [dep1, dep2] }));
+            mockFetchContentSummaries.mockImplementation((contentIds: ContentId[]) =>
+                contentIds.map((id) => createMockContent(id.toString())),
+            );
+
+            await openListBackedIssueDetails(createMockIssue('issue-1', [item1]));
+            await flushPromises();
+
+            expect($issueDialogDetailsHasExcludedDependants.get()).toBe(false);
+
+            setIssueDialogDetailsDependantIncluded(dep1, false);
+
+            expect($issueDialogDetailsHasExcludedDependants.get()).toBe(false);
+
+            await applyDraftIssueDialogDetailsSelection();
+            await flushPromises();
+
+            expect($issueDialogDetailsHasExcludedDependants.get()).toBe(true);
+        });
+
+        it('should flip the toggle and restore it on reset', async () => {
+            await excludeDep1AndApply();
+            expect($showIssueDialogDetailsExcludedDependants.get()).toBe(true);
+
+            toggleIssueDialogDetailsShowExcludedDependants();
+            expect($showIssueDialogDetailsExcludedDependants.get()).toBe(false);
+
+            resetIssueDialogDetails();
+            expect($showIssueDialogDetailsExcludedDependants.get()).toBe(true);
+        });
+
+        it('should count only the shown dependants while excluded ones are hidden', async () => {
+            await excludeDep1AndApply();
+            expect($issueDialogDetailsDependantsSelection.get().count).toBe(2);
+
+            toggleIssueDialogDetailsShowExcludedDependants();
+
+            const selection = $issueDialogDetailsDependantsSelection.get();
+            expect(selection.count).toBe(1);
+            expect(selection.selectionType).toBe('all');
+            expect(selection.selectableIds.map((id) => id.toString())).toEqual(['dep-2']);
+        });
+
+        it('should keep a staged exclusion visible, hiding only the applied ones', async () => {
+            await excludeDep1AndApply();
+            toggleIssueDialogDetailsShowExcludedDependants();
+
+            setIssueDialogDetailsDependantIncluded(dep2, false);
+
+            const selection = $issueDialogDetailsDependantsSelection.get();
+            expect(selection.count).toBe(1);
+            expect(selection.selectionType).toBe('none');
+        });
+
+        it('should snap back to shown once the last exclusion is re-included', async () => {
+            await excludeDep1AndApply();
+            toggleIssueDialogDetailsShowExcludedDependants();
+            expect($showIssueDialogDetailsExcludedDependants.get()).toBe(false);
+
+            setIssueDialogDetailsDependantIncluded(dep1, true);
+            await applyDraftIssueDialogDetailsSelection();
+            await flushPromises();
+
+            expect($issueDialogDetailsHasExcludedDependants.get()).toBe(false);
+            expect($showIssueDialogDetailsExcludedDependants.get()).toBe(true);
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/model/issueDialogDetails.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/model/issueDialogDetails.store.ts
@@ -2,7 +2,7 @@ import { AuthContext } from '@enonic/lib-admin-ui/auth/AuthContext';
 import { showError, showFeedback } from '@enonic/lib-admin-ui/notify/MessageBus';
 import { PrincipalKey } from '@enonic/lib-admin-ui/security/PrincipalKey';
 import { i18n } from '@enonic/lib-admin-ui/util/Messages';
-import { computed, map } from 'nanostores';
+import { atom, computed, map } from 'nanostores';
 import { type ContentId } from '../../../../app/content/ContentId';
 import type { ContentSummary } from '../../../../app/content/ContentSummary';
 import { IssueStatus } from '../../../../app/issue/IssueStatus';
@@ -29,6 +29,8 @@ import { resolveAppliedPublishDependencies } from '../../../entities/content/lib
 import { buildItemsFromIds } from '../../../shared/lib/cms/content/buildItems';
 import {
     calcDependantsSelection,
+    filterShownDependantIds,
+    hasHideableExcludedDependants,
     nextDependantExclusions,
     pruneExcludedDependantIds,
 } from '../../../shared/lib/cms/content/dependantsSelection';
@@ -122,6 +124,9 @@ const initialState: IssueDialogDetailsStore = {
 
 export const $issueDialogDetails = map<IssueDialogDetailsStore>(structuredClone(initialState));
 
+// Whether applied dependant exclusions are shown in the list ("Show/Hide excluded" toggle).
+export const $showIssueDialogDetailsExcludedDependants = atom<boolean>(true);
+
 export const $deleteCommentConfirmation = map<DeleteCommentConfirmation>({
     open: false,
     commentId: undefined,
@@ -173,15 +178,38 @@ export const $issueDialogDetailsHasMoreDependants = computed(
     ({ dependantIds, dependantWindow }) => dependantWindow < dependantIds.length,
 );
 
-export const $issueDialogDetailsDependantsSelection = computed(
+export const $issueDialogDetailsHasExcludedDependants = computed(
     $issueDialogDetails,
-    ({ dependantIds, requiredDependantIds, excludedDependantIds }) =>
-        calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds),
+    ({ dependantIds, appliedExcludedDependantIds }) =>
+        hasHideableExcludedDependants(dependantIds, appliedExcludedDependantIds),
+);
+
+// From the full id set, not the loaded window, and filtered by the "show excluded" toggle.
+export const $issueDialogDetailsDependantsSelection = computed(
+    [$issueDialogDetails, $showIssueDialogDetailsExcludedDependants],
+    ({ dependantIds, requiredDependantIds, excludedDependantIds, appliedExcludedDependantIds }, showExcluded) =>
+        calcDependantsSelection(
+            filterShownDependantIds(dependantIds, appliedExcludedDependantIds, showExcluded),
+            requiredDependantIds,
+            excludedDependantIds,
+        ),
 );
 
 //
 // * Public API
 //
+
+/**
+ * Snap back to "show excluded" once nothing is excluded, so the toggle never lingers hidden.
+ * Written here, not subscribed in the service: a listener would pin `$issueDialogDetails` mounted.
+ */
+const syncShowExcludedDependants = (): void => {
+    const { dependantIds, appliedExcludedDependantIds } = $issueDialogDetails.get();
+
+    if (!hasHideableExcludedDependants(dependantIds, appliedExcludedDependantIds)) {
+        $showIssueDialogDetailsExcludedDependants.set(true);
+    }
+};
 
 export const setIssueDialogDetailsTab = (detailsTab: IssueDialogDetailsTab): void => {
     $issueDialogDetails.setKey('detailsTab', detailsTab);
@@ -224,6 +252,7 @@ export const loadIssueDialogItems = async (issue?: Issue, options: IssueDialogIt
             appliedExcludeChildrenIds: [],
             appliedExcludedDependantIds: [],
         });
+        syncShowExcludedDependants();
         return;
     }
 
@@ -258,6 +287,7 @@ export const loadIssueDialogItems = async (issue?: Issue, options: IssueDialogIt
         appliedExcludeChildrenIds: serverExcludeChildrenIds,
         appliedExcludedDependantIds: serverExcludedDependantIds,
     });
+    syncShowExcludedDependants();
 
     try {
         const items = shouldFetchItems ? await fetchContentSummaries(itemIds) : currentState.items;
@@ -335,6 +365,7 @@ export const loadIssueDialogItems = async (issue?: Issue, options: IssueDialogIt
             itemsLoading: false,
             itemsError: false,
         });
+        syncShowExcludedDependants();
     } catch (error) {
         if (requestId !== dependenciesRequestId) {
             return;
@@ -881,6 +912,7 @@ export const applyDraftIssueDialogDetailsSelection = async (): Promise<void> => 
         itemsUpdating: true,
         ...commitDraftSelection(state),
     });
+    syncShowExcludedDependants();
 
     const updated = await updateIssueWithPublishRequest({
         issueId,
@@ -951,13 +983,18 @@ export const updateIssueDialogExcludedDependants = async (nextExcludedIds: Conte
     });
 };
 
+export const toggleIssueDialogDetailsShowExcludedDependants = (): void => {
+    $showIssueDialogDetailsExcludedDependants.set(!$showIssueDialogDetailsExcludedDependants.get());
+};
+
 export const toggleIssueDialogDetailsDependantsSelection = (): void => {
-    const { dependantIds, requiredDependantIds, excludedDependantIds } = $issueDialogDetails.get();
-    const selection = calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds);
+    // Read the computed: it defines the rows on screen, so a batch toggle skips hidden ones.
+    const selection = $issueDialogDetailsDependantsSelection.get();
     if (selection.selectableIds.length === 0) {
         return;
     }
 
+    const { excludedDependantIds } = $issueDialogDetails.get();
     $issueDialogDetails.setKey('excludedDependantIds', nextDependantExclusions(selection, excludedDependantIds));
 };
 
@@ -1196,5 +1233,6 @@ export const resetIssueDialogDetails = (issueId?: string): void => {
         issueId,
         detailsTab: resolveDefaultDetailsTab(issueId),
     });
+    $showIssueDialogDetailsExcludedDependants.set(true);
     $deleteCommentConfirmation.set({ open: false, commentId: undefined });
 };

--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/model/newIssueDialog.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/model/newIssueDialog.service.ts
@@ -18,7 +18,13 @@ import {
     $contentRenamed,
     $contentUpdated,
 } from '../../../shared/socket/socket.store';
-import { $newIssueDialog, reloadDependenciesDebounced, resetDependenciesState } from './newIssueDialog.store';
+import {
+    $newIssueDialog,
+    $newIssueHasExcludedDependants,
+    $showNewIssueExcludedDependants,
+    reloadDependenciesDebounced,
+    resetDependenciesState,
+} from './newIssueDialog.store';
 
 //
 // * New Issue Dialog Service
@@ -116,6 +122,12 @@ export const start = (): void => {
     }
 
     unsubscribers = [
+        // Snap back to "show excluded" once nothing is excluded, so the toggle never lingers hidden.
+        $newIssueHasExcludedDependants.subscribe((hasExcluded) => {
+            if (!hasExcluded) {
+                $showNewIssueExcludedDependants.set(true);
+            }
+        }),
         $contentCreated.subscribe(
             onNewIssueSocketEvent((event) => {
                 const matched = findContentIdsWithCreatedDescendants($newIssueDialog.get().items, event.data);

--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/model/newIssueDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/model/newIssueDialog.store.test.ts
@@ -15,6 +15,8 @@ import {
     $newIssueDialog,
     $newIssueDialogCreateCount,
     $newIssueDialogHasMoreDependants,
+    $newIssueHasExcludedDependants,
+    $showNewIssueExcludedDependants,
     applyDraftNewIssueDialogSelection,
     cancelDraftNewIssueDialogSelection,
     loadMoreNewIssueDependants,
@@ -24,6 +26,7 @@ import {
     setNewIssueDependantIncluded,
     setNewIssueItemIncludeChildren,
     toggleNewIssueDependantsSelection,
+    toggleNewIssueShowExcludedDependants,
 } from './newIssueDialog.store';
 import {
     createMockChangeItem,
@@ -421,6 +424,99 @@ describe('newIssueDialog.store', () => {
             expect($newIssueDialog.get().excludeChildrenIds).toHaveLength(0);
             expect($newIssueDialog.get().appliedExcludeChildrenIds.map((id) => id.toString())).toEqual(['item-2']);
             expect($isNewIssueSelectionSynced.get()).toBe(false);
+        });
+    });
+
+    describe('excluded dependants visibility', () => {
+        async function setupWithDependants(): Promise<void> {
+            const dependantIds = [new ContentId('dep-1'), new ContentId('dep-2')];
+
+            mockResolvePublishDependencies.mockResolvedValue(createResolveResult({ dependants: dependantIds }));
+            mockFetchContentSummaries.mockImplementation((ids: ContentId[]) =>
+                ids.map((id) => createMockContent(id.toString())),
+            );
+
+            openNewIssueDialog([createMockContent('item-1', { hasChildren: true })]);
+            await flushNewIssueReload();
+        }
+
+        async function excludeDep1AndApply(): Promise<void> {
+            await setupWithDependants();
+
+            setNewIssueDependantIncluded(new ContentId('dep-1'), false);
+            applyDraftNewIssueDialogSelection();
+            await flushNewIssueReload();
+        }
+
+        it('should offer nothing to hide until an exclusion is applied', async () => {
+            await setupWithDependants();
+
+            expect($newIssueHasExcludedDependants.get()).toBe(false);
+
+            setNewIssueDependantIncluded(new ContentId('dep-1'), false);
+
+            expect($newIssueHasExcludedDependants.get()).toBe(false);
+
+            applyDraftNewIssueDialogSelection();
+            await flushNewIssueReload();
+
+            expect($newIssueHasExcludedDependants.get()).toBe(true);
+        });
+
+        it('should not count a staged exclusion as hideable', async () => {
+            await excludeDep1AndApply();
+
+            setNewIssueDependantIncluded(new ContentId('dep-2'), false);
+
+            // Still only dep-1 is applied-excluded; the staged dep-2 does not count.
+            expect($newIssueDialog.get().appliedExcludedDependantIds.map((id) => id.toString())).toEqual(['dep-1']);
+        });
+
+        it('should flip the toggle and restore it on reset', async () => {
+            await excludeDep1AndApply();
+            expect($showNewIssueExcludedDependants.get()).toBe(true);
+
+            toggleNewIssueShowExcludedDependants();
+            expect($showNewIssueExcludedDependants.get()).toBe(false);
+
+            resetNewIssueDialogContext();
+            expect($showNewIssueExcludedDependants.get()).toBe(true);
+        });
+
+        it('should count only the shown dependants while excluded ones are hidden', async () => {
+            await excludeDep1AndApply();
+            expect($newIssueDependantsSelection.get().count).toBe(2);
+
+            toggleNewIssueShowExcludedDependants();
+
+            const selection = $newIssueDependantsSelection.get();
+            expect(selection.count).toBe(1);
+            expect(selection.selectionType).toBe('all');
+            expect(selection.selectableIds.map((id) => id.toString())).toEqual(['dep-2']);
+        });
+
+        it('should keep a staged exclusion visible, hiding only the applied ones', async () => {
+            await excludeDep1AndApply();
+            toggleNewIssueShowExcludedDependants();
+
+            setNewIssueDependantIncluded(new ContentId('dep-2'), false);
+
+            const selection = $newIssueDependantsSelection.get();
+            expect(selection.count).toBe(1);
+            expect(selection.selectionType).toBe('none');
+        });
+
+        it('should snap back to shown once the last exclusion is re-included', async () => {
+            await excludeDep1AndApply();
+            toggleNewIssueShowExcludedDependants();
+            expect($showNewIssueExcludedDependants.get()).toBe(false);
+
+            setNewIssueDependantIncluded(new ContentId('dep-1'), true);
+            applyDraftNewIssueDialogSelection();
+            await flushNewIssueReload();
+
+            expect($newIssueHasExcludedDependants.get()).toBe(false);
+            expect($showNewIssueExcludedDependants.get()).toBe(true);
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/model/newIssueDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/model/newIssueDialog.store.ts
@@ -1,7 +1,7 @@
 import { showError, showSuccess, showWarning } from '@enonic/lib-admin-ui/notify/MessageBus';
 import { PrincipalKey } from '@enonic/lib-admin-ui/security/PrincipalKey';
 import { i18n } from '@enonic/lib-admin-ui/util/Messages';
-import { computed, map } from 'nanostores';
+import { atom, computed, map } from 'nanostores';
 import { ContentId } from '../../../../app/content/ContentId';
 import type { ContentSummary } from '../../../../app/content/ContentSummary';
 import { PublishRequest } from '../../../../app/issue/PublishRequest';
@@ -16,6 +16,8 @@ import {
 import { resolveAppliedPublishDependencies } from '../../../entities/content/lib/publishDependencies';
 import {
     calcDependantsSelection,
+    filterShownDependantIds,
+    hasHideableExcludedDependants,
     nextDependantExclusions,
     pruneExcludedDependantIds,
 } from '../../../shared/lib/cms/content/dependantsSelection';
@@ -72,7 +74,16 @@ const initialState: NewIssueDialogStore = {
 
 export const $newIssueDialog = map<NewIssueDialogStore>(structuredClone(initialState));
 
+// Whether applied dependant exclusions are shown in the list ("Show/Hide excluded" toggle).
+export const $showNewIssueExcludedDependants = atom<boolean>(true);
+
 export const $isNewIssueSelectionSynced = computed($newIssueDialog, isDraftSelectionSynced);
+
+export const $newIssueHasExcludedDependants = computed(
+    $newIssueDialog,
+    ({ dependantIds, appliedExcludedDependantIds }) =>
+        hasHideableExcludedDependants(dependantIds, appliedExcludedDependantIds),
+);
 
 export const $newIssueDialogCreateCount = computed($newIssueDialog, ({ items, dependantIds, excludedDependantIds }) => {
     const includedDependants = dependantIds.filter((id) => !hasContentIdInIds(id, excludedDependantIds));
@@ -84,10 +95,15 @@ export const $newIssueDialogHasMoreDependants = computed(
     ({ dependantIds, dependantWindow }) => dependantWindow < dependantIds.length,
 );
 
+// From the full id set, not the loaded window, and filtered by the "show excluded" toggle.
 export const $newIssueDependantsSelection = computed(
-    $newIssueDialog,
-    ({ dependantIds, requiredDependantIds, excludedDependantIds }) =>
-        calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds),
+    [$newIssueDialog, $showNewIssueExcludedDependants],
+    ({ dependantIds, requiredDependantIds, excludedDependantIds, appliedExcludedDependantIds }, showExcluded) =>
+        calcDependantsSelection(
+            filterShownDependantIds(dependantIds, appliedExcludedDependantIds, showExcluded),
+            requiredDependantIds,
+            excludedDependantIds,
+        ),
 );
 
 let instanceId = 0;
@@ -116,6 +132,7 @@ export const resetNewIssueDialogContext = (): void => {
     instanceId += 1;
     reloadDependenciesDebounced.cancel();
     $newIssueDialog.set(structuredClone(initialState));
+    $showNewIssueExcludedDependants.set(true);
 };
 
 export const openNewIssueDialog = (items?: ContentSummary[]): void => {
@@ -287,13 +304,18 @@ export const setNewIssueDependantIncluded = (id: ContentId, included: boolean): 
     }
 };
 
+export const toggleNewIssueShowExcludedDependants = (): void => {
+    $showNewIssueExcludedDependants.set(!$showNewIssueExcludedDependants.get());
+};
+
 export const toggleNewIssueDependantsSelection = (): void => {
-    const { dependantIds, requiredDependantIds, excludedDependantIds } = $newIssueDialog.get();
-    const selection = calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds);
+    // Read the computed: it defines the rows on screen, so a batch toggle skips hidden ones.
+    const selection = $newIssueDependantsSelection.get();
     if (selection.selectableIds.length === 0) {
         return;
     }
 
+    const { excludedDependantIds } = $newIssueDialog.get();
     $newIssueDialog.setKey('excludedDependantIds', nextDependantExclusions(selection, excludedDependantIds));
 };
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/ui/issue/IssueDialogDetailsContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/ui/issue/IssueDialogDetailsContent.tsx
@@ -28,7 +28,9 @@ import {
     $isIssueDialogDetailsSelectionSynced,
     $issueDialogDetails,
     $issueDialogDetailsDependantsSelection,
+    $issueDialogDetailsHasExcludedDependants,
     $issueDialogDetailsHasMoreDependants,
+    $showIssueDialogDetailsExcludedDependants,
     applyDraftIssueDialogDetailsSelection,
     cancelDraftIssueDialogDetailsSelection,
     loadIssueDialogItems,
@@ -40,6 +42,7 @@ import {
     setIssueDialogDetailsTab,
     submitIssueDialogComment,
     toggleIssueDialogDetailsDependantsSelection,
+    toggleIssueDialogDetailsShowExcludedDependants,
     updateIssueDialogAssignees,
     updateIssueDialogComment,
     updateIssueDialogExcludedDependants,
@@ -66,8 +69,9 @@ import {
     $totalPublishableItems,
 } from '../../../publish/model/publishDialog.store';
 import { useItemsWithUnpublishedChildren } from '../../../../entities/content';
+import { filterShownDependants } from '../../../../shared/lib/cms/content/dependantsSelection';
 import { createDebounce } from '../../../../shared/lib/timing/createDebounce';
-import { ContentRow, SplitList } from '../../../shared/lists';
+import { ContentRow, DependantsSeparator, SplitList } from '../../../shared/lists';
 import { EditableText } from '../../../../shared/ui/primitives/EditableText';
 import { AssigneeSelector } from '../../../shared/selectors/assignee/AssigneeSelector';
 import { useAssigneeSearch, useAssigneeSelection } from '../../../shared/selectors/assignee/hooks/useAssigneeSearch';
@@ -214,6 +218,8 @@ export const IssueDialogDetailsContent = (): ReactElement => {
     const isSelectionSynced = useStore($isIssueDialogDetailsSelectionSynced);
     const canPublish = useStore($canIssueDialogDetailsPublish);
     const hasMoreDependants = useStore($issueDialogDetailsHasMoreDependants);
+    const hasExcludedDependants = useStore($issueDialogDetailsHasExcludedDependants);
+    const showExcludedDependants = useStore($showIssueDialogDetailsExcludedDependants);
     const dependantsSelection = useStore($issueDialogDetailsDependantsSelection);
     const publishCount = useStore($totalPublishableItems);
     const isPublishReady = useStore($isPublishReady);
@@ -241,6 +247,7 @@ export const IssueDialogDetailsContent = (): ReactElement => {
     const assigneesLabel = useI18n('field.assignees');
     const titleLabel = `${useI18n('field.title')} *`;
     const dependenciesLabel = useI18n('dialog.dependencies');
+    const allExcludedMessage = useI18n('dialog.dependencies.allExcluded');
     const inviteUsersLabel = useI18n('dialog.issue.inviteUsers');
     const applyLabel = useI18n('action.apply');
     const publishLabelSingle = useI18n('action.publishNow');
@@ -385,6 +392,10 @@ export const IssueDialogDetailsContent = (): ReactElement => {
     const requiredDependantSet = useMemo(
         () => new Set(requiredDependantIds.map((id) => id.toString())),
         [requiredDependantIds],
+    );
+    const visibleDependants = useMemo(
+        () => filterShownDependants(dependants, appliedExcludedDependantIds, showExcludedDependants),
+        [appliedExcludedDependantIds, dependants, showExcludedDependants],
     );
     const itemsWithUnpublishedChildren = useItemsWithUnpublishedChildren(items);
 
@@ -881,11 +892,16 @@ export const IssueDialogDetailsContent = (): ReactElement => {
                                                 );
                                             }}
                                         />
-                                        <SplitList.Separator hidden={dependants.length === 0}>
-                                            <SplitList.SeparatorLabel>{dependenciesLabel}</SplitList.SeparatorLabel>
-                                        </SplitList.Separator>
+                                        <DependantsSeparator
+                                            label={dependenciesLabel}
+                                            hasExcluded={hasExcludedDependants && isSelectionSynced}
+                                            showExcluded={showExcludedDependants}
+                                            onToggleExcluded={toggleIssueDialogDetailsShowExcludedDependants}
+                                            hidden={visibleDependants.length === 0 && !hasExcludedDependants}
+                                            disabled={isItemsDisabled || itemsLoading}
+                                        />
 
-                                        {dependants.length > 0 && (
+                                        {(visibleDependants.length > 0 || hasExcludedDependants) && (
                                             <div>
                                                 {dependantsSelection.count > 0 && (
                                                     <DependantsSelectAll
@@ -896,8 +912,11 @@ export const IssueDialogDetailsContent = (): ReactElement => {
                                                 )}
 
                                                 <SplitList.Secondary
-                                                    items={dependants}
+                                                    items={visibleDependants}
                                                     getItemId={(item) => item.getId()}
+                                                    emptyMessage={
+                                                        hasExcludedDependants ? allExcludedMessage : undefined
+                                                    }
                                                     disabled={isItemsDisabled || itemsLoading}
                                                     loading={itemsLoading}
                                                     hasMore={hasMoreDependants}

--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/ui/new-issue/NewIssueDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/ui/new-issue/NewIssueDialogContent.tsx
@@ -12,6 +12,8 @@ import {
     $newIssueDialog,
     $newIssueDialogCreateCount,
     $newIssueDialogHasMoreDependants,
+    $newIssueHasExcludedDependants,
+    $showNewIssueExcludedDependants,
     addNewIssueItemsByIds,
     applyDraftNewIssueDialogSelection,
     cancelDraftNewIssueDialogSelection,
@@ -24,9 +26,11 @@ import {
     setNewIssueTitle,
     submitNewIssueDialog,
     toggleNewIssueDependantsSelection,
+    toggleNewIssueShowExcludedDependants,
 } from '../../model/newIssueDialog.store';
 import { useItemsWithUnpublishedChildren } from '../../../../entities/content';
-import { ContentRow, SplitList } from '../../../shared/lists';
+import { filterShownDependants } from '../../../../shared/lib/cms/content/dependantsSelection';
+import { ContentRow, DependantsSeparator, SplitList } from '../../../shared/lists';
 import { AssigneeSelector } from '../../../shared/selectors/assignee/AssigneeSelector';
 import { useAssigneeSearch, useAssigneeSelection } from '../../../shared/selectors/assignee/hooks/useAssigneeSearch';
 import { ContentCombobox } from '../../../shared/selectors/content';
@@ -46,6 +50,7 @@ export const NewIssueDialogContent = (): ReactElement => {
         dependants,
         excludedDependantIds,
         requiredDependantIds,
+        appliedExcludedDependantIds,
         loading,
         failed,
         submitting,
@@ -59,6 +64,7 @@ export const NewIssueDialogContent = (): ReactElement => {
             'dependants',
             'excludedDependantIds',
             'requiredDependantIds',
+            'appliedExcludedDependantIds',
             'loading',
             'failed',
             'submitting',
@@ -67,6 +73,8 @@ export const NewIssueDialogContent = (): ReactElement => {
 
     const createCount = useStore($newIssueDialogCreateCount);
     const hasMoreDependants = useStore($newIssueDialogHasMoreDependants);
+    const hasExcludedDependants = useStore($newIssueHasExcludedDependants);
+    const showExcludedDependants = useStore($showNewIssueExcludedDependants);
     const dependantsSelection = useStore($newIssueDependantsSelection);
     const isSelectionSynced = useStore($isNewIssueSelectionSynced);
 
@@ -75,6 +83,7 @@ export const NewIssueDialogContent = (): ReactElement => {
     const assigneesLabel = useI18n('field.assignees');
     const itemsLabel = useI18n('field.items');
     const dependenciesLabel = useI18n('dialog.dependencies');
+    const allExcludedMessage = useI18n('dialog.dependencies.allExcluded');
     const createLabel = useI18n('action.createIssue');
     const applyLabel = useI18n('action.apply');
     const dialogTitle = useI18n('text.newIssue');
@@ -93,6 +102,11 @@ export const NewIssueDialogContent = (): ReactElement => {
     const requiredDependantSet = useMemo(
         () => new Set(requiredDependantIds.map((id) => id.toString())),
         [requiredDependantIds],
+    );
+
+    const visibleDependants = useMemo(
+        () => filterShownDependants(dependants, appliedExcludedDependantIds, showExcludedDependants),
+        [appliedExcludedDependantIds, dependants, showExcludedDependants],
     );
 
     const { options: assigneeOptions, handleSearchChange } = useAssigneeSearch();
@@ -255,11 +269,16 @@ export const NewIssueDialogContent = (): ReactElement => {
                                     );
                                 }}
                             />
-                            <SplitList.Separator hidden={dependants.length === 0}>
-                                <SplitList.SeparatorLabel>{dependenciesLabel}</SplitList.SeparatorLabel>
-                            </SplitList.Separator>
+                            <DependantsSeparator
+                                label={dependenciesLabel}
+                                hasExcluded={hasExcludedDependants && isSelectionSynced}
+                                showExcluded={showExcludedDependants}
+                                onToggleExcluded={toggleNewIssueShowExcludedDependants}
+                                hidden={visibleDependants.length === 0 && !hasExcludedDependants}
+                                disabled={isItemsDisabled}
+                            />
 
-                            {dependants.length > 0 && (
+                            {(visibleDependants.length > 0 || hasExcludedDependants) && (
                                 <div>
                                     {dependantsSelection.count > 0 && (
                                         <DependantsSelectAll
@@ -270,8 +289,9 @@ export const NewIssueDialogContent = (): ReactElement => {
                                     )}
 
                                     <SplitList.Secondary
-                                        items={dependants}
+                                        items={visibleDependants}
                                         getItemId={(item) => item.getId()}
+                                        emptyMessage={hasExcludedDependants ? allExcludedMessage : undefined}
                                         disabled={isItemsDisabled}
                                         loading={loading}
                                         hasMore={hasMoreDependants}

--- a/modules/lib/src/main/resources/assets/js/v6/features/publish/ui/PublishDialogMainContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/publish/ui/PublishDialogMainContent.tsx
@@ -37,7 +37,7 @@ import {
     $showPublishDependantsExcluded,
     $totalPublishableItems,
 } from '../model/publishDialog.store';
-import { ContentRow, SplitList } from '../../shared/lists';
+import { ContentRow, DependantsSeparator, SplitList } from '../../shared/lists';
 import { DependantsSelectAll } from '../../../shared/ui/dialogs/dependants/DependantsSelectAll';
 import { SelectionStatusBar } from '../../../shared/ui/dialogs/status-bar/SelectionStatusBar';
 import { PublishDialogItemStatus } from './PublishDialogItemStatus';
@@ -87,9 +87,6 @@ export const PublishDialogMainContent = ({
         (item) => !item.hidden && (showExcluded || !item.excludedByDefault),
     );
     const hasVisibleDependantItems = visibleDependantItems.length > 0;
-    const showExcludedLabel = useI18n('dialog.publish.excluded.show');
-    const hideExcludedLabel = useI18n('dialog.publish.excluded.hide');
-    const toggleExcludedLabel = showExcluded ? hideExcludedLabel : showExcludedLabel;
 
     useEffect(() => {
         if (scheduleMode && !wasScheduleMode.current && scheduleKeyboardActivation.current) {
@@ -229,16 +226,14 @@ export const PublishDialogMainContent = ({
                             }}
                         />
 
-                        <SplitList.Separator hidden={!hasVisibleDependantItems && !hasExcludedItems}>
-                            <SplitList.SeparatorLabel>{separatorLabel}</SplitList.SeparatorLabel>
-                            {hasExcludedItems && isSelectionSynced && (
-                                <SplitList.SeparatorButton
-                                    label={toggleExcludedLabel}
-                                    onClick={togglePublishDialogShowExcluded}
-                                    disabled={loading}
-                                />
-                            )}
-                        </SplitList.Separator>
+                        <DependantsSeparator
+                            label={separatorLabel}
+                            hasExcluded={hasExcludedItems && isSelectionSynced}
+                            showExcluded={showExcluded}
+                            onToggleExcluded={togglePublishDialogShowExcluded}
+                            hidden={!hasVisibleDependantItems && !hasExcludedItems}
+                            disabled={loading}
+                        />
 
                         {(hasVisibleDependantItems || hasExcludedItems) && (
                             <div>

--- a/modules/lib/src/main/resources/assets/js/v6/features/request-publish/model/requestPublishDialog.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/request-publish/model/requestPublishDialog.service.ts
@@ -13,6 +13,8 @@ import {
 } from '../../../shared/socket/socket.store';
 import {
     $requestPublishDialog,
+    $requestPublishHasExcludedDependants,
+    $showRequestPublishExcludedDependants,
     hasOpenRequestPublishDialog,
     patchTrackedRequestPublishItems,
     queueRequestPublishSocketChanges,
@@ -106,6 +108,12 @@ export const start = (): void => {
     }
 
     unsubscribers = [
+        // Snap back to "show excluded" once nothing is excluded, so the toggle never lingers hidden.
+        $requestPublishHasExcludedDependants.subscribe((hasExcluded) => {
+            if (!hasExcluded) {
+                $showRequestPublishExcludedDependants.set(true);
+            }
+        }),
         $contentCreated.subscribe(
             onRequestPublishSocketEvent((event) => {
                 const mainItemIds = findContentIdsWithCreatedDescendants($requestPublishDialog.get().items, event.data);

--- a/modules/lib/src/main/resources/assets/js/v6/features/request-publish/model/requestPublishDialog.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/request-publish/model/requestPublishDialog.store.test.ts
@@ -17,8 +17,10 @@ import {
     $requestPublishDialog,
     $requestPublishDialogCreateCount,
     $requestPublishDialogErrors,
+    $requestPublishHasExcludedDependants,
     $requestPublishHasMoreDependants,
     $requestPublishPublishableCount,
+    $showRequestPublishExcludedDependants,
     applyDraftRequestPublishDialogSelection,
     cancelDraftRequestPublishDialogSelection,
     loadMoreRequestPublishDependants,
@@ -29,6 +31,7 @@ import {
     setRequestPublishItemIncludeChildren,
     submitRequestPublishDialog,
     toggleRequestPublishDependantsSelection,
+    toggleRequestPublishShowExcludedDependants,
 } from './requestPublishDialog.store';
 import {
     createDeferredPromise,
@@ -634,6 +637,79 @@ describe('requestPublishDialog.store', () => {
                 'item-2',
             ]);
             expect($isRequestPublishSelectionSynced.get()).toBe(false);
+        });
+    });
+
+    describe('excluded dependants visibility', () => {
+        async function excludeDep1AndApply(): Promise<void> {
+            await setupWithDependants();
+
+            setRequestPublishDependantIncluded(new ContentId('dep-1'), false);
+            applyDraftRequestPublishDialogSelection();
+            await flushRequestPublishReload();
+        }
+
+        it('should offer nothing to hide until an exclusion is applied', async () => {
+            await setupWithDependants();
+
+            expect($requestPublishHasExcludedDependants.get()).toBe(false);
+
+            setRequestPublishDependantIncluded(new ContentId('dep-1'), false);
+
+            expect($requestPublishHasExcludedDependants.get()).toBe(false);
+
+            applyDraftRequestPublishDialogSelection();
+            await flushRequestPublishReload();
+
+            expect($requestPublishHasExcludedDependants.get()).toBe(true);
+        });
+
+        it('should flip the toggle and restore it on reset', async () => {
+            await excludeDep1AndApply();
+            expect($showRequestPublishExcludedDependants.get()).toBe(true);
+
+            toggleRequestPublishShowExcludedDependants();
+            expect($showRequestPublishExcludedDependants.get()).toBe(false);
+
+            resetRequestPublishDialogContext();
+            expect($showRequestPublishExcludedDependants.get()).toBe(true);
+        });
+
+        it('should count only the shown dependants while excluded ones are hidden', async () => {
+            await excludeDep1AndApply();
+            expect($requestPublishDependantsSelection.get().count).toBe(2);
+
+            toggleRequestPublishShowExcludedDependants();
+
+            const selection = $requestPublishDependantsSelection.get();
+            expect(selection.count).toBe(1);
+            expect(selection.selectionType).toBe('all');
+            expect(selection.selectableIds.map((id) => id.toString())).toEqual(['dep-2']);
+        });
+
+        it('should keep a staged exclusion visible, hiding only the applied ones', async () => {
+            await excludeDep1AndApply();
+            toggleRequestPublishShowExcludedDependants();
+
+            setRequestPublishDependantIncluded(new ContentId('dep-2'), false);
+
+            // dep-2 is excluded in the draft only, so its row stays until Apply.
+            const selection = $requestPublishDependantsSelection.get();
+            expect(selection.count).toBe(1);
+            expect(selection.selectionType).toBe('none');
+        });
+
+        it('should snap back to shown once the last exclusion is re-included', async () => {
+            await excludeDep1AndApply();
+            toggleRequestPublishShowExcludedDependants();
+            expect($showRequestPublishExcludedDependants.get()).toBe(false);
+
+            setRequestPublishDependantIncluded(new ContentId('dep-1'), true);
+            applyDraftRequestPublishDialogSelection();
+            await flushRequestPublishReload();
+
+            expect($requestPublishHasExcludedDependants.get()).toBe(false);
+            expect($showRequestPublishExcludedDependants.get()).toBe(true);
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/features/request-publish/model/requestPublishDialog.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/request-publish/model/requestPublishDialog.store.ts
@@ -1,7 +1,7 @@
 import { showError, showFeedback, showSuccess, showWarning } from '@enonic/lib-admin-ui/notify/MessageBus';
 import { PrincipalKey } from '@enonic/lib-admin-ui/security/PrincipalKey';
 import { i18n } from '@enonic/lib-admin-ui/util/Messages';
-import { computed, map } from 'nanostores';
+import { atom, computed, map } from 'nanostores';
 import { type ContentId } from '../../../../app/content/ContentId';
 import type { ContentSummary } from '../../../../app/content/ContentSummary';
 import { IssueType } from '../../../../app/issue/IssueType';
@@ -20,6 +20,8 @@ import {
 import { resolveAppliedPublishDependencies } from '../../../entities/content/lib/publishDependencies';
 import {
     calcDependantsSelection,
+    filterShownDependantIds,
+    hasHideableExcludedDependants,
     nextDependantExclusions,
     pruneExcludedDependantIds,
 } from '../../../shared/lib/cms/content/dependantsSelection';
@@ -93,7 +95,16 @@ export const $requestPublishDialog = map<RequestPublishDialogStore>(structuredCl
 
 const $requestPublishChecks = map<RequestPublishChecksStore>(structuredClone(initialChecksState));
 
+// Whether applied dependant exclusions are shown in the list ("Show/Hide excluded" toggle).
+export const $showRequestPublishExcludedDependants = atom<boolean>(true);
+
 export const $isRequestPublishSelectionSynced = computed($requestPublishDialog, isDraftSelectionSynced);
+
+export const $requestPublishHasExcludedDependants = computed(
+    $requestPublishDialog,
+    ({ dependantIds, appliedExcludedDependantIds }) =>
+        hasHideableExcludedDependants(dependantIds, appliedExcludedDependantIds),
+);
 
 export const $requestPublishDialogCreateCount = computed(
     $requestPublishDialog,
@@ -108,10 +119,15 @@ export const $requestPublishHasMoreDependants = computed(
     ({ dependantIds, dependantWindow }) => dependantWindow < dependantIds.length,
 );
 
+// From the full id set, not the loaded window, and filtered by the "show excluded" toggle.
 export const $requestPublishDependantsSelection = computed(
-    $requestPublishDialog,
-    ({ dependantIds, requiredDependantIds, excludedDependantIds }) =>
-        calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds),
+    [$requestPublishDialog, $showRequestPublishExcludedDependants],
+    ({ dependantIds, requiredDependantIds, excludedDependantIds, appliedExcludedDependantIds }, showExcluded) =>
+        calcDependantsSelection(
+            filterShownDependantIds(dependantIds, appliedExcludedDependantIds, showExcluded),
+            requiredDependantIds,
+            excludedDependantIds,
+        ),
 );
 
 export const $requestPublishDialogErrors = computed(
@@ -289,6 +305,7 @@ export const resetRequestPublishDialogContext = (): void => {
     reloadDependenciesDebounced.cancel();
     clearQueuedRequestPublishSocketChanges();
     $requestPublishDialog.set(structuredClone(initialState));
+    $showRequestPublishExcludedDependants.set(true);
     resetChecksState();
 };
 
@@ -407,13 +424,18 @@ export const setRequestPublishDependantIncluded = (id: ContentId, included: bool
     }
 };
 
+export const toggleRequestPublishShowExcludedDependants = (): void => {
+    $showRequestPublishExcludedDependants.set(!$showRequestPublishExcludedDependants.get());
+};
+
 export const toggleRequestPublishDependantsSelection = (): void => {
-    const { dependantIds, requiredDependantIds, excludedDependantIds } = $requestPublishDialog.get();
-    const selection = calcDependantsSelection(dependantIds, requiredDependantIds, excludedDependantIds);
+    // Read the computed: it defines the rows on screen, so a batch toggle skips hidden ones.
+    const selection = $requestPublishDependantsSelection.get();
     if (selection.selectableIds.length === 0) {
         return;
     }
 
+    const { excludedDependantIds } = $requestPublishDialog.get();
     $requestPublishDialog.setKey('excludedDependantIds', nextDependantExclusions(selection, excludedDependantIds));
 };
 

--- a/modules/lib/src/main/resources/assets/js/v6/features/request-publish/ui/RequestPublishDialogContent.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/request-publish/ui/RequestPublishDialogContent.tsx
@@ -12,8 +12,10 @@ import {
     $requestPublishDialog,
     $requestPublishDialogCreateCount,
     $requestPublishDialogErrors,
+    $requestPublishHasExcludedDependants,
     $requestPublishHasMoreDependants,
     $requestPublishPublishableCount,
+    $showRequestPublishExcludedDependants,
     applyDraftRequestPublishDialogSelection,
     cancelDraftRequestPublishDialogSelection,
     excludeInProgressRequestPublishItems,
@@ -28,9 +30,11 @@ import {
     setRequestPublishTitle,
     submitRequestPublishDialog,
     toggleRequestPublishDependantsSelection,
+    toggleRequestPublishShowExcludedDependants,
 } from '../model/requestPublishDialog.store';
 import { useItemsWithUnpublishedChildren } from '../../../entities/content';
-import { ContentRow, SplitList } from '../../shared/lists';
+import { filterShownDependants } from '../../../shared/lib/cms/content/dependantsSelection';
+import { ContentRow, DependantsSeparator, SplitList } from '../../shared/lists';
 import { AssigneeSelector } from '../../shared/selectors/assignee/AssigneeSelector';
 import { useAssigneeSearch, useAssigneeSelection } from '../../shared/selectors/assignee/hooks/useAssigneeSearch';
 import { DependantsSelectAll } from '../../../shared/ui/dialogs/dependants/DependantsSelectAll';
@@ -49,6 +53,7 @@ export const RequestPublishDialogContent = (): ReactElement => {
         dependants,
         excludedDependantIds,
         requiredDependantIds,
+        appliedExcludedDependantIds,
         loading,
         failed,
         submitting,
@@ -62,6 +67,7 @@ export const RequestPublishDialogContent = (): ReactElement => {
             'dependants',
             'excludedDependantIds',
             'requiredDependantIds',
+            'appliedExcludedDependantIds',
             'loading',
             'failed',
             'submitting',
@@ -70,6 +76,8 @@ export const RequestPublishDialogContent = (): ReactElement => {
     const createCount = useStore($requestPublishDialogCreateCount);
     const publishableCount = useStore($requestPublishPublishableCount);
     const hasMoreDependants = useStore($requestPublishHasMoreDependants);
+    const hasExcludedDependants = useStore($requestPublishHasExcludedDependants);
+    const showExcludedDependants = useStore($showRequestPublishExcludedDependants);
     const dependantsSelection = useStore($requestPublishDependantsSelection);
     const isPublishReady = useStore($isRequestPublishReady);
     const isSelectionSynced = useStore($isRequestPublishSelectionSynced);
@@ -82,6 +90,7 @@ export const RequestPublishDialogContent = (): ReactElement => {
     const assigneesLabel = useI18n('dialog.requestPublish.assignees');
     const itemsLabel = useI18n('field.items');
     const dependenciesLabel = useI18n('dialog.dependencies');
+    const allExcludedMessage = useI18n('dialog.dependencies.allExcluded');
     const createLabel = useI18n('action.createRequest');
     const applyLabel = useI18n('action.apply');
     const noResultsLabel = useI18n('dialog.search.result.noResults');
@@ -100,6 +109,11 @@ export const RequestPublishDialogContent = (): ReactElement => {
     const requiredDependantSet = useMemo(
         () => new Set(requiredDependantIds.map((id) => id.toString())),
         [requiredDependantIds],
+    );
+
+    const visibleDependants = useMemo(
+        () => filterShownDependants(dependants, appliedExcludedDependantIds, showExcludedDependants),
+        [appliedExcludedDependantIds, dependants, showExcludedDependants],
     );
 
     const { options: assigneeOptions, handleSearchChange } = useAssigneeSearch();
@@ -254,11 +268,16 @@ export const RequestPublishDialogContent = (): ReactElement => {
                                 }}
                             />
                         </div>
-                        <SplitList.Separator hidden={dependants.length === 0}>
-                            <SplitList.SeparatorLabel>{dependenciesLabel}</SplitList.SeparatorLabel>
-                        </SplitList.Separator>
+                        <DependantsSeparator
+                            label={dependenciesLabel}
+                            hasExcluded={hasExcludedDependants && isSelectionSynced}
+                            showExcluded={showExcludedDependants}
+                            onToggleExcluded={toggleRequestPublishShowExcludedDependants}
+                            hidden={visibleDependants.length === 0 && !hasExcludedDependants}
+                            disabled={isItemsDisabled}
+                        />
 
-                        {dependants.length > 0 && (
+                        {(visibleDependants.length > 0 || hasExcludedDependants) && (
                             <div>
                                 {dependantsSelection.count > 0 && (
                                     <DependantsSelectAll
@@ -269,8 +288,9 @@ export const RequestPublishDialogContent = (): ReactElement => {
                                 )}
 
                                 <SplitList.Secondary
-                                    items={dependants}
+                                    items={visibleDependants}
                                     getItemId={(item) => item.getId()}
+                                    emptyMessage={hasExcludedDependants ? allExcludedMessage : undefined}
                                     disabled={isItemsDisabled}
                                     loading={loading}
                                     hasMore={hasMoreDependants}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/dependants-separator/DependantsSeparator.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/dependants-separator/DependantsSeparator.tsx
@@ -1,0 +1,40 @@
+import { type ReactElement } from 'react';
+import { useI18n } from '../../../../shared/lib/hooks/useI18n';
+import { SplitList } from '../split-list';
+
+const DEPENDANTS_SEPARATOR_NAME = 'DependantsSeparator';
+
+export type DependantsSeparatorProps = {
+    label: string;
+    /** Something is applied-excluded, so the "Show/Hide excluded" toggle is offered. */
+    hasExcluded: boolean;
+    showExcluded: boolean;
+    onToggleExcluded: () => void;
+    hidden?: boolean;
+    disabled?: boolean;
+};
+
+/** DEPENDENCIES header with the "Show/Hide excluded" toggle, shared by the four publish dialogs. */
+export const DependantsSeparator = ({
+    label,
+    hasExcluded,
+    showExcluded,
+    onToggleExcluded,
+    hidden = false,
+    disabled = false,
+}: DependantsSeparatorProps): ReactElement => {
+    const showExcludedLabel = useI18n('dialog.publish.excluded.show');
+    const hideExcludedLabel = useI18n('dialog.publish.excluded.hide');
+    const toggleExcludedLabel = showExcluded ? hideExcludedLabel : showExcludedLabel;
+
+    return (
+        <SplitList.Separator hidden={hidden}>
+            <SplitList.SeparatorLabel>{label}</SplitList.SeparatorLabel>
+            {hasExcluded && (
+                <SplitList.SeparatorButton label={toggleExcludedLabel} onClick={onToggleExcluded} disabled={disabled} />
+            )}
+        </SplitList.Separator>
+    );
+};
+
+DependantsSeparator.displayName = DEPENDANTS_SEPARATOR_NAME;

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/dependants-separator/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/dependants-separator/index.ts
@@ -1,0 +1,2 @@
+export { DependantsSeparator } from './DependantsSeparator';
+export type { DependantsSeparatorProps } from './DependantsSeparator';

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/index.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/index.ts
@@ -6,8 +6,10 @@ export {
     type ContentRowStatusProps,
     type ContentRowCellProps,
 } from './content-row';
-export {SplitList} from './split-list';
-export {virtuosoComponents} from './virtuoso-components';
+export { DependantsSeparator } from './dependants-separator';
+export type { DependantsSeparatorProps } from './dependants-separator';
+export { SplitList } from './split-list';
+export { virtuosoComponents } from './virtuoso-components';
 export type {
     SplitListPrimaryProps,
     SplitListProps,

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/split-list/SplitList.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/lists/split-list/SplitList.tsx
@@ -140,13 +140,17 @@ function SplitListSecondary<T>({
         if (!emptyMessage) {
             return null;
         }
+        // Sentinel also here: with every loaded item filtered out, lazy-loading would stall.
         return (
-            <div
-                data-component={SPLIT_LIST_SECONDARY_NAME}
-                className={cn('py-2 text-sm text-subtle italic', className)}
-            >
-                {emptyMessage}
-            </div>
+            <>
+                <div
+                    data-component={SPLIT_LIST_SECONDARY_NAME}
+                    className={cn('py-2 text-sm text-subtle italic', className)}
+                >
+                    {emptyMessage}
+                </div>
+                {hasMore && <div ref={sentinelRef} aria-hidden className="h-px w-full" />}
+            </>
         );
     }
 

--- a/modules/lib/src/main/resources/assets/js/v6/shared/lib/cms/content/dependantsSelection.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/lib/cms/content/dependantsSelection.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { ContentId } from '../../../../../app/content/ContentId';
-import { calcDependantsSelection, nextDependantExclusions, pruneExcludedDependantIds } from './dependantsSelection';
+import {
+    calcDependantsSelection,
+    filterShownDependantIds,
+    filterShownDependants,
+    hasHideableExcludedDependants,
+    nextDependantExclusions,
+    pruneExcludedDependantIds,
+} from './dependantsSelection';
 
 const id = (value: string): ContentId => new ContentId(value);
 const ids = (...values: string[]): ContentId[] => values.map(id);
@@ -123,6 +130,56 @@ describe('dependantsSelection', () => {
             const next = pruneExcludedDependantIds(ids('c', 'a', 'b'), ids('a', 'b', 'c'), []);
 
             expect(next.map((item) => item.toString())).toEqual(['c', 'a', 'b']);
+        });
+    });
+
+    describe('hasHideableExcludedDependants', () => {
+        it('reports nothing to hide when no dependant is excluded', () => {
+            expect(hasHideableExcludedDependants(ids('a', 'b'), [])).toBe(false);
+        });
+
+        it('reports something to hide when a dependant is excluded', () => {
+            expect(hasHideableExcludedDependants(ids('a', 'b'), ids('b'))).toBe(true);
+        });
+
+        it('ignores exclusions that are no longer in the dependant list', () => {
+            expect(hasHideableExcludedDependants(ids('a', 'b'), ids('gone'))).toBe(false);
+        });
+    });
+
+    describe('filterShownDependantIds', () => {
+        it('returns the same array reference when excluded dependants are shown', () => {
+            const dependantIds = ids('a', 'b');
+
+            expect(filterShownDependantIds(dependantIds, ids('b'), true)).toBe(dependantIds);
+        });
+
+        it('drops the excluded dependants when they are hidden', () => {
+            const next = filterShownDependantIds(ids('a', 'b', 'c'), ids('b'), false);
+
+            expect(toStrings(next)).toEqual(['a', 'c']);
+        });
+
+        it('keeps every dependant when nothing is excluded', () => {
+            const next = filterShownDependantIds(ids('a', 'b'), [], false);
+
+            expect(toStrings(next)).toEqual(['a', 'b']);
+        });
+    });
+
+    describe('filterShownDependants', () => {
+        const summary = (value: string): { getContentId: () => ContentId } => ({ getContentId: () => id(value) });
+
+        it('returns the same array reference when excluded dependants are shown', () => {
+            const dependants = [summary('a'), summary('b')];
+
+            expect(filterShownDependants(dependants, ids('b'), true)).toBe(dependants);
+        });
+
+        it('drops the excluded dependants when they are hidden', () => {
+            const next = filterShownDependants([summary('a'), summary('b')], ids('b'), false);
+
+            expect(next.map((item) => item.getContentId().toString())).toEqual(['a']);
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/shared/lib/cms/content/dependantsSelection.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/lib/cms/content/dependantsSelection.ts
@@ -1,5 +1,5 @@
 import { type ContentId } from '../../../../../app/content/ContentId';
-import { hasContentIdInIds, uniqueIds } from './ids';
+import { hasContentIdInIds, type HasContentId, uniqueIds } from './ids';
 
 // Tri-state of a dependants list's batch "select all" checkbox (legacy `SelectionType`).
 export type DependantsSelectionType = 'all' | 'none' | 'partial';
@@ -60,6 +60,39 @@ export const pruneExcludedDependantIds = (
     requiredIds: readonly ContentId[],
 ): ContentId[] => {
     return excludedIds.filter((id) => hasContentIdInIds(id, shownIds) && !hasContentIdInIds(id, requiredIds));
+};
+
+/** True when at least one dependant is applied-excluded, so the toggle has something to hide. */
+export const hasHideableExcludedDependants = (
+    dependantIds: readonly ContentId[],
+    appliedExcludedIds: readonly ContentId[],
+): boolean => {
+    return dependantIds.some((id) => hasContentIdInIds(id, appliedExcludedIds));
+};
+
+/**
+ * The dependant ids left in the list while "Hide excluded" is active. Keyed on the applied
+ * exclusions, never the draft: a staged exclusion must not hide a row while Apply is still up.
+ */
+export const filterShownDependantIds = (
+    dependantIds: ContentId[],
+    appliedExcludedIds: readonly ContentId[],
+    showExcluded: boolean,
+): ContentId[] => {
+    if (showExcluded) return dependantIds;
+
+    return dependantIds.filter((id) => !hasContentIdInIds(id, appliedExcludedIds));
+};
+
+/** {@link filterShownDependantIds} for the loaded summary window. */
+export const filterShownDependants = <T extends HasContentId>(
+    dependants: T[],
+    appliedExcludedIds: readonly ContentId[],
+    showExcluded: boolean,
+): T[] => {
+    if (showExcluded) return dependants;
+
+    return dependants.filter((item) => !hasContentIdInIds(item.getContentId(), appliedExcludedIds));
 };
 
 const calcSelectionType = (

--- a/modules/lib/src/main/resources/assets/js/v6/shared/lib/cms/content/ids.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/lib/cms/content/ids.ts
@@ -1,6 +1,6 @@
 import { ContentId } from '../../../../../app/content/ContentId';
 
-type HasContentId = {
+export type HasContentId = {
     getContentId(): ContentId;
 };
 

--- a/testing/page_objects/issue/dependant.controls.js
+++ b/testing/page_objects/issue/dependant.controls.js
@@ -3,10 +3,9 @@
  */
 const Page = require('../page');
 const appConst = require('../../libs/app_const');
-const {COMMON, DIALOG_ITEMS, SELECTION_STATUS_BAR} = require('./../../libs/elements');
+const { BUTTONS, DIALOG_ITEMS, SELECTION_STATUS_BAR } = require('./../../libs/elements');
 
 class DependantsControls extends Page {
-
     constructor(container) {
         super();
         this.container = container;
@@ -20,12 +19,13 @@ class DependantsControls extends Page {
         return this.container + SELECTION_STATUS_BAR.BUTTON_CANCEL;
     }
 
+    // The toggle sits in the 'Dependencies' separator row, not inside the dependants list.
     get showExcludedItemsButton() {
-        return this.container + DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV + COMMON.togglerButton('Show excluded');
+        return this.container + BUTTONS.buttonByLabel('Show excluded');
     }
 
     get hideExcludedItemsButton() {
-        return this.container + DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV + COMMON.togglerButton('Hide excluded');
+        return this.container + BUTTONS.buttonByLabel('Hide excluded');
     }
 
     get dependantsBlock() {
@@ -60,18 +60,24 @@ class DependantsControls extends Page {
 
     async waitForAllDependantsCheckboxDisabled() {
         let selector = this.allDependantsCheckboxInput;
-        await this.getBrowser().waitUntil(async () => {
-            let ariaDisabled = await this.getAttribute(selector, 'aria-disabled');
-            return ariaDisabled === 'true';
-        }, {timeout: appConst.shortTimeout, timeoutMsg: "'All' checkbox should be disabled"});
+        await this.getBrowser().waitUntil(
+            async () => {
+                let ariaDisabled = await this.getAttribute(selector, 'aria-disabled');
+                return ariaDisabled === 'true';
+            },
+            { timeout: appConst.shortTimeout, timeoutMsg: "'All' checkbox should be disabled" },
+        );
     }
 
     async waitForAllDependantsCheckboxEnabled() {
         let selector = this.allDependantsCheckboxInput;
-        await this.getBrowser().waitUntil(async () => {
-            let ariaDisabled = await this.getAttribute(selector, 'aria-disabled');
-            return ariaDisabled === 'false';
-        }, {timeout: appConst.shortTimeout, timeoutMsg: "'All' checkbox should be enabled"});
+        await this.getBrowser().waitUntil(
+            async () => {
+                let ariaDisabled = await this.getAttribute(selector, 'aria-disabled');
+                return ariaDisabled === 'false';
+            },
+            { timeout: appConst.shortTimeout, timeoutMsg: "'All' checkbox should be enabled" },
+        );
     }
 
     async getNumberInAllCheckbox() {
@@ -99,7 +105,9 @@ class DependantsControls extends Page {
             return await this.waitForElementDisplayed(this.applySelectionButton, appConst.mediumTimeout);
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_apply_btn');
-            throw new Error(`Dependants block - 'Apply selection' button is not displayed, screenshot: ${screenshot} ` + err);
+            throw new Error(
+                `Dependants block - 'Apply selection' button is not displayed, screenshot: ${screenshot} ` + err,
+            );
         }
     }
 
@@ -137,7 +145,11 @@ class DependantsControls extends Page {
         try {
             return await this.waitForElementNotDisplayed(this.showExcludedItemsButton, appConst.mediumTimeout);
         } catch (err) {
-            await this.handleError(`Dependants block, 'Show excluded items' button should not be visible!`, `err_show_excluded`, err);
+            await this.handleError(
+                `Dependants block, 'Show excluded items' button should not be visible!`,
+                `err_show_excluded`,
+                err,
+            );
         }
     }
 
@@ -145,7 +157,11 @@ class DependantsControls extends Page {
         try {
             return await this.waitForElementDisplayed(this.showExcludedItemsButton, appConst.mediumTimeout);
         } catch (err) {
-            await this.handleError(`Dependants block, 'Show excluded items' button should be visible!`, `err_show_excluded_btn`, err);
+            await this.handleError(
+                `Dependants block, 'Show excluded items' button should be visible!`,
+                `err_show_excluded_btn`,
+                err,
+            );
         }
     }
 
@@ -156,7 +172,12 @@ class DependantsControls extends Page {
             await this.pause(900);
         } catch (err) {
             let screenshot = await this.saveScreenshotUniqueName('err_show_excluded_btn');
-            throw new Error('Dependants block, Error during clicking on Show Excluded button, screenshot  ' + screenshot + ' ' + err);
+            throw new Error(
+                'Dependants block, Error during clicking on Show Excluded button, screenshot  ' +
+                    screenshot +
+                    ' ' +
+                    err,
+            );
         }
     }
 
@@ -166,7 +187,11 @@ class DependantsControls extends Page {
             await this.clickOnElement(this.hideExcludedItemsButton);
             return await this.pause(1000);
         } catch (err) {
-            await this.handleError(`Dependants block, Error during clicking on Hide Excluded button`, `err_hide_excluded_btn`, err);
+            await this.handleError(
+                `Dependants block, Error during clicking on Hide Excluded button`,
+                `err_hide_excluded_btn`,
+                err,
+            );
         }
     }
 
@@ -174,7 +199,11 @@ class DependantsControls extends Page {
         try {
             return this.waitForElementDisplayed(this.hideExcludedItemsButton, appConst.mediumTimeout);
         } catch (err) {
-            await this.handleError(`Dependants block, 'Hide excluded items' button should be displayed!`, `err_hide_excluded_btn`, err);
+            await this.handleError(
+                `Dependants block, 'Hide excluded items' button should be displayed!`,
+                `err_hide_excluded_btn`,
+                err,
+            );
         }
     }
 
@@ -182,12 +211,20 @@ class DependantsControls extends Page {
         try {
             return this.waitForElementNotDisplayed(this.hideExcludedItemsButton, appConst.mediumTimeout);
         } catch (err) {
-            await this.handleError(`Dependants block, 'Hide excluded items' button should be hidden!`, `err_hide_excluded_btn`, err);
+            await this.handleError(
+                `Dependants block, 'Hide excluded items' button should be hidden!`,
+                `err_hide_excluded_btn`,
+                err,
+            );
         }
     }
 
     async getDisplayNameInDependentItems() {
-        let locator = this.container + DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV + DIALOG_ITEMS.CONTENT_ROW + DIALOG_ITEMS.ITEMS_NAME_SPAN;
+        let locator =
+            this.container +
+            DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV +
+            DIALOG_ITEMS.CONTENT_ROW +
+            DIALOG_ITEMS.ITEMS_NAME_SPAN;
         await this.waitForElementDisplayed(locator);
         return await this.getTextInDisplayedElements(locator);
     }
@@ -196,10 +233,13 @@ class DependantsControls extends Page {
     async waitForDependantItemsDisabled() {
         try {
             let gridLocator = this.container + DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV;
-            await this.getBrowser().waitUntil(async () => {
-                let ariaDisabled = await this.getAttribute(gridLocator, 'aria-disabled');
-                return ariaDisabled === 'true';
-            }, {timeout: appConst.shortTimeout, timeoutMsg: 'Dependants block should be disabled'});
+            await this.getBrowser().waitUntil(
+                async () => {
+                    let ariaDisabled = await this.getAttribute(gridLocator, 'aria-disabled');
+                    return ariaDisabled === 'true';
+                },
+                { timeout: appConst.shortTimeout, timeoutMsg: 'Dependants block should be disabled' },
+            );
         } catch (err) {
             await this.handleError('Dependants block should be disabled', 'err_dependants_disabled', err);
         }
@@ -207,25 +247,34 @@ class DependantsControls extends Page {
 
     // returns display names of the disabled dependant items - rows with aria-disabled='true' (e.g. in the closed issue):
     async getDisplayNameInDisabledDependantItems() {
-        let locator = this.container + DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV + DIALOG_ITEMS.CONTENT_ROW_DISABLED +
-                      DIALOG_ITEMS.ITEMS_NAME_SPAN;
+        let locator =
+            this.container +
+            DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV +
+            DIALOG_ITEMS.CONTENT_ROW_DISABLED +
+            DIALOG_ITEMS.ITEMS_NAME_SPAN;
         await this.waitForElementDisplayed(locator);
         return await this.getTextInDisplayedElements(locator);
     }
 
     async isDependantCheckboxSelected(name) {
         try {
-
             let checkBoxInputLocator = this.container + DIALOG_ITEMS.contentCheckboxInputByName(name);
             await this.waitForElementDisplayed(this.container + DIALOG_ITEMS.contentCheckboxLabelByName(name));
             return await this.isSelected(checkBoxInputLocator);
         } catch (err) {
-            await this.handleError(`Dependants block, is checkbox selected for item ${name}`, `err_checkbox_selected`, err);
+            await this.handleError(
+                `Dependants block, is checkbox selected for item ${name}`,
+                `err_checkbox_selected`,
+                err,
+            );
         }
     }
 
     async clickOnCheckboxInDependentItem(displayName) {
-        let selector = this.container + DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV + DIALOG_ITEMS.contentCheckboxLabelByName(displayName);
+        let selector =
+            this.container +
+            DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV +
+            DIALOG_ITEMS.contentCheckboxLabelByName(displayName);
         await this.waitForElementDisplayed(selector, appConst.shortTimeout);
         await this.clickOnElement(selector);
         return await this.pause(400);
@@ -238,18 +287,25 @@ class DependantsControls extends Page {
 
     async isDependantCheckboxEnabled(name) {
         try {
-            let checkBoxLabelLocator = this.container + DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV +
-                                       DIALOG_ITEMS.contentCheckboxLabelByName(name);
-            let checkBoxInputLocator = this.container + DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV +
-                                       DIALOG_ITEMS.contentCheckboxInputByName(name);
+            let checkBoxLabelLocator =
+                this.container +
+                DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV +
+                DIALOG_ITEMS.contentCheckboxLabelByName(name);
+            let checkBoxInputLocator =
+                this.container +
+                DIALOG_ITEMS.SECONDARY_DATA_COMPONENT_DIV +
+                DIALOG_ITEMS.contentCheckboxInputByName(name);
             await this.waitForElementDisplayed(checkBoxLabelLocator, appConst.mediumTimeout);
             let ariaDisabled = await this.getAttribute(checkBoxInputLocator, 'aria-disabled');
             return ariaDisabled !== 'true';
         } catch (err) {
-            await this.handleError(`Dependants block, is checkbox enabled for item ${name}`, 'err_checkbox_enabled', err);
+            await this.handleError(
+                `Dependants block, is checkbox enabled for item ${name}`,
+                'err_checkbox_enabled',
+                err,
+            );
         }
     }
 }
 
 module.exports = DependantsControls;
-


### PR DESCRIPTION
- Added the "Show/Hide excluded" toggle next to the DEPENDENCIES header in the three dialogs that lacked it, matching the Publish wizard.
- Extracted the header + toggle into one shared DependantsSeparator component, now used by all four dialogs.
- Each dialog tracks whether excluded dependants are visible, hides them from the list when toggled off, shows "All dependencies are excluded and hidden." when that empties the list, and snaps back to "shown" once nothing is excluded.
- Hiding is keyed on applied exclusions only, so a pending (unapplied) change never makes a row disappear mid-edit.
- The "All (n)" checkbox now counts and toggles only the rows actually on screen.
- Fixed a lazy-loading stall: with everything filtered out, the list stopped loading more items (this also affected the Publish wizard).
- Updated the e2e page object to find the toggle in its new position, plus new unit tests for all of the above.