### PR TITLE
Handle duplicated content wherever created content is handled #11266

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/entities/content/model/content.service.ts
@@ -81,6 +81,7 @@ export const start = (): void => {
         $contentDuplicated.subscribe((event) => {
             if (event?.data) {
                 setContents(event.data);
+                markParentsWithChildren(event.data);
             }
         }),
         // $contentMoved is the only event for cross-parent moves; delete/create are not emitted.

--- a/modules/lib/src/main/resources/assets/js/v6/features/delete/model/deleteDialog.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/delete/model/deleteDialog.service.ts
@@ -9,7 +9,9 @@ import {
     $contentArchived,
     $contentCreated,
     $contentDeleted,
+    $contentDuplicated,
     $contentUpdated,
+    type ContentEvent,
 } from '../../../shared/socket/socket.store';
 import { resolveForDelete } from '../api/delete.api';
 import {
@@ -183,6 +185,13 @@ const isDialogActive = (): boolean => {
     return open && !submitting && items.length > 0;
 };
 
+const handleCreatedContent = (event: ContentEvent | null): void => {
+    if (!event || !isDialogActive()) return;
+
+    // New content could be a child of items being deleted
+    reloadDeleteDialogDataDebounced();
+};
+
 //
 // * Service Lifecycle
 //
@@ -204,12 +213,8 @@ export const start = (): void => {
             void reloadDeleteDialogData();
         }),
         // Handle content created: reload dependencies as new content might be a child or dependency
-        $contentCreated.subscribe((event) => {
-            if (!event || !isDialogActive()) return;
-
-            // New content could be a child of items being deleted
-            reloadDeleteDialogDataDebounced();
-        }),
+        $contentCreated.subscribe(handleCreatedContent),
+        $contentDuplicated.subscribe(handleCreatedContent),
         // Handle content updates: patch main items, reload if dependants affected
         $contentUpdated.subscribe((event) => {
             if (!event || !isDialogActive()) return;

--- a/modules/lib/src/main/resources/assets/js/v6/features/duplicate/model/duplicateDialog.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/duplicate/model/duplicateDialog.service.ts
@@ -7,7 +7,9 @@ import {
     $contentArchived,
     $contentCreated,
     $contentDeleted,
+    $contentDuplicated,
     $contentUpdated,
+    type ContentEvent,
 } from '../../../shared/socket/socket.store';
 import { getDescendantsOfContents } from '../api/duplicate.api';
 import { $duplicateDialog, resetDuplicateDialogContext } from './duplicateDialog.store';
@@ -95,6 +97,13 @@ const isDialogActive = (): boolean => {
     return open && items.length > 0;
 };
 
+const handleCreatedContent = (event: ContentEvent | null): void => {
+    if (!event || !isDialogActive()) {
+        return;
+    }
+    reloadDuplicateDialogDataDebounced();
+};
+
 /** Remove items by IDs from both main items and dependant items */
 const removeItemsByIds = (ids: Set<string>): { removedMain: boolean; removedDependant: boolean } => {
     const { items, dependants } = $duplicateDialog.get();
@@ -176,12 +185,8 @@ export const start = (): void => {
             }
         }),
         // Handle content created: reload dependencies as new content might be a child
-        $contentCreated.subscribe((event) => {
-            if (!event || !isDialogActive()) {
-                return;
-            }
-            reloadDuplicateDialogDataDebounced();
-        }),
+        $contentCreated.subscribe(handleCreatedContent),
+        $contentDuplicated.subscribe(handleCreatedContent),
         // Handle content updates: patch main items, reload if dependants affected
         $contentUpdated.subscribe((event) => {
             if (!event || !isDialogActive()) {

--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/model/issueDialogDetails.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/model/issueDialogDetails.service.ts
@@ -18,9 +18,11 @@ import {
     $contentArchived,
     $contentCreated,
     $contentDeleted,
+    $contentDuplicated,
     $contentPublished,
     $contentRenamed,
     $contentUpdated,
+    type ContentEvent,
 } from '../../../shared/socket/socket.store';
 import { fetchIssue } from '../../../entities/issue/api/issues.api';
 import { $issueDialog, closeIssueDialog } from './issueDialog.store';
@@ -216,6 +218,14 @@ const reloadIssueDialogItemsForCurrentIssue = (): void => {
     void loadIssueDialogItems(issue, { forceReload: true });
 };
 
+const handleCreatedContent = (event: ContentEvent): void => {
+    const matched = findContentIdsWithCreatedDescendants($issueDialogDetails.get().items, event.data);
+    if (matched.length === 0) {
+        return;
+    }
+    reloadIssueDialogItemsForCurrentIssue();
+};
+
 const handleIssueDialogDetailsIssueChanged = (issueIds: string[], event: IssueServerEvent): void => {
     const currentIssueId = getCurrentIssueDialogIssueId();
     if (!currentIssueId || !isCurrentIssueDialogServerEvent(issueIds)) {
@@ -251,15 +261,8 @@ export const start = (): void => {
     }
 
     unsubscribers = [
-        $contentCreated.subscribe(
-            onIssueDialogDetailsSocketEvent((event) => {
-                const matched = findContentIdsWithCreatedDescendants($issueDialogDetails.get().items, event.data);
-                if (matched.length === 0) {
-                    return;
-                }
-                reloadIssueDialogItemsForCurrentIssue();
-            }),
-        ),
+        $contentCreated.subscribe(onIssueDialogDetailsSocketEvent(handleCreatedContent)),
+        $contentDuplicated.subscribe(onIssueDialogDetailsSocketEvent(handleCreatedContent)),
         $contentUpdated.subscribe(
             onIssueDialogDetailsSocketEvent((event) => {
                 const { updatedMain, updatedDependants } = patchTrackedIssueDialogItems(event.data);

--- a/modules/lib/src/main/resources/assets/js/v6/features/issues/model/newIssueDialog.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/issues/model/newIssueDialog.service.ts
@@ -14,9 +14,11 @@ import {
     $contentArchived,
     $contentCreated,
     $contentDeleted,
+    $contentDuplicated,
     $contentPublished,
     $contentRenamed,
     $contentUpdated,
+    type ContentEvent,
 } from '../../../shared/socket/socket.store';
 import {
     $newIssueDialog,
@@ -108,6 +110,17 @@ const refreshNewIssueMainItems = async (ids: ContentId[]): Promise<void> => {
     }
 };
 
+const handleCreatedContent = (event: ContentEvent): void => {
+    const matched = findContentIdsWithCreatedDescendants($newIssueDialog.get().items, event.data);
+    if (matched.length === 0) {
+        return;
+    }
+
+    void refreshNewIssueMainItems(matched).finally(() => {
+        reloadDependenciesDebounced();
+    });
+};
+
 //
 // * Service Lifecycle
 //
@@ -128,18 +141,8 @@ export const start = (): void => {
                 $showNewIssueExcludedDependants.set(true);
             }
         }),
-        $contentCreated.subscribe(
-            onNewIssueSocketEvent((event) => {
-                const matched = findContentIdsWithCreatedDescendants($newIssueDialog.get().items, event.data);
-                if (matched.length === 0) {
-                    return;
-                }
-
-                void refreshNewIssueMainItems(matched).finally(() => {
-                    reloadDependenciesDebounced();
-                });
-            }),
-        ),
+        $contentCreated.subscribe(onNewIssueSocketEvent(handleCreatedContent)),
+        $contentDuplicated.subscribe(onNewIssueSocketEvent(handleCreatedContent)),
         $contentUpdated.subscribe(
             onNewIssueSocketEvent((event) => {
                 const { updatedMain, updatedDependants } = patchTrackedNewIssueItems(event.data);

--- a/modules/lib/src/main/resources/assets/js/v6/features/publish/model/publishDialog.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/publish/model/publishDialog.service.ts
@@ -13,9 +13,11 @@ import {
     $contentArchived,
     $contentCreated,
     $contentDeleted,
+    $contentDuplicated,
     $contentPublished,
     $contentRenamed,
     $contentUpdated,
+    type ContentEvent,
 } from '../../../shared/socket/socket.store';
 import {
     flagPublishExclusionsReset,
@@ -152,6 +154,15 @@ const refreshPublishDialogMainItems = async (ids: ContentId[]): Promise<void> =>
     }
 };
 
+const handleCreatedContent = (event: ContentEvent): void => {
+    const mainItemIds = findContentIdsWithCreatedDescendants($publishDialog.get().items, event.data);
+    if (mainItemIds.length === 0) return;
+
+    void refreshPublishDialogMainItems(mainItemIds).finally(() => {
+        reloadPublishDialogDataDebounced();
+    });
+};
+
 //
 // * Service Lifecycle
 //
@@ -211,16 +222,8 @@ export const start = (): void => {
             }
         }),
         // Handle content created: reload dependencies as new content might be a child or dependency
-        $contentCreated.subscribe(
-            onPublishSocketEvent((event) => {
-                const mainItemIds = findContentIdsWithCreatedDescendants($publishDialog.get().items, event.data);
-                if (mainItemIds.length === 0) return;
-
-                void refreshPublishDialogMainItems(mainItemIds).finally(() => {
-                    reloadPublishDialogDataDebounced();
-                });
-            }),
-        ),
+        $contentCreated.subscribe(onPublishSocketEvent(handleCreatedContent)),
+        $contentDuplicated.subscribe(onPublishSocketEvent(handleCreatedContent)),
         // Handle content updates: patch visible items and reload checks if tracked content changed
         $contentUpdated.subscribe(
             onPublishSocketEvent((event) => {

--- a/modules/lib/src/main/resources/assets/js/v6/features/request-publish/model/requestPublishDialog.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/request-publish/model/requestPublishDialog.service.ts
@@ -7,9 +7,11 @@ import {
     $contentArchived,
     $contentCreated,
     $contentDeleted,
+    $contentDuplicated,
     $contentPublished,
     $contentRenamed,
     $contentUpdated,
+    type ContentEvent,
 } from '../../../shared/socket/socket.store';
 import {
     $requestPublishDialog,
@@ -81,6 +83,17 @@ const refreshRequestPublishMainItems = async (ids: ContentId[]): Promise<void> =
     }
 };
 
+const handleCreatedContent = (event: ContentEvent): void => {
+    const mainItemIds = findContentIdsWithCreatedDescendants($requestPublishDialog.get().items, event.data);
+    if (mainItemIds.length === 0) {
+        return;
+    }
+
+    void refreshRequestPublishMainItems(mainItemIds).finally(() => {
+        reloadDependenciesDebounced();
+    });
+};
+
 const handleRemovedRequestPublishItems = (idsToRemove: Set<string>): void => {
     const { removedMain, removedDependants } = removeTrackedRequestPublishItems(idsToRemove);
 
@@ -114,18 +127,8 @@ export const start = (): void => {
                 $showRequestPublishExcludedDependants.set(true);
             }
         }),
-        $contentCreated.subscribe(
-            onRequestPublishSocketEvent((event) => {
-                const mainItemIds = findContentIdsWithCreatedDescendants($requestPublishDialog.get().items, event.data);
-                if (mainItemIds.length === 0) {
-                    return;
-                }
-
-                void refreshRequestPublishMainItems(mainItemIds).finally(() => {
-                    reloadDependenciesDebounced();
-                });
-            }),
-        ),
+        $contentCreated.subscribe(onRequestPublishSocketEvent(handleCreatedContent)),
+        $contentDuplicated.subscribe(onRequestPublishSocketEvent(handleCreatedContent)),
         $contentUpdated.subscribe(
             onRequestPublishSocketEvent((event) => {
                 const { updatedMain, updatedDependants } = patchTrackedRequestPublishItems(event.data);

--- a/modules/lib/src/main/resources/assets/js/v6/features/unpublish/model/unpublishDialog.service.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/unpublish/model/unpublishDialog.service.ts
@@ -8,8 +8,10 @@ import {
     $contentArchived,
     $contentCreated,
     $contentDeleted,
+    $contentDuplicated,
     $contentUnpublished,
     $contentUpdated,
+    type ContentEvent,
 } from '../../../shared/socket/socket.store';
 import { resolveUnpublish } from '../api/unpublish.api';
 import {
@@ -187,6 +189,13 @@ const isDialogActive = (): boolean => {
     return open && items.length > 0 && !$unpublishDialogPending.get().submitting;
 };
 
+const handleCreatedContent = (event: ContentEvent | null): void => {
+    if (!event || !isDialogActive()) {
+        return;
+    }
+    reloadUnpublishDialogDataDebounced();
+};
+
 //
 // * Completion handling
 //
@@ -232,12 +241,8 @@ export const start = (): void => {
             }
             void reloadUnpublishDialogData();
         }),
-        $contentCreated.subscribe((event) => {
-            if (!event || !isDialogActive()) {
-                return;
-            }
-            reloadUnpublishDialogDataDebounced();
-        }),
+        $contentCreated.subscribe(handleCreatedContent),
+        $contentDuplicated.subscribe(handleCreatedContent),
         $contentUpdated.subscribe((event) => {
             if (!event || !isDialogActive()) {
                 return;


### PR DESCRIPTION
XP now reports a whole duplicated subtree in a single `node.duplicated` event instead of `node.duplicated` for the copy and `node.created` for each descendant (enonic/xp#12261, enonic/xp#12262), so handlers that only listened to the created event stopped seeing duplicates.

The seven dialog services that reload their dependants when new content appears — publish, request-publish, unpublish, delete, duplicate, new-issue and issue-details — now subscribe to `$contentDuplicated` alongside `$contentCreated`. Each shared callback was extracted into a named `handleCreatedContent` so both subscriptions run identical logic.

`content.service`'s `$contentDuplicated` handler also gained the `markParentsWithChildren` bookkeeping its `$contentCreated` handler already performed, so a cached parent whose `hasChildren` is `false` is corrected when content is duplicated into it.

No change was needed in `content-fetcher`, `filter-tree.store`, `useContentComboboxData`, `duplicateDialog.store` or the legacy browse panel — they already handle multi-node duplicated payloads.

Verified with `pnpm -C ./modules/lib run check` (types, lint, boundaries clean) and `test:run` (1685 tests passing).

Closes #11266

[Claude Code session](https://claude.ai/code/session_017cKmPRVUyVbKcZDho2MDtX)

<sub>*Drafted with AI assistance*</sub>
