### PR TITLE
Resolve the listener default that two interfaces now declare

### DIFF
--- a/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/archive/ArchiveContentProgressListener.java
+++ b/modules/app/src/main/java/com/enonic/app/contentstudio/rest/resource/archive/ArchiveContentProgressListener.java
@@ -37,7 +37,7 @@ public final class ArchiveContentProgressListener
     }
 
     @Override
-    public void contentResolved( final int count )
+    public void resolved( final int count )
     {
         // Total spans both the unpublish and archive phases and is set via setTotal
     }


### PR DESCRIPTION
`ArchiveContentProgressListener` implements **both** `ArchiveContentListener` and `PushContentListener`, and XP 8.1 (enonic/xp#12281) gives each of them a `default void resolved( int )`. A class that inherits the same default from two unrelated interfaces does not compile:

```
error: types ArchiveContentListener and PushContentListener are incompatible;
  class ArchiveContentProgressListener inherits unrelated defaults for resolved(int)
  from types ArchiveContentListener and PushContentListener
```

Java requires such a class to say which one it means. This one means neither: the total spans the unpublish phase *and* the archive phase, and `ArchiveRunnableTask` sets it through `setTotal( idsToUnpublish.size() + allIds.getSize() )`. That is exactly what the deliberately empty `contentResolved` override already said — so it is now the equally empty `resolved` override:

```java
 @Override
-public void contentResolved( final int count )
+public void resolved( final int count )
 {
     // Total spans both the unpublish and archive phases and is set via setTotal
 }
```

One line, and it does two things: it settles the conflict, and it moves the class off a name XP has deprecated. Dropping the `contentResolved` override changes nothing at runtime — producers call `resolved`, `PushContentListener.resolved` only reaches `contentResolved` through its own default, and this class no longer takes that default.

No other class in the app implements more than one XP listener, so this is the only site affected.

## Verification

The published `8.1.0-SNAPSHOT` in my environment still predates the API change, so I compiled the file directly against `core-api` built from enonic/xp#12281:

- the current `master` version fails with exactly the error above;
- this version compiles clean (the two remaining warnings are the pre-existing deprecated `ProgressReporter.progress(int,int)` calls, which every progress listener in the app uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PT3t5hDXj91Sk6idKRQwBs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PT3t5hDXj91Sk6idKRQwBs)_