### PR TITLE
Add mobile navigation drawer to browse view #11325

### DIFF
--- a/modules/app/src/main/resources/assets/js/main.ts
+++ b/modules/app/src/main/resources/assets/js/main.ts
@@ -56,6 +56,7 @@ import { ContentAppHelper } from '@enonic/lib-contentstudio/app/wizard/ContentAp
 import { ContentWizardPanelParams } from '@enonic/lib-contentstudio/app/wizard/ContentWizardPanelParams';
 import { AppElement } from '@enonic/lib-contentstudio/v6/app/App';
 import { initAiHost } from '@enonic/lib-contentstudio/v6/features/ai';
+import { $isBrowseSidebarOpen } from '@enonic/lib-contentstudio/v6/pages/browse/model/browseSidebar.store';
 import { initConfig } from '@enonic/lib-contentstudio/v6/shared/config/config.store';
 import { initLanguages } from '@enonic/lib-contentstudio/v6/entities/language/languages.store';
 import { initPrincipals } from '@enonic/lib-contentstudio/v6/entities/principal/principals.store';
@@ -474,6 +475,9 @@ function appendMenuPanel(): void {
         throw new Error('Menu URL is not defined');
     }
     const menuElement = CustomElement.create('xp-menu');
+    $isBrowseSidebarOpen.subscribe((isOpen) => {
+        menuElement.inert = isOpen;
+    });
     document.body.appendChild(menuElement);
     fetch(menuUrl)
         .then((response) => response.text())

--- a/modules/lib/src/main/resources/assets/js/app/AppWrapper.ts
+++ b/modules/lib/src/main/resources/assets/js/app/AppWrapper.ts
@@ -18,6 +18,7 @@ import {
 import { $noProjectMode } from '../v6/entities/project/projects.store';
 import { BrowseAppBarElement } from '../v6/pages/browse/BrowseAppBar';
 import { BrowseSidebarElement } from '../v6/pages/browse/BrowseSidebar';
+import { $isBrowseSidebarOpen } from '../v6/pages/browse/model/browseSidebar.store';
 import { ContentAppContainer } from './ContentAppContainer';
 import { Router } from './Router';
 import { UrlAction } from './UrlAction';
@@ -86,6 +87,10 @@ export class AppWrapper extends DivEl {
                 this.setNoProjectMode(value);
             }
         });
+
+        $isBrowseSidebarOpen.subscribe((isOpen) => {
+            this.extensionsBlock.getHTMLElement().inert = isOpen;
+        });
     }
 
     private createStudioWidgetEl(): Element {
@@ -114,16 +119,6 @@ export class AppWrapper extends DivEl {
         } else {
             this.fetchAndAppendWidget(extension);
         }
-
-        const isProjectSelectorShown: boolean = extension.getConfig().getProperty('context') === 'project';
-
-        if (isProjectSelectorShown) {
-            this.appBar.showProjectSelector();
-        } else {
-            this.appBar.hideProjectSelector();
-        }
-
-        this.appBar.setAppName(extension.getDisplayName());
     }
 
     private updateUrl(extension: Readonly<Extension>): void {

--- a/modules/lib/src/main/resources/assets/js/v6/pages/browse/BrowseAppBar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/browse/BrowseAppBar.tsx
@@ -1,21 +1,27 @@
 import { Store } from '@enonic/lib-admin-ui/store/Store';
-import { Button } from '@enonic/ui';
-import { atom } from 'nanostores';
+import { Button, cn, Toggle } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
-import { ArrowLeftRight, BellDotIcon, BellIcon } from 'lucide-react';
+import { ArrowLeftRight, BellDotIcon, BellIcon, Menu, X } from 'lucide-react';
+import { computed } from 'nanostores';
 import type { ReactElement } from 'react';
 import { ShowIssuesDialogEvent } from '../../../app/browse/ShowIssuesDialogEvent';
+import { useBreakpoints } from '../../shared/lib/hooks/useBreakpoints';
 import { useI18n } from '../../shared/lib/hooks/useI18n';
-import {$activeProjectName, $hasMultipleProjects, $noProjectMode} from '../../entities/project';
+import { $activeProjectName, $hasMultipleProjects, $noProjectMode } from '../../entities/project';
 import { setProjectSelectionDialogOpen } from '../../shared/dialogs/dialogs.store';
 import { $issuesStats } from '../../entities/issue';
 import { $activeWidget, isMainWidget } from '../../widgets/context-panel/model/sidebarWidgets.store';
 import type { IssueStatsJson } from '../../../app/issue/json/IssueStatsJson';
 import { LegacyElement } from '../../shared/ui/LegacyElement';
 import { ThemeSwitcher } from '../../features/shared/ThemeSwitcher';
+import { BROWSE_SIDEBAR_ID, BROWSE_SIDEBAR_TOGGLE_ID } from './browseSidebar.constants';
+import { $isBrowseSidebarOpen, setBrowseSidebarOpen } from './model/browseSidebar.store';
 
-const $isProjectSelectorVisible = atom<boolean>(true);
-const $appName = atom<string>('');
+const $widgetState = computed($activeWidget, (activeWidget) => ({
+    appName: activeWidget?.getDisplayName() ?? '',
+    isIssuesButtonVisible: isMainWidget(activeWidget),
+    isProjectSelectorVisible: activeWidget == null || activeWidget.getConfig().getProperty('context') === 'project',
+}));
 
 function createIssuesLabelKeys(stats: Readonly<IssueStatsJson> | undefined): [`field.${string}`, ...string[]] {
     if (stats?.openAssignedToMe > 0) {
@@ -30,49 +36,77 @@ function createIssuesLabelKeys(stats: Readonly<IssueStatsJson> | undefined): [`f
 }
 
 export const BrowseAppBar = (): ReactElement => {
+    const isSidebarOpen = useStore($isBrowseSidebarOpen);
+    const { sm } = useBreakpoints();
     const activeProjectName = useStore($activeProjectName);
     const noProjectMode = useStore($noProjectMode);
     const hasMultipleProjects = useStore($hasMultipleProjects);
-    const isProjectSelectorVisible = useStore($isProjectSelectorVisible);
-    const activeWidget = useStore($activeWidget);
-    const isIssuesButtonVisible = isMainWidget(activeWidget);
-    const appName = useStore($appName);
+    const { appName, isIssuesButtonVisible, isProjectSelectorVisible } = useStore($widgetState);
     const { stats } = useStore($issuesStats);
     const applicationName = Store.instance().get('application').getName();
     const issuesStatsLabel = useI18n(...createIssuesLabelKeys(stats));
     const projectAriaLabel = useI18n('wcag.appbar.project.label');
     const issuesAriaLabel = useI18n('wcag.appbar.issues.label');
+    const sidebarLabel = useI18n(isSidebarOpen ? 'tooltip.sidebar.close' : 'tooltip.sidebar.open');
+    const isMobileSidebarOpen = !sm && isSidebarOpen;
 
     return (
-        <header className="bg-surface-neutral h-15 px-5 py-2 pr-24 flex items-center gap-2.5 border-b border-bdr-soft">
-            {!noProjectMode && isProjectSelectorVisible ? (
-                <Button
-                    className="mr-auto disabled:opacity-100"
-                    size="sm"
-                    endIcon={hasMultipleProjects ? ArrowLeftRight : undefined}
-                    onClick={() => setProjectSelectionDialogOpen(true)}
-                    aria-label={hasMultipleProjects ? projectAriaLabel : undefined}
-                    label={activeProjectName}
-                    disabled={!hasMultipleProjects}
-                />
-            ) : (
-                <h1 className="mr-auto text-2xl font-semibold">{appName || applicationName}</h1>
-            )}
+        <header className="bg-surface-neutral h-15 px-3.5 sm:pl-5 py-2 pr-24 flex items-center gap-2.5 border-b border-bdr-soft">
+            <Toggle
+                id={BROWSE_SIDEBAR_TOGGLE_ID}
+                className={cn('relative z-20 size-9 shrink-0 p-0 sm:hidden', !hasMultipleProjects && 'max-sm:mr-auto')}
+                size="md"
+                aria-label={sidebarLabel}
+                aria-controls={BROWSE_SIDEBAR_ID}
+                aria-expanded={isSidebarOpen}
+                pressed={isSidebarOpen}
+                onPressedChange={setBrowseSidebarOpen}
+            >
+                <span className="relative size-5" aria-hidden="true">
+                    {isSidebarOpen ? (
+                        <X className="absolute inset-0 size-5" />
+                    ) : (
+                        <Menu className="absolute inset-0 size-5" />
+                    )}
+                </span>
+            </Toggle>
 
-            {!noProjectMode && isIssuesButtonVisible && (
-                <Button
-                    className="max-sm:hidden"
-                    size="sm"
-                    startIcon={stats?.open > 0 ? BellDotIcon : BellIcon}
-                    onClick={() => {
-                        new ShowIssuesDialogEvent().fire();
-                    }}
-                    aria-label={issuesAriaLabel}
-                    label={issuesStatsLabel}
-                />
-            )}
+            <div className="contents" inert={isMobileSidebarOpen} aria-hidden={isMobileSidebarOpen || undefined}>
+                {!noProjectMode && isProjectSelectorVisible ? (
+                    <Button
+                        className={cn('mr-auto min-w-0 disabled:opacity-100', !hasMultipleProjects && 'max-sm:hidden')}
+                        size="sm"
+                        endIcon={hasMultipleProjects ? ArrowLeftRight : undefined}
+                        endIconClassName="shrink-0 size-3.5"
+                        onClick={() => setProjectSelectionDialogOpen(true)}
+                        aria-label={hasMultipleProjects ? projectAriaLabel : undefined}
+                        disabled={!hasMultipleProjects}
+                    >
+                        <span title={activeProjectName} className="block min-w-0 truncate">
+                            {activeProjectName}
+                        </span>
+                    </Button>
+                ) : (
+                    <h1 title={appName || applicationName} className="mr-auto min-w-0 truncate text-2xl font-semibold">
+                        {appName || applicationName}
+                    </h1>
+                )}
 
-            {!noProjectMode && <ThemeSwitcher />}
+                {!noProjectMode && isIssuesButtonVisible && (
+                    <Button
+                        className="max-sm:hidden"
+                        size="sm"
+                        startIcon={stats?.open > 0 ? BellDotIcon : BellIcon}
+                        onClick={() => {
+                            new ShowIssuesDialogEvent().fire();
+                        }}
+                        aria-label={issuesAriaLabel}
+                        label={issuesStatsLabel}
+                    />
+                )}
+
+                {!noProjectMode && <ThemeSwitcher />}
+            </div>
         </header>
     );
 };
@@ -83,8 +117,6 @@ export class BrowseAppBarElement extends LegacyElement<typeof BrowseAppBar> {
     constructor() {
         super({}, BrowseAppBar);
     }
-
-    // Backwards compatibility - will be removed after implementing the proper stores for projects & issues
 
     static getInstance(): BrowseAppBarElement {
         let instance: BrowseAppBarElement = Store.instance().get(BrowseAppBarElement.name);
@@ -97,17 +129,5 @@ export class BrowseAppBarElement extends LegacyElement<typeof BrowseAppBar> {
         return instance;
     }
 
-    setAppName(name: string) {
-        $appName.set(name);
-    }
-
     disable() {}
-
-    showProjectSelector() {
-        $isProjectSelectorVisible.set(true);
-    }
-
-    hideProjectSelector() {
-        $isProjectSelectorVisible.set(false);
-    }
 }

--- a/modules/lib/src/main/resources/assets/js/v6/pages/browse/BrowseSidebar.test.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/browse/BrowseSidebar.test.tsx
@@ -1,0 +1,139 @@
+import { act, fireEvent, render, screen } from '@testing-library/preact';
+import { type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { $isBrowseSidebarOpen, setBrowseSidebarOpen } from './model/browseSidebar.store';
+
+const mocks = vi.hoisted(() => ({
+    sm: false,
+    setActiveWidget: vi.fn(),
+    widgets: [] as ReadonlyArray<{
+        getDescriptorKey: () => { toString: () => string };
+        getDisplayName: () => string;
+        getIconUrl: () => string | undefined;
+        getFullIconUrl: () => string | undefined;
+    }>,
+}));
+
+vi.mock('@enonic/lib-admin-ui/store/Store', () => ({
+    Store: {
+        instance: () => ({
+            get: () => ({ getName: () => 'Content Studio' }),
+        }),
+    },
+}));
+
+vi.mock('@enonic/ui', () => ({
+    cn: (...classes: unknown[]) => classes.filter(Boolean).join(' '),
+    Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@nanostores/preact', () => ({
+    useStore: (store: { get: () => unknown }) => store.get(),
+}));
+
+vi.mock('lucide-react', () => ({
+    Pen: () => null,
+    Settings: () => null,
+}));
+
+vi.mock('../../shared/lib/hooks/useBreakpoints', () => ({
+    useBreakpoints: () => ({ sm: mocks.sm }),
+}));
+
+vi.mock('../../shared/lib/hooks/useI18n', () => ({
+    useI18n: (key: string) => key,
+}));
+
+vi.mock('../../shared/ui/icons/DefaultProjectIcon', () => ({
+    DefaultProjectIcon: () => <span />,
+}));
+
+vi.mock('../../shared/ui/icons/ProjectIcon', () => ({
+    ProjectIcon: () => <span />,
+}));
+
+vi.mock('../../shared/ui/LegacyElement', () => ({
+    LegacyElement: class {},
+}));
+
+vi.mock('../../shared/ui/WidgetButton', () => ({
+    WidgetButton: ({ label, onClick }: { label: string; onClick?: () => void }) => (
+        <button type="button" onClick={onClick}>
+            {label}
+        </button>
+    ),
+}));
+
+vi.mock('../../entities/project', () => ({
+    $activeProject: { get: () => undefined },
+    $noProjectMode: { get: () => false },
+}));
+
+vi.mock('../../shared/config', () => ({
+    $config: { get: () => ({ appVersion: '6.1.0-SNAPSHOT' }) },
+}));
+
+vi.mock('../../widgets/context-panel/model/sidebarWidgets.store', () => ({
+    $sidebarWidgets: { get: () => ({ widgets: mocks.widgets, activeWidgetId: undefined }) },
+    getSettingsWidget: (widgets: typeof mocks.widgets) =>
+        widgets.find((widget) => widget.getDescriptorKey().toString().endsWith(':settings')),
+    getWidgetKey: (widget?: (typeof mocks.widgets)[number]) => widget?.getDescriptorKey().toString(),
+    isMainWidget: (widget: (typeof mocks.widgets)[number]) => widget.getDescriptorKey().toString().endsWith(':main'),
+    isSettingsWidget: (widget: (typeof mocks.widgets)[number]) =>
+        widget.getDescriptorKey().toString().endsWith(':settings'),
+    setActiveWidget: mocks.setActiveWidget,
+}));
+
+import { BrowseSidebar } from './BrowseSidebar';
+
+function createWidget(key: string, label: string): (typeof mocks.widgets)[number] {
+    return {
+        getDescriptorKey: () => ({ toString: () => key }),
+        getDisplayName: () => label,
+        getIconUrl: () => undefined,
+        getFullIconUrl: () => undefined,
+    };
+}
+
+describe('BrowseSidebar', () => {
+    beforeEach(() => {
+        mocks.sm = false;
+        mocks.setActiveWidget.mockClear();
+        mocks.widgets = [createWidget('studio:main', 'Content'), createWidget('studio:settings', 'Settings')];
+        setBrowseSidebarOpen(false);
+    });
+
+    it('closes after selecting main or footer widget', () => {
+        setBrowseSidebarOpen(true);
+        const { rerender } = render(<BrowseSidebar />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Content' }));
+        expect(mocks.setActiveWidget).toHaveBeenCalledWith(mocks.widgets[0]);
+        expect($isBrowseSidebarOpen.get()).toBe(false);
+
+        setBrowseSidebarOpen(true);
+        rerender(<BrowseSidebar />);
+        fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+        expect(mocks.setActiveWidget).toHaveBeenCalledWith(mocks.widgets[1]);
+        expect($isBrowseSidebarOpen.get()).toBe(false);
+    });
+
+    it('resets open state after crossing to desktop breakpoint', () => {
+        setBrowseSidebarOpen(true);
+        const { rerender } = render(<BrowseSidebar />);
+
+        mocks.sm = true;
+        act(() => rerender(<BrowseSidebar />));
+
+        expect($isBrowseSidebarOpen.get()).toBe(false);
+    });
+
+    it('uses dialog backdrop styling', () => {
+        setBrowseSidebarOpen(true);
+        render(<BrowseSidebar />);
+
+        const backdrop = document.querySelector('.bg-overlay');
+        expect(backdrop).not.toBeNull();
+        expect(backdrop?.classList.contains('backdrop-blur-xs')).toBe(true);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/pages/browse/BrowseSidebar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/browse/BrowseSidebar.tsx
@@ -1,9 +1,10 @@
 import type { Extension } from '@enonic/lib-admin-ui/extension/Extension';
 import { Store } from '@enonic/lib-admin-ui/store/Store';
-import { Tooltip } from '@enonic/ui';
+import { cn, Tooltip } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
 import { type LucideIcon, Pen, Settings } from 'lucide-react';
-import { type ReactElement, useCallback } from 'react';
+import { type ReactElement, useCallback, useEffect } from 'react';
+import { useBreakpoints } from '../../shared/lib/hooks/useBreakpoints';
 import { useI18n } from '../../shared/lib/hooks/useI18n';
 import { DefaultProjectIcon } from '../../shared/ui/icons/DefaultProjectIcon';
 import { ProjectIcon } from '../../shared/ui/icons/ProjectIcon';
@@ -11,6 +12,8 @@ import { LegacyElement } from '../../shared/ui/LegacyElement';
 import { WidgetButton } from '../../shared/ui/WidgetButton';
 import { $activeProject, $noProjectMode } from '../../entities/project';
 import { $config } from '../../shared/config';
+import { BROWSE_SIDEBAR_ID, BROWSE_SIDEBAR_TOGGLE_ID } from './browseSidebar.constants';
+import { $isBrowseSidebarOpen, setBrowseSidebarOpen } from './model/browseSidebar.store';
 import {
     $sidebarWidgets,
     getSettingsWidget,
@@ -21,8 +24,12 @@ import {
 } from '../../widgets/context-panel/model/sidebarWidgets.store';
 
 function getWidgetIcon(widget: Readonly<Extension>): LucideIcon | undefined {
-    if (isMainWidget(widget)) return Pen;
-    if (isSettingsWidget(widget)) return Settings;
+    if (isMainWidget(widget)) {
+        return Pen;
+    }
+    if (isSettingsWidget(widget)) {
+        return Settings;
+    }
     return undefined;
 }
 
@@ -31,15 +38,25 @@ function stripVersionSuffix(version: string): string {
 }
 
 export const BrowseSidebar = (): ReactElement => {
+    const isOpen = useStore($isBrowseSidebarOpen);
+    const { sm } = useBreakpoints();
     const activeProject = useStore($activeProject);
     const noProjectMode = useStore($noProjectMode);
     const { widgets, activeWidgetId } = useStore($sidebarWidgets);
     const config = useStore($config, { keys: ['appVersion'] });
-    const name = Store.instance().get('application').getName();
+    const applicationName = Store.instance().get('application').getName();
     const version = `v${stripVersionSuffix(config.appVersion)}`;
     const settingsWidget = getSettingsWidget(widgets);
     const mainWidgets = noProjectMode ? [] : widgets.slice(0, -1);
     const footerWidget = noProjectMode ? settingsWidget : widgets.at(-1);
+    const footerWidgetButtonId = footerWidget ? `browse-sidebar-widget-${getWidgetKey(footerWidget)}` : undefined;
+    const sidebarLabel = useI18n('wcag.sidebar.label');
+    const isMobileSidebarClosed = !sm && !isOpen;
+
+    const closeSidebar = useCallback((): void => {
+        setBrowseSidebarOpen(false);
+        document.getElementById(BROWSE_SIDEBAR_TOGGLE_ID)?.focus();
+    }, []);
 
     const isWidgetActive = useCallback(
         (widget: Readonly<Extension> | undefined) => {
@@ -48,62 +65,133 @@ export const BrowseSidebar = (): ReactElement => {
         [activeWidgetId],
     );
 
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const closeOnEscape = (event: KeyboardEvent): void => {
+            if (event.key === 'Escape') {
+                closeSidebar();
+            }
+        };
+
+        window.addEventListener('keydown', closeOnEscape);
+        return () => window.removeEventListener('keydown', closeOnEscape);
+    }, [closeSidebar, isOpen]);
+
+    useEffect(() => {
+        if (sm && isOpen) {
+            setBrowseSidebarOpen(false);
+        }
+    }, [isOpen, sm]);
+
     return (
-        <nav
-            class="bg-surface-neutral absolute h-dvh w-15 flex flex-col gap-10 items-center py-2.5 px-1.75 border-r border-t-0 border-bdr-soft"
-            aria-label={useI18n('wcag.sidebar.label')}
-        >
-            {noProjectMode ? (
-                <DefaultProjectIcon className="size-8 flex-shrink-0 my-1.75 ml-0" />
-            ) : (
-                <ProjectIcon
-                    projectName={activeProject?.getName()}
-                    language={activeProject?.getLanguage()}
-                    hasIcon={!!activeProject?.getIcon()}
-                    iconHash={activeProject?.getIcon()?.getSha512()}
-                    className="flex-shrink-0 my-1.75 ml-0"
+        <>
+            {isOpen && !sm && (
+                <div
+                    className="fixed inset-0 z-10 bg-overlay backdrop-blur-xs"
+                    aria-hidden="true"
+                    onPointerDown={closeSidebar}
                 />
             )}
-            <h1 title={name} class="[writing-mode:vertical-lr] text-nowrap text-base font-semibold">
-                {name}
-            </h1>
-            <div class="flex flex-col justify-between h-full">
-                {/* Widgets */}
-                <div className="flex flex-col gap-2 items-center">
-                    {mainWidgets.map((widget) => (
-                        <WidgetButton
-                            key={widget.getDescriptorKey()}
-                            label={widget.getDisplayName()}
-                            icon={getWidgetIcon(widget)}
-                            active={isWidgetActive(widget)}
-                            iconUrl={widget.getIconUrl() && widget.getFullIconUrl()}
-                            onClick={() => {
-                                setActiveWidget(widget);
-                            }}
-                        />
-                    ))}
-                </div>
-                {/* Footer */}
-                <div className="flex flex-col gap-1">
-                    {footerWidget && (
-                        <WidgetButton
-                            label={footerWidget.getDisplayName()}
-                            active={isWidgetActive(footerWidget)}
-                            icon={getWidgetIcon(footerWidget)}
-                            iconUrl={footerWidget.getIconUrl() && footerWidget.getFullIconUrl()}
-                            onClick={() => {
-                                setActiveWidget(footerWidget);
-                            }}
+            <nav
+                id={BROWSE_SIDEBAR_ID}
+                className={cn(
+                    'bg-surface-neutral absolute z-20 flex h-dvh w-64 flex-col items-start gap-5 border-r border-t-0 border-bdr-soft px-3.5 py-1.75',
+                    'sm:z-auto sm:w-15 sm:translate-x-0 sm:items-center sm:gap-10 sm:px-1.75 sm:py-2.5 sm:pointer-events-auto',
+                    isOpen ? 'translate-x-0' : '-translate-x-full pointer-events-none',
+                )}
+                aria-label={sidebarLabel}
+                aria-hidden={isMobileSidebarClosed || undefined}
+                inert={isMobileSidebarClosed}
+            >
+                <div className="flex h-11 w-full shrink-0 items-center justify-end sm:contents">
+                    {noProjectMode ? (
+                        <DefaultProjectIcon className="size-7.5 sm:size-8 flex-shrink-0 sm:my-1.75 sm:ml-0" />
+                    ) : (
+                        <ProjectIcon
+                            projectName={activeProject?.getName()}
+                            language={activeProject?.getLanguage()}
+                            hasIcon={!!activeProject?.getIcon()}
+                            iconHash={activeProject?.getIcon()?.getSha512()}
+                            className="max-sm:size-7.5 flex-shrink-0 sm:my-1.75 sm:ml-0"
                         />
                     )}
-                    <Tooltip delay={300} value={version} side="right">
-                        <p class="text-xs text-subtle text-center overflow-hidden text-nowrap max-w-[40px] text-ellipsis">
-                            {version}
-                        </p>
-                    </Tooltip>
                 </div>
-            </div>
-        </nav>
+                <h1
+                    title={applicationName}
+                    className="my-1.5 max-w-full overflow-hidden text-ellipsis text-right text-nowrap text-base font-semibold sm:my-0 sm:ml-0 sm:max-w-none sm:overflow-visible sm:text-left sm:text-clip sm:[writing-mode:vertical-lr]"
+                >
+                    {applicationName}
+                </h1>
+                <div className="flex h-full w-full max-w-full flex-col justify-between sm:w-auto">
+                    {/* Widgets */}
+                    <div className="flex flex-col items-start gap-5 sm:items-center sm:gap-2">
+                        {mainWidgets.map((widget) => {
+                            const widgetKey = getWidgetKey(widget);
+                            const widgetButtonId = `browse-sidebar-widget-${widgetKey}`;
+
+                            return (
+                                <div key={widgetKey} className="flex w-full items-center gap-1.5 sm:block sm:w-auto">
+                                    <WidgetButton
+                                        id={widgetButtonId}
+                                        label={widget.getDisplayName()}
+                                        icon={getWidgetIcon(widget)}
+                                        active={isWidgetActive(widget)}
+                                        iconUrl={widget.getIconUrl() && widget.getFullIconUrl()}
+                                        tooltipClassName="max-sm:hidden"
+                                        onClick={() => {
+                                            setActiveWidget(widget);
+                                            closeSidebar();
+                                        }}
+                                    />
+                                    <label
+                                        htmlFor={widgetButtonId}
+                                        className="block min-w-0 flex-1 truncate cursor-pointer sm:hidden"
+                                    >
+                                        {widget.getDisplayName()}
+                                    </label>
+                                </div>
+                            );
+                        })}
+                    </div>
+                    {/* Footer */}
+                    <div className="flex gap-1 max-sm:items-end max-sm:justify-between sm:flex-col">
+                        {footerWidget && (
+                            <div className="flex min-w-0 items-center gap-1.5 sm:block sm:w-auto">
+                                <WidgetButton
+                                    id={footerWidgetButtonId}
+                                    label={footerWidget.getDisplayName()}
+                                    active={isWidgetActive(footerWidget)}
+                                    icon={getWidgetIcon(footerWidget)}
+                                    iconUrl={footerWidget.getIconUrl() && footerWidget.getFullIconUrl()}
+                                    onClick={() => {
+                                        setActiveWidget(footerWidget);
+                                        closeSidebar();
+                                    }}
+                                    tooltipClassName="max-sm:hidden"
+                                />
+                                <label
+                                    htmlFor={footerWidgetButtonId}
+                                    className="block min-w-0 flex-1 truncate cursor-pointer sm:hidden"
+                                >
+                                    {footerWidget.getDisplayName()}
+                                </label>
+                            </div>
+                        )}
+                        <Tooltip delay={300} value={version} side="right" className="max-sm:hidden">
+                            <p
+                                aria-label={version}
+                                className="max-w-[40px] overflow-hidden text-center text-xs text-nowrap text-ellipsis text-subtle max-sm:ml-auto"
+                            >
+                                {version}
+                            </p>
+                        </Tooltip>
+                    </div>
+                </div>
+            </nav>
+        </>
     );
 };
 

--- a/modules/lib/src/main/resources/assets/js/v6/pages/browse/browseSidebar.constants.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/browse/browseSidebar.constants.ts
@@ -1,0 +1,2 @@
+export const BROWSE_SIDEBAR_ID = 'browse-sidebar';
+export const BROWSE_SIDEBAR_TOGGLE_ID = 'browse-sidebar-toggle';

--- a/modules/lib/src/main/resources/assets/js/v6/pages/browse/model/browseSidebar.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/browse/model/browseSidebar.store.ts
@@ -1,0 +1,7 @@
+import { atom } from 'nanostores';
+
+export const $isBrowseSidebarOpen = atom<boolean>(false);
+
+export const setBrowseSidebarOpen = (open: boolean): void => {
+    $isBrowseSidebarOpen.set(open);
+};

--- a/modules/lib/src/main/resources/assets/js/v6/shared/ui/WidgetButton.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/shared/ui/WidgetButton.tsx
@@ -1,22 +1,37 @@
 import { IconButton, Tooltip, Button, cn } from '@enonic/ui';
 import { CircleQuestionMark, LucideIcon } from 'lucide-react';
-import { ComponentPropsWithoutRef } from 'preact/compat';
+import type { ComponentPropsWithoutRef } from 'react';
 
 type Props = {
     label: string;
     icon?: LucideIcon;
     iconUrl?: string;
     active?: boolean;
-} & ComponentPropsWithoutRef<'button'>;
+    tooltipClassName?: string;
+    disabled?: boolean;
+} & Omit<ComponentPropsWithoutRef<'button'>, 'disabled'>;
 
-export const WidgetButton = ({ label, icon, iconUrl, active, onClick }: Props): React.ReactElement => {
+export const WidgetButton = ({
+    label,
+    icon,
+    iconUrl,
+    active,
+    className,
+    tooltipClassName,
+    'aria-label': ariaLabel,
+    ...buttonProps
+}: Props): React.ReactElement => {
     if (!icon && iconUrl) {
         return (
-            <Tooltip delay={300} value={label} side="right">
+            <Tooltip delay={300} value={label} side="right" className={tooltipClassName}>
                 <Button
-                    className={cn('size-10 p-1', active && 'bg-surface-selected hover:bg-surface-selected-hover')}
-                    aria-label={label}
-                    onClick={onClick}
+                    {...buttonProps}
+                    className={cn(
+                        'size-10 shrink-0 p-1',
+                        active && 'bg-surface-selected hover:bg-surface-selected-hover',
+                        className,
+                    )}
+                    aria-label={ariaLabel ?? label}
                 >
                     <img
                         className={cn('w-6 invert-100 dark:invert-0 active:invert-0', active && 'invert-0')}
@@ -29,14 +44,14 @@ export const WidgetButton = ({ label, icon, iconUrl, active, onClick }: Props): 
     }
 
     return (
-        <Tooltip delay={300} value={label} side="right">
+        <Tooltip delay={300} value={label} side="right" className={tooltipClassName}>
             <IconButton
-                className="size-10"
+                {...buttonProps}
+                className={cn('size-10 shrink-0', className)}
                 icon={icon || CircleQuestionMark}
                 iconSize={24}
-                aria-label={label}
+                aria-label={ariaLabel ?? label}
                 data-active={active}
-                onClick={onClick}
             />
         </Tooltip>
     );

--- a/modules/lib/src/main/resources/assets/styles/main-app-wrapper.less
+++ b/modules/lib/src/main/resources/assets/styles/main-app-wrapper.less
@@ -66,6 +66,7 @@
 
   .header-widgets-block {
     margin-left: 60px;
+
     .app-container {
       position: absolute;
       top: 60px; //@app-header-height;
@@ -84,6 +85,16 @@
             display: none;
           }
         }
+      }
+    }
+  }
+
+  @media not all and (min-width: 40rem) {
+    .header-widgets-block {
+      margin-left: 0;
+
+      .app-container {
+        left: 0;
       }
     }
   }


### PR DESCRIPTION
### Summary
Add a mobile-only navigation drawer for BrowseSidebar controlled by a hamburger button in BrowseAppBar. Drawer should overlay browse content without reducing available content width. Desktop and tablet sidebar behavior must remain unchanged.
Current behavior
- Sidebar permanently occupies 60px on mobile.
- Browse content retains sidebar-related left offsets.
- Mobile navigation lacks dedicated open and close interactions.
- Narrow header content can shrink fixed-size controls.

Expected behavior
- Mobile sidebar remains closed by default.
- Hamburger icon animates into a close icon while drawer is open.
- Sidebar slides smoothly over content when opening and closing.
- Clicking outside drawer or pressing Escape closes it.
- Content and XP menu controls outside open drawer cannot receive pointer or keyboard interaction.
- Mobile browse content uses full width with no sidebar offset.

<img width="378" height="669" alt="Image" src="https://github.com/user-attachments/assets/3c882c24-aa1b-4e7a-8450-1afafd406148" />

<img width="378" height="669" alt="Image" src="https://github.com/user-attachments/assets/bd4a269b-6b81-46d4-823d-d5285d80946b" />