### PR TITLE
Project wizard - Parent Project and Language should be comboboxes #11334

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/LanguageSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/LanguageSelector.tsx
@@ -86,6 +86,13 @@ const matchesQuery = (option: LanguageSelectorOption, normalizedQuery: string): 
 // * Component
 //
 
+/**
+ * Combobox for picking a language. Single selection only.
+ *
+ * Hides the combobox once the selected language resolves against the options, leaving
+ * the label in place. The caller is expected to render the selected language along with
+ * a way to remove it, which brings the combobox back.
+ */
 export const LanguageSelector = ({
     label,
     options,
@@ -107,6 +114,7 @@ export const LanguageSelector = ({
 
     const selectedIds = selection ?? [];
     const safeSelection = useMemo(() => new Set(selectedIds.map(toOptionKey)), [selectedIds]);
+    const hideCombobox = selectedIds.some((id) => options.some((option) => option.id === id));
 
     const optionKeyMap = useMemo(() => {
         return new Map(options.map((option) => [toOptionKey(option.id), option.id]));
@@ -181,79 +189,81 @@ export const LanguageSelector = ({
     return (
         <div data-component={LANGUAGE_SELECTOR_NAME} className={cn('flex flex-col gap-2', className)}>
             {label && (
-                <label htmlFor={inputId} className="font-semibold">
+                <label htmlFor={hideCombobox ? undefined : inputId} className="font-semibold">
                     {label}
                 </label>
             )}
-            <Combobox.Root
-                open={open}
-                onOpenChange={handleOpenChange}
-                value={inputValue}
-                onChange={setInputValue}
-                contentType="tree"
-                disabled={disabled}
-                closeOnBlur={closeOnBlur}
-            >
-                <Combobox.Content>
-                    <Combobox.Control>
-                        <Combobox.Search>
-                            <Combobox.SearchIcon />
-                            <Combobox.Input
-                                id={inputId}
-                                placeholder={searchPlaceholder ?? placeholder}
-                                aria-label={label}
-                            />
-                            <Combobox.Toggle />
-                        </Combobox.Search>
-                    </Combobox.Control>
-                    <Combobox.Portal>
-                        <Combobox.Popup>
-                            {flatNodes.length === 0 && emptyLabel ? (
-                                <div className="px-4.5 py-2 text-sm text-subtle">{emptyLabel}</div>
-                            ) : (
-                                <Combobox.TreeContent style={{ height: treeHeight }}>
-                                    <VirtualizedTreeList
-                                        items={flatNodes}
-                                        preserveFilteredSelection
-                                        clearSelectionOnEscape={false}
-                                        selection={safeSelection}
-                                        onSelectionChange={handleSelectionChange}
-                                        selectionMode="single"
-                                        rowClickSelection="toggle"
-                                        active={activeId}
-                                        onActiveChange={setActiveId}
-                                        virtuosoRef={virtuosoRef}
-                                        aria-label={label}
-                                        className="h-full"
-                                    >
-                                        {({ items, getItemProps, containerProps }) => (
-                                            <Virtuoso<LanguageFlatNode>
-                                                ref={virtuosoRef}
-                                                data={items as LanguageFlatNode[]}
-                                                components={virtuosoComponents}
-                                                {...containerProps}
-                                                className={cn('h-full', containerProps.className)}
-                                                itemContent={(index, node) => {
-                                                    const itemProps = getItemProps(index, node);
-                                                    return (
-                                                        <VirtualizedTreeList.Row {...itemProps}>
-                                                            <VirtualizedTreeList.RowContent>
-                                                                <span className="text-sm font-medium group-data-[tone=inverse]:text-alt">
-                                                                    {node.data.label}
-                                                                </span>
-                                                            </VirtualizedTreeList.RowContent>
-                                                        </VirtualizedTreeList.Row>
-                                                    );
-                                                }}
-                                            />
-                                        )}
-                                    </VirtualizedTreeList>
-                                </Combobox.TreeContent>
-                            )}
-                        </Combobox.Popup>
-                    </Combobox.Portal>
-                </Combobox.Content>
-            </Combobox.Root>
+            {!hideCombobox && (
+                <Combobox.Root
+                    open={open}
+                    onOpenChange={handleOpenChange}
+                    value={inputValue}
+                    onChange={setInputValue}
+                    contentType="tree"
+                    disabled={disabled}
+                    closeOnBlur={closeOnBlur}
+                >
+                    <Combobox.Content>
+                        <Combobox.Control>
+                            <Combobox.Search>
+                                <Combobox.SearchIcon />
+                                <Combobox.Input
+                                    id={inputId}
+                                    placeholder={searchPlaceholder ?? placeholder}
+                                    aria-label={label}
+                                />
+                                <Combobox.Toggle />
+                            </Combobox.Search>
+                        </Combobox.Control>
+                        <Combobox.Portal>
+                            <Combobox.Popup>
+                                {flatNodes.length === 0 && emptyLabel ? (
+                                    <div className="px-4.5 py-2 text-sm text-subtle">{emptyLabel}</div>
+                                ) : (
+                                    <Combobox.TreeContent style={{ height: treeHeight }}>
+                                        <VirtualizedTreeList
+                                            items={flatNodes}
+                                            preserveFilteredSelection
+                                            clearSelectionOnEscape={false}
+                                            selection={safeSelection}
+                                            onSelectionChange={handleSelectionChange}
+                                            selectionMode="single"
+                                            rowClickSelection="toggle"
+                                            active={activeId}
+                                            onActiveChange={setActiveId}
+                                            virtuosoRef={virtuosoRef}
+                                            aria-label={label}
+                                            className="h-full"
+                                        >
+                                            {({ items, getItemProps, containerProps }) => (
+                                                <Virtuoso<LanguageFlatNode>
+                                                    ref={virtuosoRef}
+                                                    data={items as LanguageFlatNode[]}
+                                                    components={virtuosoComponents}
+                                                    {...containerProps}
+                                                    className={cn('h-full', containerProps.className)}
+                                                    itemContent={(index, node) => {
+                                                        const itemProps = getItemProps(index, node);
+                                                        return (
+                                                            <VirtualizedTreeList.Row {...itemProps}>
+                                                                <VirtualizedTreeList.RowContent>
+                                                                    <span className="text-sm font-medium group-data-[tone=inverse]:text-alt">
+                                                                        {node.data.label}
+                                                                    </span>
+                                                                </VirtualizedTreeList.RowContent>
+                                                            </VirtualizedTreeList.Row>
+                                                        );
+                                                    }}
+                                                />
+                                            )}
+                                        </VirtualizedTreeList>
+                                    </Combobox.TreeContent>
+                                )}
+                            </Combobox.Popup>
+                        </Combobox.Portal>
+                    </Combobox.Content>
+                </Combobox.Root>
+            )}
         </div>
     );
 };

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/LanguageSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/LanguageSelector.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useEffect, useId, useMemo, useRef, useState, type HTMLAttri
 import type { VirtuosoHandle } from 'react-virtuoso';
 import { Virtuoso } from 'react-virtuoso';
 import { buildKey } from '../../../shared/lib/format/keys';
+import { useComboboxCollapse } from './shared/useComboboxCollapse';
 
 //
 // * Types
@@ -86,13 +87,6 @@ const matchesQuery = (option: LanguageSelectorOption, normalizedQuery: string): 
 // * Component
 //
 
-/**
- * Combobox for picking a language. Single selection only.
- *
- * Hides the combobox once the selected language resolves against the options, leaving
- * the label in place. The caller is expected to render the selected language along with
- * a way to remove it, which brings the combobox back.
- */
 export const LanguageSelector = ({
     label,
     options,
@@ -115,6 +109,7 @@ export const LanguageSelector = ({
     const selectedIds = selection ?? [];
     const safeSelection = useMemo(() => new Set(selectedIds.map(toOptionKey)), [selectedIds]);
     const hideCombobox = selectedIds.some((id) => options.some((option) => option.id === id));
+    const { rootRef, inputRef } = useComboboxCollapse(hideCombobox);
 
     const optionKeyMap = useMemo(() => {
         return new Map(options.map((option) => [toOptionKey(option.id), option.id]));
@@ -187,7 +182,12 @@ export const LanguageSelector = ({
     };
 
     return (
-        <div data-component={LANGUAGE_SELECTOR_NAME} className={cn('flex flex-col gap-2', className)}>
+        <div
+            ref={rootRef}
+            tabIndex={-1}
+            data-component={LANGUAGE_SELECTOR_NAME}
+            className={cn('flex flex-col gap-2 focus:outline-none', className)}
+        >
             {label && (
                 <label htmlFor={hideCombobox ? undefined : inputId} className="font-semibold">
                     {label}
@@ -208,6 +208,7 @@ export const LanguageSelector = ({
                             <Combobox.Search>
                                 <Combobox.SearchIcon />
                                 <Combobox.Input
+                                    ref={inputRef}
                                     id={inputId}
                                     placeholder={searchPlaceholder ?? placeholder}
                                     aria-label={label}

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/PrincipalSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/PrincipalSelector.tsx
@@ -24,6 +24,15 @@ type PrincipalSelectorProps = {
     className?: string;
 };
 
+/**
+ * Combobox for picking principals.
+ *
+ * For single selection mode: hides the combobox once the selected principal resolves,
+ * leaving the label in place. The caller is expected to render the selected principal
+ * along with a way to remove it, which brings the combobox back.
+ *
+ * For staged/multiple selection mode: the combobox stays so more principals can be added.
+ */
 export const PrincipalSelector = ({
     selection,
     onSelectionChange,
@@ -42,6 +51,10 @@ export const PrincipalSelector = ({
     const inputId = `${PRINCIPAL_SELECTOR_NAME}-${baseId}-input`;
     const [searchValue, setSearchValue] = useState('');
     const allowedTypesKey = allowedTypes.join(','); // Serialize array for stable comparison in useEffect dependencies
+
+    const hideCombobox =
+        selectionMode === 'single' &&
+        selection.some((key) => principals.some((principal) => principal.getKey().toString() === key));
 
     const allowedPrincipals = useMemo(() => {
         return principals.filter((principal) => allowedTypes.includes(principal.getType()) && customFilter(principal));
@@ -66,40 +79,42 @@ export const PrincipalSelector = ({
     return (
         <div data-component={PRINCIPAL_SELECTOR_NAME} className={cn('flex flex-col gap-2', className)}>
             {label && (
-                <label htmlFor={inputId} className="font-semibold">
+                <label htmlFor={hideCombobox ? undefined : inputId} className="font-semibold">
                     {label}
                 </label>
             )}
-            <Combobox.Root
-                value={searchValue}
-                onChange={setSearchValue}
-                selection={selection}
-                onSelectionChange={onSelectionChange}
-                selectionMode={selectionMode}
-                closeOnBlur={closeOnBlur}
-                disabled={disabled}
-                contentType="listbox"
-            >
-                <Combobox.Content>
-                    <Combobox.Control>
-                        <Combobox.Search>
-                            <Combobox.SearchIcon />
-                            <Combobox.Input id={inputId} placeholder={placeholder} />
-                            {selectionMode === 'staged' && <Combobox.Apply />}
-                            <Combobox.Toggle />
-                        </Combobox.Search>
-                    </Combobox.Control>
-                    <Combobox.Portal>
-                        <Combobox.Popup>
-                            <PrincipalSelectorList
-                                items={filtered}
-                                selectionMode={selectionMode}
-                                emptyLabel={emptyLabel}
-                            />
-                        </Combobox.Popup>
-                    </Combobox.Portal>
-                </Combobox.Content>
-            </Combobox.Root>
+            {!hideCombobox && (
+                <Combobox.Root
+                    value={searchValue}
+                    onChange={setSearchValue}
+                    selection={selection}
+                    onSelectionChange={onSelectionChange}
+                    selectionMode={selectionMode}
+                    closeOnBlur={closeOnBlur}
+                    disabled={disabled}
+                    contentType="listbox"
+                >
+                    <Combobox.Content>
+                        <Combobox.Control>
+                            <Combobox.Search>
+                                <Combobox.SearchIcon />
+                                <Combobox.Input id={inputId} placeholder={placeholder} />
+                                {selectionMode === 'staged' && <Combobox.Apply />}
+                                <Combobox.Toggle />
+                            </Combobox.Search>
+                        </Combobox.Control>
+                        <Combobox.Portal>
+                            <Combobox.Popup>
+                                <PrincipalSelectorList
+                                    items={filtered}
+                                    selectionMode={selectionMode}
+                                    emptyLabel={emptyLabel}
+                                />
+                            </Combobox.Popup>
+                        </Combobox.Portal>
+                    </Combobox.Content>
+                </Combobox.Root>
+            )}
         </div>
     );
 };

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/PrincipalSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/PrincipalSelector.tsx
@@ -6,6 +6,7 @@ import { useEffect, useId, useMemo, useState, type ReactElement } from 'react';
 import { $principals, loadPrincipals } from '../../../entities/principal';
 import { useDebouncedCallback } from '../../../shared/lib/hooks/useDebouncedCallback';
 import { PrincipalLabel } from '../../../shared/ui/PrincipalLabel';
+import { useComboboxCollapse } from './shared/useComboboxCollapse';
 
 const PRINCIPAL_SELECTOR_NAME = 'PrincipalSelector';
 const DEFAULT_DEBOUNCE = 500;
@@ -24,15 +25,6 @@ type PrincipalSelectorProps = {
     className?: string;
 };
 
-/**
- * Combobox for picking principals.
- *
- * For single selection mode: hides the combobox once the selected principal resolves,
- * leaving the label in place. The caller is expected to render the selected principal
- * along with a way to remove it, which brings the combobox back.
- *
- * For staged/multiple selection mode: the combobox stays so more principals can be added.
- */
 export const PrincipalSelector = ({
     selection,
     onSelectionChange,
@@ -55,6 +47,7 @@ export const PrincipalSelector = ({
     const hideCombobox =
         selectionMode === 'single' &&
         selection.some((key) => principals.some((principal) => principal.getKey().toString() === key));
+    const { rootRef, inputRef } = useComboboxCollapse(hideCombobox);
 
     const allowedPrincipals = useMemo(() => {
         return principals.filter((principal) => allowedTypes.includes(principal.getType()) && customFilter(principal));
@@ -76,8 +69,20 @@ export const PrincipalSelector = ({
         void debouncedLoadPrincipals(searchValue);
     }, [searchValue, debouncedLoadPrincipals]);
 
+    const handleSelectionChange = (next: readonly string[]): void => {
+        if (selectionMode === 'single') {
+            setSearchValue('');
+        }
+        onSelectionChange([...next]);
+    };
+
     return (
-        <div data-component={PRINCIPAL_SELECTOR_NAME} className={cn('flex flex-col gap-2', className)}>
+        <div
+            ref={rootRef}
+            tabIndex={-1}
+            data-component={PRINCIPAL_SELECTOR_NAME}
+            className={cn('flex flex-col gap-2 focus:outline-none', className)}
+        >
             {label && (
                 <label htmlFor={hideCombobox ? undefined : inputId} className="font-semibold">
                     {label}
@@ -88,7 +93,7 @@ export const PrincipalSelector = ({
                     value={searchValue}
                     onChange={setSearchValue}
                     selection={selection}
-                    onSelectionChange={onSelectionChange}
+                    onSelectionChange={handleSelectionChange}
                     selectionMode={selectionMode}
                     closeOnBlur={closeOnBlur}
                     disabled={disabled}
@@ -98,7 +103,7 @@ export const PrincipalSelector = ({
                         <Combobox.Control>
                             <Combobox.Search>
                                 <Combobox.SearchIcon />
-                                <Combobox.Input id={inputId} placeholder={placeholder} />
+                                <Combobox.Input ref={inputRef} id={inputId} placeholder={placeholder} />
                                 {selectionMode === 'staged' && <Combobox.Apply />}
                                 <Combobox.Toggle />
                             </Combobox.Search>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/ProjectSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/ProjectSelector.tsx
@@ -31,6 +31,15 @@ type ProjectSelectorProps = {
 
 const PROJECT_SELECTOR_NAME = 'ProjectSelector';
 
+/**
+ * Combobox for picking projects, rendered as a tree.
+ *
+ * For single selection mode: hides the combobox once the selected project resolves,
+ * leaving the label in place. The caller is expected to render the selected project
+ * along with a way to remove it, which brings the combobox back.
+ *
+ * For staged/multiple selection mode: the combobox stays so more projects can be added.
+ */
 export const ProjectSelector = (props: ProjectSelectorProps): ReactElement => {
     const {
         selection,
@@ -51,6 +60,8 @@ export const ProjectSelector = (props: ProjectSelectorProps): ReactElement => {
     const [searchValue, setSearchValue] = useState<string | undefined>();
     const [expanded, setExpanded] = useState<string[]>([]);
     const virtuosoRef = useRef<VirtuosoHandle>(null);
+    const hideCombobox =
+        selectionMode === 'single' && selection.some((name) => projects.some((p) => p.getName() === name));
 
     // Items
     const items = useMemo(() => projectsToTreeListItems(projects, expanded), [projects, expanded]);
@@ -77,45 +88,47 @@ export const ProjectSelector = (props: ProjectSelectorProps): ReactElement => {
             {(label || description) && (
                 <div className="flex flex-col gap-1">
                     {label && (
-                        <label htmlFor={inputId} className="font-semibold">
+                        <label htmlFor={hideCombobox ? undefined : inputId} className="font-semibold">
                             {label}
                         </label>
                     )}
                     {description && <div className="text-sm text-subtle">{description}</div>}
                 </div>
             )}
-            <Combobox.Root
-                value={searchValue}
-                onChange={setSearchValue}
-                selection={selection}
-                onSelectionChange={onSelectionChange}
-                contentType="tree"
-                selectionMode={selectionMode}
-                closeOnBlur={closeOnBlur}
-            >
-                <Combobox.Content>
-                    <Combobox.Control>
-                        <Combobox.Search>
-                            <Combobox.SearchIcon />
-                            <Combobox.Input id={inputId} placeholder={placeholder} />
-                            <Combobox.Apply />
-                            <Combobox.Toggle />
-                        </Combobox.Search>
-                    </Combobox.Control>
-                    <Combobox.Portal>
-                        <Combobox.Popup className="mt-1.5">
-                            <ProjectSelectorTreeContent
-                                items={filteredItems}
-                                handleExpand={handleExpand}
-                                handleCollapse={handleCollapse}
-                                selectionMode={selectionMode}
-                                emptyLabel={emptyLabel}
-                                virtuosoRef={virtuosoRef}
-                            />
-                        </Combobox.Popup>
-                    </Combobox.Portal>
-                </Combobox.Content>
-            </Combobox.Root>
+            {!hideCombobox && (
+                <Combobox.Root
+                    value={searchValue}
+                    onChange={setSearchValue}
+                    selection={selection}
+                    onSelectionChange={onSelectionChange}
+                    contentType="tree"
+                    selectionMode={selectionMode}
+                    closeOnBlur={closeOnBlur}
+                >
+                    <Combobox.Content>
+                        <Combobox.Control>
+                            <Combobox.Search>
+                                <Combobox.SearchIcon />
+                                <Combobox.Input id={inputId} placeholder={placeholder} />
+                                <Combobox.Apply />
+                                <Combobox.Toggle />
+                            </Combobox.Search>
+                        </Combobox.Control>
+                        <Combobox.Portal>
+                            <Combobox.Popup className="mt-1.5">
+                                <ProjectSelectorTreeContent
+                                    items={filteredItems}
+                                    handleExpand={handleExpand}
+                                    handleCollapse={handleCollapse}
+                                    selectionMode={selectionMode}
+                                    emptyLabel={emptyLabel}
+                                    virtuosoRef={virtuosoRef}
+                                />
+                            </Combobox.Popup>
+                        </Combobox.Portal>
+                    </Combobox.Content>
+                </Combobox.Root>
+            )}
         </div>
     );
 };

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/ProjectSelector.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/ProjectSelector.tsx
@@ -16,6 +16,7 @@ import type { Project } from '../../../../app/settings/data/project/Project';
 import { $projects } from '../../../entities/project';
 import { projectsToTreeListItems } from '../../../shared/lib/url/projects';
 import { ProjectLabel } from '../../../entities/project/ui/ProjectLabel';
+import { useComboboxCollapse } from './shared/useComboboxCollapse';
 
 type ProjectSelectorProps = {
     selection: readonly string[];
@@ -31,15 +32,6 @@ type ProjectSelectorProps = {
 
 const PROJECT_SELECTOR_NAME = 'ProjectSelector';
 
-/**
- * Combobox for picking projects, rendered as a tree.
- *
- * For single selection mode: hides the combobox once the selected project resolves,
- * leaving the label in place. The caller is expected to render the selected project
- * along with a way to remove it, which brings the combobox back.
- *
- * For staged/multiple selection mode: the combobox stays so more projects can be added.
- */
 export const ProjectSelector = (props: ProjectSelectorProps): ReactElement => {
     const {
         selection,
@@ -62,6 +54,7 @@ export const ProjectSelector = (props: ProjectSelectorProps): ReactElement => {
     const virtuosoRef = useRef<VirtuosoHandle>(null);
     const hideCombobox =
         selectionMode === 'single' && selection.some((name) => projects.some((p) => p.getName() === name));
+    const { rootRef, inputRef } = useComboboxCollapse(hideCombobox);
 
     // Items
     const items = useMemo(() => projectsToTreeListItems(projects, expanded), [projects, expanded]);
@@ -82,9 +75,20 @@ export const ProjectSelector = (props: ProjectSelectorProps): ReactElement => {
     const handleCollapse = (id: string): void => {
         setExpanded((prev) => prev.filter((idd) => idd !== id));
     };
+    const handleSelectionChange = (next: readonly string[]): void => {
+        if (selectionMode === 'single') {
+            setSearchValue(undefined);
+        }
+        onSelectionChange(next);
+    };
 
     return (
-        <div data-component={PROJECT_SELECTOR_NAME} className={cn('flex flex-col gap-2', className)}>
+        <div
+            ref={rootRef}
+            tabIndex={-1}
+            data-component={PROJECT_SELECTOR_NAME}
+            className={cn('flex flex-col gap-2 focus:outline-none', className)}
+        >
             {(label || description) && (
                 <div className="flex flex-col gap-1">
                     {label && (
@@ -100,7 +104,7 @@ export const ProjectSelector = (props: ProjectSelectorProps): ReactElement => {
                     value={searchValue}
                     onChange={setSearchValue}
                     selection={selection}
-                    onSelectionChange={onSelectionChange}
+                    onSelectionChange={handleSelectionChange}
                     contentType="tree"
                     selectionMode={selectionMode}
                     closeOnBlur={closeOnBlur}
@@ -109,7 +113,7 @@ export const ProjectSelector = (props: ProjectSelectorProps): ReactElement => {
                         <Combobox.Control>
                             <Combobox.Search>
                                 <Combobox.SearchIcon />
-                                <Combobox.Input id={inputId} placeholder={placeholder} />
+                                <Combobox.Input ref={inputRef} id={inputId} placeholder={placeholder} />
                                 <Combobox.Apply />
                                 <Combobox.Toggle />
                             </Combobox.Search>

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/shared/useComboboxCollapse.test.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/shared/useComboboxCollapse.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/preact';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { useComboboxCollapse } from './useComboboxCollapse';
+
+const Harness = ({ resolved = true }: { resolved?: boolean }) => {
+    const [selected, setSelected] = useState<string | null>(null);
+    const collapsed = selected !== null && resolved;
+    const { rootRef, inputRef } = useComboboxCollapse(collapsed);
+
+    return (
+        <div>
+            <div ref={rootRef} tabIndex={-1} data-testid="root">
+                {!collapsed && <input ref={inputRef} data-testid="input" onKeyDown={() => setSelected('en')} />}
+            </div>
+            {selected && (
+                <button data-testid="remove" onClick={() => setSelected(null)}>
+                    X
+                </button>
+            )}
+            <button data-testid="next">next</button>
+        </div>
+    );
+};
+
+describe('useComboboxCollapse', () => {
+    it('moves focus to the root when the collapse removes the focused element', () => {
+        render(<Harness />);
+        const input = screen.getByTestId('input');
+        input.focus();
+
+        fireEvent.keyDown(input, { key: 'Enter' });
+
+        expect(screen.queryByTestId('input')).toBeNull();
+        expect(document.activeElement).toBe(screen.getByTestId('root'));
+    });
+
+    it('returns focus to the input when the combobox comes back after focus was lost', () => {
+        render(<Harness />);
+        const input = screen.getByTestId('input');
+        input.focus();
+        fireEvent.keyDown(input, { key: 'Enter' });
+
+        const remove = screen.getByTestId('remove');
+        remove.focus();
+        fireEvent.click(remove);
+
+        expect(document.activeElement).toBe(screen.getByTestId('input'));
+    });
+
+    it('leaves focus alone when the collapse happens while focus is elsewhere', () => {
+        const { rerender } = render(<Harness resolved={false} />);
+        const input = screen.getByTestId('input');
+        input.focus();
+        fireEvent.keyDown(input, { key: 'Enter' });
+
+        const outside = screen.getByTestId('next');
+        outside.focus();
+        rerender(<Harness resolved={true} />);
+
+        expect(document.activeElement).toBe(outside);
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/shared/useComboboxCollapse.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/features/shared/selectors/shared/useComboboxCollapse.ts
@@ -1,0 +1,35 @@
+import { useLayoutEffect, useRef, type RefObject } from 'react';
+
+type ComboboxCollapse = {
+    rootRef: RefObject<HTMLDivElement>;
+    inputRef: RefObject<HTMLInputElement>;
+};
+
+// Focus falls back to the body when the element holding it is removed.
+const hasLostFocus = (): boolean => {
+    const active = document.activeElement;
+    return active == null || active === document.body;
+};
+
+export function useComboboxCollapse(collapsed: boolean): ComboboxCollapse {
+    const rootRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const prevCollapsedRef = useRef(collapsed);
+
+    useLayoutEffect(() => {
+        const wasCollapsed = prevCollapsedRef.current;
+        prevCollapsedRef.current = collapsed;
+
+        if (collapsed === wasCollapsed || !hasLostFocus()) {
+            return;
+        }
+
+        if (collapsed) {
+            rootRef.current?.focus();
+        } else {
+            inputRef.current?.focus();
+        }
+    }, [collapsed]);
+
+    return { rootRef, inputRef };
+}


### PR DESCRIPTION
- Hid the combobox in 'ProjectSelector', 'LanguageSelector' and 'PrincipalSelector' once a single selection resolves
- Kept the input in staged mode, so multi-inheritance parent projects are unaffected