### PR TITLE
Filter panel mobile #11361

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/features/search/ui/BrowseFilter.test.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/search/ui/BrowseFilter.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from '@testing-library/preact';
+import { forwardRef, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    $contentFilterState,
+    $isContentFilterOpen,
+    resetContentFilter,
+    setContentFilterOpen,
+} from '../model/contentFilter.store';
+
+const mocks = vi.hoisted(() => ({ breakpoints: { sm: false } }));
+
+vi.mock('@enonic/ui', () => ({
+    // Mirrors the real Button: aria-label defaults to label, then caller props override it
+    Button: ({
+        children,
+        label,
+        className,
+        onClick,
+        ...props
+    }: {
+        children?: ReactNode;
+        label?: string;
+        className?: string;
+        onClick?: () => void;
+    } & Record<string, unknown>) => (
+        <button type="button" aria-label={label} className={className} onClick={onClick} {...props}>
+            {children}
+            {label}
+        </button>
+    ),
+    SearchField: {
+        Root: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+        Input: forwardRef<HTMLInputElement>((_, ref) => <input ref={ref} />),
+        Clear: () => null,
+    },
+}));
+
+vi.mock('../../../shared/lib/hooks/useBreakpoints', () => ({
+    useBreakpoints: () => mocks.breakpoints,
+}));
+
+vi.mock('../../../shared/lib/hooks/useI18n', () => ({
+    useI18n: (key: string, hits?: number) => {
+        if (key === 'field.search.show.results') {
+            return `Show ${hits} results`;
+        }
+        if (key === 'field.search.results') {
+            return `${hits} results`;
+        }
+        return key;
+    },
+}));
+
+vi.mock('../../../shared/ui/LegacyElement', () => ({
+    LegacyElement: class {},
+}));
+
+vi.mock('../../shared/buckets/FilterableBucketAggregation', () => ({
+    FilterableBucketAggregation: () => null,
+}));
+
+vi.mock('../../shared/buckets/StaticBucketAggregation', () => ({
+    StaticBucketAggregation: () => null,
+}));
+
+import { BrowseFilter } from './BrowseFilter';
+
+describe('BrowseFilter', () => {
+    beforeEach(() => {
+        mocks.breakpoints = { sm: false };
+        resetContentFilter();
+        $contentFilterState.setKey('value', 'query');
+        setContentFilterOpen(true);
+    });
+
+    it('names the mobile results action by its visible label', () => {
+        render(<BrowseFilter hits={3} bucketAggregations={[]} />);
+
+        expect(screen.getByRole('button', { name: 'Show 3 results' })).toBeTruthy();
+    });
+
+    it('collapses the filter panel when the mobile results action is clicked', () => {
+        render(<BrowseFilter hits={3} bucketAggregations={[]} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show 3 results' }));
+
+        expect($isContentFilterOpen.get()).toBe(false);
+    });
+
+    it('keeps plain text when nothing was found', () => {
+        render(<BrowseFilter hits={0} bucketAggregations={[]} />);
+
+        expect(screen.queryByRole('button', { name: /results/ })).toBeNull();
+        expect(screen.getByText('0 results')).toBeTruthy();
+    });
+
+    it('keeps plain text while the filter is untouched', () => {
+        resetContentFilter();
+
+        render(<BrowseFilter hits={3} bucketAggregations={[]} />);
+
+        expect(screen.queryByRole('button', { name: /results/ })).toBeNull();
+        expect(screen.getByText('3 results')).toBeTruthy();
+    });
+
+    it('keeps plain text on desktop', () => {
+        mocks.breakpoints = { sm: true };
+
+        render(<BrowseFilter hits={3} bucketAggregations={[]} />);
+
+        expect(screen.queryByRole('button', { name: /results/ })).toBeNull();
+        expect(screen.getByText('3 results')).toBeTruthy();
+    });
+
+    it('hides the export action on mobile', () => {
+        render(<BrowseFilter hits={3} bucketAggregations={[]} exportOptions={{ label: 'Export', action: vi.fn() }} />);
+
+        expect(screen.getByRole('button', { name: 'Export' }).className).toContain('max-sm:hidden');
+    });
+});

--- a/modules/lib/src/main/resources/assets/js/v6/features/search/ui/BrowseFilter.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/features/search/ui/BrowseFilter.tsx
@@ -5,11 +5,13 @@ import { Button, SearchField } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
 import { Download } from 'lucide-react';
 import { useEffect, useMemo, useRef } from 'react';
+import { useBreakpoints } from '../../../shared/lib/hooks/useBreakpoints';
 import {
     $contentFilterState,
     $isContentFilterDirty,
     $isContentFilterOpen,
     resetContentFilter,
+    setContentFilterOpen,
     setContentFilterSelection,
     setContentFilterValue,
 } from '../model/contentFilter.store';
@@ -48,6 +50,9 @@ export const BrowseFilter = ({
     const clearLabel = useI18n('panel.filter.clear');
     const exportFallbackLabel = useI18n('action.export');
     const resultsLabel = useI18n('field.search.results', hits);
+    const showResultsLabel = useI18n('field.search.show.results', hits);
+    const { sm } = useBreakpoints();
+    const showResultsButton = !sm && isFilterDirty && hits > 0;
 
     const exportAction = exportOptions?.action;
     const exportLabel = exportOptions?.label ?? exportFallbackLabel;
@@ -103,12 +108,29 @@ export const BrowseFilter = ({
                 <SearchField.Clear />
             </SearchField.Root>
 
-            <div className="flex mt-2 mb-7.5 items-center">
+            <div className="flex mt-2 mb-7.5 items-center max-sm:min-h-10">
                 <div className="grow">
-                    <span className="text-lg pl-4.5 pr-4.5">{resultsLabel}</span>
+                    {showResultsButton ? (
+                        <Button
+                            variant="text"
+                            onClick={() => setContentFilterOpen(false)}
+                            className="text-lg pl-4.5 pr-4.5 underline underline-offset-4"
+                        >
+                            {showResultsLabel}
+                        </Button>
+                    ) : (
+                        <span className="text-lg pl-4.5 pr-4.5">{resultsLabel}</span>
+                    )}
                 </div>
                 {exportAction && hits > 0 && (
-                    <Button size="sm" label={exportLabel} variant="outline" endIcon={Download} onClick={exportAction} />
+                    <Button
+                        className="max-sm:hidden"
+                        size="sm"
+                        label={exportLabel}
+                        variant="outline"
+                        endIcon={Download}
+                        onClick={exportAction}
+                    />
                 )}
             </div>
             <div className="flex flex-col gap-7.5">

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/browse-toolbar/SearchToggle.test.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/browse-toolbar/SearchToggle.test.tsx
@@ -2,7 +2,11 @@ import { act, render, screen } from '@testing-library/preact';
 import { cloneElement, forwardRef, isValidElement, type ReactElement, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Action } from '@enonic/lib-admin-ui/ui/Action';
-import { setContentFilterOpen } from '../../features/search/model/contentFilter.store';
+import {
+    resetContentFilter,
+    setContentFilterOpen,
+    setContentFilterValue,
+} from '../../features/search/model/contentFilter.store';
 
 vi.mock('@enonic/ui', () => {
     type MockToggleProps = {
@@ -19,7 +23,7 @@ vi.mock('@enonic/ui', () => {
             {
                 pressed,
                 onPressedChange,
-                startIcon: _startIcon,
+                startIcon,
                 iconStrokeWidth: _iconStrokeWidth,
                 size: _size,
                 className,
@@ -32,6 +36,7 @@ vi.mock('@enonic/ui', () => {
                 type="button"
                 aria-pressed={pressed}
                 className={className}
+                data-icon={(startIcon as { displayName?: string })?.displayName}
                 onClick={() => onPressedChange?.(!pressed)}
                 {...props}
             />
@@ -68,7 +73,8 @@ vi.mock('../../shared/lib/hooks/useI18n', () => ({
 }));
 
 vi.mock('lucide-react', () => ({
-    Search: () => null,
+    Search: Object.assign(() => null, { displayName: 'Search' }),
+    SearchCheck: Object.assign(() => null, { displayName: 'SearchCheck' }),
 }));
 
 import { SearchToggle } from './SearchToggle';
@@ -90,6 +96,7 @@ const flushStoreUpdates = async () => {
 describe('SearchToggle', () => {
     beforeEach(() => {
         setContentFilterOpen(false);
+        resetContentFilter();
     });
 
     afterEach(() => {
@@ -137,6 +144,22 @@ describe('SearchToggle', () => {
         await flushStoreUpdates();
 
         expect(document.activeElement).toBe(toggle);
+    });
+
+    it('should show the plain search icon while the filter is untouched', async () => {
+        render(<SearchToggle action={createAction()} />);
+        await flushStoreUpdates();
+
+        expect(screen.getByRole('button').getAttribute('data-icon')).toBe('Search');
+    });
+
+    it('should show the search-check icon once the filter is applied', async () => {
+        render(<SearchToggle action={createAction()} />);
+
+        setContentFilterValue('query');
+        await flushStoreUpdates();
+
+        expect(screen.getByRole('button').getAttribute('data-icon')).toBe('SearchCheck');
     });
 
     it('should not focus the toggle button when the panel was never open', async () => {

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/browse-toolbar/SearchToggle.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/browse-toolbar/SearchToggle.tsx
@@ -1,11 +1,12 @@
 import { type Action } from '@enonic/lib-admin-ui/ui/Action';
 import { cn, Toggle, Toolbar, Tooltip } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
-import { Search } from 'lucide-react';
+import { Search, SearchCheck } from 'lucide-react';
 import { type ReactElement, useEffect, useRef } from 'react';
 import { useAction } from '../../shared/lib/hooks/useAction';
+import { useBreakpoints } from '../../shared/lib/hooks/useBreakpoints';
 import { useI18n } from '../../shared/lib/hooks/useI18n';
-import { $isContentFilterOpen } from '../../features/search/model/contentFilter.store';
+import { $isContentFilterOpen, $isContentFilterDirty } from '../../features/search/model/contentFilter.store';
 
 type Props = {
     action: Action;
@@ -16,12 +17,14 @@ export const SearchToggle = ({ action, className }: Props): ReactElement => {
     const toggleRef = useRef<HTMLButtonElement>(null);
     const isContentFilterOpen = useStore($isContentFilterOpen);
     const wasContentFilterOpen = useRef(isContentFilterOpen);
-
+    const isFilterDirty = useStore($isContentFilterDirty);
     const { label, enabled, execute } = useAction(action);
 
     const showReachLabel = useI18n('tooltip.filterPanel.show');
     const hideReachLabel = useI18n('tooltip.filterPanel.hide');
     const searchLabel = label || (isContentFilterOpen ? hideReachLabel : showReachLabel);
+
+    const { sm } = useBreakpoints();
 
     // Closing the filter panel hides the focused search input, so focus returns here
     useEffect(() => {
@@ -32,7 +35,7 @@ export const SearchToggle = ({ action, className }: Props): ReactElement => {
     }, [isContentFilterOpen]);
 
     return (
-        <Tooltip delay={300} value={searchLabel} asChild>
+        <Tooltip side={sm ? 'bottom' : 'right'} delay={300} value={searchLabel} asChild>
             <Toolbar.Item asChild disabled={!enabled}>
                 <Toggle
                     ref={toggleRef}
@@ -40,7 +43,7 @@ export const SearchToggle = ({ action, className }: Props): ReactElement => {
                     size="sm"
                     iconStrokeWidth={2}
                     aria-label={searchLabel}
-                    startIcon={Search}
+                    startIcon={isFilterDirty ? SearchCheck : Search}
                     pressed={isContentFilterOpen}
                     onPressedChange={() => execute()}
                 />


### PR DESCRIPTION
Mobile changes:

Hide “Export” button
Turn “X results” into a link “Show X results” which will collapse the panel and show the filtered grid. When nothing found (0 results), it should be a simple text “0 results”, like now.
Global change:

If search is applied, replace the magnifying glass icon with “search-check” to show user that the grid is filtered. NB! Also for desktop.

This issue was resolved by a human :)