### PR TITLE
Fix touch behavior in page components tree #11371

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsContextMenu.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsContextMenu.tsx
@@ -1,14 +1,7 @@
 import { ContextMenu, getIsMobile } from '@enonic/ui';
 import { useStore } from '@nanostores/preact';
 import { Box, Columns2, PenLine, Puzzle } from 'lucide-react';
-import {
-    type MouseEvent as ReactMouseEvent,
-    type ReactElement,
-    type ReactNode,
-    useCallback,
-    useMemo,
-    useState,
-} from 'react';
+import { type ReactElement, type ReactNode, useCallback, useMemo, useState } from 'react';
 import { SaveAsTemplateAction } from '../../../../../../app/wizard/action/SaveAsTemplateAction';
 import { FragmentComponent } from '../../../../../../app/page/region/FragmentComponent';
 import { ComponentPath } from '../../../../../../app/page/region/ComponentPath';
@@ -86,30 +79,6 @@ export const PageComponentsContextMenu = ({ node, children }: PageComponentsCont
     const editFragmentLabel = useI18n('action.editFragment');
     const saveAsTemplateLabel = useI18n('action.saveAsTemplate');
 
-    const handleClickCapture = useCallback((event: ReactMouseEvent<HTMLDivElement>): void => {
-        if (!getIsMobile() || event.button !== 0 || (event.target as Element).closest('button')) return;
-
-        event.preventDefault();
-        event.stopPropagation();
-        event.currentTarget.dispatchEvent(
-            new MouseEvent('contextmenu', {
-                bubbles: true,
-                cancelable: true,
-                clientX: event.clientX,
-                clientY: event.clientY,
-                button: 2,
-                view: window,
-            }),
-        );
-    }, []);
-
-    const handleContextMenuCapture = useCallback((event: ReactMouseEvent<HTMLDivElement>): void => {
-        if (!getIsMobile() || !event.isTrusted) return;
-
-        event.preventDefault();
-        event.stopPropagation();
-    }, []);
-
     const handlePointerDownOutside = useCallback((event: PointerEvent): void => {
         if (getIsMobile()) event.preventDefault();
     }, []);
@@ -137,13 +106,7 @@ export const PageComponentsContextMenu = ({ node, children }: PageComponentsCont
     if (isPageRoot) {
         return (
             <ContextMenu open={open} onOpenChange={setOpen} data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
-                <ContextMenu.Trigger
-                    className="flex-1 min-w-0"
-                    onClickCapture={handleClickCapture}
-                    onContextMenuCapture={handleContextMenuCapture}
-                >
-                    {children}
-                </ContextMenu.Trigger>
+                <ContextMenu.Trigger className="flex-1 min-w-0">{children}</ContextMenu.Trigger>
                 <ContextMenu.Portal>
                     {mobileDismissLayer}
                     <ContextMenu.Content className="min-w-48" onPointerDownOutside={handlePointerDownOutside}>
@@ -163,13 +126,7 @@ export const PageComponentsContextMenu = ({ node, children }: PageComponentsCont
 
     return (
         <ContextMenu open={open} onOpenChange={setOpen} data-component={PAGE_COMPONENTS_CONTEXT_MENU_NAME}>
-            <ContextMenu.Trigger
-                className="flex-1 min-w-0"
-                onClickCapture={handleClickCapture}
-                onContextMenuCapture={handleContextMenuCapture}
-            >
-                {children}
-            </ContextMenu.Trigger>
+            <ContextMenu.Trigger className="flex-1 min-w-0">{children}</ContextMenu.Trigger>
             <ContextMenu.Portal>
                 {mobileDismissLayer}
                 <ContextMenu.Content className="min-w-48" onPointerDownOutside={handlePointerDownOutside}>

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/PageComponentsView.tsx
@@ -195,12 +195,17 @@ export const PageComponentsView = ({ showTitle = false }: PageComponentsViewProp
         setFocusedNodeId(null);
     }, []);
 
-    const handleSelect = useCallback((nodeId: string): void => {
-        const path = ComponentPath.fromString(nodeId);
-        PageNavigationMediator.get().notify(
-            new PageNavigationEvent(PageNavigationEventType.SELECT, new PageNavigationEventData(path)),
-        );
-    }, []);
+    const handleSelect = useCallback(
+        (nodeId: string): void => {
+            const path = ComponentPath.fromString(nodeId);
+            const eventType =
+                getIsMobile() && inspectedPath === nodeId
+                    ? PageNavigationEventType.DESELECT
+                    : PageNavigationEventType.SELECT;
+            PageNavigationMediator.get().notify(new PageNavigationEvent(eventType, new PageNavigationEventData(path)));
+        },
+        [inspectedPath],
+    );
 
     const handleKeyDownCapture = useCallback(
         (event: ReactKeyboardEvent<HTMLDivElement>): void => {

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/model/page-editor/bridge.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/model/page-editor/bridge.ts
@@ -97,14 +97,16 @@ export function initPageEditorBridge(options?: InitPageEditorBridgeOptions): voi
             const type = event.getType();
             const isMobile = getIsMobile();
 
-            if (type === PageNavigationEventType.INSPECT || (type === PageNavigationEventType.SELECT && !isMobile)) {
+            if (type === PageNavigationEventType.INSPECT || type === PageNavigationEventType.SELECT) {
                 const path = event.getData().getPath();
                 $inspectedPath.set(path?.toString() ?? null);
                 bumpSelectionEventNonce();
-                setContextOpen(true);
+                if (type === PageNavigationEventType.INSPECT || !isMobile) {
+                    setContextOpen(true);
+                }
                 return;
             }
-            if (type === PageNavigationEventType.DESELECT && !isMobile) {
+            if (type === PageNavigationEventType.DESELECT) {
                 $inspectedPath.set(null);
                 bumpSelectionEventNonce();
             }


### PR DESCRIPTION
Restores standard touch behavior in the page components tree. A single tap now selects the component and synchronizes it with the page, while a long press opens the context menu.