### PR TITLE
Improve content editor layout on narrow screens  #11369

### DIFF
--- a/modules/lib/src/main/resources/assets/js/app/wizard/page/FrameContainer.ts
+++ b/modules/lib/src/main/resources/assets/js/app/wizard/page/FrameContainer.ts
@@ -23,7 +23,7 @@ export class FrameContainer extends Panel {
         this.setDoOffset(false);
 
         this.proxy = config.proxy;
-        this.toolbar = new PreviewToolbarElement();
+        this.toolbar = new PreviewToolbarElement({ editorLayout: true });
         this.imageEditor = new LiveViewImageEditorElement();
 
         this.wrapper = new DivEl('wrapper');

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/DisplayNameInput.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/DisplayNameInput.tsx
@@ -190,7 +190,7 @@ export const DisplayNameInput = (): ReactElement => {
                     onClick={startEditing}
                     onFocus={startEditing}
                     className={cn(
-                        'block w-full min-w-64 border-0 border-l-1 bg-transparent text-left text-[2rem] font-semibold',
+                        'block w-full min-w-64 border-0 border-l-1 bg-transparent text-left text-[1.5rem] sm:text-[2rem] font-semibold',
                         'px-2.5 py-1 pl-4.5 rounded-none',
                         'hover:not-disabled:border-l-4 hover:not-disabled:pl-3.75',
                         'focus:outline-none focus:ring-0 focus:ring-offset-0',
@@ -222,7 +222,7 @@ export const DisplayNameInput = (): ReactElement => {
                     disabled={readOnly}
                     className={cn(
                         'block w-full min-w-64 resize-none overflow-hidden whitespace-pre-wrap break-words bg-transparent',
-                        'border-0 border-l-1 text-[2rem] font-semibold px-2.5 py-1 pl-4.5',
+                        'border-0 border-l-1 text-[1.5rem] sm:text-[2rem] font-semibold px-2.5 py-1 pl-4.5',
                         '[&:hover,&:focus]:border-l-4 [&:hover,&:focus]:pl-3.75 placeholder:text-subtle/50 rounded-none',
                         'transition-highlight focus:outline-none disabled:select-none disabled:cursor-not-allowed',
                         'focus:ring-0 focus:ring-offset-0 focus:border-transparent',

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/browse-toolbar/ContentWizardToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/browse-toolbar/ContentWizardToolbar.tsx
@@ -123,6 +123,7 @@ export const ContentWizardToolbar = ({
     const nameFieldLabel = useI18n('field.name');
     const unnamedFieldLabel = useI18n('field.unnamed');
     const aiAssistantLabel = useI18n('tooltip.ai.assistant');
+    const actionsLabel = useI18n('action.actions');
     const pathExistsLabel = useI18n('notify.path.not.available');
     const projectViewLabel = projectLabel || projectRoot;
     const unnamedPathLabel = `<${unnamedFieldLabel}>`;
@@ -214,6 +215,7 @@ export const ContentWizardToolbar = ({
                         <SplitActionButton
                             actions={mobileSplitActions}
                             disabled={!isMobileActionsSplitVisible || isPathFetchingDelayed}
+                            menuOnlyLabel={actionsLabel}
                         />
                     </div>
                     <OverflowActionRow actions={toolbarActions} className="hidden sm:flex min-w-0 flex-1" />

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/browse-toolbar/SplitActionButton.test.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/browse-toolbar/SplitActionButton.test.tsx
@@ -224,13 +224,15 @@ describe('SplitActionButton', () => {
         expect(menuItems.every((item) => item.disabled)).toBe(true);
     });
 
-    it('renders every action in one menu when configured as menu-only', () => {
+    it('renders every visible action in one menu when configured as menu-only', () => {
         const primary = createAction({ label: 'Primary' });
         const secondary = createAction({ label: 'Secondary' });
+        const hidden = createAction({ label: 'Hidden', visible: false });
 
-        render(<SplitActionButton actions={[[primary, secondary]]} menuOnlyLabel="Actions" />);
+        render(<SplitActionButton actions={[[primary, secondary, hidden]]} menuOnlyLabel="Actions" />);
 
         expect(screen.getByRole('button', { name: 'Actions' })).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Primary' })).toBeNull();
         expect(screen.getAllByRole('menuitem').map((item) => item.textContent?.trim())).toEqual([
             'Primary',
             'Secondary',

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/preview-panel/ui/PreviewToolbar.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/preview-panel/ui/PreviewToolbar.tsx
@@ -14,12 +14,14 @@ type PreviewToolbarProps = {
     item?: ContentSummaryAndCompareStatus | null;
     onRefresh?: () => void;
     hideInMobileMode?: boolean;
+    editorLayout?: boolean;
 };
 
 const PreviewToolbar = ({
     item = null,
     onRefresh,
     hideInMobileMode = false,
+    editorLayout = false,
 }: PreviewToolbarProps): ReactElement | null => {
     const mode = useStore($contextPanelMode);
 
@@ -30,18 +32,31 @@ const PreviewToolbar = ({
             <Toolbar.Container
                 aria-label="Preview toolbar"
                 className={cn(
-                    '@container bg-surface-neutral h-15 px-5 py-3.75 flex items-center justify-between border-b border-bdr-soft',
+                    '@container bg-surface-neutral h-15 py-3.75 flex items-center justify-between border-b border-bdr-soft',
+                    editorLayout ? 'px-2' : 'px-5',
                     hideInMobileMode && mode === 'mobile' && 'hidden',
                 )}
             >
-                <PreviewToolbarVersionHistoryItem contentSummary={item.getContentSummary()} />
+                <PreviewToolbarVersionHistoryItem contentSummary={item.getContentSummary()} showStatus={editorLayout} />
 
-                <div className="flex gap-2 @md:gap-5 flex-nowrap shrink-0">
-                    <PreviewToolbarEmulatorSelector />
-                    <PreviewToolbarWidgetSelector />
-                </div>
+                {editorLayout ? (
+                    <>
+                        <PreviewToolbarEmulatorSelector />
+                        <div className="flex items-center gap-2 flex-nowrap shrink-0">
+                            <PreviewToolbarWidgetSelector />
+                            <PreviewToolbarRefreshItem onRefresh={onRefresh} />
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        <div className="flex gap-2 @md:gap-5 flex-nowrap shrink-0">
+                            <PreviewToolbarEmulatorSelector />
+                            <PreviewToolbarWidgetSelector />
+                        </div>
 
-                <PreviewToolbarRefreshItem onRefresh={onRefresh} />
+                        <PreviewToolbarRefreshItem onRefresh={onRefresh} />
+                    </>
+                )}
             </Toolbar.Container>
         </Toolbar>
     );
@@ -50,7 +65,7 @@ const PreviewToolbar = ({
 PreviewToolbar.displayName = 'PreviewToolbar';
 
 export class PreviewToolbarElement extends LegacyElement<typeof PreviewToolbar, PreviewToolbarProps> {
-    constructor(props: Pick<PreviewToolbarProps, 'hideInMobileMode'> = {}) {
+    constructor(props: Pick<PreviewToolbarProps, 'hideInMobileMode' | 'editorLayout'> = {}) {
         super(props, PreviewToolbar);
     }
 

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/preview-panel/ui/PreviewToolbarVersionHistoryItem.tsx
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/preview-panel/ui/PreviewToolbarVersionHistoryItem.tsx
@@ -17,11 +17,13 @@ import { VERSIONS_WIDGET_NAME } from '../../../shared/lib/widget/versions/versio
 type PreviewToolbarVersionHistoryItemProps = {
     contentSummary: ContentSummary;
     mobile?: boolean;
+    showStatus?: boolean;
 };
 
 export function PreviewToolbarVersionHistoryItem({
     contentSummary,
     mobile = false,
+    showStatus = false,
 }: PreviewToolbarVersionHistoryItemProps): ReactElement {
     const ariaLabel = useI18n('wcag.preview.toolbar.versionHistory.label');
 
@@ -43,13 +45,15 @@ export function PreviewToolbarVersionHistoryItem({
         <Toolbar.Item asChild>
             <Button
                 size="sm"
-                className={mobile ? 'min-w-9 flex-shrink-0' : 'min-w-9 @max-sm:p-0 flex-shrink-0'}
+                className={mobile ? 'min-w-9 shrink-0' : showStatus ? 'min-w-0 shrink' : 'min-w-9 @max-sm:p-0 shrink-0'}
                 aria-label={ariaLabel}
                 startIcon={History}
-                startIconClassName={mobile ? 'size-5' : undefined}
+                startIconClassName={mobile ? 'size-5 shrink-0' : 'shrink-0'}
                 onClick={handleShowVersionHistory}
             >
-                <span className={mobile ? 'inline' : 'hidden @sm:inline'}>{buttonLabel}</span>
+                <span className={mobile ? 'inline' : showStatus ? 'min-w-0 truncate' : 'hidden @sm:inline'}>
+                    {buttonLabel}
+                </span>
             </Button>
         </Toolbar.Item>
     );


### PR DESCRIPTION
Replace the editor action control with a localized Actions dropdown containing visible actions.
Change the display name text size to 1.5rem in compact layouts.
Use 8px horizontal padding in the editor preview toolbar without changing vertical padding.
Keep publication status visible without overflowing long labels.
Group widget and refresh controls together in the editor layout.