### PR TITLE
Fix layout fragment validation after moving fragments #11363

### DIFF
--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponents.store.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponents.store.test.ts
@@ -79,6 +79,58 @@ describe('pageComponents.store layout fragments', () => {
         expect(fetchContentByIdMock).toHaveBeenCalledWith('shared-fragment');
     });
 
+    it('reuses resolved fragment kind while rebuilding the same page', async () => {
+        fetchContentByIdMock.mockReturnValue(okAsync(makeFragmentContent(false)));
+        const page = makePage('fragment-id');
+
+        rebuild(page);
+        await vi.waitFor(() => {
+            expect(getLayoutFragment('/main/0')).toBe(false);
+        });
+
+        rebuild(page);
+        expect(getLayoutFragment('/main/0')).toBe(false);
+
+        expect(fetchContentByIdMock).toHaveBeenCalledOnce();
+    });
+
+    it('resets resolved fragment kinds when the page changes', async () => {
+        fetchContentByIdMock
+            .mockReturnValueOnce(okAsync(makeFragmentContent(false)))
+            .mockReturnValueOnce(okAsync(makeFragmentContent(true)));
+
+        rebuild(makePage('fragment-id'));
+        await vi.waitFor(() => {
+            expect(getLayoutFragment('/main/0')).toBe(false);
+        });
+
+        rebuild(makePage('fragment-id'));
+
+        expect(fetchContentByIdMock).toHaveBeenCalledTimes(2);
+        await vi.waitFor(() => {
+            expect(getLayoutFragment('/main/0')).toBe(true);
+        });
+    });
+
+    it('deduplicates fragment kind requests across rebuilds', async () => {
+        let resolveRequest: (content: unknown) => void;
+        const response = new Promise<unknown>((resolve) => {
+            resolveRequest = resolve;
+        });
+        fetchContentByIdMock.mockReturnValue(ResultAsync.fromPromise(response, (error) => error));
+        const page = makePage('fragment-id');
+
+        rebuild(page);
+        rebuild(page);
+
+        expect(fetchContentByIdMock).toHaveBeenCalledOnce();
+
+        resolveRequest!(makeFragmentContent(false));
+        await vi.waitFor(() => {
+            expect(getLayoutFragment('/main/0')).toBe(false);
+        });
+    });
+
     it('resolves referenced fragments inside a detached layout component', async () => {
         fetchContentByIdMock.mockReturnValue(okAsync(makeFragmentContent(false)));
 
@@ -119,6 +171,7 @@ describe('pageComponents.store layout fragments', () => {
 
         resolveFirstRequest!(makeFragmentContent(true));
         await firstResult;
+        await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(getLayoutFragment('/main/0')).toBe(false);
     });

--- a/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponents.store.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/pages/wizard/ui/content-wizard-tabs/page-components/pageComponents.store.ts
@@ -46,6 +46,7 @@ export const $componentsFlatNodes = computed($componentsTreeState, flattenTree);
 let lastRebuildVersion = -1;
 let lastLayoutsByPath = new Map<string, LayoutComponent>();
 let layoutFragmentResolutionId = 0;
+let layoutFragmentKindCache = createLayoutFragmentKindCache(null);
 
 export function rebuildComponentsTree(preserveExpanded = true): void {
     const currentVersion = $pageVersion.get();
@@ -53,6 +54,10 @@ export function rebuildComponentsTree(preserveExpanded = true): void {
     lastRebuildVersion = currentVersion;
 
     const page = $page.get();
+    if (layoutFragmentKindCache.page !== page) {
+        layoutFragmentKindCache = createLayoutFragmentKindCache(page);
+    }
+
     const currentState = $componentsTreeState.get();
     const isRebuild = preserveExpanded && currentState.nodes.size > 0;
     const resolutionId = ++layoutFragmentResolutionId;
@@ -395,7 +400,8 @@ function buildComponentNodes(
     const componentId = buildComponentPath(regionPath, index);
     const nodeType = getComponentNodeType(component);
     const isLayout = component instanceof LayoutComponent;
-    const isReferencedFragment = component instanceof FragmentComponent && component.hasFragment();
+    const fragmentId =
+        component instanceof FragmentComponent && component.hasFragment() ? component.getFragment().toString() : null;
     const regions = isLayout ? (component.getRegions()?.getRegions() ?? []) : [];
     const childIds = regions.map((r) => buildRegionPath(componentId, r.getName()));
 
@@ -413,7 +419,7 @@ function buildComponentNodes(
             draggable: true,
             // Referenced fragments are treated as layouts until their content is resolved. This
             // keeps a fast drag from nesting an unresolved layout fragment inside another layout.
-            layoutFragment: isReferencedFragment,
+            layoutFragment: fragmentId == null ? false : (layoutFragmentKindCache.resolved.get(fragmentId) ?? true),
             hasDescriptor: componentHasDescriptor,
         },
         parentId: regionPath,
@@ -430,24 +436,59 @@ function resolveLayoutFragments(page: Page, resolutionId: number): void {
     const fragmentPathsById = collectReferencedFragments(page);
 
     for (const [fragmentId, paths] of fragmentPathsById) {
-        void fetchContentById(fragmentId).match(
-            (content) => {
-                if (resolutionId !== layoutFragmentResolutionId) {
-                    return;
-                }
+        void resolveLayoutFragmentKind(fragmentId).then((isLayoutFragment) => {
+            if (isLayoutFragment == null || resolutionId !== layoutFragmentResolutionId) {
+                return;
+            }
 
-                const isLayoutFragment = content.getPage()?.getFragment() instanceof LayoutComponent;
-                let state = $componentsTreeState.get();
+            let state = $componentsTreeState.get();
 
-                for (const path of paths) {
-                    state = updateNodeData(state, path, { layoutFragment: isLayoutFragment });
-                }
+            for (const path of paths) {
+                state = updateNodeData(state, path, { layoutFragment: isLayoutFragment });
+            }
 
-                $componentsTreeState.set(state);
-            },
-            () => undefined,
-        );
+            $componentsTreeState.set(state);
+        });
     }
+}
+
+type LayoutFragmentKindCache = {
+    page: Page | null;
+    resolved: Map<string, boolean>;
+    pending: Map<string, Promise<boolean | undefined>>;
+};
+
+function createLayoutFragmentKindCache(page: Page | null): LayoutFragmentKindCache {
+    return { page, resolved: new Map(), pending: new Map() };
+}
+
+function resolveLayoutFragmentKind(fragmentId: string): Promise<boolean | undefined> {
+    const cache = layoutFragmentKindCache;
+    const resolved = cache.resolved.get(fragmentId);
+    if (resolved != null) {
+        return Promise.resolve(resolved);
+    }
+
+    const pending = cache.pending.get(fragmentId);
+    if (pending != null) {
+        return pending;
+    }
+
+    const request = fetchContentById(fragmentId)
+        .match(
+            (content) => content.getPage()?.getFragment() instanceof LayoutComponent,
+            () => undefined,
+        )
+        .then((kind) => {
+            cache.pending.delete(fragmentId);
+            if (kind != null) {
+                cache.resolved.set(fragmentId, kind);
+            }
+            return kind;
+        });
+
+    cache.pending.set(fragmentId, request);
+    return request;
 }
 
 function collectReferencedFragments(page: Page): Map<string, string[]> {

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/ui/page-editor/inspect/fragment/hooks/useFragmentContentSelector.test.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/ui/page-editor/inspect/fragment/hooks/useFragmentContentSelector.test.ts
@@ -56,11 +56,13 @@ import { LayoutComponent } from '../../../../../../../../app/page/region/LayoutC
 import { LayoutComponentType } from '../../../../../../../../app/page/region/LayoutComponentType';
 import * as fragmentInspectionStore from '../../../../../model/fragment-inspection.store';
 import { $inspectedItem, requestSetFragmentComponent } from '../../../../../model/page-editor';
+import { $pageVersion } from '../../../../../model/page-editor/store';
 import { useFragmentContentSelector } from './useFragmentContentSelector';
 
 const $inspected = $inspectedItem as unknown as WritableAtom<unknown>;
 const $options = fragmentInspectionStore.$fragmentOptions as unknown as WritableAtom<unknown[]>;
 const $selectedId = fragmentInspectionStore.$selectedFragmentId as unknown as WritableAtom<string | null>;
+const $version = $pageVersion as WritableAtom<number>;
 
 function makeFragmentSummary(id: string, displayName: string, path = `/fragments/${id}`): unknown {
     return {
@@ -75,6 +77,16 @@ function makeInspectedFragment(parent: unknown = null): unknown {
 
     return Object.assign(fragment, {
         getParent: () => parent,
+        getPath: () => 'fragment-path',
+        getName: () => null,
+    });
+}
+
+function makeMovedFragment(parent: { current: unknown }): unknown {
+    const fragment = Object.create(FragmentComponent.prototype) as object;
+
+    return Object.assign(fragment, {
+        getParent: () => parent.current,
         getPath: () => 'fragment-path',
         getName: () => null,
     });
@@ -100,6 +112,7 @@ describe('useFragmentContentSelector', () => {
         $inspected.set(null);
         $options.set([]);
         $selectedId.set(null);
+        $version.set(0);
         vi.clearAllMocks();
     });
 
@@ -200,6 +213,24 @@ describe('useFragmentContentSelector', () => {
 
             expect(showWarning).toHaveBeenCalledWith('Nested layouts are not allowed');
             expect(requestSetFragmentComponent).not.toHaveBeenCalled();
+        });
+
+        it('should allow a layout fragment after the empty fragment is moved out of a layout', async () => {
+            const parent = { current: makeLayoutParentRegion() };
+            $inspected.set(makeMovedFragment(parent));
+            $options.set([makeFragmentSummary('frag-b', 'Layout Fragment')]);
+
+            const { result } = renderHook(() => useFragmentContentSelector());
+
+            parent.current = { getParent: () => null };
+            await act(async () => {
+                $version.set(1);
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            });
+            act(() => result.current.handleSelectionChange(['frag-b']));
+
+            expect(fetchContentByIdMock).not.toHaveBeenCalled();
+            expect(requestSetFragmentComponent).toHaveBeenCalledWith('fragment-path', 'frag-b', 'Layout Fragment');
         });
     });
 });

--- a/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/ui/page-editor/inspect/fragment/hooks/useFragmentContentSelector.ts
+++ b/modules/lib/src/main/resources/assets/js/v6/widgets/inspectors/ui/page-editor/inspect/fragment/hooks/useFragmentContentSelector.ts
@@ -61,12 +61,7 @@ export function useFragmentContentSelector(): UseFragmentContentSelectorResult {
     const fragment = item instanceof FragmentComponent ? item : null;
     const disabled = lifecycle.isPageLocked;
 
-    const isInsideLayout = useMemo((): boolean => {
-        if (!fragment) return false;
-        const parentRegion = fragment.getParent();
-        if (!parentRegion) return false;
-        return parentRegion.getParent() instanceof LayoutComponent;
-    }, [fragment]);
+    const isInsideLayout = fragment?.getParent()?.getParent() instanceof LayoutComponent;
 
     const options = useMemo((): FragmentOption[] => {
         const real = fragments.map((f) => ({


### PR DESCRIPTION
Recalculated fragment ancestry after component moves.
Cached resolved fragment kinds and deduplicated pending requests.